### PR TITLE
PERSONALITY-DETAIL-FAQ-SEO-01: feat(personality): add backend FAQ content contract

### DIFF
--- a/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
+++ b/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
@@ -22,6 +22,8 @@ final class MbtiCanonicalSectionRegistry
 
     public const RENDER_VARIANT_PREFERRED_ROLE_LIST = 'preferred_role_list';
 
+    public const RENDER_VARIANT_FAQ = 'faq';
+
     public const RENDER_VARIANT_PREMIUM_TEASER = 'premium_teaser';
 
     /**
@@ -85,6 +87,19 @@ final class MbtiCanonicalSectionRegistry
                 'description' => 'Backend-authored module explaining how the Assertive and Turbulent variants differ for the same MBTI base type.',
                 'sort_order' => 31,
                 'enabled' => true,
+            ],
+            'faq' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_FAQ,
+                'group' => 'seo',
+                'label' => 'Visible FAQ',
+                'title' => 'Frequently asked questions',
+                'description' => 'Backend-authored visible FAQ items for public MBTI personality detail pages.',
+                'sort_order' => 90,
+                'enabled' => true,
+                'payload_schema' => [
+                    'items' => 'list<faq_item:{key,question,answer}>',
+                ],
             ],
             'traits.why_this_type' => [
                 'bucket' => self::BUCKET_SECTIONS,

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -796,6 +796,44 @@ final class PersonalityPublicApiTest extends TestCase
                     (string) ($projectionDifferenceSection['body_md'] ?? ''),
                 );
 
+                /** @var array<string, mixed>|null $faqSection */
+                $faqSection = collect($sections)
+                    ->firstWhere('section_key', 'faq');
+                self::assertIsArray($faqSection, $runtimeTypeCode.' should expose a backend-authored visible FAQ section.');
+                self::assertSame('faq', $faqSection['render_variant'] ?? null);
+                self::assertSame(90, (int) ($faqSection['sort_order'] ?? 0));
+                self::assertSame($runtimeTypeCode, data_get($faqSection, 'payload_json.runtime_type_code'));
+                self::assertSame($this->siblingRuntimeTypeCode($runtimeTypeCode), data_get($faqSection, 'payload_json.sibling_runtime_type_code'));
+                self::assertCount(4, (array) data_get($faqSection, 'payload_json.items'));
+                self::assertSame(
+                    $this->expectedFaqMeaningQuestion($locale, $runtimeTypeCode),
+                    data_get($faqSection, 'payload_json.items.0.question'),
+                    $runtimeTypeCode.' FAQ question should come from backend baseline content.',
+                );
+
+                $projectionFaqSection = collect((array) $detail->json('mbti_public_projection_v1.sections'))
+                    ->firstWhere('key', 'faq');
+                self::assertIsArray(
+                    $projectionFaqSection,
+                    $runtimeTypeCode.' should include the FAQ section in mbti_public_projection_v1.',
+                );
+                self::assertSame('faq', $projectionFaqSection['render'] ?? null);
+                self::assertSame(
+                    $this->expectedFaqMeaningQuestion($locale, $runtimeTypeCode),
+                    data_get($projectionFaqSection, 'payload.items.0.question'),
+                );
+
+                $answerFaqBlocks = (array) $detail->json('answer_surface_v1.faq_blocks');
+                self::assertCount(4, $answerFaqBlocks, $runtimeTypeCode.' should expose four FAQ blocks for frontend FAQ rendering.');
+                self::assertSame(
+                    $this->expectedFaqMeaningQuestion($locale, $runtimeTypeCode),
+                    data_get($answerFaqBlocks, '0.question'),
+                );
+                self::assertStringContainsString(
+                    $runtimeTypeCode,
+                    (string) data_get($answerFaqBlocks, '0.answer'),
+                );
+
                 $checkedRoutes[] = $locale.':'.$routeSlug;
 
                 if ($locale === 'zh-CN' && $runtimeTypeCode === 'ENTJ-T') {
@@ -818,6 +856,15 @@ final class PersonalityPublicApiTest extends TestCase
         }
 
         return $baseTypeCode.'-A vs '.$baseTypeCode.'-T: what is the difference?';
