### PR TITLE
PERSONALITY-BIG5-CONTENT-COVERAGE-01: add Big Five public content coverage

### DIFF
--- a/backend/app/Console/Commands/PersonalityPublicAssetsImport.php
+++ b/backend/app/Console/Commands/PersonalityPublicAssetsImport.php
@@ -224,6 +224,14 @@ final class PersonalityPublicAssetsImport extends Command
 
     private function comparable(mixed $value): mixed
     {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d\TH:i:sP');
+        }
+
+        if (is_string($value) && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/', $value) === 1) {
+            return (new \DateTimeImmutable($value))->format('Y-m-d\TH:i:sP');
+        }
+
         if (is_array($value)) {
             $this->sortAssociativeRecursive($value);
 

--- a/backend/app/DTO/Personality/PersonalityPublicContentAssetData.php
+++ b/backend/app/DTO/Personality/PersonalityPublicContentAssetData.php
@@ -18,11 +18,13 @@ final readonly class PersonalityPublicContentAssetData
      * @param  array<string,mixed>  $schema
      * @param  array<string,mixed>  $methodBoundary
      * @param  array<int,array<string,mixed>>  $evidenceNotes
+     * @param  array<int,array<string,mixed>>  $internalLinks
      */
     public function __construct(
         public int $orgId,
         public string $framework,
         public string $entityType,
+        public string $code,
         public string $entityKey,
         public string $slug,
         public string $locale,
@@ -30,6 +32,7 @@ final readonly class PersonalityPublicContentAssetData
         public ?string $summary,
         public array $contentSections,
         public array $seo,
+        public string $robots,
         public array $canonical,
         public array $hreflang,
         public array $faq,
@@ -37,6 +40,7 @@ final readonly class PersonalityPublicContentAssetData
         public array $schema,
         public array $methodBoundary,
         public array $evidenceNotes,
+        public array $internalLinks,
         public bool $isPublic,
         public bool $indexEligible,
         public bool $sitemapEligible,
@@ -46,6 +50,7 @@ final readonly class PersonalityPublicContentAssetData
         public string $contractVersion,
         public ?string $sourcePackage,
         public ?string $sourceHash,
+        public ?string $lastReviewedAt,
     ) {}
 
     /**
@@ -53,17 +58,22 @@ final readonly class PersonalityPublicContentAssetData
      */
     public static function fromValidatedPayload(array $payload): self
     {
+        $code = PersonalityPublicContentAsset::normalizeEntityKey((string) ($payload['code'] ?? $payload['entity_key']));
+        $contentSections = $payload['content_sections'] ?? $payload['sections'] ?? [];
+
         return new self(
             orgId: max(0, (int) ($payload['org_id'] ?? 0)),
             framework: PersonalityPublicContentAsset::normalizeToken((string) $payload['framework']),
             entityType: PersonalityPublicContentAsset::normalizeToken((string) $payload['entity_type']),
-            entityKey: PersonalityPublicContentAsset::normalizeEntityKey((string) $payload['entity_key']),
+            code: $code,
+            entityKey: PersonalityPublicContentAsset::normalizeEntityKey((string) ($payload['entity_key'] ?? $code)),
             slug: PersonalityPublicContentAsset::normalizeSlug((string) $payload['slug']),
             locale: PersonalityPublicContentAsset::normalizeLocale((string) $payload['locale']),
             title: trim((string) $payload['title']),
             summary: self::nullableString($payload['summary'] ?? null),
-            contentSections: array_values(is_array($payload['content_sections'] ?? null) ? $payload['content_sections'] : []),
+            contentSections: array_values(is_array($contentSections) ? $contentSections : []),
             seo: is_array($payload['seo'] ?? null) ? $payload['seo'] : [],
+            robots: PersonalityPublicContentAsset::normalizeRobots((string) ($payload['robots'] ?? PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)),
             canonical: is_array($payload['canonical'] ?? null) ? $payload['canonical'] : [],
             hreflang: is_array($payload['hreflang'] ?? null) ? $payload['hreflang'] : [],
             faq: array_values(is_array($payload['faq'] ?? null) ? $payload['faq'] : []),
@@ -71,6 +81,7 @@ final readonly class PersonalityPublicContentAssetData
             schema: is_array($payload['schema'] ?? null) ? $payload['schema'] : [],
             methodBoundary: is_array($payload['method_boundary'] ?? null) ? $payload['method_boundary'] : [],
             evidenceNotes: array_values(is_array($payload['evidence_notes'] ?? null) ? $payload['evidence_notes'] : []),
+            internalLinks: array_values(is_array($payload['internal_links'] ?? null) ? $payload['internal_links'] : []),
             isPublic: (bool) ($payload['is_public'] ?? true),
             indexEligible: (bool) ($payload['index_eligible'] ?? false),
             sitemapEligible: (bool) ($payload['sitemap_eligible'] ?? false),
@@ -80,6 +91,7 @@ final readonly class PersonalityPublicContentAssetData
             contractVersion: trim((string) ($payload['contract_version'] ?? PersonalityPublicContentAsset::CONTRACT_VERSION_V1)) ?: PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
             sourcePackage: self::nullableString($payload['source_package'] ?? null),
             sourceHash: self::nullableString($payload['source_hash'] ?? null),
+            lastReviewedAt: self::nullableString($payload['last_reviewed_at'] ?? null),
         );
     }
 
@@ -99,6 +111,7 @@ final readonly class PersonalityPublicContentAssetData
             'summary' => $this->summary,
             'content_sections_json' => $this->contentSections,
             'seo_json' => $this->seo,
+            'robots' => $this->robots,
             'canonical_json' => $this->canonical,
             'hreflang_json' => $this->hreflang,
             'faq_json' => $this->faq,
@@ -106,6 +119,7 @@ final readonly class PersonalityPublicContentAssetData
             'schema_json' => $this->schema,
             'method_boundary_json' => $this->methodBoundary,
             'evidence_notes_json' => $this->evidenceNotes,
+            'internal_links_json' => $this->internalLinks,
             'is_public' => $this->isPublic,
             'index_eligible' => $this->indexEligible,
             'sitemap_eligible' => $this->sitemapEligible,
@@ -115,6 +129,7 @@ final readonly class PersonalityPublicContentAssetData
             'contract_version' => $this->contractVersion,
             'source_package' => $this->sourcePackage,
             'source_hash' => $this->sourceHash,
+            'last_reviewed_at' => $this->lastReviewedAt,
         ];
     }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php
@@ -73,11 +73,47 @@ final class PersonalityPublicContentAssetController extends Controller
             ->first();
 
         if (! $asset instanceof PersonalityPublicContentAsset) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'NOT_FOUND',
-                'message' => 'personality content asset not found.',
-            ], 404);
+            return $this->notFoundResponse();
+        }
+
+        return response()->json([
+            'ok' => true,
+            'asset' => $this->assetPayload($asset),
+            'personality_public_content_asset_v1' => $this->assetPayload($asset),
+        ]);
+    }
+
+    public function showByCode(Request $request, string $framework, string $entityType, string $code): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $normalizedFramework = PersonalityPublicContentAsset::normalizeToken($framework);
+        $normalizedEntityType = PersonalityPublicContentAsset::normalizeToken($entityType);
+        $normalizedCode = PersonalityPublicContentAsset::normalizeEntityKey($code);
+
+        if (! in_array($normalizedFramework, PersonalityPublicContentAsset::FRAMEWORKS, true)) {
+            return $this->notFoundResponse();
+        }
+
+        if (! in_array($normalizedEntityType, PersonalityPublicContentAsset::ENTITY_TYPES, true)) {
+            return $this->notFoundResponse();
+        }
+
+        $asset = PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $validated['org_id'])
+            ->where('framework', $normalizedFramework)
+            ->where('entity_type', $normalizedEntityType)
+            ->where('entity_key', $normalizedCode)
+            ->forLocale($validated['locale'])
+            ->publiclyReadable()
+            ->first();
+
+        if (! $asset instanceof PersonalityPublicContentAsset) {
+            return $this->notFoundResponse();
         }
 
         return response()->json([
@@ -127,26 +163,34 @@ final class PersonalityPublicContentAssetController extends Controller
      */
     private function assetPayload(PersonalityPublicContentAsset $asset): array
     {
+        $contentSections = is_array($asset->content_sections_json) ? $asset->content_sections_json : [];
+        $canonical = is_array($asset->canonical_json) ? $asset->canonical_json : [];
+
         return [
             'id' => (int) $asset->id,
             'org_id' => (int) $asset->org_id,
             'contract_version' => (string) $asset->contract_version,
             'framework' => (string) $asset->framework,
             'entity_type' => (string) $asset->entity_type,
+            'code' => (string) $asset->entity_key,
             'entity_key' => (string) $asset->entity_key,
             'slug' => (string) $asset->slug,
             'locale' => (string) $asset->locale,
             'title' => (string) $asset->title,
             'summary' => $asset->summary,
-            'content_sections' => is_array($asset->content_sections_json) ? $asset->content_sections_json : [],
+            'sections' => $contentSections,
+            'content_sections' => $contentSections,
             'seo' => is_array($asset->seo_json) ? $asset->seo_json : [],
-            'canonical' => is_array($asset->canonical_json) ? $asset->canonical_json : [],
+            'robots' => PersonalityPublicContentAsset::normalizeRobots((string) $asset->robots),
+            'canonical_path' => (string) data_get($canonical, 'path', ''),
+            'canonical' => $canonical,
             'hreflang' => is_array($asset->hreflang_json) ? $asset->hreflang_json : [],
             'faq' => is_array($asset->faq_json) ? $asset->faq_json : [],
             'media' => is_array($asset->media_json) ? $asset->media_json : [],
             'schema' => is_array($asset->schema_json) ? $asset->schema_json : [],
             'method_boundary' => is_array($asset->method_boundary_json) ? $asset->method_boundary_json : [],
             'evidence_notes' => is_array($asset->evidence_notes_json) ? $asset->evidence_notes_json : [],
+            'internal_links' => is_array($asset->internal_links_json) ? $asset->internal_links_json : [],
             'is_public' => (bool) $asset->is_public,
             'index_eligible' => (bool) $asset->index_eligible,
             'sitemap_eligible' => (bool) $asset->sitemap_eligible,
@@ -159,5 +203,14 @@ final class PersonalityPublicContentAssetController extends Controller
             'last_reviewed_at' => $asset->last_reviewed_at?->toAtomString(),
             'updated_at' => $asset->updated_at?->toAtomString(),
         ];
+    }
+
+    private function notFoundResponse(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+            'message' => 'personality content asset not found.',
+        ], 404);
     }
 }

--- a/backend/app/Models/PersonalityPublicContentAsset.php
+++ b/backend/app/Models/PersonalityPublicContentAsset.php
@@ -30,6 +30,8 @@ final class PersonalityPublicContentAsset extends Model
 
     public const ENTITY_POLARITY = 'polarity';
 
+    public const ENTITY_FACET_HUB = 'facet_hub';
+
     public const ENTITY_FACET = 'facet';
 
     public const ENTITY_CENTER = 'center';
@@ -44,6 +46,7 @@ final class PersonalityPublicContentAsset extends Model
         self::ENTITY_HUB,
         self::ENTITY_DOMAIN,
         self::ENTITY_POLARITY,
+        self::ENTITY_FACET_HUB,
         self::ENTITY_FACET,
         self::ENTITY_CENTER,
         self::ENTITY_CORE_TYPE,
@@ -56,6 +59,7 @@ final class PersonalityPublicContentAsset extends Model
             self::ENTITY_HUB,
             self::ENTITY_DOMAIN,
             self::ENTITY_POLARITY,