+    }
+
+    private function expectedFaqMeaningQuestion(string $locale, string $runtimeTypeCode): string
+    {
+        if ($locale === 'zh-CN') {
+            return $runtimeTypeCode.' 是什么意思？';
+        }
+
+        return 'What does '.$runtimeTypeCode.' mean?';
     }
 
     private function siblingRuntimeTypeCode(string $runtimeTypeCode): string

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -280,6 +280,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_personality_detail_faq_section_files(): void
+    {
+        $changed = [
+            'backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php',
+            'backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_english_variant_section_enrichment_files(): void
     {
         $changed = [

--- a/backend/tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php
+++ b/backend/tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php
@@ -22,6 +22,7 @@ final class MbtiCanonicalSectionRegistryTest extends TestCase
         $this->assertArrayHasKey('career.work_experiments', $definitions);
         $this->assertArrayHasKey('career.next_step', $definitions);
         $this->assertArrayHasKey('traits.at_difference', $definitions);
+        $this->assertArrayHasKey('faq', $definitions);
         $this->assertArrayHasKey('traits.why_this_type', $definitions);
         $this->assertArrayHasKey('traits.close_call_axes', $definitions);
         $this->assertArrayHasKey('traits.adjacent_type_contrast', $definitions);
@@ -40,6 +41,10 @@ final class MbtiCanonicalSectionRegistryTest extends TestCase
         $this->assertSame(
             MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREFERRED_ROLE_LIST,
             $definitions['career.preferred_roles']['render_variant']
+        );
+        $this->assertSame(
+            MbtiCanonicalSectionRegistry::RENDER_VARIANT_FAQ,
+            $definitions['faq']['render_variant']
         );
     }
 

--- a/content_baselines/personality/mbti.en.json
+++ b/content_baselines/personality/mbti.en.json
@@ -3099,6 +3099,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENFJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENFJ-A",
+            "base_type_code": "ENFJ",
+            "sibling_runtime_type_code": "ENFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfj-a-meaning",
+                "question": "What does ENFJ-A mean?",
+                "answer": "ENFJ-A describes the ENFJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "enfj-a-at-difference",
+                "question": "How is ENFJ-A different from ENFJ-T?",
+                "answer": "ENFJ-A and ENFJ-T share the same ENFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "enfj-a-career",
+                "question": "Which careers fit ENFJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENFJ-A usually works best when the role matches the ENFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "enfj-a-relationships",
+                "question": "What should ENFJ-A watch for in relationships?",
+                "answer": "ENFJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-functioning and carrying too much responsibility for the emotional climate.",
@@ -3594,6 +3632,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENFJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENFJ-T",
+            "base_type_code": "ENFJ",
+            "sibling_runtime_type_code": "ENFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfj-t-meaning",
+                "question": "What does ENFJ-T mean?",
+                "answer": "ENFJ-T describes the ENFJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "enfj-t-at-difference",
+                "question": "How is ENFJ-T different from ENFJ-A?",
+                "answer": "ENFJ-T and ENFJ-A share the same ENFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "enfj-t-career",
+                "question": "Which careers fit ENFJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENFJ-T usually works best when the role matches the ENFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "enfj-t-relationships",
+                "question": "What should ENFJ-T watch for in relationships?",
+                "answer": "ENFJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -4095,6 +4171,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENFP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENFP-A",
+            "base_type_code": "ENFP",
+            "sibling_runtime_type_code": "ENFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfp-a-meaning",
+                "question": "What does ENFP-A mean?",
+                "answer": "ENFP-A describes the ENFP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "enfp-a-at-difference",
+                "question": "How is ENFP-A different from ENFP-T?",
+                "answer": "ENFP-A and ENFP-T share the same ENFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "enfp-a-career",
+                "question": "Which careers fit ENFP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENFP-A usually works best when the role matches the ENFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "enfp-a-relationships",
+                "question": "What should ENFP-A watch for in relationships?",
+                "answer": "ENFP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into scattering your energy or drifting when connection stops evolving.",
@@ -4590,6 +4704,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENFP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENFP-T",
+            "base_type_code": "ENFP",
+            "sibling_runtime_type_code": "ENFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfp-t-meaning",
+                "question": "What does ENFP-T mean?",
+                "answer": "ENFP-T describes the ENFP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "enfp-t-at-difference",
+                "question": "How is ENFP-T different from ENFP-A?",
+                "answer": "ENFP-T and ENFP-A share the same ENFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "enfp-t-career",
+                "question": "Which careers fit ENFP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENFP-T usually works best when the role matches the ENFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "enfp-t-relationships",
+                "question": "What should ENFP-T watch for in relationships?",
+                "answer": "ENFP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -5091,6 +5243,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENTJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENTJ-A",
+            "base_type_code": "ENTJ",
+            "sibling_runtime_type_code": "ENTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entj-a-meaning",
+                "question": "What does ENTJ-A mean?",
+                "answer": "ENTJ-A describes the ENTJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "entj-a-at-difference",
+                "question": "How is ENTJ-A different from ENTJ-T?",
+                "answer": "ENTJ-A and ENTJ-T share the same ENTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "entj-a-career",
+                "question": "Which careers fit ENTJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENTJ-A usually works best when the role matches the ENTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "entj-a-relationships",
+                "question": "What should ENTJ-A watch for in relationships?",
+                "answer": "ENTJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into letting achievement logic overshadow emotional softness or shared pace.",
@@ -5586,6 +5776,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENTJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENTJ-T",
+            "base_type_code": "ENTJ",
+            "sibling_runtime_type_code": "ENTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entj-t-meaning",
+                "question": "What does ENTJ-T mean?",
+                "answer": "ENTJ-T describes the ENTJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "entj-t-at-difference",
+                "question": "How is ENTJ-T different from ENTJ-A?",
+                "answer": "ENTJ-T and ENTJ-A share the same ENTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "entj-t-career",
+                "question": "Which careers fit ENTJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENTJ-T usually works best when the role matches the ENTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "entj-t-relationships",
+                "question": "What should ENTJ-T watch for in relationships?",
+                "answer": "ENTJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -6087,6 +6315,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENTP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENTP-A",
+            "base_type_code": "ENTP",
+            "sibling_runtime_type_code": "ENTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entp-a-meaning",
+                "question": "What does ENTP-A mean?",
+                "answer": "ENTP-A describes the ENTP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "entp-a-at-difference",
+                "question": "How is ENTP-A different from ENTP-T?",
+                "answer": "ENTP-A and ENTP-T share the same ENTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "entp-a-career",
+                "question": "Which careers fit ENTP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENTP-A usually works best when the role matches the ENTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "entp-a-relationships",
+                "question": "What should ENTP-A watch for in relationships?",
+                "answer": "ENTP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying at the level of ideas when deeper emotional processing is needed.",
@@ -6582,6 +6848,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ENTP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ENTP-T",
+            "base_type_code": "ENTP",
+            "sibling_runtime_type_code": "ENTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entp-t-meaning",
+                "question": "What does ENTP-T mean?",
+                "answer": "ENTP-T describes the ENTP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "entp-t-at-difference",
+                "question": "How is ENTP-T different from ENTP-A?",
+                "answer": "ENTP-T and ENTP-A share the same ENTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "entp-t-career",
+                "question": "Which careers fit ENTP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ENTP-T usually works best when the role matches the ENTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "entp-t-relationships",
+                "question": "What should ENTP-T watch for in relationships?",
+                "answer": "ENTP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -7083,6 +7387,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESFJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESFJ-A",
+            "base_type_code": "ESFJ",
+            "sibling_runtime_type_code": "ESFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfj-a-meaning",
+                "question": "What does ESFJ-A mean?",
+                "answer": "ESFJ-A describes the ESFJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "esfj-a-at-difference",
+                "question": "How is ESFJ-A different from ESFJ-T?",
+                "answer": "ESFJ-A and ESFJ-T share the same ESFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "esfj-a-career",
+                "question": "Which careers fit ESFJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESFJ-A usually works best when the role matches the ESFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "esfj-a-relationships",
+                "question": "What should ESFJ-A watch for in relationships?",
+                "answer": "ESFJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into over-giving and hoping care alone will restore balance.",
@@ -7578,6 +7920,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESFJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESFJ-T",
+            "base_type_code": "ESFJ",
+            "sibling_runtime_type_code": "ESFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfj-t-meaning",
+                "question": "What does ESFJ-T mean?",
+                "answer": "ESFJ-T describes the ESFJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "esfj-t-at-difference",
+                "question": "How is ESFJ-T different from ESFJ-A?",
+                "answer": "ESFJ-T and ESFJ-A share the same ESFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "esfj-t-career",
+                "question": "Which careers fit ESFJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESFJ-T usually works best when the role matches the ESFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "esfj-t-relationships",
+                "question": "What should ESFJ-T watch for in relationships?",
+                "answer": "ESFJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -8079,6 +8459,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESFP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESFP-A",
+            "base_type_code": "ESFP",
+            "sibling_runtime_type_code": "ESFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfp-a-meaning",
+                "question": "What does ESFP-A mean?",
+                "answer": "ESFP-A describes the ESFP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "esfp-a-at-difference",
+                "question": "How is ESFP-A different from ESFP-T?",
+                "answer": "ESFP-A and ESFP-T share the same ESFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "esfp-a-career",
+                "question": "Which careers fit ESFP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESFP-A usually works best when the role matches the ESFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "esfp-a-relationships",
+                "question": "What should ESFP-A watch for in relationships?",
+                "answer": "ESFP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping things bright while avoiding slower, heavier emotions.",
@@ -8574,6 +8992,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESFP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESFP-T",
+            "base_type_code": "ESFP",
+            "sibling_runtime_type_code": "ESFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfp-t-meaning",
+                "question": "What does ESFP-T mean?",
+                "answer": "ESFP-T describes the ESFP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "esfp-t-at-difference",
+                "question": "How is ESFP-T different from ESFP-A?",
+                "answer": "ESFP-T and ESFP-A share the same ESFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "esfp-t-career",
+                "question": "Which careers fit ESFP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESFP-T usually works best when the role matches the ESFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "esfp-t-relationships",
+                "question": "What should ESFP-T watch for in relationships?",
+                "answer": "ESFP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -9075,6 +9531,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESTJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESTJ-A",
+            "base_type_code": "ESTJ",
+            "sibling_runtime_type_code": "ESTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estj-a-meaning",
+                "question": "What does ESTJ-A mean?",
+                "answer": "ESTJ-A describes the ESTJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "estj-a-at-difference",
+                "question": "How is ESTJ-A different from ESTJ-T?",
+                "answer": "ESTJ-A and ESTJ-T share the same ESTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "estj-a-career",
+                "question": "Which careers fit ESTJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESTJ-A usually works best when the role matches the ESTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "estj-a-relationships",
+                "question": "What should ESTJ-A watch for in relationships?",
+                "answer": "ESTJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into turning care into control or correction without enough softness.",
@@ -9570,6 +10064,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESTJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESTJ-T",
+            "base_type_code": "ESTJ",
+            "sibling_runtime_type_code": "ESTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estj-t-meaning",
+                "question": "What does ESTJ-T mean?",
+                "answer": "ESTJ-T describes the ESTJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "estj-t-at-difference",
+                "question": "How is ESTJ-T different from ESTJ-A?",
+                "answer": "ESTJ-T and ESTJ-A share the same ESTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "estj-t-career",
+                "question": "Which careers fit ESTJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESTJ-T usually works best when the role matches the ESTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "estj-t-relationships",
+                "question": "What should ESTJ-T watch for in relationships?",
+                "answer": "ESTJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -10071,6 +10603,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESTP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESTP-A",
+            "base_type_code": "ESTP",
+            "sibling_runtime_type_code": "ESTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estp-a-meaning",
+                "question": "What does ESTP-A mean?",
+                "answer": "ESTP-A describes the ESTP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "estp-a-at-difference",
+                "question": "How is ESTP-A different from ESTP-T?",
+                "answer": "ESTP-A and ESTP-T share the same ESTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "estp-a-career",
+                "question": "Which careers fit ESTP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESTP-A usually works best when the role matches the ESTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "estp-a-relationships",
+                "question": "What should ESTP-A watch for in relationships?",
+                "answer": "ESTP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into moving faster than emotional understanding or long-term reflection.",
@@ -10566,6 +11136,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ESTP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ESTP-T",
+            "base_type_code": "ESTP",
+            "sibling_runtime_type_code": "ESTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estp-t-meaning",
+                "question": "What does ESTP-T mean?",
+                "answer": "ESTP-T describes the ESTP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "estp-t-at-difference",
+                "question": "How is ESTP-T different from ESTP-A?",
+                "answer": "ESTP-T and ESTP-A share the same ESTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "estp-t-career",
+                "question": "Which careers fit ESTP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ESTP-T usually works best when the role matches the ESTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "estp-t-relationships",
+                "question": "What should ESTP-T watch for in relationships?",
+                "answer": "ESTP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -11067,6 +11675,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INFJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INFJ-A",
+            "base_type_code": "INFJ",
+            "sibling_runtime_type_code": "INFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infj-a-meaning",
+                "question": "What does INFJ-A mean?",
+                "answer": "INFJ-A describes the INFJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "infj-a-at-difference",
+                "question": "How is INFJ-A different from INFJ-T?",
+                "answer": "INFJ-A and INFJ-T share the same INFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "infj-a-career",
+                "question": "Which careers fit INFJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INFJ-A usually works best when the role matches the INFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "infj-a-relationships",
+                "question": "What should INFJ-A watch for in relationships?",
+                "answer": "INFJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into keeping too much inside and carrying hurt without naming it clearly enough.",
@@ -11562,6 +12208,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INFJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INFJ-T",
+            "base_type_code": "INFJ",
+            "sibling_runtime_type_code": "INFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infj-t-meaning",
+                "question": "What does INFJ-T mean?",
+                "answer": "INFJ-T describes the INFJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "infj-t-at-difference",
+                "question": "How is INFJ-T different from INFJ-A?",
+                "answer": "INFJ-T and INFJ-A share the same INFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "infj-t-career",
+                "question": "Which careers fit INFJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INFJ-T usually works best when the role matches the INFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "infj-t-relationships",
+                "question": "What should INFJ-T watch for in relationships?",
+                "answer": "INFJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -12063,6 +12747,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INFP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INFP-A",
+            "base_type_code": "INFP",
+            "sibling_runtime_type_code": "INFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infp-a-meaning",
+                "question": "What does INFP-A mean?",
+                "answer": "INFP-A describes the INFP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "infp-a-at-difference",
+                "question": "How is INFP-A different from INFP-T?",
+                "answer": "INFP-A and INFP-T share the same INFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "infp-a-career",
+                "question": "Which careers fit INFP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INFP-A usually works best when the role matches the INFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "infp-a-relationships",
+                "question": "What should INFP-A watch for in relationships?",
+                "answer": "INFP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying quiet about pain while hoping harmony or potential will fix what is wrong.",
@@ -12558,6 +13280,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INFP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INFP-T",
+            "base_type_code": "INFP",
+            "sibling_runtime_type_code": "INFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infp-t-meaning",
+                "question": "What does INFP-T mean?",
+                "answer": "INFP-T describes the INFP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "infp-t-at-difference",
+                "question": "How is INFP-T different from INFP-A?",
+                "answer": "INFP-T and INFP-A share the same INFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "infp-t-career",
+                "question": "Which careers fit INFP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INFP-T usually works best when the role matches the INFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "infp-t-relationships",
+                "question": "What should INFP-T watch for in relationships?",
+                "answer": "INFP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -13059,6 +13819,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INTJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INTJ-A",
+            "base_type_code": "INTJ",
+            "sibling_runtime_type_code": "INTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intj-a-meaning",
+                "question": "What does INTJ-A mean?",
+                "answer": "INTJ-A describes the INTJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "intj-a-at-difference",
+                "question": "How is INTJ-A different from INTJ-T?",
+                "answer": "INTJ-A and INTJ-T share the same INTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "intj-a-career",
+                "question": "Which careers fit INTJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INTJ-A usually works best when the role matches the INTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "intj-a-relationships",
+                "question": "What should INTJ-A watch for in relationships?",
+                "answer": "INTJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into retreating into analysis or distance when emotional complexity rises.",
@@ -13554,6 +14352,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INTJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INTJ-T",
+            "base_type_code": "INTJ",
+            "sibling_runtime_type_code": "INTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intj-t-meaning",
+                "question": "What does INTJ-T mean?",
+                "answer": "INTJ-T describes the INTJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "intj-t-at-difference",
+                "question": "How is INTJ-T different from INTJ-A?",
+                "answer": "INTJ-T and INTJ-A share the same INTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "intj-t-career",
+                "question": "Which careers fit INTJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INTJ-T usually works best when the role matches the INTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "intj-t-relationships",
+                "question": "What should INTJ-T watch for in relationships?",
+                "answer": "INTJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -14055,6 +14891,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INTP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INTP-A",
+            "base_type_code": "INTP",
+            "sibling_runtime_type_code": "INTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intp-a-meaning",
+                "question": "What does INTP-A mean?",
+                "answer": "INTP-A describes the INTP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "intp-a-at-difference",
+                "question": "How is INTP-A different from INTP-T?",
+                "answer": "INTP-A and INTP-T share the same INTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "intp-a-career",
+                "question": "Which careers fit INTP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INTP-A usually works best when the role matches the INTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "intp-a-relationships",
+                "question": "What should INTP-A watch for in relationships?",
+                "answer": "INTP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into staying too much in your head and under-translating warmth or emotional clarity.",
@@ -14550,6 +15424,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about INTP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "INTP-T",
+            "base_type_code": "INTP",
+            "sibling_runtime_type_code": "INTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intp-t-meaning",
+                "question": "What does INTP-T mean?",
+                "answer": "INTP-T describes the INTP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "intp-t-at-difference",
+                "question": "How is INTP-T different from INTP-A?",
+                "answer": "INTP-T and INTP-A share the same INTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "intp-t-career",
+                "question": "Which careers fit INTP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. INTP-T usually works best when the role matches the INTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "intp-t-relationships",
+                "question": "What should INTP-T watch for in relationships?",
+                "answer": "INTP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -15051,6 +15963,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISFJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISFJ-A",
+            "base_type_code": "ISFJ",
+            "sibling_runtime_type_code": "ISFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfj-a-meaning",
+                "question": "What does ISFJ-A mean?",
+                "answer": "ISFJ-A describes the ISFJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "isfj-a-at-difference",
+                "question": "How is ISFJ-A different from ISFJ-T?",
+                "answer": "ISFJ-A and ISFJ-T share the same ISFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "isfj-a-career",
+                "question": "Which careers fit ISFJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISFJ-A usually works best when the role matches the ISFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "isfj-a-relationships",
+                "question": "What should ISFJ-A watch for in relationships?",
+                "answer": "ISFJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into absorbing too much strain while minimizing your own needs.",
@@ -15546,6 +16496,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISFJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISFJ-T",
+            "base_type_code": "ISFJ",
+            "sibling_runtime_type_code": "ISFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfj-t-meaning",
+                "question": "What does ISFJ-T mean?",
+                "answer": "ISFJ-T describes the ISFJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "isfj-t-at-difference",
+                "question": "How is ISFJ-T different from ISFJ-A?",
+                "answer": "ISFJ-T and ISFJ-A share the same ISFJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "isfj-t-career",
+                "question": "Which careers fit ISFJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISFJ-T usually works best when the role matches the ISFJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "isfj-t-relationships",
+                "question": "What should ISFJ-T watch for in relationships?",
+                "answer": "ISFJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -16047,6 +17035,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISFP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISFP-A",
+            "base_type_code": "ISFP",
+            "sibling_runtime_type_code": "ISFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfp-a-meaning",
+                "question": "What does ISFP-A mean?",
+                "answer": "ISFP-A describes the ISFP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "isfp-a-at-difference",
+                "question": "How is ISFP-A different from ISFP-T?",
+                "answer": "ISFP-A and ISFP-T share the same ISFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "isfp-a-career",
+                "question": "Which careers fit ISFP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISFP-A usually works best when the role matches the ISFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "isfp-a-relationships",
+                "question": "What should ISFP-A watch for in relationships?",
+                "answer": "ISFP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into going silent under strain instead of making needs and boundaries explicit.",
@@ -16542,6 +17568,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISFP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISFP-T",
+            "base_type_code": "ISFP",
+            "sibling_runtime_type_code": "ISFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfp-t-meaning",
+                "question": "What does ISFP-T mean?",
+                "answer": "ISFP-T describes the ISFP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "isfp-t-at-difference",
+                "question": "How is ISFP-T different from ISFP-A?",
+                "answer": "ISFP-T and ISFP-A share the same ISFP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "isfp-t-career",
+                "question": "Which careers fit ISFP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISFP-T usually works best when the role matches the ISFP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "isfp-t-relationships",
+                "question": "What should ISFP-T watch for in relationships?",
+                "answer": "ISFP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -17043,6 +18107,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISTJ-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISTJ-A",
+            "base_type_code": "ISTJ",
+            "sibling_runtime_type_code": "ISTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istj-a-meaning",
+                "question": "What does ISTJ-A mean?",
+                "answer": "ISTJ-A describes the ISTJ core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "istj-a-at-difference",
+                "question": "How is ISTJ-A different from ISTJ-T?",
+                "answer": "ISTJ-A and ISTJ-T share the same ISTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "istj-a-career",
+                "question": "Which careers fit ISTJ-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISTJ-A usually works best when the role matches the ISTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "istj-a-relationships",
+                "question": "What should ISTJ-A watch for in relationships?",
+                "answer": "ISTJ-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into becoming dutiful but under-expressive when stress rises.",
@@ -17538,6 +18640,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISTJ-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISTJ-T",
+            "base_type_code": "ISTJ",
+            "sibling_runtime_type_code": "ISTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istj-t-meaning",
+                "question": "What does ISTJ-T mean?",
+                "answer": "ISTJ-T describes the ISTJ core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "istj-t-at-difference",
+                "question": "How is ISTJ-T different from ISTJ-A?",
+                "answer": "ISTJ-T and ISTJ-A share the same ISTJ preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "istj-t-career",
+                "question": "Which careers fit ISTJ-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISTJ-T usually works best when the role matches the ISTJ decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "istj-t-relationships",
+                "question": "What should ISTJ-T watch for in relationships?",
+                "answer": "ISTJ-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -18039,6 +19179,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISTP-A, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISTP-A",
+            "base_type_code": "ISTP",
+            "sibling_runtime_type_code": "ISTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istp-a-meaning",
+                "question": "What does ISTP-A mean?",
+                "answer": "ISTP-A describes the ISTP core pattern with a more assertive identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "istp-a-at-difference",
+                "question": "How is ISTP-A different from ISTP-T?",
+                "answer": "ISTP-A and ISTP-T share the same ISTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "istp-a-career",
+                "question": "Which careers fit ISTP-A?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISTP-A usually works best when the role matches the ISTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "istp-a-relationships",
+                "question": "What should ISTP-A watch for in relationships?",
+                "answer": "ISTP-A should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "Growth for you is less about becoming someone else and more about making your natural strengths sustainable.\n\nYour key lesson is learning how to use your strengths fully without slipping into disappearing into self-sufficiency and leaving feelings underexplained.",
@@ -18534,6 +19712,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "Frequently asked questions",
+          "render_variant": "faq",
+          "body_md": "Common questions about ISTP-T, covering this page's scope, the A/T layer, career reading, and relationship interpretation boundaries.",
+          "body_html": null,
+          "payload_json": {
+            "title": "Frequently asked questions",
+            "runtime_type_code": "ISTP-T",
+            "base_type_code": "ISTP",
+            "sibling_runtime_type_code": "ISTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istp-t-meaning",
+                "question": "What does ISTP-T mean?",
+                "answer": "ISTP-T describes the ISTP core pattern with a more turbulent identity layer. Read it as a pressure-and-feedback style on top of the same four-letter base, not as a completely separate type."
+              },
+              {
+                "key": "istp-t-at-difference",
+                "question": "How is ISTP-T different from ISTP-A?",
+                "answer": "ISTP-T and ISTP-A share the same ISTP preferences. The difference is mainly how confidence, stress recovery, feedback sensitivity, and self-questioning tend to show up in daily decisions."
+              },
+              {
+                "key": "istp-t-career",
+                "question": "Which careers fit ISTP-T?",
+                "answer": "Use the career guidance on this page as a direction map rather than a job label. ISTP-T usually works best when the role matches the ISTP decision style, energy pattern, and growth needs described in the sections above."
+              },
+              {
+                "key": "istp-t-relationships",
+                "question": "What should ISTP-T watch for in relationships?",
+                "answer": "ISTP-T should compare its communication style, stress response, and feedback habits with the relationship sections on this page. The goal is practical self-awareness, not a fixed prediction about compatibility."
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {

--- a/content_baselines/personality/mbti.zh-CN.json
+++ b/content_baselines/personality/mbti.zh-CN.json
@@ -3097,6 +3097,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENFJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENFJ-A",
+            "base_type_code": "ENFJ",
+            "sibling_runtime_type_code": "ENFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfj-a-meaning",
+                "question": "ENFJ-A 是什么意思？",
+                "answer": "ENFJ-A 表示 ENFJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "enfj-a-at-difference",
+                "question": "ENFJ-A 和 ENFJ-T 有什么区别？",
+                "answer": "ENFJ-A 和 ENFJ-T 共享 ENFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "enfj-a-career",
+                "question": "ENFJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENFJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "enfj-a-relationships",
+                "question": "ENFJ-A 在关系中需要注意什么？",
+                "answer": "ENFJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ENFJ-A 来说，成长更像是一条“持续升级影响力”的路：在保持温度与理想的同时，让自己的内在更加稳、边界更加清晰。\n\n这一章节，会从你的强项、短板，以及能量管理几个角度，帮你看清更适合自己的成长路径。",
@@ -3915,6 +3953,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENFJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENFJ-T",
+            "base_type_code": "ENFJ",
+            "sibling_runtime_type_code": "ENFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfj-t-meaning",
+                "question": "ENFJ-T 是什么意思？",
+                "answer": "ENFJ-T 表示 ENFJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "enfj-t-at-difference",
+                "question": "ENFJ-T 和 ENFJ-A 有什么区别？",
+                "answer": "ENFJ-T 和 ENFJ-A 共享 ENFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "enfj-t-career",
+                "question": "ENFJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENFJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "enfj-t-relationships",
+                "question": "ENFJ-T 在关系中需要注意什么？",
+                "answer": "ENFJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -4739,6 +4815,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENFP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENFP-A",
+            "base_type_code": "ENFP",
+            "sibling_runtime_type_code": "ENFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfp-a-meaning",
+                "question": "ENFP-A 是什么意思？",
+                "answer": "ENFP-A 表示 ENFP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "enfp-a-at-difference",
+                "question": "ENFP-A 和 ENFP-T 有什么区别？",
+                "answer": "ENFP-A 和 ENFP-T 共享 ENFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "enfp-a-career",
+                "question": "ENFP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENFP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "enfp-a-relationships",
+                "question": "ENFP-A 在关系中需要注意什么？",
+                "answer": "ENFP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ENFP-A 来说，成长不是把自己变成“更听话、更标准”的样子，而是在保留好奇与热情的前提下，学会更稳定、更持续地发挥天赋。\n\n这一部分，会从你的强项与短板出发，帮你更清晰地看到：怎样设计一条既不压抑自己、又能持续进步的成长路径。",
@@ -5558,6 +5672,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENFP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENFP-T",
+            "base_type_code": "ENFP",
+            "sibling_runtime_type_code": "ENFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "enfp-t-meaning",
+                "question": "ENFP-T 是什么意思？",
+                "answer": "ENFP-T 表示 ENFP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "enfp-t-at-difference",
+                "question": "ENFP-T 和 ENFP-A 有什么区别？",
+                "answer": "ENFP-T 和 ENFP-A 共享 ENFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "enfp-t-career",
+                "question": "ENFP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENFP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "enfp-t-relationships",
+                "question": "ENFP-T 在关系中需要注意什么？",
+                "answer": "ENFP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -6386,6 +6538,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENTJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENTJ-A",
+            "base_type_code": "ENTJ",
+            "sibling_runtime_type_code": "ENTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entj-a-meaning",
+                "question": "ENTJ-A 是什么意思？",
+                "answer": "ENTJ-A 表示 ENTJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "entj-a-at-difference",
+                "question": "ENTJ-A 和 ENTJ-T 有什么区别？",
+                "answer": "ENTJ-A 和 ENTJ-T 共享 ENTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "entj-a-career",
+                "question": "ENTJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENTJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "entj-a-relationships",
+                "question": "ENTJ-A 在关系中需要注意什么？",
+                "answer": "ENTJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ENTJ-A 来说，成长不只是“更高的位置”和“更大的盘子”，而是学会在强大的执行力之外，加上一套同样成熟的情绪与关系能力。\n\n这一章节，从你的成长优势、短板，以及驱动你前进或让你消耗的因素入手，帮你看清下一步可以优化的方向。",
@@ -7208,6 +7398,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENTJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENTJ-T",
+            "base_type_code": "ENTJ",
+            "sibling_runtime_type_code": "ENTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entj-t-meaning",
+                "question": "ENTJ-T 是什么意思？",
+                "answer": "ENTJ-T 表示 ENTJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "entj-t-at-difference",
+                "question": "ENTJ-T 和 ENTJ-A 有什么区别？",
+                "answer": "ENTJ-T 和 ENTJ-A 共享 ENTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "entj-t-career",
+                "question": "ENTJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENTJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "entj-t-relationships",
+                "question": "ENTJ-T 在关系中需要注意什么？",
+                "answer": "ENTJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ENTJ-T 来说，成长不是“从弱到强”，而是“从只会赢项目，到也会赢人心，从只看结果，到也关照过程”。你已经拥有强大的执行与决策能力，接下来要练习的，是如何与自己和他人更好地相处。\n\n这一章节会从你的内在优势、潜在短板，以及能量的来源与流失，帮你更清晰地看见自己的成长路径。",
@@ -8026,6 +8254,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENTP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENTP-A",
+            "base_type_code": "ENTP",
+            "sibling_runtime_type_code": "ENTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entp-a-meaning",
+                "question": "ENTP-A 是什么意思？",
+                "answer": "ENTP-A 表示 ENTP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "entp-a-at-difference",
+                "question": "ENTP-A 和 ENTP-T 有什么区别？",
+                "answer": "ENTP-A 和 ENTP-T 共享 ENTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "entp-a-career",
+                "question": "ENTP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENTP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "entp-a-relationships",
+                "question": "ENTP-A 在关系中需要注意什么？",
+                "answer": "ENTP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -8853,6 +9119,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ENTP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ENTP-T",
+            "base_type_code": "ENTP",
+            "sibling_runtime_type_code": "ENTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "entp-t-meaning",
+                "question": "ENTP-T 是什么意思？",
+                "answer": "ENTP-T 表示 ENTP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "entp-t-at-difference",
+                "question": "ENTP-T 和 ENTP-A 有什么区别？",
+                "answer": "ENTP-T 和 ENTP-A 共享 ENTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "entp-t-career",
+                "question": "ENTP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ENTP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "entp-t-relationships",
+                "question": "ENTP-T 在关系中需要注意什么？",
+                "answer": "ENTP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ENTP-T 来说，成长不是“乖乖变稳定”，而是学会在保持好奇与锋利的同时，让自己的行动更有方向感和持续性。\n\n你既不甘心被日常磨平，又不想永远停留在“想得多、做得少”的悖论里。这一章，会帮你看清：你的天然优势、典型短板，以及能帮你升级的关键杠杆。",
@@ -9672,6 +9976,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESFJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESFJ-A",
+            "base_type_code": "ESFJ",
+            "sibling_runtime_type_code": "ESFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfj-a-meaning",
+                "question": "ESFJ-A 是什么意思？",
+                "answer": "ESFJ-A 表示 ESFJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "esfj-a-at-difference",
+                "question": "ESFJ-A 和 ESFJ-T 有什么区别？",
+                "answer": "ESFJ-A 和 ESFJ-T 共享 ESFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "esfj-a-career",
+                "question": "ESFJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESFJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "esfj-a-relationships",
+                "question": "ESFJ-A 在关系中需要注意什么？",
+                "answer": "ESFJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -10495,6 +10837,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESFJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESFJ-T",
+            "base_type_code": "ESFJ",
+            "sibling_runtime_type_code": "ESFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfj-t-meaning",
+                "question": "ESFJ-T 是什么意思？",
+                "answer": "ESFJ-T 表示 ESFJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "esfj-t-at-difference",
+                "question": "ESFJ-T 和 ESFJ-A 有什么区别？",
+                "answer": "ESFJ-T 和 ESFJ-A 共享 ESFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "esfj-t-career",
+                "question": "ESFJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESFJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "esfj-t-relationships",
+                "question": "ESFJ-T 在关系中需要注意什么？",
+                "answer": "ESFJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ESFJ-T 来说，成长不是变成一个“完全不在乎别人看法的人”，而是在关心他人的同时，也允许自己按照内心的节奏生活。\n\n这一章节，会从你的强项、短板，以及能量的来源与消耗几个角度，帮你看清：怎样的成长，是真正属于你的。",
@@ -11311,6 +11691,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESFP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESFP-A",
+            "base_type_code": "ESFP",
+            "sibling_runtime_type_code": "ESFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfp-a-meaning",
+                "question": "ESFP-A 是什么意思？",
+                "answer": "ESFP-A 表示 ESFP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "esfp-a-at-difference",
+                "question": "ESFP-A 和 ESFP-T 有什么区别？",
+                "answer": "ESFP-A 和 ESFP-T 共享 ESFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "esfp-a-career",
+                "question": "ESFP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESFP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "esfp-a-relationships",
+                "question": "ESFP-A 在关系中需要注意什么？",
+                "answer": "ESFP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -12135,6 +12553,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESFP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESFP-T",
+            "base_type_code": "ESFP",
+            "sibling_runtime_type_code": "ESFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "esfp-t-meaning",
+                "question": "ESFP-T 是什么意思？",
+                "answer": "ESFP-T 表示 ESFP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "esfp-t-at-difference",
+                "question": "ESFP-T 和 ESFP-A 有什么区别？",
+                "answer": "ESFP-T 和 ESFP-A 共享 ESFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "esfp-t-career",
+                "question": "ESFP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESFP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "esfp-t-relationships",
+                "question": "ESFP-T 在关系中需要注意什么？",
+                "answer": "ESFP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ESFP-T 来说，成长并不是把自己变成另一个类型，而是学会：在继续热爱当下的同时，也为未来留一点空间。\n\n你天生就会为别人带来快乐和活力，但若想让自己的生活同样稳定而有质感，你需要在节奏、自律和内在安定感上多花一点心思。",
@@ -12954,6 +13410,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESTJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESTJ-A",
+            "base_type_code": "ESTJ",
+            "sibling_runtime_type_code": "ESTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estj-a-meaning",
+                "question": "ESTJ-A 是什么意思？",
+                "answer": "ESTJ-A 表示 ESTJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "estj-a-at-difference",
+                "question": "ESTJ-A 和 ESTJ-T 有什么区别？",
+                "answer": "ESTJ-A 和 ESTJ-T 共享 ESTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "estj-a-career",
+                "question": "ESTJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESTJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "estj-a-relationships",
+                "question": "ESTJ-A 在关系中需要注意什么？",
+                "answer": "ESTJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -13780,6 +14274,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESTJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESTJ-T",
+            "base_type_code": "ESTJ",
+            "sibling_runtime_type_code": "ESTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estj-t-meaning",
+                "question": "ESTJ-T 是什么意思？",
+                "answer": "ESTJ-T 表示 ESTJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "estj-t-at-difference",
+                "question": "ESTJ-T 和 ESTJ-A 有什么区别？",
+                "answer": "ESTJ-T 和 ESTJ-A 共享 ESTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "estj-t-career",
+                "question": "ESTJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESTJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "estj-t-relationships",
+                "question": "ESTJ-T 在关系中需要注意什么？",
+                "answer": "ESTJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ESTJ-T 来说，成长并不只是“做得更快、更准”，而是“在坚持原则的同时，让自己活得更轻松，让关系更顺畅”。\n\n你天生就具备很强的执行力与责任感，这让你在很多场景里成为“关键人物”。而接下来的成长，更像是在你的骨架之上，加上一些柔韧与空间。",
@@ -14598,6 +15130,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESTP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESTP-A",
+            "base_type_code": "ESTP",
+            "sibling_runtime_type_code": "ESTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estp-a-meaning",
+                "question": "ESTP-A 是什么意思？",
+                "answer": "ESTP-A 表示 ESTP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "estp-a-at-difference",
+                "question": "ESTP-A 和 ESTP-T 有什么区别？",
+                "answer": "ESTP-A 和 ESTP-T 共享 ESTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "estp-a-career",
+                "question": "ESTP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESTP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "estp-a-relationships",
+                "question": "ESTP-A 在关系中需要注意什么？",
+                "answer": "ESTP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -15423,6 +15993,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ESTP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ESTP-T",
+            "base_type_code": "ESTP",
+            "sibling_runtime_type_code": "ESTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "estp-t-meaning",
+                "question": "ESTP-T 是什么意思？",
+                "answer": "ESTP-T 表示 ESTP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "estp-t-at-difference",
+                "question": "ESTP-T 和 ESTP-A 有什么区别？",
+                "answer": "ESTP-T 和 ESTP-A 共享 ESTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "estp-t-career",
+                "question": "ESTP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ESTP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "estp-t-relationships",
+                "question": "ESTP-T 在关系中需要注意什么？",
+                "answer": "ESTP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ESTP-T 来说，成长不是“把自己变成一个慢吞吞的规划型”，而是：在保留你锐利的直觉和行动力的前提下，让它们变得更稳、更可控。\n\n这一章节，会从你的强项、短板，以及能量的来源与消耗几个角度，帮你看清自己的进阶路径。",
@@ -16240,6 +16848,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INFJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INFJ-A",
+            "base_type_code": "INFJ",
+            "sibling_runtime_type_code": "INFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infj-a-meaning",
+                "question": "INFJ-A 是什么意思？",
+                "answer": "INFJ-A 表示 INFJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "infj-a-at-difference",
+                "question": "INFJ-A 和 INFJ-T 有什么区别？",
+                "answer": "INFJ-A 和 INFJ-T 共享 INFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "infj-a-career",
+                "question": "INFJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INFJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "infj-a-relationships",
+                "question": "INFJ-A 在关系中需要注意什么？",
+                "answer": "INFJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -17066,6 +17712,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INFJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INFJ-T",
+            "base_type_code": "INFJ",
+            "sibling_runtime_type_code": "INFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infj-t-meaning",
+                "question": "INFJ-T 是什么意思？",
+                "answer": "INFJ-T 表示 INFJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "infj-t-at-difference",
+                "question": "INFJ-T 和 INFJ-A 有什么区别？",
+                "answer": "INFJ-T 和 INFJ-A 共享 INFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "infj-t-career",
+                "question": "INFJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INFJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "infj-t-relationships",
+                "question": "INFJ-T 在关系中需要注意什么？",
+                "answer": "INFJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -17900,6 +18584,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INFP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INFP-A",
+            "base_type_code": "INFP",
+            "sibling_runtime_type_code": "INFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infp-a-meaning",
+                "question": "INFP-A 是什么意思？",
+                "answer": "INFP-A 表示 INFP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "infp-a-at-difference",
+                "question": "INFP-A 和 INFP-T 有什么区别？",
+                "answer": "INFP-A 和 INFP-T 共享 INFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "infp-a-career",
+                "question": "INFP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INFP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "infp-a-relationships",
+                "question": "INFP-A 在关系中需要注意什么？",
+                "answer": "INFP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 INFP-A 来说，成长既是“向外找到合适的位置”，也是“向内与自己和解”。你想成为更好的自己，但又不想在这个过程中丢掉本来的那份纯粹。\n\n这一部分，会从你的强项、短板，以及能量的来源与流失几个角度，帮你看清：怎样的成长，才是真的对你有用。",
@@ -18728,6 +19450,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INFP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INFP-T",
+            "base_type_code": "INFP",
+            "sibling_runtime_type_code": "INFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "infp-t-meaning",
+                "question": "INFP-T 是什么意思？",
+                "answer": "INFP-T 表示 INFP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "infp-t-at-difference",
+                "question": "INFP-T 和 INFP-A 有什么区别？",
+                "answer": "INFP-T 和 INFP-A 共享 INFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "infp-t-career",
+                "question": "INFP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INFP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "infp-t-relationships",
+                "question": "INFP-T 在关系中需要注意什么？",
+                "answer": "INFP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 INFP-T 来说，成长更多是一场“和自己和解”的旅程。你一方面渴望成为更好的自己，另一方面又害怕在这个过程中失去原本的温柔与真诚。\n\n这一章节，会从你的强项、短板，以及能量的来源与流失等角度，帮你更清晰地看见：怎样的成长路径更适合你。",
@@ -19553,6 +20313,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INTJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INTJ-A",
+            "base_type_code": "INTJ",
+            "sibling_runtime_type_code": "INTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intj-a-meaning",
+                "question": "INTJ-A 是什么意思？",
+                "answer": "INTJ-A 表示 INTJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "intj-a-at-difference",
+                "question": "INTJ-A 和 INTJ-T 有什么区别？",
+                "answer": "INTJ-A 和 INTJ-T 共享 INTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "intj-a-career",
+                "question": "INTJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INTJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "intj-a-relationships",
+                "question": "INTJ-A 在关系中需要注意什么？",
+                "answer": "INTJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 INTJ-A 来说，成长很少只是“多学几项技能”，而更像是在不断升级自己的操作系统：优化认知模型、打磨决策质量、调整人生策略。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点几个角度，帮你更清晰地看到：如何在保持锋利的同时，变得更柔韧、更耐久。",
@@ -20372,6 +21170,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INTJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INTJ-T",
+            "base_type_code": "INTJ",
+            "sibling_runtime_type_code": "INTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intj-t-meaning",
+                "question": "INTJ-T 是什么意思？",
+                "answer": "INTJ-T 表示 INTJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "intj-t-at-difference",
+                "question": "INTJ-T 和 INTJ-A 有什么区别？",
+                "answer": "INTJ-T 和 INTJ-A 共享 INTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "intj-t-career",
+                "question": "INTJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INTJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "intj-t-relationships",
+                "question": "INTJ-T 在关系中需要注意什么？",
+                "answer": "INTJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -21195,6 +22031,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INTP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INTP-A",
+            "base_type_code": "INTP",
+            "sibling_runtime_type_code": "INTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intp-a-meaning",
+                "question": "INTP-A 是什么意思？",
+                "answer": "INTP-A 表示 INTP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "intp-a-at-difference",
+                "question": "INTP-A 和 INTP-T 有什么区别？",
+                "answer": "INTP-A 和 INTP-T 共享 INTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "intp-a-career",
+                "question": "INTP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INTP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "intp-a-relationships",
+                "question": "INTP-A 在关系中需要注意什么？",
+                "answer": "INTP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -22023,6 +22897,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 INTP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "INTP-T",
+            "base_type_code": "INTP",
+            "sibling_runtime_type_code": "INTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "intp-t-meaning",
+                "question": "INTP-T 是什么意思？",
+                "answer": "INTP-T 表示 INTP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "intp-t-at-difference",
+                "question": "INTP-T 和 INTP-A 有什么区别？",
+                "answer": "INTP-T 和 INTP-A 共享 INTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "intp-t-career",
+                "question": "INTP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。INTP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "intp-t-relationships",
+                "question": "INTP-T 在关系中需要注意什么？",
+                "answer": "INTP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 INTP-T 来说，成长更像是“不断迭代自己的操作系统”。你会周期性地重新审视：我的世界观有没有过期？我现在用的这些判断标准，还适不适合当前的人生阶段？\n\n这一部分会帮你看见：你天然具备的成长优势、容易绊倒自己的地方，以及在能量管理上的关键提醒。",
@@ -22848,6 +23760,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISFJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISFJ-A",
+            "base_type_code": "ISFJ",
+            "sibling_runtime_type_code": "ISFJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfj-a-meaning",
+                "question": "ISFJ-A 是什么意思？",
+                "answer": "ISFJ-A 表示 ISFJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "isfj-a-at-difference",
+                "question": "ISFJ-A 和 ISFJ-T 有什么区别？",
+                "answer": "ISFJ-A 和 ISFJ-T 共享 ISFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "isfj-a-career",
+                "question": "ISFJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISFJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "isfj-a-relationships",
+                "question": "ISFJ-A 在关系中需要注意什么？",
+                "answer": "ISFJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ISFJ-A 来说，成长的关键不在于变得多外向、多张扬，而是在于：在继续照顾他人的同时，也把自己照顾进你关心的范围里。\n\n这一章节，会从你的强项、短板，以及能量的来源和流失几个角度，帮你更立体地看见自己。",
@@ -23665,6 +24615,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISFJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISFJ-T",
+            "base_type_code": "ISFJ",
+            "sibling_runtime_type_code": "ISFJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfj-t-meaning",
+                "question": "ISFJ-T 是什么意思？",
+                "answer": "ISFJ-T 表示 ISFJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "isfj-t-at-difference",
+                "question": "ISFJ-T 和 ISFJ-A 有什么区别？",
+                "answer": "ISFJ-T 和 ISFJ-A 共享 ISFJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "isfj-t-career",
+                "question": "ISFJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISFJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "isfj-t-relationships",
+                "question": "ISFJ-T 在关系中需要注意什么？",
+                "answer": "ISFJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -24487,6 +25475,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISFP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISFP-A",
+            "base_type_code": "ISFP",
+            "sibling_runtime_type_code": "ISFP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfp-a-meaning",
+                "question": "ISFP-A 是什么意思？",
+                "answer": "ISFP-A 表示 ISFP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "isfp-a-at-difference",
+                "question": "ISFP-A 和 ISFP-T 有什么区别？",
+                "answer": "ISFP-A 和 ISFP-T 共享 ISFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "isfp-a-career",
+                "question": "ISFP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISFP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "isfp-a-relationships",
+                "question": "ISFP-A 在关系中需要注意什么？",
+                "answer": "ISFP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -25313,6 +26339,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISFP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISFP-T",
+            "base_type_code": "ISFP",
+            "sibling_runtime_type_code": "ISFP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "isfp-t-meaning",
+                "question": "ISFP-T 是什么意思？",
+                "answer": "ISFP-T 表示 ISFP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "isfp-t-at-difference",
+                "question": "ISFP-T 和 ISFP-A 有什么区别？",
+                "answer": "ISFP-T 和 ISFP-A 共享 ISFP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "isfp-t-career",
+                "question": "ISFP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISFP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "isfp-t-relationships",
+                "question": "ISFP-T 在关系中需要注意什么？",
+                "answer": "ISFP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ISFP-T 来说，成长不是把自己磨成一颗坚硬的石头，而是在保持柔软、真实与感受力的同时，学会照顾好自己，不再被情绪和环境牵着走。\n\n这一章节，会从你的强项、短板，以及能量相关的提示，帮助你更温柔地理解并升级自己。",
@@ -26135,6 +27199,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISTJ-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISTJ-A",
+            "base_type_code": "ISTJ",
+            "sibling_runtime_type_code": "ISTJ-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istj-a-meaning",
+                "question": "ISTJ-A 是什么意思？",
+                "answer": "ISTJ-A 表示 ISTJ 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "istj-a-at-difference",
+                "question": "ISTJ-A 和 ISTJ-T 有什么区别？",
+                "answer": "ISTJ-A 和 ISTJ-T 共享 ISTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "istj-a-career",
+                "question": "ISTJ-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISTJ-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "istj-a-relationships",
+                "question": "ISTJ-A 在关系中需要注意什么？",
+                "answer": "ISTJ-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ISTJ-A 来说，成长往往不是“轰轰烈烈的大转变”，而是一点点优化：在保持自己可靠、务实、守信用的前提下，让自己在变化中也不至于僵硬，在关系中也不至于孤立。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点几个角度，帮你看清自己的成长轨迹。",
@@ -26954,6 +28056,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISTJ-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISTJ-T",
+            "base_type_code": "ISTJ",
+            "sibling_runtime_type_code": "ISTJ-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istj-t-meaning",
+                "question": "ISTJ-T 是什么意思？",
+                "answer": "ISTJ-T 表示 ISTJ 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "istj-t-at-difference",
+                "question": "ISTJ-T 和 ISTJ-A 有什么区别？",
+                "answer": "ISTJ-T 和 ISTJ-A 共享 ISTJ 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "istj-t-career",
+                "question": "ISTJ-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISTJ-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "istj-t-relationships",
+                "question": "ISTJ-T 在关系中需要注意什么？",
+                "answer": "ISTJ-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {
@@ -27780,6 +28920,44 @@
           "is_enabled": true
         },
         {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISTP-A 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISTP-A",
+            "base_type_code": "ISTP",
+            "sibling_runtime_type_code": "ISTP-T",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istp-a-meaning",
+                "question": "ISTP-A 是什么意思？",
+                "answer": "ISTP-A 表示 ISTP 的核心人格结构叠加了“自信型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "istp-a-at-difference",
+                "question": "ISTP-A 和 ISTP-T 有什么区别？",
+                "answer": "ISTP-A 和 ISTP-T 共享 ISTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "istp-a-career",
+                "question": "ISTP-A 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISTP-A 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "istp-a-relationships",
+                "question": "ISTP-A 在关系中需要注意什么？",
+                "answer": "ISTP-A 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
           "section_key": "growth.summary",
           "render_variant": "rich_text",
           "body_md": "对 ISTP-A 来说，成长不是“变得话多、变得感性”，而是：在保持自己冷静、务实、独立的同时，学会更好地连接他人、理解情绪，并为未来留一点余地。\n\n这一章节会从你的强项、短板，以及能量来源与消耗点的角度，帮你看清：怎样升级，才既不违背本性，又能走得更远。",
@@ -28602,6 +29780,44 @@
             ]
           },
           "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": "关于 ISTP-T 的常见问题，用于帮助读者快速理解这个人格页面的范围、A/T 含义、职业参考和关系解读边界。",
+          "body_html": null,
+          "payload_json": {
+            "title": "常见问题",
+            "runtime_type_code": "ISTP-T",
+            "base_type_code": "ISTP",
+            "sibling_runtime_type_code": "ISTP-A",
+            "source": "backend_visible_faq",
+            "items": [
+              {
+                "key": "istp-t-meaning",
+                "question": "ISTP-T 是什么意思？",
+                "answer": "ISTP-T 表示 ISTP 的核心人格结构叠加了“动荡型”身份层。它不是一个完全独立的新类型，而是同一四字母类型在压力、反馈和自我确认方式上的具体呈现。"
+              },
+              {
+                "key": "istp-t-at-difference",
+                "question": "ISTP-T 和 ISTP-A 有什么区别？",
+                "answer": "ISTP-T 和 ISTP-A 共享 ISTP 的基本偏好，差异主要体现在自信感、压力恢复、反馈敏感度和自我怀疑强度。阅读时应把 A/T 当作理解状态与节奏的补充层。"
+              },
+              {
+                "key": "istp-t-career",
+                "question": "ISTP-T 适合什么职业？",
+                "answer": "职业建议应作为方向参考，而不是固定岗位标签。ISTP-T 更适合结合本页呈现的决策方式、能量来源、优势盲点和成长需求，去判断工作环境与角色匹配度。"
+              },
+              {
+                "key": "istp-t-relationships",
+                "question": "ISTP-T 在关系中需要注意什么？",
+                "answer": "ISTP-T 可以重点观察自己的沟通节奏、压力反应和对反馈的处理方式。本页关系内容用于提升自我理解，不用于对亲密关系或合作关系做绝对预测。"
+              }
+            ]
+          },
+          "sort_order": 90,
           "is_enabled": true
         },
         {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38349,7 +38349,7 @@
     "merge_commit": "42a8caacb4f4bfa0fb5a83ecd69c25e3b5e83973"
   },
   "AUDIT-SEC-TRAIN-LEDGER-CLOSEOUT-01": {
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "branch": "audit/sec-train-ledger-closeout-01",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1804",
     "base": "main",
@@ -54258,8 +54258,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "bb2a9863bcea53fc540a39b20378800ed009f17b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2084",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -54677,6 +54677,11 @@
         "at": "2026-06-14T02:37:32+08:00",
         "status": "local_checks_passed",
         "note": "Rebased onto latest origin/main, removed /tmp/fap-ci.sqlite, reran the required full ci_verify_mbti.sh gate successfully, and restored generated Big Five compiled artifacts outside this PR scope."
+      },
+      {
+        "at": "2026-06-14T02:39:24+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2084 after local checks and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36944,7 +36944,7 @@
     "id": "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01",
     "repo": "fap-api",
     "branch": "ops/release-train-workflow-production-env-binding-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "commit_sha": "c17da937",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1771",
     "checks": {
@@ -54258,7 +54258,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "bb2a9863bcea53fc540a39b20378800ed009f17b",
+    "commit_sha": "2a2f3053c0d23e1b1ed046445373c1c41af3ad2a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2084",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -54653,7 +54653,8 @@
         "evidence": "Focused FAQ baseline contract passed with 1870 assertions; full PersonalityPublicApiTest passed with 2044 assertions; registry test passed with 38 assertions; targeted Big Five FAQ classifier test passed; Pint passed; route:list showed 6 personality routes; sqlite migrate passed; php artisan test --filter Personality passed with 92 tests / 6849 assertions; JSON/YAML/diff checks passed. Required full ci_verify_mbti.sh initially failed late in AuthGuestRouteWiringTest with SQLite `database disk image is malformed` for /tmp/fap-ci.sqlite; after removing /tmp/fap-ci.sqlite and rebasing onto latest origin/main, rerun `cd backend && bash -lc 'rm -f /tmp/fap-ci.sqlite /tmp/fap-ci.sqlite-* && bash scripts/ci_verify_mbti.sh'` passed through schema baseline runtime introspection, Big5 ops controller layering, legacy service request coupling, constructor injection, env usage, events dedupe explain, share flow alignment, dependency security, webhook/attempt regression, queue backlog, and cleanup gates."
       },
       "github": {
-        "status": "pending"
+        "status": "pass",
+        "evidence": "PR #2084 checks passed on head 2a2f3053c0d23e1b1ed046445373c1c41af3ad2a: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
       }
     },
     "failure_reason": null,
@@ -54682,6 +54683,11 @@
         "at": "2026-06-14T02:39:24+08:00",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2084 after local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-14T02:45:13+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and pre-merge scope validation showed only the 8 declared PR files changed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -54608,5 +54608,76 @@
         "note": "PR #2078 was squash-merged as 1069eafd5a43dbf20f86b4f2558ce8be8b780c1d; remote branch deletion was verified and local task branch cleanup was executed from detached origin/main because main is held by another worktree."
       }
     ]