+            self::ENTITY_FACET_HUB,
             self::ENTITY_FACET,
         ],
         self::FRAMEWORK_ENNEAGRAM => [
@@ -73,6 +77,10 @@ final class PersonalityPublicContentAsset extends Model
 
     public const LAUNCH_APPROVED = 'approved';
 
+    public const LAUNCH_CONTENT_READY = 'content_ready';
+
+    public const LAUNCH_CONTENT_STUB = 'content_stub';
+
     public const LAUNCH_PUBLISHED = 'published';
 
     public const LAUNCH_ARCHIVED = 'archived';
@@ -81,8 +89,22 @@ final class PersonalityPublicContentAsset extends Model
         self::LAUNCH_DRAFT,
         self::LAUNCH_REVIEW,
         self::LAUNCH_APPROVED,
+        self::LAUNCH_CONTENT_READY,
+        self::LAUNCH_CONTENT_STUB,
         self::LAUNCH_PUBLISHED,
         self::LAUNCH_ARCHIVED,
+    ];
+
+    public const ROBOTS_INDEX_FOLLOW = 'index,follow';
+
+    public const ROBOTS_NOINDEX_FOLLOW = 'noindex,follow';
+
+    public const ROBOTS_NOINDEX_NOFOLLOW = 'noindex,nofollow';
+
+    public const ROBOTS_VALUES = [
+        self::ROBOTS_INDEX_FOLLOW,
+        self::ROBOTS_NOINDEX_FOLLOW,
+        self::ROBOTS_NOINDEX_NOFOLLOW,
     ];
 
     public const SUPPORTED_LOCALES = [
@@ -103,6 +125,7 @@ final class PersonalityPublicContentAsset extends Model
         'summary',
         'content_sections_json',
         'seo_json',
+        'robots',
         'canonical_json',
         'hreflang_json',
         'faq_json',
@@ -110,6 +133,7 @@ final class PersonalityPublicContentAsset extends Model
         'schema_json',
         'method_boundary_json',
         'evidence_notes_json',
+        'internal_links_json',
         'is_public',
         'index_eligible',
         'sitemap_eligible',
@@ -136,6 +160,7 @@ final class PersonalityPublicContentAsset extends Model
         'schema_json' => 'array',
         'method_boundary_json' => 'array',
         'evidence_notes_json' => 'array',
+        'internal_links_json' => 'array',
         'is_public' => 'boolean',
         'index_eligible' => 'boolean',
         'sitemap_eligible' => 'boolean',
@@ -163,10 +188,15 @@ final class PersonalityPublicContentAsset extends Model
             $asset->slug = self::normalizeSlug((string) $asset->slug);
             $asset->locale = self::normalizeLocale((string) $asset->locale);
             $asset->launch_state = self::normalizeLaunchState((string) $asset->launch_state);
+            $asset->robots = self::normalizeRobots((string) ($asset->robots ?: self::ROBOTS_NOINDEX_FOLLOW));
             $asset->review_state = trim((string) ($asset->review_state ?: 'draft'));
             $asset->contract_version = trim((string) ($asset->contract_version ?: self::CONTRACT_VERSION_V1));
 
-            if ($asset->launch_state !== self::LAUNCH_PUBLISHED || ! (bool) $asset->index_eligible) {
+            if (
+                $asset->launch_state !== self::LAUNCH_PUBLISHED
+                || ! (bool) $asset->index_eligible
+                || $asset->robots !== self::ROBOTS_INDEX_FOLLOW
+            ) {
                 $asset->sitemap_eligible = false;
                 $asset->llms_eligible = false;
             }
@@ -177,8 +207,10 @@ final class PersonalityPublicContentAsset extends Model
     {
         return $query
             ->where('is_public', true)
-            ->where('index_eligible', true)
-            ->where('launch_state', self::LAUNCH_PUBLISHED)
+            ->whereIn('launch_state', [
+                self::LAUNCH_CONTENT_READY,
+                self::LAUNCH_PUBLISHED,
+            ])
             ->where(static function (Builder $publishedAtQuery): void {
                 $publishedAtQuery
                     ->whereNull('published_at')
@@ -220,5 +252,14 @@ final class PersonalityPublicContentAsset extends Model
         return in_array($normalized, self::LAUNCH_STATES, true)
             ? $normalized
             : self::LAUNCH_DRAFT;
+    }
+
+    public static function normalizeRobots(string $value): string
+    {
+        $normalized = strtolower(str_replace(' ', '', trim($value)));
+
+        return in_array($normalized, self::ROBOTS_VALUES, true)
+            ? $normalized
+            : self::ROBOTS_NOINDEX_FOLLOW;
     }
 }

--- a/backend/app/Services/Cms/PersonalityPublicContentAssetContract.php
+++ b/backend/app/Services/Cms/PersonalityPublicContentAssetContract.php
@@ -40,6 +40,7 @@ final class PersonalityPublicContentAssetContract
             'org_id' => ['nullable', 'integer', 'min:0'],
             'framework' => ['required', Rule::in(PersonalityPublicContentAsset::FRAMEWORKS)],
             'entity_type' => ['required', Rule::in(PersonalityPublicContentAsset::ENTITY_TYPES)],
+            'code' => ['required', 'string', 'max:128', 'regex:/^[a-z0-9][a-z0-9_\\-.\\/]*$/i'],
             'entity_key' => ['required', 'string', 'max:128', 'regex:/^[a-z0-9][a-z0-9_\\-.\\/]*$/i'],
             'slug' => ['required', 'string', 'max:160', 'regex:/^[a-z0-9][a-z0-9\\-\\/]*$/i'],
             'locale' => ['required', Rule::in(PersonalityPublicContentAsset::SUPPORTED_LOCALES)],
@@ -50,6 +51,8 @@ final class PersonalityPublicContentAssetContract
             'content_sections.*.title' => ['nullable', 'string', 'max:255'],
             'content_sections.*.body_md' => ['nullable', 'string'],
             'seo' => ['required', 'array'],
+            'robots' => ['required', Rule::in(PersonalityPublicContentAsset::ROBOTS_VALUES)],
+            'canonical_path' => ['nullable', 'string', 'max:255'],
             'canonical' => ['required', 'array'],
             'hreflang' => ['present', 'array'],
             'faq' => ['present', 'array'],
@@ -57,6 +60,7 @@ final class PersonalityPublicContentAssetContract
             'schema' => ['present', 'array'],
             'method_boundary' => ['present', 'array'],
             'evidence_notes' => ['present', 'array'],
+            'internal_links' => ['present', 'array'],
             'is_public' => ['nullable', 'boolean'],
             'index_eligible' => ['nullable', 'boolean'],
             'sitemap_eligible' => ['nullable', 'boolean'],
@@ -66,6 +70,7 @@ final class PersonalityPublicContentAssetContract
             'contract_version' => ['nullable', 'string', 'max:64'],
             'source_package' => ['nullable', 'string', 'max:160'],
             'source_hash' => ['nullable', 'string', 'max:64'],
+            'last_reviewed_at' => ['nullable', 'date'],
         ]);
 
         $validator->after(function ($validator) use ($normalized): void {
@@ -118,18 +123,27 @@ final class PersonalityPublicContentAssetContract
         $payload['org_id'] = max(0, (int) ($payload['org_id'] ?? 0));
         $payload['framework'] = PersonalityPublicContentAsset::normalizeToken((string) ($payload['framework'] ?? ''));
         $payload['entity_type'] = PersonalityPublicContentAsset::normalizeToken((string) ($payload['entity_type'] ?? ''));
-        $payload['entity_key'] = PersonalityPublicContentAsset::normalizeEntityKey((string) ($payload['entity_key'] ?? ''));
+        $payload['code'] = PersonalityPublicContentAsset::normalizeEntityKey((string) ($payload['code'] ?? $payload['entity_key'] ?? ''));
+        $payload['entity_key'] = PersonalityPublicContentAsset::normalizeEntityKey((string) ($payload['entity_key'] ?? $payload['code'] ?? ''));
         $payload['slug'] = PersonalityPublicContentAsset::normalizeSlug((string) ($payload['slug'] ?? ''));
         $payload['locale'] = PersonalityPublicContentAsset::normalizeLocale((string) ($payload['locale'] ?? 'en'));
-        $payload['content_sections'] = is_array($payload['content_sections'] ?? null) ? $payload['content_sections'] : [];
+        $payload['content_sections'] = is_array($payload['content_sections'] ?? null)
+            ? $payload['content_sections']
+            : (is_array($payload['sections'] ?? null) ? $payload['sections'] : []);
         $payload['seo'] = is_array($payload['seo'] ?? null) ? $payload['seo'] : [];
+        $payload['robots'] = PersonalityPublicContentAsset::normalizeRobots((string) ($payload['robots'] ?? PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
+        if (! isset($payload['canonical']) && isset($payload['canonical_path'])) {
+            $payload['canonical'] = ['path' => (string) $payload['canonical_path']];
+        }
         $payload['canonical'] = is_array($payload['canonical'] ?? null) ? $payload['canonical'] : [];
+        $payload['canonical_path'] = trim((string) ($payload['canonical_path'] ?? data_get($payload, 'canonical.path', '')));
         $payload['hreflang'] = is_array($payload['hreflang'] ?? null) ? $payload['hreflang'] : [];
         $payload['faq'] = is_array($payload['faq'] ?? null) ? $payload['faq'] : [];
         $payload['media'] = is_array($payload['media'] ?? null) ? $payload['media'] : [];
         $payload['schema'] = is_array($payload['schema'] ?? null) ? $payload['schema'] : [];
         $payload['method_boundary'] = is_array($payload['method_boundary'] ?? null) ? $payload['method_boundary'] : [];
         $payload['evidence_notes'] = is_array($payload['evidence_notes'] ?? null) ? $payload['evidence_notes'] : [];
+        $payload['internal_links'] = is_array($payload['internal_links'] ?? null) ? $payload['internal_links'] : [];
         $payload['is_public'] = (bool) ($payload['is_public'] ?? true);
         $payload['index_eligible'] = (bool) ($payload['index_eligible'] ?? false);
         $payload['sitemap_eligible'] = (bool) ($payload['sitemap_eligible'] ?? false);
@@ -167,12 +181,21 @@ final class PersonalityPublicContentAssetContract
     private function validateLaunchGate($validator, array $payload): void
     {
         $launchState = (string) ($payload['launch_state'] ?? PersonalityPublicContentAsset::LAUNCH_DRAFT);
+        $robots = PersonalityPublicContentAsset::normalizeRobots((string) ($payload['robots'] ?? PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
         $indexEligible = (bool) ($payload['index_eligible'] ?? false);
         $sitemapEligible = (bool) ($payload['sitemap_eligible'] ?? false);
         $llmsEligible = (bool) ($payload['llms_eligible'] ?? false);
 
         if ($indexEligible && $launchState !== PersonalityPublicContentAsset::LAUNCH_PUBLISHED) {
             $validator->errors()->add('index_eligible', 'index_eligible=true requires launch_state=published.');
+        }
+
+        if ($indexEligible && $robots !== PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW) {
+            $validator->errors()->add('robots', 'index_eligible=true requires robots=index,follow.');
+        }
+
+        if ($robots === PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW && (! $indexEligible || $launchState !== PersonalityPublicContentAsset::LAUNCH_PUBLISHED)) {
+            $validator->errors()->add('robots', 'robots=index,follow requires published index_eligible assets.');
         }
 
         if (($sitemapEligible || $llmsEligible) && (! $indexEligible || $launchState !== PersonalityPublicContentAsset::LAUNCH_PUBLISHED)) {
@@ -188,6 +211,7 @@ final class PersonalityPublicContentAssetContract
         $surface = implode(' ', [
             (string) ($payload['framework'] ?? ''),
             (string) ($payload['entity_type'] ?? ''),
+            (string) ($payload['code'] ?? ''),
             (string) ($payload['entity_key'] ?? ''),
             (string) ($payload['slug'] ?? ''),
             (string) ($payload['title'] ?? ''),

--- a/backend/content_assets/personality_public/big_five_v1_seed.json
+++ b/backend/content_assets/personality_public/big_five_v1_seed.json
@@ -1,371 +1,7419 @@
 {
-  "package": "personality_public_big_five_v1_seed",
-  "contract_version": "personality_public_asset.v1",
-  "notes": [
-    "Draft-only Big Five public content asset contract seed.",
-    "No asset in this seed is index eligible, sitemap eligible, or llms eligible.",
-    "This seed intentionally does not define 32 OCEAN SEO pages."
-  ],
-  "assets": [
-    {
-      "framework": "big_five",
-      "entity_type": "hub",
-      "entity_key": "big-five",
-      "slug": "big-five",
-      "locale": "en",
-      "title": "Big Five Personality",
-      "summary": "Draft contract shell for the Big Five public content hub.",
-      "content_sections": [
+    "package": "personality_public_big_five_v1_seed",
+    "contract_version": "personality_public_asset.v1",
+    "generated_at": "2026-06-14T00:00:00Z",
+    "assets": [
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored public Big Five hub content."
-        }
-      ],
-      "seo": {
-        "title": "Big Five Personality | FermatMind",
-        "description": "Draft noindex Big Five public content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Big Five is a dimensional model, not a fixed type system."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "hub",
+            "code": "big-five",
+            "entity_key": "big-five",
+            "slug": "big-five",
+            "locale": "en",
+            "title": "Big Five Personality",
+            "summary": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neuroticism.",
+            "seo": {
+                "title": "Big Five Personality | FermatMind Big Five",
+                "description": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neuroticis"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five",
+            "canonical": {
+                "path": "/en/personality/big-five"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five",
+                "zh-CN": "/zh/personality/big-five"
+            },
+            "faq": [
+                {
+                    "question": "Is Big Five a type test?",
+                    "answer": "No. Big Five is dimensional and does not place people into a small set of fixed types."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Big Five Personality"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/openness"
+                },
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/extraversion"
+                },
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Model overview",
+                    "body_md": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neuroticism."
+                },
+                {
+                    "key": "dimensions",
+                    "title": "Five dimensions",
+                    "body_md": "Each dimension is continuous. High and low poles can both be useful in different contexts."
+                },
+                {
+                    "key": "use_cases",
+                    "title": "Appropriate uses",
+                    "body_md": "Use it for self-understanding, communication preferences, and reflection, not diagnosis or deterministic decisions."
+                }
+            ]
+        },
         {
-          "source_type": "method_boundary",
-          "note": "Public copy must avoid presenting Big Five as official 32 fixed types."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "domain",
-      "entity_key": "openness",
-      "slug": "big-five/openness",
-      "locale": "en",
-      "title": "Openness",
-      "summary": "Draft contract shell for the Openness dimension.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "openness",
+            "entity_key": "openness",
+            "slug": "big-five/openness",
+            "locale": "en",
+            "title": "Openness",
+            "summary": "Openness describes curiosity, imagination, aesthetic sensitivity, and comfort with new ideas or experiences.",
+            "seo": {
+                "title": "Openness | FermatMind Big Five",
+                "description": "Openness describes curiosity, imagination, aesthetic sensitivity, and comfort with new ideas or experiences."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/openness",
+            "canonical": {
+                "path": "/en/personality/big-five/openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/openness",
+                "zh-CN": "/zh/personality/big-five/openness"
+            },
+            "faq": [
+                {
+                    "question": "Can Openness alone determine career fit?",
+                    "answer": "No. Career fit also depends on skills, interests, values, opportunity, and constraints."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Openness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "High Openness",
+                    "target_code": "high-openness",
+                    "relationship": "high_pole",
+                    "href": "/en/personality/big-five/high-openness"
+                },
+                {
+                    "label": "Low Openness",
+                    "target_code": "low-openness",
+                    "relationship": "low_pole",
+                    "href": "/en/personality/big-five/low-openness"
+                },
+                {
+                    "label": "30 facets",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/en/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "What this domain describes",
+                    "body_md": "Openness describes curiosity, imagination, aesthetic sensitivity, and comfort with new ideas or experiences."
+                },
+                {
+                    "key": "high_low",
+                    "title": "High and low poles",
+                    "body_md": "High and low scores are not better or worse; they describe different preferences, energies, and risk patterns."
+                },
+                {
+                    "key": "interpretation",
+                    "title": "How to interpret it",
+                    "body_md": "Interpret this domain with context, other domains, and recent state; avoid single-trait labeling."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored Openness content."
-        }
-      ],
-      "seo": {
-        "title": "Openness in Big Five Personality | FermatMind",
-        "description": "Draft noindex Openness content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/openness"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Dimension pages describe score tendencies, not diagnostic labels."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "conscientiousness",
+            "entity_key": "conscientiousness",
+            "slug": "big-five/conscientiousness",
+            "locale": "en",
+            "title": "Conscientiousness",
+            "summary": "Conscientiousness describes organization, reliability, planning, persistence, and follow-through.",
+            "seo": {
+                "title": "Conscientiousness | FermatMind Big Five",
+                "description": "Conscientiousness describes organization, reliability, planning, persistence, and follow-through."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/conscientiousness",
+            "canonical": {
+                "path": "/en/personality/big-five/conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/conscientiousness",
+                "zh-CN": "/zh/personality/big-five/conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "Can Conscientiousness alone determine career fit?",
+                    "answer": "No. Career fit also depends on skills, interests, values, opportunity, and constraints."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Conscientiousness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "High Conscientiousness",
+                    "target_code": "high-conscientiousness",
+                    "relationship": "high_pole",
+                    "href": "/en/personality/big-five/high-conscientiousness"
+                },
+                {
+                    "label": "Low Conscientiousness",
+                    "target_code": "low-conscientiousness",
+                    "relationship": "low_pole",
+                    "href": "/en/personality/big-five/low-conscientiousness"
+                },
+                {
+                    "label": "30 facets",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/en/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "What this domain describes",
+                    "body_md": "Conscientiousness describes organization, reliability, planning, persistence, and follow-through."
+                },
+                {
+                    "key": "high_low",
+                    "title": "High and low poles",
+                    "body_md": "High and low scores are not better or worse; they describe different preferences, energies, and risk patterns."
+                },
+                {
+                    "key": "interpretation",
+                    "title": "How to interpret it",
+                    "body_md": "Interpret this domain with context, other domains, and recent state; avoid single-trait labeling."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires editorial and method review before indexability."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "domain",
-      "entity_key": "conscientiousness",
-      "slug": "big-five/conscientiousness",
-      "locale": "en",
-      "title": "Conscientiousness",
-      "summary": "Draft contract shell for the Conscientiousness dimension.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "extraversion",
+            "entity_key": "extraversion",
+            "slug": "big-five/extraversion",
+            "locale": "en",
+            "title": "Extraversion",
+            "summary": "Extraversion describes social energy, assertiveness, activity level, and the tendency to seek stimulation.",
+            "seo": {
+                "title": "Extraversion | FermatMind Big Five",
+                "description": "Extraversion describes social energy, assertiveness, activity level, and the tendency to seek stimulation."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/extraversion",
+            "canonical": {
+                "path": "/en/personality/big-five/extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/extraversion",
+                "zh-CN": "/zh/personality/big-five/extraversion"
+            },
+            "faq": [
+                {
+                    "question": "Can Extraversion alone determine career fit?",
+                    "answer": "No. Career fit also depends on skills, interests, values, opportunity, and constraints."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Extraversion"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "High Extraversion",
+                    "target_code": "high-extraversion",
+                    "relationship": "high_pole",
+                    "href": "/en/personality/big-five/high-extraversion"
+                },
+                {
+                    "label": "Low Extraversion",
+                    "target_code": "low-extraversion",
+                    "relationship": "low_pole",
+                    "href": "/en/personality/big-five/low-extraversion"
+                },
+                {
+                    "label": "30 facets",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/en/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "What this domain describes",
+                    "body_md": "Extraversion describes social energy, assertiveness, activity level, and the tendency to seek stimulation."
+                },
+                {
+                    "key": "high_low",
+                    "title": "High and low poles",
+                    "body_md": "High and low scores are not better or worse; they describe different preferences, energies, and risk patterns."
+                },
+                {
+                    "key": "interpretation",
+                    "title": "How to interpret it",
+                    "body_md": "Interpret this domain with context, other domains, and recent state; avoid single-trait labeling."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored Conscientiousness content."
-        }
-      ],
-      "seo": {
-        "title": "Conscientiousness in Big Five Personality | FermatMind",
-        "description": "Draft noindex Conscientiousness content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/conscientiousness"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Dimension pages describe score tendencies, not diagnostic labels."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "agreeableness",
+            "entity_key": "agreeableness",
+            "slug": "big-five/agreeableness",
+            "locale": "en",
+            "title": "Agreeableness",
+            "summary": "Agreeableness describes trust, cooperation, empathy, modesty, and concern for other people.",
+            "seo": {
+                "title": "Agreeableness | FermatMind Big Five",
+                "description": "Agreeableness describes trust, cooperation, empathy, modesty, and concern for other people."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/agreeableness",
+            "canonical": {
+                "path": "/en/personality/big-five/agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/agreeableness",
+                "zh-CN": "/zh/personality/big-five/agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "Can Agreeableness alone determine career fit?",
+                    "answer": "No. Career fit also depends on skills, interests, values, opportunity, and constraints."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Agreeableness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "High Agreeableness",
+                    "target_code": "high-agreeableness",
+                    "relationship": "high_pole",
+                    "href": "/en/personality/big-five/high-agreeableness"
+                },
+                {
+                    "label": "Low Agreeableness",
+                    "target_code": "low-agreeableness",
+                    "relationship": "low_pole",
+                    "href": "/en/personality/big-five/low-agreeableness"
+                },
+                {
+                    "label": "30 facets",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/en/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "What this domain describes",
+                    "body_md": "Agreeableness describes trust, cooperation, empathy, modesty, and concern for other people."
+                },
+                {
+                    "key": "high_low",
+                    "title": "High and low poles",
+                    "body_md": "High and low scores are not better or worse; they describe different preferences, energies, and risk patterns."
+                },
+                {
+                    "key": "interpretation",
+                    "title": "How to interpret it",
+                    "body_md": "Interpret this domain with context, other domains, and recent state; avoid single-trait labeling."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires editorial and method review before indexability."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "domain",
-      "entity_key": "extraversion",
-      "slug": "big-five/extraversion",
-      "locale": "en",
-      "title": "Extraversion",
-      "summary": "Draft contract shell for the Extraversion dimension.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "neuroticism",
+            "entity_key": "neuroticism",
+            "slug": "big-five/neuroticism",
+            "locale": "en",
+            "title": "Neuroticism",
+            "summary": "Neuroticism describes sensitivity to stress, emotional reactivity, worry, and vulnerability under pressure.",
+            "seo": {
+                "title": "Neuroticism | FermatMind Big Five",
+                "description": "Neuroticism describes sensitivity to stress, emotional reactivity, worry, and vulnerability under pressure."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/neuroticism",
+            "canonical": {
+                "path": "/en/personality/big-five/neuroticism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/neuroticism",
+                "zh-CN": "/zh/personality/big-five/neuroticism"
+            },
+            "faq": [
+                {
+                    "question": "Can Neuroticism alone determine career fit?",
+                    "answer": "No. Career fit also depends on skills, interests, values, opportunity, and constraints."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Neuroticism"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "High Neuroticism",
+                    "target_code": "high-neuroticism",
+                    "relationship": "high_pole",
+                    "href": "/en/personality/big-five/high-neuroticism"
+                },
+                {
+                    "label": "Emotional Stability",
+                    "target_code": "emotional-stability",
+                    "relationship": "low_pole",
+                    "href": "/en/personality/big-five/emotional-stability"
+                },
+                {
+                    "label": "30 facets",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/en/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "What this domain describes",
+                    "body_md": "Neuroticism describes sensitivity to stress, emotional reactivity, worry, and vulnerability under pressure."
+                },
+                {
+                    "key": "high_low",
+                    "title": "High and low poles",
+                    "body_md": "High and low scores are not better or worse; they describe different preferences, energies, and risk patterns."
+                },
+                {
+                    "key": "interpretation",
+                    "title": "How to interpret it",
+                    "body_md": "Interpret this domain with context, other domains, and recent state; avoid single-trait labeling."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored Extraversion content."
-        }
-      ],
-      "seo": {
-        "title": "Extraversion in Big Five Personality | FermatMind",
-        "description": "Draft noindex Extraversion content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/extraversion"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Dimension pages describe score tendencies, not diagnostic labels."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-openness",
+            "entity_key": "high-openness",
+            "slug": "big-five/high-openness",
+            "locale": "en",
+            "title": "High Openness",
+            "summary": "High openness often shows up as curiosity, comfort with ambiguity, creative exploration, and interest in ideas beyond routine practice.",
+            "seo": {
+                "title": "High Openness | FermatMind Big Five",
+                "description": "High openness often shows up as curiosity, comfort with ambiguity, creative exploration, and interest in ideas beyond routine practice."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/high-openness",
+            "canonical": {
+                "path": "/en/personality/big-five/high-openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-openness",
+                "zh-CN": "/zh/personality/big-five/high-openness"
+            },
+            "faq": [
+                {
+                    "question": "Does high openness mean someone is more intelligent?",
+                    "answer": "No. It describes style and preference, not intelligence or worth."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "High Openness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "High openness often shows up as curiosity, comfort with ambiguity, creative exploration, and interest in ideas beyond routine practice."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A high-openness person may enjoy learning unfamiliar frameworks, changing a workflow after evidence appears, or turning abstract ideas into experiments."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires editorial and method review before indexability."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "domain",
-      "entity_key": "agreeableness",
-      "slug": "big-five/agreeableness",
-      "locale": "en",
-      "title": "Agreeableness",
-      "summary": "Draft contract shell for the Agreeableness dimension.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-openness",
+            "entity_key": "low-openness",
+            "slug": "big-five/low-openness",
+            "locale": "en",
+            "title": "Low Openness",
+            "summary": "Lower openness often shows up as practicality, preference for familiar methods, and interest in concrete evidence before changing course.",
+            "seo": {
+                "title": "Low Openness | FermatMind Big Five",
+                "description": "Lower openness often shows up as practicality, preference for familiar methods, and interest in concrete evidence before changing course."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/low-openness",
+            "canonical": {
+                "path": "/en/personality/big-five/low-openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-openness",
+                "zh-CN": "/zh/personality/big-five/low-openness"
+            },
+            "faq": [
+                {
+                    "question": "Is low openness a weakness?",
+                    "answer": "No. It can support consistency, realism, and careful filtering of novelty."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Low Openness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "Lower openness often shows up as practicality, preference for familiar methods, and interest in concrete evidence before changing course."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A lower-openness person may protect useful routines, ask for proven examples, and avoid change that has no practical reason."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored Agreeableness content."
-        }
-      ],
-      "seo": {
-        "title": "Agreeableness in Big Five Personality | FermatMind",
-        "description": "Draft noindex Agreeableness content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/agreeableness"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Dimension pages describe score tendencies, not diagnostic labels."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-conscientiousness",
+            "entity_key": "high-conscientiousness",
+            "slug": "big-five/high-conscientiousness",
+            "locale": "en",
+            "title": "High Conscientiousness",
+            "summary": "High conscientiousness often shows up as planning, reliability, persistence, and strong attention to commitments.",
+            "seo": {
+                "title": "High Conscientiousness | FermatMind Big Five",
+                "description": "High conscientiousness often shows up as planning, reliability, persistence, and strong attention to commitments."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/high-conscientiousness",
+            "canonical": {
+                "path": "/en/personality/big-five/high-conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-conscientiousness",
+                "zh-CN": "/zh/personality/big-five/high-conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "Does high conscientiousness mean perfectionism?",
+                    "answer": "Not necessarily. Perfectionism is only one possible pattern and can depend on stress, standards, and context."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "High Conscientiousness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "High conscientiousness often shows up as planning, reliability, persistence, and strong attention to commitments."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A high-conscientiousness person may maintain checklists, finish tasks before deadlines, and notice when responsibilities are underspecified."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires editorial and method review before indexability."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "domain",
-      "entity_key": "neuroticism",
-      "slug": "big-five/neuroticism",
-      "locale": "en",
-      "title": "Neuroticism",
-      "summary": "Draft contract shell for the Neuroticism dimension.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-conscientiousness",
+            "entity_key": "low-conscientiousness",
+            "slug": "big-five/low-conscientiousness",
+            "locale": "en",
+            "title": "Low Conscientiousness",
+            "summary": "Lower conscientiousness often shows up as spontaneity, flexible work rhythm, and less reliance on rigid planning systems.",
+            "seo": {
+                "title": "Low Conscientiousness | FermatMind Big Five",
+                "description": "Lower conscientiousness often shows up as spontaneity, flexible work rhythm, and less reliance on rigid planning systems."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/low-conscientiousness",
+            "canonical": {
+                "path": "/en/personality/big-five/low-conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-conscientiousness",
+                "zh-CN": "/zh/personality/big-five/low-conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "Does low conscientiousness mean unreliable?",
+                    "answer": "No. Reliability depends on habits, incentives, systems, and context, not one trait score alone."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Low Conscientiousness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "Lower conscientiousness often shows up as spontaneity, flexible work rhythm, and less reliance on rigid planning systems."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A lower-conscientiousness person may improvise effectively, move quickly when rules are loose, or prefer lightweight planning over detailed schedules."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder for CMS-authored Neuroticism content."
-        }
-      ],
-      "seo": {
-        "title": "Neuroticism in Big Five Personality | FermatMind",
-        "description": "Draft noindex Neuroticism content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/neuroticism"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Dimension pages describe score tendencies, not diagnostic labels."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-extraversion",
+            "entity_key": "high-extraversion",
+            "slug": "big-five/high-extraversion",
+            "locale": "en",
+            "title": "High Extraversion",
+            "summary": "High extraversion often shows up as visible social energy, active expression, enthusiasm, and comfort initiating interaction.",
+            "seo": {
+                "title": "High Extraversion | FermatMind Big Five",
+                "description": "High extraversion often shows up as visible social energy, active expression, enthusiasm, and comfort initiating interaction."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/high-extraversion",
+            "canonical": {
+                "path": "/en/personality/big-five/high-extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-extraversion",
+                "zh-CN": "/zh/personality/big-five/high-extraversion"
+            },
+            "faq": [
+                {
+                    "question": "Does high extraversion mean someone is always outgoing?",
+                    "answer": "No. People vary by setting, fatigue, role, and trust level."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "High Extraversion"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "High extraversion often shows up as visible social energy, active expression, enthusiasm, and comfort initiating interaction."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A high-extraversion person may think aloud in meetings, create momentum in groups, and recharge through active environments."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires editorial and method review before indexability."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "polarity",
-      "entity_key": "high-openness",
-      "slug": "big-five/high-openness",
-      "locale": "en",
-      "title": "High Openness",
-      "summary": "Draft contract shell for a high-score polarity page.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-extraversion",
+            "entity_key": "low-extraversion",
+            "slug": "big-five/low-extraversion",
+            "locale": "en",
+            "title": "Low Extraversion",
+            "summary": "Lower extraversion often shows up as reserved expression, preference for lower-stimulation settings, and more selective social energy.",
+            "seo": {
+                "title": "Low Extraversion | FermatMind Big Five",
+                "description": "Lower extraversion often shows up as reserved expression, preference for lower-stimulation settings, and more selective social energy."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/low-extraversion",
+            "canonical": {
+                "path": "/en/personality/big-five/low-extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-extraversion",
+                "zh-CN": "/zh/personality/big-five/low-extraversion"
+            },
+            "faq": [
+                {
+                    "question": "Is low extraversion the same as social anxiety?",
+                    "answer": "No. Extraversion is a preference dimension; anxiety is a different experience and may require separate support."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Low Extraversion"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "Lower extraversion often shows up as reserved expression, preference for lower-stimulation settings, and more selective social energy."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A lower-extraversion person may contribute best after reflection, prefer smaller groups, or need quiet time after intense interaction."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder; polarity pages must not be described as fixed personality types."
-        }
-      ],
-      "seo": {
-        "title": "High Openness in Big Five Personality | FermatMind",
-        "description": "Draft noindex high Openness content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/high-openness"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "High/low pages describe score ranges and should avoid type-like identity claims."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-agreeableness",
+            "entity_key": "high-agreeableness",
+            "slug": "big-five/high-agreeableness",
+            "locale": "en",
+            "title": "High Agreeableness",
+            "summary": "High agreeableness often shows up as empathy, cooperation, trust, and attention to relational harmony.",
+            "seo": {
+                "title": "High Agreeableness | FermatMind Big Five",
+                "description": "High agreeableness often shows up as empathy, cooperation, trust, and attention to relational harmony."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/high-agreeableness",
+            "canonical": {
+                "path": "/en/personality/big-five/high-agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-agreeableness",
+                "zh-CN": "/zh/personality/big-five/high-agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "Does high agreeableness mean avoiding conflict?",
+                    "answer": "Not always. It may mean approaching conflict with relationship repair in mind."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "High Agreeableness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "High agreeableness often shows up as empathy, cooperation, trust, and attention to relational harmony."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A high-agreeableness person may notice emotional friction early, offer help before being asked, or seek solutions that preserve trust."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; no 32 OCEAN SEO combination pages are authorized."
-        }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    },
-    {
-      "framework": "big_five",
-      "entity_type": "facet",
-      "entity_key": "o1-imagination",
-      "slug": "big-five/facets/imagination",
-      "locale": "en",
-      "title": "Imagination",
-      "summary": "Draft contract shell for a Big Five facet page.",
-      "content_sections": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-agreeableness",
+            "entity_key": "low-agreeableness",
+            "slug": "big-five/low-agreeableness",
+            "locale": "en",
+            "title": "Low Agreeableness",
+            "summary": "Lower agreeableness often shows up as directness, skepticism, competitive stance, and willingness to challenge assumptions.",
+            "seo": {
+                "title": "Low Agreeableness | FermatMind Big Five",
+                "description": "Lower agreeableness often shows up as directness, skepticism, competitive stance, and willingness to challenge assumptions."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/low-agreeableness",
+            "canonical": {
+                "path": "/en/personality/big-five/low-agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-agreeableness",
+                "zh-CN": "/zh/personality/big-five/low-agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "Does low agreeableness mean unkind?",
+                    "answer": "No. It describes interpersonal style, not moral character."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Low Agreeableness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "Lower agreeableness often shows up as directness, skepticism, competitive stance, and willingness to challenge assumptions."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A lower-agreeableness person may question consensus, negotiate firmly, or prioritize clarity over immediate harmony."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "key": "overview",
-          "title": "Overview",
-          "body_md": "Draft placeholder; facet pages require unique CMS-authored depth before indexability."
-        }
-      ],
-      "seo": {
-        "title": "Imagination Facet in Big Five Personality | FermatMind",
-        "description": "Draft noindex Imagination facet content asset contract."
-      },
-      "canonical": {
-        "path": "/en/personality/big-five/facets/imagination"
-      },
-      "hreflang": {},
-      "faq": [],
-      "media": {
-        "hero_image_asset_key": null
-      },
-      "schema": {
-        "@type": "WebPage"
-      },
-      "method_boundary": {
-        "summary": "Facet pages must explain narrow trait tendencies and avoid diagnostic claims."
-      },
-      "evidence_notes": [
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-neuroticism",
+            "entity_key": "high-neuroticism",
+            "slug": "big-five/high-neuroticism",
+            "locale": "en",
+            "title": "High Neuroticism",
+            "summary": "High neuroticism often shows up as stronger emotional reactivity, stress sensitivity, worry, and vigilance toward risk.",
+            "seo": {
+                "title": "High Neuroticism | FermatMind Big Five",
+                "description": "High neuroticism often shows up as stronger emotional reactivity, stress sensitivity, worry, and vigilance toward risk."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/high-neuroticism",
+            "canonical": {
+                "path": "/en/personality/big-five/high-neuroticism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-neuroticism",
+                "zh-CN": "/zh/personality/big-five/high-neuroticism"
+            },
+            "faq": [
+                {
+                    "question": "Is high neuroticism a diagnosis?",
+                    "answer": "No. It is a normal-range personality dimension, not a clinical diagnosis."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "High Neuroticism"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "High neuroticism often shows up as stronger emotional reactivity, stress sensitivity, worry, and vigilance toward risk."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "A high-neuroticism person may detect potential problems early, need more recovery after stress, or benefit from explicit coping systems."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
         {
-          "source_type": "contract",
-          "note": "Draft only; requires content depth review before launch."
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "emotional-stability",
+            "entity_key": "emotional-stability",
+            "slug": "big-five/emotional-stability",
+            "locale": "en",
+            "title": "Emotional Stability",
+            "summary": "Emotional stability describes the lower-neuroticism pole: steadier mood, lower stress reactivity, and calmness under pressure.",
+            "seo": {
+                "title": "Emotional Stability | FermatMind Big Five",
+                "description": "Emotional stability describes the lower-neuroticism pole: steadier mood, lower stress reactivity, and calmness under pressure."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/emotional-stability",
+            "canonical": {
+                "path": "/en/personality/big-five/emotional-stability"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/emotional-stability",
+                "zh-CN": "/zh/personality/big-five/emotional-stability"
+            },
+            "faq": [
+                {
+                    "question": "Does emotional stability mean having no feelings?",
+                    "answer": "No. It means emotions may be less disruptive or recover more quickly, not absent."
+                },
+                {
+                    "question": "Can this pole directly decide relationships or work?",
+                    "answer": "No. It is an interpretive clue, not a substitute for communication, skill assessment, or real-world choice."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Emotional Stability"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This pole is one end of a continuous dimension, not a personality type, diagnosis, or value judgment.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                },
+                {
+                    "label": "Big Five Personality",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/en/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Tendency overview",
+                    "body_md": "Emotional stability describes the lower-neuroticism pole: steadier mood, lower stress reactivity, and calmness under pressure."
+                },
+                {
+                    "key": "example",
+                    "title": "Concrete example",
+                    "body_md": "An emotionally stable person may stay composed during uncertainty, recover quickly from setbacks, or avoid overreacting to minor stressors."
+                },
+                {
+                    "key": "balance",
+                    "title": "Balancing note",
+                    "body_md": "This page explains one pole only; a real profile should combine all five domains and lived context."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet_hub",
+            "code": "facets",
+            "entity_key": "facets",
+            "slug": "big-five/facets",
+            "locale": "en",
+            "title": "Big Five 30 Facets",
+            "summary": "The 30 facets provide finer-grained interpretation under the five domains, but this contract currently treats them as taxonomy and future draft sources.",
+            "seo": {
+                "title": "Big Five 30 Facets | FermatMind Big Five",
+                "description": "The 30 facets provide finer-grained interpretation under the five domains, but this contract currently treats them as taxonomy and future draft sources."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets",
+            "canonical": {
+                "path": "/en/personality/big-five/facets"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets",
+                "zh-CN": "/zh/personality/big-five/facets"
+            },
+            "faq": [
+                {
+                    "question": "Will the 30 facets be indexed individually?",
+                    "answer": "Not in this version. They remain noindex as structured drafts and future expansion material."
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Big Five 30 Facets"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "Big Five is a dimensional model, not a clinical diagnosis, hiring screen, or fixed type label.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/openness"
+                },
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/extraversion"
+                },
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "Facet use",
+                    "body_md": "The 30 facets provide finer-grained interpretation under the five domains, but this contract currently treats them as taxonomy and future draft sources."
+                },
+                {
+                    "key": "status",
+                    "title": "Launch status",
+                    "body_md": "Individual facets are not released as standalone SEO pages yet."
+                },
+                {
+                    "key": "boundary",
+                    "title": "Boundary",
+                    "body_md": "Facets can support interpretation but should not be packaged as new official personality types."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "imagination",
+            "entity_key": "imagination",
+            "slug": "big-five/facets/imagination",
+            "locale": "en",
+            "title": "Imagination",
+            "summary": "Imagination is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Imagination | FermatMind Big Five",
+                "description": "Imagination is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/imagination",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/imagination"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/imagination",
+                "zh-CN": "/zh/personality/big-five/facets/imagination"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Imagination"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Imagination is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "aesthetics",
+            "entity_key": "aesthetics",
+            "slug": "big-five/facets/aesthetics",
+            "locale": "en",
+            "title": "Aesthetics",
+            "summary": "Aesthetics is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Aesthetics | FermatMind Big Five",
+                "description": "Aesthetics is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/aesthetics",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/aesthetics"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/aesthetics",
+                "zh-CN": "/zh/personality/big-five/facets/aesthetics"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Aesthetics"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Aesthetics is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "feelings",
+            "entity_key": "feelings",
+            "slug": "big-five/facets/feelings",
+            "locale": "en",
+            "title": "Feelings",
+            "summary": "Feelings is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Feelings | FermatMind Big Five",
+                "description": "Feelings is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/feelings",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/feelings"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/feelings",
+                "zh-CN": "/zh/personality/big-five/facets/feelings"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Feelings"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Feelings is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "actions",
+            "entity_key": "actions",
+            "slug": "big-five/facets/actions",
+            "locale": "en",
+            "title": "Actions",
+            "summary": "Actions is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Actions | FermatMind Big Five",
+                "description": "Actions is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/actions",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/actions"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/actions",
+                "zh-CN": "/zh/personality/big-five/facets/actions"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Actions"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Actions is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "ideas",
+            "entity_key": "ideas",
+            "slug": "big-five/facets/ideas",
+            "locale": "en",
+            "title": "Ideas",
+            "summary": "Ideas is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Ideas | FermatMind Big Five",
+                "description": "Ideas is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/ideas",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/ideas"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/ideas",
+                "zh-CN": "/zh/personality/big-five/facets/ideas"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Ideas"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Ideas is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "values",
+            "entity_key": "values",
+            "slug": "big-five/facets/values",
+            "locale": "en",
+            "title": "Values",
+            "summary": "Values is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Values | FermatMind Big Five",
+                "description": "Values is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/values",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/values"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/values",
+                "zh-CN": "/zh/personality/big-five/facets/values"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Values"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Openness",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Values is a finer-grained facet under Openness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "competence",
+            "entity_key": "competence",
+            "slug": "big-five/facets/competence",
+            "locale": "en",
+            "title": "Competence",
+            "summary": "Competence is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Competence | FermatMind Big Five",
+                "description": "Competence is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/competence",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/competence"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/competence",
+                "zh-CN": "/zh/personality/big-five/facets/competence"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Competence"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Competence is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "order",
+            "entity_key": "order",
+            "slug": "big-five/facets/order",
+            "locale": "en",
+            "title": "Order",
+            "summary": "Order is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Order | FermatMind Big Five",
+                "description": "Order is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/order",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/order"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/order",
+                "zh-CN": "/zh/personality/big-five/facets/order"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Order"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Order is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "dutifulness",
+            "entity_key": "dutifulness",
+            "slug": "big-five/facets/dutifulness",
+            "locale": "en",
+            "title": "Dutifulness",
+            "summary": "Dutifulness is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Dutifulness | FermatMind Big Five",
+                "description": "Dutifulness is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/dutifulness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/dutifulness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/dutifulness",
+                "zh-CN": "/zh/personality/big-five/facets/dutifulness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Dutifulness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Dutifulness is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "achievement-striving",
+            "entity_key": "achievement-striving",
+            "slug": "big-five/facets/achievement-striving",
+            "locale": "en",
+            "title": "Achievement Striving",
+            "summary": "Achievement Striving is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Achievement Striving | FermatMind Big Five",
+                "description": "Achievement Striving is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/achievement-striving",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/achievement-striving"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/achievement-striving",
+                "zh-CN": "/zh/personality/big-five/facets/achievement-striving"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Achievement Striving"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Achievement Striving is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "self-discipline",
+            "entity_key": "self-discipline",
+            "slug": "big-five/facets/self-discipline",
+            "locale": "en",
+            "title": "Self-Discipline",
+            "summary": "Self-Discipline is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Self-Discipline | FermatMind Big Five",
+                "description": "Self-Discipline is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/self-discipline",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/self-discipline"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/self-discipline",
+                "zh-CN": "/zh/personality/big-five/facets/self-discipline"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Self-Discipline"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Self-Discipline is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "deliberation",
+            "entity_key": "deliberation",
+            "slug": "big-five/facets/deliberation",
+            "locale": "en",
+            "title": "Deliberation",
+            "summary": "Deliberation is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Deliberation | FermatMind Big Five",
+                "description": "Deliberation is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/deliberation",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/deliberation"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/deliberation",
+                "zh-CN": "/zh/personality/big-five/facets/deliberation"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Deliberation"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Conscientiousness",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Deliberation is a finer-grained facet under Conscientiousness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "warmth",
+            "entity_key": "warmth",
+            "slug": "big-five/facets/warmth",
+            "locale": "en",
+            "title": "Warmth",
+            "summary": "Warmth is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Warmth | FermatMind Big Five",
+                "description": "Warmth is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/warmth",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/warmth"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/warmth",
+                "zh-CN": "/zh/personality/big-five/facets/warmth"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Warmth"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Warmth is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "gregariousness",
+            "entity_key": "gregariousness",
+            "slug": "big-five/facets/gregariousness",
+            "locale": "en",
+            "title": "Gregariousness",
+            "summary": "Gregariousness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Gregariousness | FermatMind Big Five",
+                "description": "Gregariousness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/gregariousness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/gregariousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/gregariousness",
+                "zh-CN": "/zh/personality/big-five/facets/gregariousness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Gregariousness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Gregariousness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "assertiveness",
+            "entity_key": "assertiveness",
+            "slug": "big-five/facets/assertiveness",
+            "locale": "en",
+            "title": "Assertiveness",
+            "summary": "Assertiveness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Assertiveness | FermatMind Big Five",
+                "description": "Assertiveness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/assertiveness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/assertiveness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/assertiveness",
+                "zh-CN": "/zh/personality/big-five/facets/assertiveness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Assertiveness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Assertiveness is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "activity",
+            "entity_key": "activity",
+            "slug": "big-five/facets/activity",
+            "locale": "en",
+            "title": "Activity",
+            "summary": "Activity is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Activity | FermatMind Big Five",
+                "description": "Activity is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/activity",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/activity"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/activity",
+                "zh-CN": "/zh/personality/big-five/facets/activity"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Activity"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Activity is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "excitement-seeking",
+            "entity_key": "excitement-seeking",
+            "slug": "big-five/facets/excitement-seeking",
+            "locale": "en",
+            "title": "Excitement Seeking",
+            "summary": "Excitement Seeking is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Excitement Seeking | FermatMind Big Five",
+                "description": "Excitement Seeking is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/excitement-seeking",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/excitement-seeking"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/excitement-seeking",
+                "zh-CN": "/zh/personality/big-five/facets/excitement-seeking"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Excitement Seeking"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Excitement Seeking is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "positive-emotions",
+            "entity_key": "positive-emotions",
+            "slug": "big-five/facets/positive-emotions",
+            "locale": "en",
+            "title": "Positive Emotions",
+            "summary": "Positive Emotions is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Positive Emotions | FermatMind Big Five",
+                "description": "Positive Emotions is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/positive-emotions",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/positive-emotions"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/positive-emotions",
+                "zh-CN": "/zh/personality/big-five/facets/positive-emotions"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Positive Emotions"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Extraversion",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Positive Emotions is a finer-grained facet under Extraversion. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "trust",
+            "entity_key": "trust",
+            "slug": "big-five/facets/trust",
+            "locale": "en",
+            "title": "Trust",
+            "summary": "Trust is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Trust | FermatMind Big Five",
+                "description": "Trust is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/trust",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/trust"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/trust",
+                "zh-CN": "/zh/personality/big-five/facets/trust"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Trust"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Trust is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "straightforwardness",
+            "entity_key": "straightforwardness",
+            "slug": "big-five/facets/straightforwardness",
+            "locale": "en",
+            "title": "Straightforwardness",
+            "summary": "Straightforwardness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Straightforwardness | FermatMind Big Five",
+                "description": "Straightforwardness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/straightforwardness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/straightforwardness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/straightforwardness",
+                "zh-CN": "/zh/personality/big-five/facets/straightforwardness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Straightforwardness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Straightforwardness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "altruism",
+            "entity_key": "altruism",
+            "slug": "big-five/facets/altruism",
+            "locale": "en",
+            "title": "Altruism",
+            "summary": "Altruism is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Altruism | FermatMind Big Five",
+                "description": "Altruism is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/altruism",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/altruism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/altruism",
+                "zh-CN": "/zh/personality/big-five/facets/altruism"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Altruism"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Altruism is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "compliance",
+            "entity_key": "compliance",
+            "slug": "big-five/facets/compliance",
+            "locale": "en",
+            "title": "Compliance",
+            "summary": "Compliance is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Compliance | FermatMind Big Five",
+                "description": "Compliance is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/compliance",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/compliance"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/compliance",
+                "zh-CN": "/zh/personality/big-five/facets/compliance"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Compliance"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Compliance is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "modesty",
+            "entity_key": "modesty",
+            "slug": "big-five/facets/modesty",
+            "locale": "en",
+            "title": "Modesty",
+            "summary": "Modesty is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Modesty | FermatMind Big Five",
+                "description": "Modesty is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/modesty",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/modesty"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/modesty",
+                "zh-CN": "/zh/personality/big-five/facets/modesty"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Modesty"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Modesty is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "tender-mindedness",
+            "entity_key": "tender-mindedness",
+            "slug": "big-five/facets/tender-mindedness",
+            "locale": "en",
+            "title": "Tender-Mindedness",
+            "summary": "Tender-Mindedness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Tender-Mindedness | FermatMind Big Five",
+                "description": "Tender-Mindedness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/tender-mindedness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/tender-mindedness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/tender-mindedness",
+                "zh-CN": "/zh/personality/big-five/facets/tender-mindedness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Tender-Mindedness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Agreeableness",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Tender-Mindedness is a finer-grained facet under Agreeableness. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "anxiety",
+            "entity_key": "anxiety",
+            "slug": "big-five/facets/anxiety",
+            "locale": "en",
+            "title": "Anxiety",
+            "summary": "Anxiety is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Anxiety | FermatMind Big Five",
+                "description": "Anxiety is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/anxiety",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/anxiety"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/anxiety",
+                "zh-CN": "/zh/personality/big-five/facets/anxiety"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Anxiety"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Anxiety is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "anger",
+            "entity_key": "anger",
+            "slug": "big-five/facets/anger",
+            "locale": "en",
+            "title": "Anger",
+            "summary": "Anger is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Anger | FermatMind Big Five",
+                "description": "Anger is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/anger",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/anger"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/anger",
+                "zh-CN": "/zh/personality/big-five/facets/anger"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Anger"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Anger is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "depression",
+            "entity_key": "depression",
+            "slug": "big-five/facets/depression",
+            "locale": "en",
+            "title": "Depression",
+            "summary": "Depression is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Depression | FermatMind Big Five",
+                "description": "Depression is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/depression",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/depression"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/depression",
+                "zh-CN": "/zh/personality/big-five/facets/depression"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Depression"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Depression is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "self-consciousness",
+            "entity_key": "self-consciousness",
+            "slug": "big-five/facets/self-consciousness",
+            "locale": "en",
+            "title": "Self-Consciousness",
+            "summary": "Self-Consciousness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Self-Consciousness | FermatMind Big Five",
+                "description": "Self-Consciousness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/self-consciousness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/self-consciousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/self-consciousness",
+                "zh-CN": "/zh/personality/big-five/facets/self-consciousness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Self-Consciousness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Self-Consciousness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "impulsiveness",
+            "entity_key": "impulsiveness",
+            "slug": "big-five/facets/impulsiveness",
+            "locale": "en",
+            "title": "Impulsiveness",
+            "summary": "Impulsiveness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Impulsiveness | FermatMind Big Five",
+                "description": "Impulsiveness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/impulsiveness",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/impulsiveness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/impulsiveness",
+                "zh-CN": "/zh/personality/big-five/facets/impulsiveness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Impulsiveness"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Impulsiveness is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "vulnerability",
+            "entity_key": "vulnerability",
+            "slug": "big-five/facets/vulnerability",
+            "locale": "en",
+            "title": "Vulnerability",
+            "summary": "Vulnerability is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page.",
+            "seo": {
+                "title": "Vulnerability | FermatMind Big Five",
+                "description": "Vulnerability is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/en/personality/big-five/facets/vulnerability",
+            "canonical": {
+                "path": "/en/personality/big-five/facets/vulnerability"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/vulnerability",
+                "zh-CN": "/zh/personality/big-five/facets/vulnerability"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "Vulnerability"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "This facet is taxonomy draft material only and should not be treated as complete SEO copy or an official type page.",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "Product copy should use bounded wording such as tends to, may, and often."
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "Neuroticism",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/en/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "Draft note",
+                    "body_md": "Vulnerability is a finer-grained facet under Neuroticism. This version keeps it as draft taxonomy, not a standalone public SEO page."
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "hub",
+            "code": "big-five",
+            "entity_key": "big-five",
+            "slug": "big-five",
+            "locale": "zh-CN",
+            "title": "大五人格",
+            "summary": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度描述人格差异。",
+            "seo": {
+                "title": "大五人格 | FermatMind Big Five",
+                "description": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度描述人格差异。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five",
+            "canonical": {
+                "path": "/zh/personality/big-five"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five",
+                "zh-CN": "/zh/personality/big-five"
+            },
+            "faq": [
+                {
+                    "question": "大五是类型测试吗？",
+                    "answer": "不是。大五是维度模型，不把人固定分成少数类型。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "大五人格"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/openness"
+                },
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                },
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "模型概览",
+                    "body_md": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度描述人格差异。"
+                },
+                {
+                    "key": "dimensions",
+                    "title": "五个维度",
+                    "body_md": "每个维度都是连续分布，高低两端都可能在不同情境中有价值。"
+                },
+                {
+                    "key": "use_cases",
+                    "title": "适合用途",
+                    "body_md": "适合用于自我理解、沟通偏好和学习反思，不适合用于诊断或决定论判断。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "openness",
+            "entity_key": "openness",
+            "slug": "big-five/openness",
+            "locale": "zh-CN",
+            "title": "开放性",
+            "summary": "开放性描述一个人对新想法、新体验、想象力、审美和抽象思考的偏好。",
+            "seo": {
+                "title": "开放性 | FermatMind Big Five",
+                "description": "开放性描述一个人对新想法、新体验、想象力、审美和抽象思考的偏好。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/openness",
+            "canonical": {
+                "path": "/zh/personality/big-five/openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/openness",
+                "zh-CN": "/zh/personality/big-five/openness"
+            },
+            "faq": [
+                {
+                    "question": "开放性能单独决定职业吗？",
+                    "answer": "不能。职业选择还需要能力、兴趣、价值观、机会和现实约束。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "开放性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "高开放性",
+                    "target_code": "high-openness",
+                    "relationship": "high_pole",
+                    "href": "/zh/personality/big-five/high-openness"
+                },
+                {
+                    "label": "低开放性",
+                    "target_code": "low-openness",
+                    "relationship": "low_pole",
+                    "href": "/zh/personality/big-five/low-openness"
+                },
+                {
+                    "label": "30个小维度",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/zh/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "维度含义",
+                    "body_md": "开放性描述一个人对新想法、新体验、想象力、审美和抽象思考的偏好。"
+                },
+                {
+                    "key": "high_low",
+                    "title": "高低两端",
+                    "body_md": "高低分不是好坏排序，而是不同偏好、能量和风险模式。"
+                },
+                {
+                    "key": "interpretation",
+                    "title": "解读方式",
+                    "body_md": "结合具体情境、其他维度和近期状态解读，避免单维度贴标签。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "conscientiousness",
+            "entity_key": "conscientiousness",
+            "slug": "big-five/conscientiousness",
+            "locale": "zh-CN",
+            "title": "尽责性",
+            "summary": "尽责性描述组织性、可靠性、计划性、坚持度和执行到底的倾向。",
+            "seo": {
+                "title": "尽责性 | FermatMind Big Five",
+                "description": "尽责性描述组织性、可靠性、计划性、坚持度和执行到底的倾向。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/conscientiousness",
+            "canonical": {
+                "path": "/zh/personality/big-five/conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/conscientiousness",
+                "zh-CN": "/zh/personality/big-five/conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "尽责性能单独决定职业吗？",
+                    "answer": "不能。职业选择还需要能力、兴趣、价值观、机会和现实约束。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "尽责性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "高尽责性",
+                    "target_code": "high-conscientiousness",
+                    "relationship": "high_pole",
+                    "href": "/zh/personality/big-five/high-conscientiousness"
+                },
+                {
+                    "label": "低尽责性",
+                    "target_code": "low-conscientiousness",
+                    "relationship": "low_pole",
+                    "href": "/zh/personality/big-five/low-conscientiousness"
+                },
+                {
+                    "label": "30个小维度",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/zh/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "维度含义",
+                    "body_md": "尽责性描述组织性、可靠性、计划性、坚持度和执行到底的倾向。"
+                },
+                {
+                    "key": "high_low",
+                    "title": "高低两端",
+                    "body_md": "高低分不是好坏排序，而是不同偏好、能量和风险模式。"
+                },
+                {
+                    "key": "interpretation",
+                    "title": "解读方式",
+                    "body_md": "结合具体情境、其他维度和近期状态解读，避免单维度贴标签。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "extraversion",
+            "entity_key": "extraversion",
+            "slug": "big-five/extraversion",
+            "locale": "zh-CN",
+            "title": "外向性",
+            "summary": "外向性描述社交能量、表达主动性、活动水平以及寻求刺激的倾向。",
+            "seo": {
+                "title": "外向性 | FermatMind Big Five",
+                "description": "外向性描述社交能量、表达主动性、活动水平以及寻求刺激的倾向。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/extraversion",
+            "canonical": {
+                "path": "/zh/personality/big-five/extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/extraversion",
+                "zh-CN": "/zh/personality/big-five/extraversion"
+            },
+            "faq": [
+                {
+                    "question": "外向性能单独决定职业吗？",
+                    "answer": "不能。职业选择还需要能力、兴趣、价值观、机会和现实约束。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "外向性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "高外向性",
+                    "target_code": "high-extraversion",
+                    "relationship": "high_pole",
+                    "href": "/zh/personality/big-five/high-extraversion"
+                },
+                {
+                    "label": "低外向性",
+                    "target_code": "low-extraversion",
+                    "relationship": "low_pole",
+                    "href": "/zh/personality/big-five/low-extraversion"
+                },
+                {
+                    "label": "30个小维度",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/zh/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "维度含义",
+                    "body_md": "外向性描述社交能量、表达主动性、活动水平以及寻求刺激的倾向。"
+                },
+                {
+                    "key": "high_low",
+                    "title": "高低两端",
+                    "body_md": "高低分不是好坏排序，而是不同偏好、能量和风险模式。"
+                },
+                {
+                    "key": "interpretation",
+                    "title": "解读方式",
+                    "body_md": "结合具体情境、其他维度和近期状态解读，避免单维度贴标签。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "agreeableness",
+            "entity_key": "agreeableness",
+            "slug": "big-five/agreeableness",
+            "locale": "zh-CN",
+            "title": "宜人性",
+            "summary": "宜人性描述信任、合作、同理心、谦逊以及对他人需要的关注。",
+            "seo": {
+                "title": "宜人性 | FermatMind Big Five",
+                "description": "宜人性描述信任、合作、同理心、谦逊以及对他人需要的关注。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/agreeableness",
+            "canonical": {
+                "path": "/zh/personality/big-five/agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/agreeableness",
+                "zh-CN": "/zh/personality/big-five/agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "宜人性能单独决定职业吗？",
+                    "answer": "不能。职业选择还需要能力、兴趣、价值观、机会和现实约束。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "宜人性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "高宜人性",
+                    "target_code": "high-agreeableness",
+                    "relationship": "high_pole",
+                    "href": "/zh/personality/big-five/high-agreeableness"
+                },
+                {
+                    "label": "低宜人性",
+                    "target_code": "low-agreeableness",
+                    "relationship": "low_pole",
+                    "href": "/zh/personality/big-five/low-agreeableness"
+                },
+                {
+                    "label": "30个小维度",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/zh/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "维度含义",
+                    "body_md": "宜人性描述信任、合作、同理心、谦逊以及对他人需要的关注。"
+                },
+                {
+                    "key": "high_low",
+                    "title": "高低两端",
+                    "body_md": "高低分不是好坏排序，而是不同偏好、能量和风险模式。"
+                },
+                {
+                    "key": "interpretation",
+                    "title": "解读方式",
+                    "body_md": "结合具体情境、其他维度和近期状态解读，避免单维度贴标签。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "domain",
+            "code": "neuroticism",
+            "entity_key": "neuroticism",
+            "slug": "big-five/neuroticism",
+            "locale": "zh-CN",
+            "title": "神经质 / 情绪敏感性",
+            "summary": "神经质描述压力敏感度、情绪反应强度、担忧倾向以及在压力下的脆弱性。",
+            "seo": {
+                "title": "神经质 / 情绪敏感性 | FermatMind Big Five",
+                "description": "神经质描述压力敏感度、情绪反应强度、担忧倾向以及在压力下的脆弱性。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/neuroticism",
+            "canonical": {
+                "path": "/zh/personality/big-five/neuroticism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/neuroticism",
+                "zh-CN": "/zh/personality/big-five/neuroticism"
+            },
+            "faq": [
+                {
+                    "question": "神经质 / 情绪敏感性能单独决定职业吗？",
+                    "answer": "不能。职业选择还需要能力、兴趣、价值观、机会和现实约束。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "神经质 / 情绪敏感性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "高神经质 / 高情绪敏感性",
+                    "target_code": "high-neuroticism",
+                    "relationship": "high_pole",
+                    "href": "/zh/personality/big-five/high-neuroticism"
+                },
+                {
+                    "label": "情绪稳定性",
+                    "target_code": "emotional-stability",
+                    "relationship": "low_pole",
+                    "href": "/zh/personality/big-five/emotional-stability"
+                },
+                {
+                    "label": "30个小维度",
+                    "target_code": "facets",
+                    "relationship": "facet_hub",
+                    "href": "/zh/personality/big-five/facets"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "维度含义",
+                    "body_md": "神经质描述压力敏感度、情绪反应强度、担忧倾向以及在压力下的脆弱性。"
+                },
+                {
+                    "key": "high_low",
+                    "title": "高低两端",
+                    "body_md": "高低分不是好坏排序，而是不同偏好、能量和风险模式。"
+                },
+                {
+                    "key": "interpretation",
+                    "title": "解读方式",
+                    "body_md": "结合具体情境、其他维度和近期状态解读，避免单维度贴标签。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-openness",
+            "entity_key": "high-openness",
+            "slug": "big-five/high-openness",
+            "locale": "zh-CN",
+            "title": "高开放性",
+            "summary": "高开放性通常表现为好奇、能接受不确定性、愿意探索创意，并对超出日常经验的想法感兴趣。",
+            "seo": {
+                "title": "高开放性 | FermatMind Big Five",
+                "description": "高开放性通常表现为好奇、能接受不确定性、愿意探索创意，并对超出日常经验的想法感兴趣。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/high-openness",
+            "canonical": {
+                "path": "/zh/personality/big-five/high-openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-openness",
+                "zh-CN": "/zh/personality/big-five/high-openness"
+            },
+            "faq": [
+                {
+                    "question": "高开放性是不是代表更聪明？",
+                    "answer": "不是。它描述偏好和风格，不代表智力或价值高低。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "高开放性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "高开放性通常表现为好奇、能接受不确定性、愿意探索创意，并对超出日常经验的想法感兴趣。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "高开放性的人可能喜欢学习陌生框架、根据证据调整流程，或把抽象想法转化为实验。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-openness",
+            "entity_key": "low-openness",
+            "slug": "big-five/low-openness",
+            "locale": "zh-CN",
+            "title": "低开放性",
+            "summary": "低开放性通常表现为务实、偏好熟悉方法，并希望在改变方向前看到具体证据。",
+            "seo": {
+                "title": "低开放性 | FermatMind Big Five",
+                "description": "低开放性通常表现为务实、偏好熟悉方法，并希望在改变方向前看到具体证据。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/low-openness",
+            "canonical": {
+                "path": "/zh/personality/big-five/low-openness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-openness",
+                "zh-CN": "/zh/personality/big-five/low-openness"
+            },
+            "faq": [
+                {
+                    "question": "低开放性是不是缺点？",
+                    "answer": "不是。它也可能带来稳定、现实感和对新事物的谨慎筛选。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "低开放性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "低开放性通常表现为务实、偏好熟悉方法，并希望在改变方向前看到具体证据。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "低开放性的人可能会维护有效流程、要求经过验证的例子，并避免没有实际理由的改变。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-conscientiousness",
+            "entity_key": "high-conscientiousness",
+            "slug": "big-five/high-conscientiousness",
+            "locale": "zh-CN",
+            "title": "高尽责性",
+            "summary": "高尽责性通常表现为计划性、可靠、持续投入，并重视承诺和责任。",
+            "seo": {
+                "title": "高尽责性 | FermatMind Big Five",
+                "description": "高尽责性通常表现为计划性、可靠、持续投入，并重视承诺和责任。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/high-conscientiousness",
+            "canonical": {
+                "path": "/zh/personality/big-five/high-conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-conscientiousness",
+                "zh-CN": "/zh/personality/big-five/high-conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "高尽责性是否等于完美主义？",
+                    "answer": "不一定。完美主义只是可能模式之一，还取决于压力、标准和情境。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "高尽责性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "高尽责性通常表现为计划性、可靠、持续投入，并重视承诺和责任。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "高尽责性的人可能会维护清单、提前完成任务，并注意到职责描述不清的地方。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-conscientiousness",
+            "entity_key": "low-conscientiousness",
+            "slug": "big-five/low-conscientiousness",
+            "locale": "zh-CN",
+            "title": "低尽责性",
+            "summary": "低尽责性通常表现为更随性、更灵活的工作节奏，以及较少依赖严格计划系统。",
+            "seo": {
+                "title": "低尽责性 | FermatMind Big Five",
+                "description": "低尽责性通常表现为更随性、更灵活的工作节奏，以及较少依赖严格计划系统。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/low-conscientiousness",
+            "canonical": {
+                "path": "/zh/personality/big-five/low-conscientiousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-conscientiousness",
+                "zh-CN": "/zh/personality/big-five/low-conscientiousness"
+            },
+            "faq": [
+                {
+                    "question": "低尽责性是否代表不可靠？",
+                    "answer": "不是。可靠性还取决于习惯、激励、系统和情境，不能只看一个维度分数。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "低尽责性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "低尽责性通常表现为更随性、更灵活的工作节奏，以及较少依赖严格计划系统。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "低尽责性的人可能擅长即兴处理、在规则较少时快速行动，或偏好轻量计划而非详细日程。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-extraversion",
+            "entity_key": "high-extraversion",
+            "slug": "big-five/high-extraversion",
+            "locale": "zh-CN",
+            "title": "高外向性",
+            "summary": "高外向性通常表现为明显的社交能量、主动表达、热情，以及更容易发起互动。",
+            "seo": {
+                "title": "高外向性 | FermatMind Big Five",
+                "description": "高外向性通常表现为明显的社交能量、主动表达、热情，以及更容易发起互动。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/high-extraversion",
+            "canonical": {
+                "path": "/zh/personality/big-five/high-extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-extraversion",
+                "zh-CN": "/zh/personality/big-five/high-extraversion"
+            },
+            "faq": [
+                {
+                    "question": "高外向性是否代表永远外向？",
+                    "answer": "不是。人在不同场景、疲劳程度、角色和信任关系下会有变化。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "高外向性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "高外向性通常表现为明显的社交能量、主动表达、热情，以及更容易发起互动。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "高外向性的人可能在会议中边说边想、带动群体气氛，并通过活跃环境补充能量。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-extraversion",
+            "entity_key": "low-extraversion",
+            "slug": "big-five/low-extraversion",
+            "locale": "zh-CN",
+            "title": "低外向性",
+            "summary": "低外向性通常表现为表达更克制、偏好低刺激环境，并更有选择地投入社交能量。",
+            "seo": {
+                "title": "低外向性 | FermatMind Big Five",
+                "description": "低外向性通常表现为表达更克制、偏好低刺激环境，并更有选择地投入社交能量。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/low-extraversion",
+            "canonical": {
+                "path": "/zh/personality/big-five/low-extraversion"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-extraversion",
+                "zh-CN": "/zh/personality/big-five/low-extraversion"
+            },
+            "faq": [
+                {
+                    "question": "低外向性是否等于社交焦虑？",
+                    "answer": "不是。外向性是偏好维度；焦虑是另一类体验，可能需要单独支持。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "低外向性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "低外向性通常表现为表达更克制、偏好低刺激环境，并更有选择地投入社交能量。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "低外向性的人可能在思考后贡献更好、偏好小组交流，或在密集互动后需要安静时间。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-agreeableness",
+            "entity_key": "high-agreeableness",
+            "slug": "big-five/high-agreeableness",
+            "locale": "zh-CN",
+            "title": "高宜人性",
+            "summary": "高宜人性通常表现为同理心、合作、信任，以及对关系和谐的关注。",
+            "seo": {
+                "title": "高宜人性 | FermatMind Big Five",
+                "description": "高宜人性通常表现为同理心、合作、信任，以及对关系和谐的关注。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/high-agreeableness",
+            "canonical": {
+                "path": "/zh/personality/big-five/high-agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-agreeableness",
+                "zh-CN": "/zh/personality/big-five/high-agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "高宜人性是否代表逃避冲突？",
+                    "answer": "不一定。它也可能意味着以修复关系为目标处理冲突。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "高宜人性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "高宜人性通常表现为同理心、合作、信任，以及对关系和谐的关注。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "高宜人性的人可能较早察觉情绪摩擦、主动提供帮助，或寻找能保留信任的解决方案。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "low-agreeableness",
+            "entity_key": "low-agreeableness",
+            "slug": "big-five/low-agreeableness",
+            "locale": "zh-CN",
+            "title": "低宜人性",
+            "summary": "低宜人性通常表现为直接、怀疑、竞争姿态，以及愿意挑战默认假设。",
+            "seo": {
+                "title": "低宜人性 | FermatMind Big Five",
+                "description": "低宜人性通常表现为直接、怀疑、竞争姿态，以及愿意挑战默认假设。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/low-agreeableness",
+            "canonical": {
+                "path": "/zh/personality/big-five/low-agreeableness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/low-agreeableness",
+                "zh-CN": "/zh/personality/big-five/low-agreeableness"
+            },
+            "faq": [
+                {
+                    "question": "低宜人性是否代表不友善？",
+                    "answer": "不是。它描述人际风格，不等于道德品质。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "低宜人性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "低宜人性通常表现为直接、怀疑、竞争姿态，以及愿意挑战默认假设。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "低宜人性的人可能质疑共识、坚定谈判，或把清晰度放在即时和谐之前。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "high-neuroticism",
+            "entity_key": "high-neuroticism",
+            "slug": "big-five/high-neuroticism",
+            "locale": "zh-CN",
+            "title": "高神经质 / 高情绪敏感性",
+            "summary": "高神经质通常表现为更强的情绪反应、压力敏感、担忧倾向，以及对风险更警觉。",
+            "seo": {
+                "title": "高神经质 / 高情绪敏感性 | FermatMind Big Five",
+                "description": "高神经质通常表现为更强的情绪反应、压力敏感、担忧倾向，以及对风险更警觉。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/high-neuroticism",
+            "canonical": {
+                "path": "/zh/personality/big-five/high-neuroticism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/high-neuroticism",
+                "zh-CN": "/zh/personality/big-five/high-neuroticism"
+            },
+            "faq": [
+                {
+                    "question": "高神经质是否是诊断？",
+                    "answer": "不是。它是正常范围内的人格维度，不是临床诊断。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "高神经质 / 高情绪敏感性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "高神经质通常表现为更强的情绪反应、压力敏感、担忧倾向，以及对风险更警觉。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "高神经质的人可能较早发现潜在问题、压力后需要更多恢复，或受益于明确的应对系统。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "polarity",
+            "code": "emotional-stability",
+            "entity_key": "emotional-stability",
+            "slug": "big-five/emotional-stability",
+            "locale": "zh-CN",
+            "title": "情绪稳定性",
+            "summary": "情绪稳定性是神经质的低端表现：情绪更平稳、压力反应较低，并更容易在压力下保持冷静。",
+            "seo": {
+                "title": "情绪稳定性 | FermatMind Big Five",
+                "description": "情绪稳定性是神经质的低端表现：情绪更平稳、压力反应较低，并更容易在压力下保持冷静。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/emotional-stability",
+            "canonical": {
+                "path": "/zh/personality/big-five/emotional-stability"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/emotional-stability",
+                "zh-CN": "/zh/personality/big-five/emotional-stability"
+            },
+            "faq": [
+                {
+                    "question": "情绪稳定是否代表没有情绪？",
+                    "answer": "不是。它表示情绪干扰较少或恢复较快，并不是没有情绪。"
+                },
+                {
+                    "question": "这个端点能直接判断关系或职业吗？",
+                    "answer": "不能。它只能提供一种解释线索，不能替代沟通、能力评估或现实选择。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "情绪稳定性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该端点是连续维度的一端，不是人格类型、诊断标签或价值判断。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                },
+                {
+                    "label": "大五人格",
+                    "target_code": "big-five",
+                    "relationship": "hub",
+                    "href": "/zh/personality/big-five"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "倾向概览",
+                    "body_md": "情绪稳定性是神经质的低端表现：情绪更平稳、压力反应较低，并更容易在压力下保持冷静。"
+                },
+                {
+                    "key": "example",
+                    "title": "具体例子",
+                    "body_md": "情绪稳定性较高的人可能在不确定中保持镇定、从挫折中较快恢复，或不容易被小压力触发过度反应。"
+                },
+                {
+                    "key": "balance",
+                    "title": "平衡点",
+                    "body_md": "这个页面只解释一个端点倾向，实际画像应结合五个维度和生活情境。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet_hub",
+            "code": "facets",
+            "entity_key": "facets",
+            "slug": "big-five/facets",
+            "locale": "zh-CN",
+            "title": "大五人格30个小维度",
+            "summary": "30个小维度可以更细地解释五大维度下的行为倾向，但当前仅作为 taxonomy 和后续内容草稿入口。",
+            "seo": {
+                "title": "大五人格30个小维度 | FermatMind Big Five",
+                "description": "30个小维度可以更细地解释五大维度下的行为倾向，但当前仅作为 taxonomy 和后续内容草稿入口。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets",
+                "zh-CN": "/zh/personality/big-five/facets"
+            },
+            "faq": [
+                {
+                    "question": "30个 facet 会单独收录吗？",
+                    "answer": "本版本不会。它们保持 noindex，仅作为结构化草稿和后续扩展基础。"
+                }
+            ],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "大五人格30个小维度"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "大五人格是维度模型，不是临床诊断、招聘筛选或固定类型标签。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/openness"
+                },
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                },
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                },
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                },
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_ready",
+            "review_state": "content_reviewed",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "overview",
+                    "title": "小维度用途",
+                    "body_md": "30个小维度可以更细地解释五大维度下的行为倾向，但当前仅作为 taxonomy 和后续内容草稿入口。"
+                },
+                {
+                    "key": "status",
+                    "title": "发布状态",
+                    "body_md": "单个 facet 暂不作为独立 SEO 页面发布。"
+                },
+                {
+                    "key": "boundary",
+                    "title": "边界",
+                    "body_md": "facet 适合辅助解释，不应被包装成新的官方人格类型。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "imagination",
+            "entity_key": "imagination",
+            "slug": "big-five/facets/imagination",
+            "locale": "zh-CN",
+            "title": "想象力",
+            "summary": "想象力是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "想象力 | FermatMind Big Five",
+                "description": "想象力是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/imagination",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/imagination"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/imagination",
+                "zh-CN": "/zh/personality/big-five/facets/imagination"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "想象力"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "想象力是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "aesthetics",
+            "entity_key": "aesthetics",
+            "slug": "big-five/facets/aesthetics",
+            "locale": "zh-CN",
+            "title": "审美",
+            "summary": "审美是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "审美 | FermatMind Big Five",
+                "description": "审美是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/aesthetics",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/aesthetics"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/aesthetics",
+                "zh-CN": "/zh/personality/big-five/facets/aesthetics"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "审美"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "审美是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "feelings",
+            "entity_key": "feelings",
+            "slug": "big-five/facets/feelings",
+            "locale": "zh-CN",
+            "title": "感受性",
+            "summary": "感受性是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "感受性 | FermatMind Big Five",
+                "description": "感受性是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/feelings",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/feelings"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/feelings",
+                "zh-CN": "/zh/personality/big-five/facets/feelings"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "感受性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "感受性是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "actions",
+            "entity_key": "actions",
+            "slug": "big-five/facets/actions",
+            "locale": "zh-CN",
+            "title": "行动开放",
+            "summary": "行动开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "行动开放 | FermatMind Big Five",
+                "description": "行动开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/actions",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/actions"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/actions",
+                "zh-CN": "/zh/personality/big-five/facets/actions"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "行动开放"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "行动开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "ideas",
+            "entity_key": "ideas",
+            "slug": "big-five/facets/ideas",
+            "locale": "zh-CN",
+            "title": "观念开放",
+            "summary": "观念开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "观念开放 | FermatMind Big Five",
+                "description": "观念开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/ideas",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/ideas"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/ideas",
+                "zh-CN": "/zh/personality/big-five/facets/ideas"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "观念开放"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "观念开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "values",
+            "entity_key": "values",
+            "slug": "big-five/facets/values",
+            "locale": "zh-CN",
+            "title": "价值开放",
+            "summary": "价值开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "价值开放 | FermatMind Big Five",
+                "description": "价值开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/values",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/values"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/values",
+                "zh-CN": "/zh/personality/big-five/facets/values"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "价值开放"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "开放性",
+                    "target_code": "openness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/openness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "价值开放是开放性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "competence",
+            "entity_key": "competence",
+            "slug": "big-five/facets/competence",
+            "locale": "zh-CN",
+            "title": "胜任感",
+            "summary": "胜任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "胜任感 | FermatMind Big Five",
+                "description": "胜任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/competence",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/competence"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/competence",
+                "zh-CN": "/zh/personality/big-five/facets/competence"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "胜任感"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "胜任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "order",
+            "entity_key": "order",
+            "slug": "big-five/facets/order",
+            "locale": "zh-CN",
+            "title": "条理性",
+            "summary": "条理性是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "条理性 | FermatMind Big Five",
+                "description": "条理性是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/order",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/order"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/order",
+                "zh-CN": "/zh/personality/big-five/facets/order"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "条理性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "条理性是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "dutifulness",
+            "entity_key": "dutifulness",
+            "slug": "big-five/facets/dutifulness",
+            "locale": "zh-CN",
+            "title": "责任感",
+            "summary": "责任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "责任感 | FermatMind Big Five",
+                "description": "责任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/dutifulness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/dutifulness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/dutifulness",
+                "zh-CN": "/zh/personality/big-five/facets/dutifulness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "责任感"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "责任感是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "achievement-striving",
+            "entity_key": "achievement-striving",
+            "slug": "big-five/facets/achievement-striving",
+            "locale": "zh-CN",
+            "title": "成就追求",
+            "summary": "成就追求是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "成就追求 | FermatMind Big Five",
+                "description": "成就追求是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/achievement-striving",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/achievement-striving"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/achievement-striving",
+                "zh-CN": "/zh/personality/big-five/facets/achievement-striving"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "成就追求"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "成就追求是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "self-discipline",
+            "entity_key": "self-discipline",
+            "slug": "big-five/facets/self-discipline",
+            "locale": "zh-CN",
+            "title": "自律",
+            "summary": "自律是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "自律 | FermatMind Big Five",
+                "description": "自律是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/self-discipline",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/self-discipline"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/self-discipline",
+                "zh-CN": "/zh/personality/big-five/facets/self-discipline"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "自律"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "自律是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "deliberation",
+            "entity_key": "deliberation",
+            "slug": "big-five/facets/deliberation",
+            "locale": "zh-CN",
+            "title": "审慎",
+            "summary": "审慎是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "审慎 | FermatMind Big Five",
+                "description": "审慎是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/deliberation",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/deliberation"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/deliberation",
+                "zh-CN": "/zh/personality/big-five/facets/deliberation"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "审慎"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "尽责性",
+                    "target_code": "conscientiousness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/conscientiousness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "审慎是尽责性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "warmth",
+            "entity_key": "warmth",
+            "slug": "big-five/facets/warmth",
+            "locale": "zh-CN",
+            "title": "热情",
+            "summary": "热情是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "热情 | FermatMind Big Five",
+                "description": "热情是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/warmth",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/warmth"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/warmth",
+                "zh-CN": "/zh/personality/big-five/facets/warmth"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "热情"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "热情是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "gregariousness",
+            "entity_key": "gregariousness",
+            "slug": "big-five/facets/gregariousness",
+            "locale": "zh-CN",
+            "title": "合群性",
+            "summary": "合群性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "合群性 | FermatMind Big Five",
+                "description": "合群性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/gregariousness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/gregariousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/gregariousness",
+                "zh-CN": "/zh/personality/big-five/facets/gregariousness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "合群性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "合群性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "assertiveness",
+            "entity_key": "assertiveness",
+            "slug": "big-five/facets/assertiveness",
+            "locale": "zh-CN",
+            "title": "表达主导性",
+            "summary": "表达主导性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "表达主导性 | FermatMind Big Five",
+                "description": "表达主导性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/assertiveness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/assertiveness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/assertiveness",
+                "zh-CN": "/zh/personality/big-five/facets/assertiveness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "表达主导性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "表达主导性是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "activity",
+            "entity_key": "activity",
+            "slug": "big-five/facets/activity",
+            "locale": "zh-CN",
+            "title": "活跃度",
+            "summary": "活跃度是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "活跃度 | FermatMind Big Five",
+                "description": "活跃度是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/activity",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/activity"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/activity",
+                "zh-CN": "/zh/personality/big-five/facets/activity"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "活跃度"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "活跃度是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "excitement-seeking",
+            "entity_key": "excitement-seeking",
+            "slug": "big-five/facets/excitement-seeking",
+            "locale": "zh-CN",
+            "title": "刺激寻求",
+            "summary": "刺激寻求是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "刺激寻求 | FermatMind Big Five",
+                "description": "刺激寻求是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/excitement-seeking",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/excitement-seeking"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/excitement-seeking",
+                "zh-CN": "/zh/personality/big-five/facets/excitement-seeking"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "刺激寻求"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "刺激寻求是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "positive-emotions",
+            "entity_key": "positive-emotions",
+            "slug": "big-five/facets/positive-emotions",
+            "locale": "zh-CN",
+            "title": "积极情绪",
+            "summary": "积极情绪是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "积极情绪 | FermatMind Big Five",
+                "description": "积极情绪是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/positive-emotions",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/positive-emotions"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/positive-emotions",
+                "zh-CN": "/zh/personality/big-five/facets/positive-emotions"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "积极情绪"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "外向性",
+                    "target_code": "extraversion",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/extraversion"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "积极情绪是外向性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "trust",
+            "entity_key": "trust",
+            "slug": "big-five/facets/trust",
+            "locale": "zh-CN",
+            "title": "信任",
+            "summary": "信任是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "信任 | FermatMind Big Five",
+                "description": "信任是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/trust",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/trust"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/trust",
+                "zh-CN": "/zh/personality/big-five/facets/trust"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "信任"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "信任是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "straightforwardness",
+            "entity_key": "straightforwardness",
+            "slug": "big-five/facets/straightforwardness",
+            "locale": "zh-CN",
+            "title": "坦率",
+            "summary": "坦率是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "坦率 | FermatMind Big Five",
+                "description": "坦率是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/straightforwardness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/straightforwardness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/straightforwardness",
+                "zh-CN": "/zh/personality/big-five/facets/straightforwardness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "坦率"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "坦率是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "altruism",
+            "entity_key": "altruism",
+            "slug": "big-five/facets/altruism",
+            "locale": "zh-CN",
+            "title": "利他",
+            "summary": "利他是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "利他 | FermatMind Big Five",
+                "description": "利他是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/altruism",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/altruism"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/altruism",
+                "zh-CN": "/zh/personality/big-five/facets/altruism"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "利他"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "利他是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "compliance",
+            "entity_key": "compliance",
+            "slug": "big-five/facets/compliance",
+            "locale": "zh-CN",
+            "title": "顺应",
+            "summary": "顺应是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "顺应 | FermatMind Big Five",
+                "description": "顺应是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/compliance",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/compliance"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/compliance",
+                "zh-CN": "/zh/personality/big-five/facets/compliance"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "顺应"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "顺应是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "modesty",
+            "entity_key": "modesty",
+            "slug": "big-five/facets/modesty",
+            "locale": "zh-CN",
+            "title": "谦逊",
+            "summary": "谦逊是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "谦逊 | FermatMind Big Five",
+                "description": "谦逊是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/modesty",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/modesty"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/modesty",
+                "zh-CN": "/zh/personality/big-five/facets/modesty"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "谦逊"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "谦逊是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "tender-mindedness",
+            "entity_key": "tender-mindedness",
+            "slug": "big-five/facets/tender-mindedness",
+            "locale": "zh-CN",
+            "title": "柔软心肠",
+            "summary": "柔软心肠是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "柔软心肠 | FermatMind Big Five",
+                "description": "柔软心肠是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/tender-mindedness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/tender-mindedness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/tender-mindedness",
+                "zh-CN": "/zh/personality/big-five/facets/tender-mindedness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "柔软心肠"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "宜人性",
+                    "target_code": "agreeableness",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/agreeableness"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "柔软心肠是宜人性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "anxiety",
+            "entity_key": "anxiety",
+            "slug": "big-five/facets/anxiety",
+            "locale": "zh-CN",
+            "title": "焦虑倾向",
+            "summary": "焦虑倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "焦虑倾向 | FermatMind Big Five",
+                "description": "焦虑倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/anxiety",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/anxiety"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/anxiety",
+                "zh-CN": "/zh/personality/big-five/facets/anxiety"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "焦虑倾向"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "焦虑倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "anger",
+            "entity_key": "anger",
+            "slug": "big-five/facets/anger",
+            "locale": "zh-CN",
+            "title": "愤怒倾向",
+            "summary": "愤怒倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "愤怒倾向 | FermatMind Big Five",
+                "description": "愤怒倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/anger",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/anger"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/anger",
+                "zh-CN": "/zh/personality/big-five/facets/anger"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "愤怒倾向"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "愤怒倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "depression",
+            "entity_key": "depression",
+            "slug": "big-five/facets/depression",
+            "locale": "zh-CN",
+            "title": "低落倾向",
+            "summary": "低落倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "低落倾向 | FermatMind Big Five",
+                "description": "低落倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/depression",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/depression"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/depression",
+                "zh-CN": "/zh/personality/big-five/facets/depression"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "低落倾向"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "低落倾向是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "self-consciousness",
+            "entity_key": "self-consciousness",
+            "slug": "big-five/facets/self-consciousness",
+            "locale": "zh-CN",
+            "title": "自我意识",
+            "summary": "自我意识是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "自我意识 | FermatMind Big Five",
+                "description": "自我意识是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/self-consciousness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/self-consciousness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/self-consciousness",
+                "zh-CN": "/zh/personality/big-five/facets/self-consciousness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "自我意识"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "自我意识是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "impulsiveness",
+            "entity_key": "impulsiveness",
+            "slug": "big-five/facets/impulsiveness",
+            "locale": "zh-CN",
+            "title": "冲动性",
+            "summary": "冲动性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "冲动性 | FermatMind Big Five",
+                "description": "冲动性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/impulsiveness",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/impulsiveness"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/impulsiveness",
+                "zh-CN": "/zh/personality/big-five/facets/impulsiveness"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "冲动性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "冲动性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
+        },
+        {
+            "framework": "big_five",
+            "entity_type": "facet",
+            "code": "vulnerability",
+            "entity_key": "vulnerability",
+            "slug": "big-five/facets/vulnerability",
+            "locale": "zh-CN",
+            "title": "脆弱性",
+            "summary": "脆弱性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。",
+            "seo": {
+                "title": "脆弱性 | FermatMind Big Five",
+                "description": "脆弱性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+            },
+            "robots": "noindex,follow",
+            "canonical_path": "/zh/personality/big-five/facets/vulnerability",
+            "canonical": {
+                "path": "/zh/personality/big-five/facets/vulnerability"
+            },
+            "hreflang": {
+                "en": "/en/personality/big-five/facets/vulnerability",
+                "zh-CN": "/zh/personality/big-five/facets/vulnerability"
+            },
+            "faq": [],
+            "media": {
+                "status": "placeholder",
+                "hero_image_asset_key": null,
+                "alt": "脆弱性"
+            },
+            "schema": {
+                "@type": "WebPage",
+                "about": "Big Five personality model"
+            },
+            "method_boundary": {
+                "summary": "该 facet 仅作 taxonomy 草稿，不应作为完整 SEO 正文或官方类型页面。",
+                "not_for": [
+                    "clinical diagnosis",
+                    "employment screening",
+                    "deterministic life decisions"
+                ]
+            },
+            "evidence_notes": [
+                {
+                    "source_type": "method_boundary",
+                    "note": "产品文案应使用“倾向”“可能”“通常”等限定表达。"
+                }
+            ],
+            "internal_links": [
+                {
+                    "label": "神经质 / 情绪敏感性",
+                    "target_code": "neuroticism",
+                    "relationship": "parent_domain",
+                    "href": "/zh/personality/big-five/neuroticism"
+                }
+            ],
+            "is_public": true,
+            "index_eligible": false,
+            "sitemap_eligible": false,
+            "llms_eligible": false,
+            "launch_state": "content_stub",
+            "review_state": "taxonomy_stub",
+            "last_reviewed_at": "2026-06-14T00:00:00Z",
+            "sections": [
+                {
+                    "key": "taxonomy_note",
+                    "title": "草稿说明",
+                    "body_md": "脆弱性是神经质 / 情绪敏感性下的一个细分 facet。本版本保留为草稿 taxonomy，不作为独立公开 SEO 页面。"
+                }
+            ]
         }
-      ],
-      "launch_state": "draft",
-      "review_state": "draft",
-      "index_eligible": false,
-      "sitemap_eligible": false,
-      "llms_eligible": false
-    }
-  ]
+    ]
 }

--- a/backend/database/migrations/2026_06_14_000200_add_render_contract_fields_to_personality_public_content_assets_table.php
+++ b/backend/database/migrations/2026_06_14_000200_add_render_contract_fields_to_personality_public_content_assets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personality_public_content_assets', function (Blueprint $table): void {
+            $table->string('robots', 32)->default('noindex,follow')->after('seo_json');
+            $table->json('internal_links_json')->nullable()->after('evidence_notes_json');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent content authority loss.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -4056,10 +4056,41 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PersonalityPublicContentAssetListResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityPublicContentAssetController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/personality-content-assets/{framework}/{entityType}/{code}": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_content_assets_framework_entitytype_code_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PersonalityPublicContentAssetItemResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityPublicContentAssetController@showByCode",
                 "x-laravel-middleware": [
                     "api"
                 ]
@@ -4073,7 +4104,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PersonalityPublicContentAssetItemResponse"
+                                }
+                            }
+                        }
                     }
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityPublicContentAssetController@show",
@@ -4356,6 +4394,383 @@
                 "x-laravel-middleware": [
                     "api"
                 ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "PersonalityPublicContentAssetListResponse": {
+                "type": "object",
+                "required": [
+                    "ok",
+                    "items",
+                    "pagination"
+                ],
+                "properties": {
+                    "ok": {
+                        "type": "boolean"
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityPublicContentAsset"
+                        }
+                    },
+                    "pagination": {
+                        "type": "object",
+                        "required": [
+                            "current_page",
+                            "per_page",
+                            "total",
+                            "last_page"
+                        ],
+                        "properties": {
+                            "current_page": {
+                                "type": "integer"
+                            },
+                            "per_page": {
+                                "type": "integer"
+                            },
+                            "total": {
+                                "type": "integer"
+                            },
+                            "last_page": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "PersonalityPublicContentAssetItemResponse": {
+                "type": "object",
+                "required": [
+                    "ok",
+                    "asset",
+                    "personality_public_content_asset_v1"
+                ],
+                "properties": {
+                    "ok": {
+                        "type": "boolean"
+                    },
+                    "asset": {
+                        "$ref": "#/components/schemas/PersonalityPublicContentAsset"
+                    },
+                    "personality_public_content_asset_v1": {
+                        "$ref": "#/components/schemas/PersonalityPublicContentAsset"
+                    }
+                }
+            },
+            "PersonalityPublicContentAsset": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "org_id",
+                    "contract_version",
+                    "framework",
+                    "entity_type",
+                    "code",
+                    "entity_key",
+                    "slug",
+                    "locale",
+                    "title",
+                    "sections",
+                    "content_sections",
+                    "seo",
+                    "robots",
+                    "canonical_path",
+                    "canonical",
+                    "hreflang",
+                    "faq",
+                    "media",
+                    "schema",
+                    "method_boundary",
+                    "evidence_notes",
+                    "internal_links",
+                    "is_public",
+                    "index_eligible",
+                    "sitemap_eligible",
+                    "llms_eligible",
+                    "launch_state"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "org_id": {
+                        "type": "integer"
+                    },
+                    "contract_version": {
+                        "type": "string"
+                    },
+                    "framework": {
+                        "type": "string",
+                        "enum": [
+                            "big_five",
+                            "enneagram"
+                        ]
+                    },
+                    "entity_type": {
+                        "type": "string",
+                        "enum": [
+                            "hub",
+                            "domain",
+                            "polarity",
+                            "facet_hub",
+                            "facet",
+                            "center",
+                            "core_type",
+                            "wing",
+                            "instinctual_subtype"
+                        ]
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "entity_key": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "locale": {
+                        "type": "string",
+                        "enum": [
+                            "en",
+                            "zh-CN"
+                        ]
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityContentSection"
+                        }
+                    },
+                    "content_sections": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityContentSection"
+                        }
+                    },
+                    "seo": {
+                        "$ref": "#/components/schemas/PersonalitySeo"
+                    },
+                    "robots": {
+                        "type": "string",
+                        "enum": [
+                            "index,follow",
+                            "noindex,follow",
+                            "noindex,nofollow"
+                        ]
+                    },
+                    "canonical_path": {
+                        "type": "string"
+                    },
+                    "canonical": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "hreflang": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "faq": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityFaq"
+                        }
+                    },
+                    "media": {
+                        "$ref": "#/components/schemas/PersonalityMedia"
+                    },
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    "method_boundary": {
+                        "$ref": "#/components/schemas/PersonalityMethodBoundary"
+                    },
+                    "evidence_notes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityEvidenceNote"
+                        }
+                    },
+                    "internal_links": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PersonalityInternalLink"
+                        }
+                    },
+                    "is_public": {
+                        "type": "boolean"
+                    },
+                    "index_eligible": {
+                        "type": "boolean"
+                    },
+                    "sitemap_eligible": {
+                        "type": "boolean"
+                    },
+                    "llms_eligible": {
+                        "type": "boolean"
+                    },
+                    "launch_state": {
+                        "type": "string",
+                        "enum": [
+                            "draft",
+                            "review",
+                            "approved",
+                            "content_ready",
+                            "content_stub",
+                            "published",
+                            "archived"
+                        ]
+                    },
+                    "review_state": {
+                        "type": "string"
+                    },
+                    "source_package": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "source_hash": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "published_at": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "date-time"
+                    },
+                    "last_reviewed_at": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "date-time"
+                    }
+                }
+            },
+            "PersonalitySeo": {
+                "type": "object",
+                "required": [
+                    "title",
+                    "description"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityContentSection": {
+                "type": "object",
+                "required": [
+                    "key"
+                ],
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "body_md": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityFaq": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string"
+                    },
+                    "answer": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityMedia": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "hero_image_asset_key": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "alt": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityMethodBoundary": {
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string"
+                    },
+                    "not_for": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityEvidenceNote": {
+                "type": "object",
+                "properties": {
+                    "source_type": {
+                        "type": "string"
+                    },
+                    "note": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": true
+            },
+            "PersonalityInternalLink": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "target_code": {
+                        "type": "string"
+                    },
+                    "relationship": {
+                        "type": "string"
+                    },
+                    "href": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": true
             }
         }
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -597,6 +597,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career-recommendations/mbti', [CareerRecommendationController::class, 'index']);
     Route::get('/career-recommendations/mbti/{type}', [CareerRecommendationController::class, 'show']);
     Route::get('/personality-content-assets', [PersonalityPublicContentAssetController::class, 'index']);
+    Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);
     Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);
     Route::get('/personality', [PersonalityController::class, 'index']);
     Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show']);

--- a/backend/scripts/export_openapi.sh
+++ b/backend/scripts/export_openapi.sh
@@ -111,6 +111,171 @@ foreach ($paths as $p => $ops) {
     $paths[$p] = $ops;
 }
 
+$personalityAssetSchemaRef = ["\$ref" => "#/components/schemas/PersonalityPublicContentAsset"];
+$personalitySchemas = [
+    "PersonalityPublicContentAssetListResponse" => [
+        "type" => "object",
+        "required" => ["ok", "items", "pagination"],
+        "properties" => [
+            "ok" => ["type" => "boolean"],
+            "items" => ["type" => "array", "items" => $personalityAssetSchemaRef],
+            "pagination" => [
+                "type" => "object",
+                "required" => ["current_page", "per_page", "total", "last_page"],
+                "properties" => [
+                    "current_page" => ["type" => "integer"],
+                    "per_page" => ["type" => "integer"],
+                    "total" => ["type" => "integer"],
+                    "last_page" => ["type" => "integer"],
+                ],
+            ],
+        ],
+    ],
+    "PersonalityPublicContentAssetItemResponse" => [
+        "type" => "object",
+        "required" => ["ok", "asset", "personality_public_content_asset_v1"],
+        "properties" => [
+            "ok" => ["type" => "boolean"],
+            "asset" => $personalityAssetSchemaRef,
+            "personality_public_content_asset_v1" => $personalityAssetSchemaRef,
+        ],
+    ],
+    "PersonalityPublicContentAsset" => [
+        "type" => "object",
+        "required" => [
+            "id", "org_id", "contract_version", "framework", "entity_type", "code", "entity_key",
+            "slug", "locale", "title", "sections", "content_sections", "seo", "robots", "canonical_path",
+            "canonical", "hreflang", "faq", "media", "schema", "method_boundary", "evidence_notes",
+            "internal_links", "is_public", "index_eligible", "sitemap_eligible", "llms_eligible", "launch_state",
+        ],
+        "properties" => [
+            "id" => ["type" => "integer"],
+            "org_id" => ["type" => "integer"],
+            "contract_version" => ["type" => "string"],
+            "framework" => ["type" => "string", "enum" => ["big_five", "enneagram"]],
+            "entity_type" => ["type" => "string", "enum" => ["hub", "domain", "polarity", "facet_hub", "facet", "center", "core_type", "wing", "instinctual_subtype"]],
+            "code" => ["type" => "string"],
+            "entity_key" => ["type" => "string"],
+            "slug" => ["type" => "string"],
+            "locale" => ["type" => "string", "enum" => ["en", "zh-CN"]],
+            "title" => ["type" => "string"],
+            "summary" => ["type" => "string", "nullable" => true],
+            "sections" => ["type" => "array", "items" => ["\$ref" => "#/components/schemas/PersonalityContentSection"]],
+            "content_sections" => ["type" => "array", "items" => ["\$ref" => "#/components/schemas/PersonalityContentSection"]],
+            "seo" => ["\$ref" => "#/components/schemas/PersonalitySeo"],
+            "robots" => ["type" => "string", "enum" => ["index,follow", "noindex,follow", "noindex,nofollow"]],
+            "canonical_path" => ["type" => "string"],
+            "canonical" => ["type" => "object", "additionalProperties" => true],
+            "hreflang" => ["type" => "object", "additionalProperties" => ["type" => "string"]],
+            "faq" => ["type" => "array", "items" => ["\$ref" => "#/components/schemas/PersonalityFaq"]],
+            "media" => ["\$ref" => "#/components/schemas/PersonalityMedia"],
+            "schema" => ["type" => "object", "additionalProperties" => true],
+            "method_boundary" => ["\$ref" => "#/components/schemas/PersonalityMethodBoundary"],
+            "evidence_notes" => ["type" => "array", "items" => ["\$ref" => "#/components/schemas/PersonalityEvidenceNote"]],
+            "internal_links" => ["type" => "array", "items" => ["\$ref" => "#/components/schemas/PersonalityInternalLink"]],
+            "is_public" => ["type" => "boolean"],
+            "index_eligible" => ["type" => "boolean"],
+            "sitemap_eligible" => ["type" => "boolean"],
+            "llms_eligible" => ["type" => "boolean"],
+            "launch_state" => ["type" => "string", "enum" => ["draft", "review", "approved", "content_ready", "content_stub", "published", "archived"]],
+            "review_state" => ["type" => "string"],
+            "source_package" => ["type" => "string", "nullable" => true],
+            "source_hash" => ["type" => "string", "nullable" => true],
+            "published_at" => ["type" => "string", "nullable" => true, "format" => "date-time"],
+            "last_reviewed_at" => ["type" => "string", "nullable" => true, "format" => "date-time"],
+            "updated_at" => ["type" => "string", "nullable" => true, "format" => "date-time"],
+        ],
+    ],
+    "PersonalitySeo" => [
+        "type" => "object",
+        "required" => ["title", "description"],
+        "properties" => [
+            "title" => ["type" => "string"],
+            "description" => ["type" => "string"],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityContentSection" => [
+        "type" => "object",
+        "required" => ["key"],
+        "properties" => [
+            "key" => ["type" => "string"],
+            "title" => ["type" => "string", "nullable" => true],
+            "body_md" => ["type" => "string", "nullable" => true],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityFaq" => [
+        "type" => "object",
+        "properties" => [
+            "question" => ["type" => "string"],
+            "answer" => ["type" => "string"],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityMedia" => [
+        "type" => "object",
+        "properties" => [
+            "status" => ["type" => "string"],
+            "hero_image_asset_key" => ["type" => "string", "nullable" => true],
+            "alt" => ["type" => "string", "nullable" => true],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityMethodBoundary" => [
+        "type" => "object",
+        "properties" => [
+            "summary" => ["type" => "string"],
+            "not_for" => ["type" => "array", "items" => ["type" => "string"]],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityEvidenceNote" => [
+        "type" => "object",
+        "properties" => [
+            "source_type" => ["type" => "string"],
+            "note" => ["type" => "string"],
+        ],
+        "additionalProperties" => true,
+    ],
+    "PersonalityInternalLink" => [
+        "type" => "object",
+        "properties" => [
+            "label" => ["type" => "string"],
+            "target_code" => ["type" => "string"],
+            "relationship" => ["type" => "string"],
+            "href" => ["type" => "string"],
+        ],
+        "additionalProperties" => true,
+    ],
+];
+
+foreach ($paths as $pathKey => &$ops) {
+    if (!str_starts_with($pathKey, "/api/v0.5/personality-content-assets")) {
+        continue;
+    }
+
+    foreach ($ops as $method => &$operation) {
+        if ($method !== "get") {
+            continue;
+        }
+
+        $schemaRef = $pathKey === "/api/v0.5/personality-content-assets"
+            ? "#/components/schemas/PersonalityPublicContentAssetListResponse"
+            : "#/components/schemas/PersonalityPublicContentAssetItemResponse";
+        $operation["responses"]["200"] = [
+            "description" => "OK",
+            "content" => [
+                "application/json" => [
+                    "schema" => ["\$ref" => $schemaRef],
+                ],
+            ],
+        ];
+    }
+    unset($operation);
+}
+unset($ops);
+
 $doc = [
     "openapi" => "3.0.3",
     "info" => [
@@ -118,6 +283,9 @@ $doc = [
         "version" => "route-list-v1",
     ],
     "paths" => $paths,
+    "components" => [
+        "schemas" => $personalitySchemas,
+    ],
 ];
 
 $encoded = json_encode($doc, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php
@@ -19,8 +19,8 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
     {
         $this->artisan('personality-public-assets:import')
             ->expectsOutputToContain('dry_run=1')
-            ->expectsOutputToContain('assets_found=8')
-            ->expectsOutputToContain('valid_count=8')
+            ->expectsOutputToContain('assets_found=94')
+            ->expectsOutputToContain('valid_count=94')
             ->expectsOutputToContain('errors_count=0')
             ->expectsOutputToContain('indexable_count=0')
             ->expectsOutputToContain('sitemap_eligible_count=0')
@@ -30,26 +30,33 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
     }
 
-    public function test_write_import_keeps_seed_assets_draft_noindex_and_hidden_from_public_api(): void
+    public function test_write_import_is_idempotent_and_exposes_only_render_candidates(): void
     {
         $this->artisan('personality-public-assets:import', [
             '--write' => true,
         ])
             ->expectsOutputToContain('dry_run=0')
-            ->expectsOutputToContain('will_create=8')
+            ->expectsOutputToContain('will_create=94')
             ->expectsOutputToContain('indexable_count=0')
             ->expectsOutputToContain('sitemap_eligible_count=0')
             ->expectsOutputToContain('llms_eligible_count=0')
             ->assertExitCode(0);
 
-        $this->assertSame(8, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame(94, PersonalityPublicContentAsset::query()->count());
+
+        $this->artisan('personality-public-assets:import', [
+            '--write' => true,
+        ])
+            ->expectsOutputToContain('will_skip=94')
+            ->assertExitCode(0);
 
         $asset = PersonalityPublicContentAsset::query()
             ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
             ->where('entity_type', PersonalityPublicContentAsset::ENTITY_HUB)
             ->firstOrFail();
 
-        $this->assertSame(PersonalityPublicContentAsset::LAUNCH_DRAFT, $asset->launch_state);
+        $this->assertSame(PersonalityPublicContentAsset::LAUNCH_CONTENT_READY, $asset->launch_state);
+        $this->assertSame(PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW, $asset->robots);
         $this->assertFalse((bool) $asset->index_eligible);
         $this->assertFalse((bool) $asset->sitemap_eligible);
         $this->assertFalse((bool) $asset->llms_eligible);
@@ -57,14 +64,67 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         $this->getJson('/api/v0.5/personality-content-assets?framework=big_five&locale=en')
             ->assertOk()
             ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 17)
+            ->assertJsonCount(17, 'items')
+            ->assertJsonPath('items.0.index_eligible', false)
+            ->assertJsonPath('items.0.robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW);
+
+        $this->getJson('/api/v0.5/personality-content-assets?framework=big_five&locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 17)
+            ->assertJsonCount(17, 'items');
+
+        $this->getJson('/api/v0.5/personality-content-assets?framework=big_five&locale=en&entity_type=facet')
+            ->assertOk()
             ->assertJsonPath('pagination.total', 0)
             ->assertJsonCount(0, 'items');
+
+        $this->getJson('/api/v0.5/personality-content-assets/big_five/domain/openness?locale=en')
+            ->assertOk()
+            ->assertJsonPath('personality_public_content_asset_v1.code', 'openness')
+            ->assertJsonPath('personality_public_content_asset_v1.entity_type', PersonalityPublicContentAsset::ENTITY_DOMAIN)
+            ->assertJsonPath('personality_public_content_asset_v1.launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)
+            ->assertJsonPath('personality_public_content_asset_v1.robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW);
+
+        $this->getJson('/api/v0.5/personality-content-assets/big_five/facet/imagination?locale=en')
+            ->assertNotFound();
 
         $sitemapLocs = collect(app(SitemapGenerator::class)->generateUrls())
             ->pluck('loc')
             ->implode("\n");
 
         $this->assertStringNotContainsString('/personality/big-five', $sitemapLocs);
+    }
+
+    public function test_big_five_seed_has_expected_counts_parity_and_indexability(): void
+    {
+        $payload = json_decode((string) file_get_contents(base_path('content_assets/personality_public/big_five_v1_seed.json')), true);
+        $assets = collect(is_array($payload['assets'] ?? null) ? $payload['assets'] : []);
+
+        $this->assertSame(94, $assets->count());
+        $this->assertSame(['en' => 47, 'zh-CN' => 47], $assets->countBy('locale')->sortKeys()->all());
+        $this->assertSame([
+            'domain' => 10,
+            'facet' => 60,
+            'facet_hub' => 2,
+            'hub' => 2,
+            'polarity' => 20,
+        ], $assets->countBy('entity_type')->sortKeys()->all());
+
+        $renderCandidates = $assets->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->values();
+        $facetStubs = $assets->where('entity_type', PersonalityPublicContentAsset::ENTITY_FACET)->values();
+
+        $this->assertSame(34, $renderCandidates->count());
+        $this->assertSame(60, $facetStubs->count());
+        $this->assertTrue($renderCandidates->every(fn (array $asset): bool => $asset['robots'] === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
+        $this->assertTrue($renderCandidates->every(fn (array $asset): bool => $asset['index_eligible'] === false && $asset['sitemap_eligible'] === false && $asset['llms_eligible'] === false));
+        $this->assertTrue($facetStubs->every(fn (array $asset): bool => $asset['launch_state'] === PersonalityPublicContentAsset::LAUNCH_CONTENT_STUB));
+        $this->assertTrue($facetStubs->every(fn (array $asset): bool => $asset['robots'] === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW));
+        $this->assertTrue($facetStubs->every(fn (array $asset): bool => $asset['index_eligible'] === false && $asset['sitemap_eligible'] === false && $asset['llms_eligible'] === false));
+
+        $enCodes = $renderCandidates->where('locale', 'en')->pluck('code')->sort()->values()->all();
+        $zhCodes = $renderCandidates->where('locale', 'zh-CN')->pluck('code')->sort()->values()->all();
+        $this->assertSame($enCodes, $zhCodes);
     }
 
     public function test_published_indexable_asset_can_be_read_without_sitemap_or_llms_flags(): void
@@ -82,6 +142,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
             ->assertJsonPath('pagination.total', 1)
             ->assertJsonPath('items.0.framework', 'big_five')
             ->assertJsonPath('items.0.entity_type', 'hub')
+            ->assertJsonPath('items.0.robots', PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW)
             ->assertJsonPath('items.0.index_eligible', true)
             ->assertJsonPath('items.0.sitemap_eligible', false)
             ->assertJsonPath('items.0.llms_eligible', false);
@@ -148,6 +209,18 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         app(PersonalityPublicContentAssetContract::class)->validateAsset($this->contractPayload([
             'launch_state' => PersonalityPublicContentAsset::LAUNCH_DRAFT,
             'index_eligible' => true,
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
+        ]));
+    }
+
+    public function test_contract_rejects_index_follow_without_published_indexable_asset(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        app(PersonalityPublicContentAssetContract::class)->validateAsset($this->contractPayload([
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'index_eligible' => false,
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
         ]));
     }
 
@@ -176,6 +249,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
                 'title' => 'Big Five Personality',
                 'description' => 'Published fixture.',
             ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_INDEX_FOLLOW,
             'canonical_json' => [
                 'path' => '/en/personality/big-five',
             ],
@@ -194,6 +268,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
                     'note' => 'Test fixture.',
                 ],
             ],
+            'internal_links_json' => [],
             'is_public' => true,
             'index_eligible' => false,
             'sitemap_eligible' => false,
@@ -213,6 +288,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
         return array_merge([
             'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
             'entity_type' => PersonalityPublicContentAsset::ENTITY_HUB,
+            'code' => 'big-five',
             'entity_key' => 'big-five',
             'slug' => 'big-five',
             'locale' => 'en',
@@ -228,6 +304,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
                 'title' => 'Big Five Personality',
                 'description' => 'Contract fixture.',
             ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
             'canonical' => [
                 'path' => '/en/personality/big-five',
             ],
@@ -246,6 +323,7 @@ final class PersonalityPublicContentAssetContractTest extends TestCase
                     'note' => 'Contract fixture.',
                 ],
             ],
+            'internal_links' => [],
             'launch_state' => PersonalityPublicContentAsset::LAUNCH_DRAFT,
             'review_state' => 'draft',
             'index_eligible' => false,

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2707,6 +2707,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $routeChangedLines = [
             '+use App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityPublicContentAssetController;',
             "+    Route::get('/personality-content-assets', [PersonalityPublicContentAssetController::class, 'index']);",
+            "+    Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);",
             "+    Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);",
         ];
 
@@ -5977,6 +5978,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowedLines = [
             '+use App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityPublicContentAssetController;',
             "+    Route::get('/personality-content-assets', [PersonalityPublicContentAssetController::class, 'index']);",
+            "+    Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);",
             "+    Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);",
         ];
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2702,6 +2702,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/PersonalityPublicContentAsset.php',
             'backend/app/Services/Cms/PersonalityPublicContentAssetContract.php',
             'backend/database/migrations/2026_06_14_000100_create_personality_public_content_assets_table.php',
+            'backend/database/migrations/2026_06_14_000200_add_render_contract_fields_to_personality_public_content_assets_table.php',
             'backend/routes/api.php',
         ];
         $routeChangedLines = [
@@ -3832,6 +3833,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/PersonalityPublicContentAsset.php',
             'backend/app/Services/Cms/PersonalityPublicContentAssetContract.php',
             'backend/database/migrations/2026_06_14_000100_create_personality_public_content_assets_table.php',
+            'backend/database/migrations/2026_06_14_000200_add_render_contract_fields_to_personality_public_content_assets_table.php',
         ], true);
     }
 

--- a/docs/research/personality/big-five-content-coverage/00-executive-summary.md
+++ b/docs/research/personality/big-five-content-coverage/00-executive-summary.md
@@ -1,0 +1,33 @@
+# Big Five Content Coverage Executive Summary
+
+## Scope
+
+PR ID: `PERSONALITY-BIG5-CONTENT-COVERAGE-01`
+
+This PR fills the backend CMS/API authority input for FermatMind Big Five public content assets. It does not add frontend routes, public SEO pages, MBTI changes, Big Five result-page behavior changes, Enneagram content coverage, or scoring changes.
+
+## Outcome
+
+Status: `GO_FOR_FAP_WEB_NOINDEX_RENDER_CONSUMER`
+
+The Big Five V1 seed now contains 94 assets:
+
+- 34 bilingual render candidates: `content_ready`, `robots=noindex,follow`, `index_eligible=false`, `sitemap_eligible=false`, `llms_eligible=false`
+- 60 bilingual facet stubs: `content_stub`, hidden from public API, noindex, not sitemap/llms eligible
+
+## Key Contract Changes
+
+- `robots` is a first-class persisted field and API payload field.
+- `code` is exposed as a stable alias for `entity_key`.
+- `internal_links` is persisted and exposed.
+- Public API can expose `content_ready` noindex render candidates without making them indexable.
+- Facet stubs remain unavailable through the public render API.
+- Stable lookup exists at `/api/v0.5/personality-content-assets/{framework}/{entityType}/{code}`.
+
+## Evidence
+
+- Code evidence: `backend/app/Models/PersonalityPublicContentAsset.php`, `backend/app/DTO/Personality/PersonalityPublicContentAssetData.php`, `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php`
+- Seed evidence: `backend/content_assets/personality_public/big_five_v1_seed.json`
+- Test evidence: `backend/tests/Feature/V0_5/PersonalityPublicContentAssetContractTest.php`
+- OpenAPI evidence: `backend/docs/contracts/openapi.snapshot.json`
+

--- a/docs/research/personality/big-five-content-coverage/01-seed-coverage-summary.md
+++ b/docs/research/personality/big-five-content-coverage/01-seed-coverage-summary.md
@@ -1,0 +1,38 @@
+# Big Five Seed Coverage Summary
+
+## Totals
+
+- Total assets: 94
+- `en`: 47
+- `zh-CN`: 47
+
+## Entity Distribution
+
+- `hub`: 2
+- `domain`: 10
+- `polarity`: 20
+- `facet_hub`: 2
+- `facet`: 60
+
+## Render Candidates
+
+- Total render candidates: 34
+- Per locale: 17
+- Entity mix per locale: 1 hub, 5 domains, 10 polarity pages, 1 facet hub
+- Launch state: `content_ready`
+- Robots: `noindex,follow`
+- Index/sitemap/llms: all false
+
+## Facet Stubs
+
+- Total facet stubs: 60
+- Per locale: 30
+- Launch state: `content_stub`
+- Robots: `noindex,follow`
+- Index/sitemap/llms: all false
+
+## Evidence
+
+- Seed evidence: `backend/content_assets/personality_public/big_five_v1_seed.json`
+- Test evidence: `test_big_five_seed_has_expected_counts_parity_and_indexability`
+

--- a/docs/research/personality/big-five-content-coverage/02-locale-parity-audit.md
+++ b/docs/research/personality/big-five-content-coverage/02-locale-parity-audit.md
@@ -1,0 +1,25 @@
+# Locale Parity Audit
+
+## Result
+
+Status: `PASS`
+
+The Big Five seed has zh-CN/en parity for both V1 render candidates and facet stubs.
+
+## Parity Checks
+
+- `en` total: 47
+- `zh-CN` total: 47
+- Render candidate code set: equal across `en` and `zh-CN`
+- Facet count: 30 per locale
+- Render candidate count: 17 per locale
+
+## Notes
+
+The same stable `code` values are used across locales. Locale-specific copy, title, SEO title/description, FAQ, and summaries are localized in the source seed.
+
+## Evidence
+
+- Seed evidence: `backend/content_assets/personality_public/big_five_v1_seed.json`
+- Test evidence: `test_big_five_seed_has_expected_counts_parity_and_indexability`
+

--- a/docs/research/personality/big-five-content-coverage/03-indexability-audit.md
+++ b/docs/research/personality/big-five-content-coverage/03-indexability-audit.md
@@ -1,0 +1,28 @@
+# Indexability Audit
+
+## Result
+
+Status: `PASS`
+
+No Big Five content asset in this PR is indexable.
+
+## Rules Enforced
+
+- `index_eligible=true` requires `launch_state=published`
+- `index_eligible=true` requires `robots=index,follow`
+- `robots=index,follow` requires published indexable assets
+- `sitemap_eligible` and `llms_eligible` require published indexable assets
+- Model save logic forces sitemap/llms false unless the asset is published, indexable, and `robots=index,follow`
+
+## Public API Visibility
+
+`content_ready` assets are visible to the public API for fap-web noindex render consumption. They are not indexable and do not enter sitemap/llms.
+
+`content_stub` facet assets are hidden from the public API and remain taxonomy/future-draft records.
+
+## Evidence
+
+- Code evidence: `backend/app/Models/PersonalityPublicContentAsset.php`
+- Contract evidence: `backend/app/Services/Cms/PersonalityPublicContentAssetContract.php`
+- Test evidence: `test_write_import_is_idempotent_and_exposes_only_render_candidates`
+

--- a/docs/research/personality/big-five-content-coverage/04-openapi-schema-readiness.md
+++ b/docs/research/personality/big-five-content-coverage/04-openapi-schema-readiness.md
@@ -1,0 +1,51 @@
+# OpenAPI Schema Readiness
+
+## Result
+
+Status: `PASS`
+
+The OpenAPI route snapshot now includes structured response schemas for personality content assets.
+
+## Covered Schemas
+
+- List response
+- Item response
+- Asset object
+- SEO object
+- Section object
+- FAQ object
+- Media object
+- Method boundary object
+- Evidence note object
+- Internal link object
+- Indexability fields: `robots`, `launch_state`, `index_eligible`, `sitemap_eligible`, `llms_eligible`
+
+## Consumer Fields
+
+The API payload exposes:
+
+- `framework`
+- `entity_type`
+- `code`
+- `entity_key`
+- `locale`
+- `slug`
+- `seo`
+- `robots`
+- `canonical_path`
+- `canonical`
+- `hreflang`
+- `sections`
+- `faq`
+- `media`
+- `schema`
+- `method_boundary`
+- `evidence_notes`
+- `internal_links`
+
+## Evidence
+
+- OpenAPI evidence: `backend/docs/contracts/openapi.snapshot.json`
+- Exporter evidence: `backend/scripts/export_openapi.sh`
+- Check evidence: `bash scripts/export_openapi.sh --check`
+

--- a/docs/research/personality/big-five-content-coverage/05-fap-web-consumer-readiness.md
+++ b/docs/research/personality/big-five-content-coverage/05-fap-web-consumer-readiness.md
@@ -1,0 +1,29 @@
+# fap-web Consumer Readiness
+
+## Result
+
+Status: `GO_FOR_NOINDEX_RENDER_CONSUMER`
+
+The backend contract is ready for fap-web to consume Big Five public content assets in a noindex render phase.
+
+## Required fap-web Behavior
+
+- Render only backend/API-provided content.
+- Preserve `robots=noindex,follow` for Big Five V1 render candidates.
+- Do not enumerate these assets in sitemap or llms.
+- Do not render `content_stub` facets as public pages.
+- Do not create Big Five 32-type/OCEAN profile SEO pages.
+- Do not reuse private result-page modules as public SEO body content.
+
+## API Paths
+
+- List: `/api/v0.5/personality-content-assets`
+- Slug lookup: `/api/v0.5/personality-content-assets/{framework}/{slug}`
+- Stable code lookup: `/api/v0.5/personality-content-assets/{framework}/{entityType}/{code}`
+
+## Evidence
+
+- Route evidence: `backend/routes/api.php`
+- Controller evidence: `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityPublicContentAssetController.php`
+- Test evidence: `test_write_import_is_idempotent_and_exposes_only_render_candidates`
+

--- a/docs/research/personality/big-five-content-coverage/06-go-no-go-for-big-five-render.md
+++ b/docs/research/personality/big-five-content-coverage/06-go-no-go-for-big-five-render.md
@@ -1,0 +1,35 @@
+# GO / NO-GO for Big Five Render
+
+## Decision
+
+Decision: `GO_FOR_FAP_WEB_NOINDEX_RENDER`
+
+## Why GO
+
+- Bilingual Big Five V1 render candidates are present with parity.
+- Public API exposes only `content_ready` render candidates.
+- Facet stubs are present but hidden from public API.
+- All assets remain noindex and excluded from sitemap/llms.
+- OpenAPI snapshot includes typed response schema.
+- Stable code lookup route exists.
+- Import is idempotent.
+- sqlite migration/import smoke passes.
+
+## Conditions
+
+fap-web must keep this as a noindex/render consumer phase. It must not create sitemap, llms, or publicly indexable SEO pages until a later backend approval explicitly sets assets to `published`, `index_eligible=true`, and `robots=index,follow`.
+
+## Blockers
+
+None for noindex render consumer.
+
+## Explicit Non-Goals Preserved
+
+- No MBTI changes.
+- No Big Five result-page behavior changes.
+- No Enneagram result-page behavior changes.
+- No test scoring changes.
+- No 32 OCEAN SEO.
+- No Enneagram 54 wing x instinct.
+- No Tritype.
+


### PR DESCRIPTION
## What changed

- Added persisted `robots` and `internal_links_json` fields for personality public content assets.
- Added `content_ready`, `content_stub`, `facet_hub`, first-class `robots`, API `code`, and stable framework/entity_type/code lookup.
- Expanded `big_five_v1_seed.json` to 94 bilingual assets:
  - 34 render candidates: hub, 5 domains, 10 high/low polarity assets, facet hub across `en` and `zh-CN`
  - 60 facet stubs: 30 facets across `en` and `zh-CN`
- Updated OpenAPI snapshot with typed personality content asset response schemas.
- Added contract tests for import idempotence, seed counts, locale parity, indexability, public API visibility, facet hiding, and code lookup.
- Added readiness reports under `docs/research/personality/big-five-content-coverage/`.

## Why

Post-merge smoke for PR #2079 showed the contract existed but Big Five V1 coverage was not ready for fap-web noindex rendering: seed coverage was too small, en-only, draft-only, missing polarity/facet hub/facet coverage, and OpenAPI lacked typed response schemas.

This PR makes the backend CMS/API contract ready for the next fap-web noindex render consumer phase without creating public frontend pages or indexable SEO surfaces.

## Validation

- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_api_personality_big5.sqlite PAYMENTS_ALLOW_STUB=true php artisan migrate:fresh --force`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_api_personality_big5.sqlite PAYMENTS_ALLOW_STUB=true php artisan personality-public-assets:import`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_api_personality_big5.sqlite PAYMENTS_ALLOW_STUB=true php artisan personality-public-assets:import --write`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_api_personality_big5.sqlite PAYMENTS_ALLOW_STUB=true php artisan personality-public-assets:import --write` (`will_skip=94`)
- `APP_ENV=testing PAYMENTS_ALLOW_STUB=true vendor/bin/phpunit --filter PersonalityPublicContentAssetContractTest`
- `APP_ENV=testing PAYMENTS_ALLOW_STUB=true vendor/bin/phpunit --filter 'runtime_freeze_classifier_ignores_personality_public_asset_contract_changes|PersonalityPublicContentAssetContractTest'`
- `bash scripts/export_openapi.sh && bash scripts/export_openapi.sh --check`
- `PORT=1837 APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Note: the first `ci_verify_mbti.sh` attempt was blocked by an unrelated stale local `artisan serve` from another worktree holding `/tmp/fap-ci.sqlite`; after stopping that stale process and rerunning on `PORT=1837`, the full gate passed.

## Intentionally deferred

- No fap-web rendering changes.
- No public frontend routes.
- No sitemap or llms inclusion.
- No MBTI changes.
- No Big Five or Enneagram result-page behavior changes.
- No scoring changes.
- No 32 OCEAN SEO pages.
- No Enneagram 54 wing x instinct or Tritype coverage.

## Repository rule impact

This introduces backend-authoritative public personality content assets for Big Five noindex render consumption. The surface remains CMS/API-authoritative; frontend consumers must render backend payloads and preserve noindex/sitemap/llms gates until a future backend approval explicitly publishes indexable assets.