+  },
+  "PERSONALITY-DETAIL-FAQ-SEO-01": {
+    "repo": "fap-api",
+    "branch": "codex/personality-detail-faq-seo-01-backend",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "personality_seo",
+    "title": "PERSONALITY-DETAIL-FAQ-SEO-01: feat(personality): add backend FAQ content contract",
+    "depends_on": [
+      "PERSONALITY-AT-DIFFERENCE-SECTIONS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized continuing execution after being told the fap-api manifest/state entry was required for PERSONALITY-DETAIL-FAQ-SEO-01."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PERSONALITY-AT-DIFFERENCE-SECTIONS-01 is recorded merged in fap-api PR #2078 with merge commit 1069eafd5a43dbf20f86b4f2558ce8be8b780c1d."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend MBTI canonical registry, backend personality API contract tests, committed MBTI personality baselines, Big Five runtime-freeze classifier coverage, and docs/codex PR-train metadata. No fap-web, sitemap, llms, title metadata, comparison page, production CMS mutation, or publish-state mutation is in scope."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_detail_faq --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Support/Mbti/MbtiCanonicalSectionRegistry.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-detail-faq.sqlite php artisan migrate --force --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter Personality --no-ansi",
+          "cd backend && bash -lc 'rm -f /tmp/fap-ci.sqlite /tmp/fap-ci.sqlite-* && bash scripts/ci_verify_mbti.sh'",
+          "python3 -m json.tool content_baselines/personality/mbti.en.json >/dev/null",
+          "python3 -m json.tool content_baselines/personality/mbti.zh-CN.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "Focused FAQ baseline contract passed with 1870 assertions; full PersonalityPublicApiTest passed with 2044 assertions; registry test passed with 38 assertions; targeted Big Five FAQ classifier test passed; Pint passed; route:list showed 6 personality routes; sqlite migrate passed; php artisan test --filter Personality passed with 92 tests / 6849 assertions; JSON/YAML/diff checks passed. Required full ci_verify_mbti.sh initially failed late in AuthGuestRouteWiringTest with SQLite `database disk image is malformed` for /tmp/fap-ci.sqlite; after removing /tmp/fap-ci.sqlite and rebasing onto latest origin/main, rerun `cd backend && bash -lc 'rm -f /tmp/fap-ci.sqlite /tmp/fap-ci.sqlite-* && bash scripts/ci_verify_mbti.sh'` passed through schema baseline runtime introspection, Big5 ops controller layering, legacy service request coupling, constructor injection, env usage, events dedupe explain, share flow alignment, dependency security, webhook/attempt regression, queue backlog, and cleanup gates."
+      },
+      "github": {
+        "status": "pending"
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-14T01:51:00+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit continuation authorization and started backend-only FAQ content contract implementation."
+      },
+      {
+        "at": "2026-06-14T02:01:00+08:00",
+        "status": "local_checks_failed",
+        "note": "Implementation and focused checks passed, but required full ci_verify_mbti.sh failed late in AuthGuestRouteWiringTest with sqlite database disk image malformed for /tmp/fap-ci.sqlite. Stopped before commit, push, or PR creation."
+      },
+      {
+        "at": "2026-06-14T02:37:32+08:00",
+        "status": "local_checks_passed",
+        "note": "Rebased onto latest origin/main, removed /tmp/fap-ci.sqlite, reran the required full ci_verify_mbti.sh gate successfully, and restored generated Big Five compiled artifacts outside this PR scope."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23903,6 +23903,61 @@ prs:
     content_authority: backend
     next_task: SEO-CONV-OPS-05 in fap-api after this PR is merged
 
+  - id: PERSONALITY-DETAIL-FAQ-SEO-01
+    repo: fap-api
+    depends_on:
+      - PERSONALITY-AT-DIFFERENCE-SECTIONS-01
+    branch: codex/personality-detail-faq-seo-01-backend
+    title: "PERSONALITY-DETAIL-FAQ-SEO-01: feat(personality): add backend FAQ content contract"
+    train_scope: personality_seo
+    status: user_authorized
+    scope:
+      - Register a backend canonical MBTI FAQ section for public personality detail pages.
+      - Add backend-authored visible FAQ payloads to the committed en and zh-CN 32-variant personality baselines.
+      - Ensure public detail API, mbti_public_projection_v1, and answer_surface_v1 expose FAQ data for all 64 A/T pages.
+      - Add backend contracts proving frontend can render visible FAQ and derive FAQPage JSON-LD from backend authority.
+    allowed_paths:
+      - backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
+      - backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+      - backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php
+      - backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+      - backend/tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - content_baselines/personality/mbti.en.json
+      - content_baselines/personality/mbti.zh-CN.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Add title metadata rewrites, comparison pages, sitemap changes, llms changes, or frontend fallback copy.
+      - Promise Google FAQ rich results or add hidden FAQ-only structured data.
+      - Mutate production CMS data or publish state.
+      - Move personality editorial authority into frontend code.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_detail_faq --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Support/Mbti/MbtiCanonicalSectionRegistry.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-detail-faq.sqlite php artisan migrate --force --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter Personality --no-ansi
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - python3 -m json.tool content_baselines/personality/mbti.en.json >/dev/null
+      - python3 -m json.tool content_baselines/personality/mbti.zh-CN.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+    next_task: PERSONALITY-SEO-TITLE-METADATA-01 after the fap-web consumer portion is merged
+
   - id: ARTICLE-H1-02
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added backend MBTI canonical `faq` section metadata and render variant registration.
- Added visible FAQ sections for all committed MBTI A/T personality baseline pages in `en` and `zh-CN`.
- Extended public personality baseline contract tests to require FAQ projection into `mbti_public_projection_v1.sections` and `answer_surface_v1.faq_blocks`.
- Added a Big Five runtime-freeze classifier regression so MBTI FAQ section files remain outside the Big Five runtime diff gate.
- Registered this backend-only PR-train item in `docs/codex/pr-train.yaml` and updated state ledger evidence.

## Why
This is the backend authority contract for `PERSONALITY-DETAIL-FAQ-SEO-01`: each MBTI A/T detail page now has visible FAQ data available from committed backend baselines, without moving content authority into fap-web and without promising Google FAQ rich results.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_detail_faq --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Support/Mbti/MbtiCanonicalSectionRegistry.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-detail-faq.sqlite php artisan migrate --force --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter Personality --no-ansi`
- `cd backend && bash -lc 'rm -f /tmp/fap-ci.sqlite /tmp/fap-ci.sqlite-* && bash scripts/ci_verify_mbti.sh'`
- `python3 -m json.tool content_baselines/personality/mbti.en.json >/dev/null`
- `python3 -m json.tool content_baselines/personality/mbti.zh-CN.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No fap-web rendering, FAQ UI, or FAQPage JSON-LD changes; frontend consumption is a dependent PR.
- No sitemap, llms.txt, title/metadata, comparison pages, or 32 hub changes.
- No production CMS mutation or publish-state mutation.
- No claim that visible FAQ content guarantees Google FAQ rich result display.

## Repository rule impact
Backend remains the authority for MBTI personality profile content and SEO sections. This PR adds a backend-authored FAQ section contract and baseline content only; frontend should consume the returned fields rather than adding local editorial FAQ fallback content.
