### PR TITLE
SEO-OPS-DAILY-ARTICLE-BACKEND-PIPELINE-STABILITY-00

### DIFF
--- a/backend/app/Console/Commands/ContentReleaseRevalidate.php
+++ b/backend/app/Console/Commands/ContentReleaseRevalidate.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Filament\Ops\Support\ContentReleaseFollowUp;
+use App\Models\Article;
+use App\Services\Cms\ContentReleasePathPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+
+final class ContentReleaseRevalidate extends Command
+{
+    protected $signature = 'content-release:revalidate
+        {--type=article : Content type to revalidate}
+        {--article-id= : Article id when --type=article}
+        {--source=manual_revalidate : Safe audit/source label}
+        {--dry-run : Plan paths without posting to configured revalidation endpoints}
+        {--execute : Dispatch configured frontend revalidation endpoints}
+        {--json : Emit safe machine-readable JSON}';
+
+    protected $description = 'Safely plan or dispatch content-release revalidation without exposing revalidation tokens.';
+
+    public function handle(ContentReleasePathPlanner $pathPlanner): int
+    {
+        $summary = $this->summary($pathPlanner);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function summary(ContentReleasePathPlanner $pathPlanner): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $type = trim((string) $this->option('type'));
+        $articleId = (int) $this->option('article-id');
+        $issues = [];
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $issues[] = 'execute_dry_run_conflict';
+        }
+
+        if ($type !== 'article') {
+            $issues[] = 'unsupported_type';
+        }
+
+        if ($articleId <= 0) {
+            $issues[] = 'article_id_required';
+        }
+
+        $article = null;
+        if ($type === 'article' && $articleId > 0) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()])
+                ->find($articleId);
+
+            if (! $article instanceof Article) {
+                $issues[] = 'article_not_found';
+            }
+        }
+
+        $paths = $article instanceof Article ? $pathPlanner->paths('article', $article) : [];
+        $endpoints = $this->cacheInvalidationUrls();
+        $tokenPresent = $this->cacheInvalidationSecretPresent();
+
+        if ($execute && $endpoints === []) {
+            $issues[] = 'cache_invalidation_urls_missing';
+        }
+
+        if ($execute && ! $tokenPresent) {
+            $issues[] = 'cache_invalidation_secret_missing';
+        }
+
+        $ok = $issues === [];
+        $action = $execute ? 'revalidation_dispatched' : 'would_revalidate_content_release_paths';
+
+        if (! $ok) {
+            $action = 'will_skip';
+        } elseif ($execute && $article instanceof Article) {
+            ContentReleaseFollowUp::dispatch(
+                'article',
+                $article,
+                $this->safeSource(),
+                Request::create('/ops/content-release/revalidate-command', 'POST')
+            );
+        }
+
+        return [
+            'runtime' => 'content_release_revalidate',
+            'status' => $ok ? 'success' : 'blocked',
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'type' => $type,
+            'article_id' => $articleId > 0 ? $articleId : null,
+            'paths' => $paths,
+            'endpoint_count' => count($endpoints),
+            'token_present' => $tokenPresent,
+            'token_output' => false,
+            'external_search_submission_attempted' => false,
+            'search_submission_attempted' => false,
+            'live_submission_attempted' => false,
+            'secrets_read_from_environment_by_operator' => false,
+            'issues' => array_values(array_unique($issues)),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function cacheInvalidationUrls(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) config('ops.content_release_observability.cache_invalidation_urls', [])
+        )));
+    }
+
+    private function cacheInvalidationSecretPresent(): bool
+    {
+        return trim((string) config('ops.content_release_observability.cache_invalidation_secret', '')) !== '';
+    }
+
+    private function safeSource(): string
+    {
+        $source = preg_replace('/[^A-Za-z0-9:_@.-]/', '_', trim((string) $this->option('source'))) ?: 'manual_revalidate';
+
+        return substr($source, 0, 128);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        foreach (['status', 'dry_run', 'action', 'type', 'article_id', 'endpoint_count', 'token_present', 'token_output'] as $key) {
+            $value = $summary[$key] ?? null;
+            $this->line($key.'='.$this->stringValue($value));
+        }
+        $this->line('paths='.$this->stringValue($summary['paths'] ?? []));
+        $this->line('issues='.$this->stringValue($summary['issues'] ?? []));
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return (string) json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+
+        return (string) $value;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -5,10 +5,12 @@ namespace App\Console;
 use App\Console\Commands\AdminBootstrapOwner;
 use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\ArticleCoverPropagationSmoke;
+use App\Console\Commands\ArticleEnsureSeoMetaBaseline;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 use App\Console\Commands\ArticleReplaceInlineImageUrl;
+use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
@@ -97,6 +99,7 @@ use App\Console\Commands\CommerceRepairPaidOrders;
 use App\Console\Commands\CommerceRepairPostCommitFailed;
 use App\Console\Commands\ContentCompile;
 use App\Console\Commands\ContentLint;
+use App\Console\Commands\ContentReleaseRevalidate;
 use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
@@ -155,6 +158,8 @@ use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
+use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
 use App\Console\Commands\StorageMigrateLegacyArtifacts;
@@ -327,11 +332,16 @@ class Kernel extends ConsoleKernel
         ExperimentGuardrailsEvaluate::class,
         ArticleImportEditorialPackage::class,
         ArticleImportSeoContentPackageDraft::class,
+        ArticleEnsureSeoMetaBaseline::class,
+        ArticleUpdateExistingSeoContentPackage::class,
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
         ArticleReplaceInlineImageUrl::class,
         ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
+        SeoIntelUrlTruthHandoffCommand::class,
+        SeoIntelSearchChannelQueueCommand::class,
+        ContentReleaseRevalidate::class,
     ];
 
     /**

--- a/backend/tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php
@@ -14,6 +14,21 @@ final class ArticleEnsureSeoMetaBaselineCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_daily_article_pipeline_commands_are_registered_for_production_artisan_path(): void
+    {
+        $commands = Artisan::all();
+
+        foreach ([
+            'articles:ensure-seo-meta-baseline',
+            'articles:update-existing-seo-content-package',
+            'content-release:revalidate',
+            'seo-intel:search-channel-queue',
+            'seo-intel:url-truth-handoff',
+        ] as $commandName) {
+            $this->assertArrayHasKey($commandName, $commands);
+        }
+    }
+
     public function test_default_invocation_is_dry_run_and_does_not_write(): void
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);

--- a/backend/tests/Feature/Console/ContentReleaseRevalidateCommandTest.php
+++ b/backend/tests/Feature/Console/ContentReleaseRevalidateCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class ContentReleaseRevalidateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_article_paths_without_posting_or_outputting_token(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake();
+
+        $article = $this->articleWithSeoMeta('zh-CN', [
+            'target_topics' => ['mbti'],
+        ]);
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article',
+            '--article-id' => (string) $article->id,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $rawOutput = Artisan::output();
+        $payload = $this->jsonOutput($rawOutput);
+
+        $this->assertSame(0, $exitCode, $rawOutput);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertSame('would_revalidate_content_release_paths', $payload['action'] ?? null);
+        $this->assertContains('/zh/articles/content-release-article', $payload['paths'] ?? []);
+        $this->assertContains('/zh/topics/mbti', $payload['paths'] ?? []);
+        $this->assertContains('/llms.txt', $payload['paths'] ?? []);
+        $this->assertContains('/llms-full.txt', $payload['paths'] ?? []);
+        $this->assertSame(1, $payload['endpoint_count'] ?? null);
+        $this->assertTrue((bool) ($payload['token_present'] ?? false));
+        $this->assertFalse((bool) ($payload['token_output'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['live_submission_attempted'] ?? true));
+        $this->assertStringNotContainsString('release-secret', $rawOutput);
+        $this->assertStringNotContainsString('cache.example.test', $rawOutput);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_execute_dispatches_revalidation_without_outputting_token(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake([
+            'https://cache.example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $article = $this->articleWithSeoMeta('en', [
+            'target_topics' => ['big-five'],
+        ]);
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article',
+            '--article-id' => (string) $article->id,
+            '--source' => 'manual_revalidate',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $rawOutput = Artisan::output();
+        $payload = $this->jsonOutput($rawOutput);
+
+        $this->assertSame(0, $exitCode, $rawOutput);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['dry_run'] ?? true));
+        $this->assertSame('revalidation_dispatched', $payload['action'] ?? null);
+        $this->assertSame(1, $payload['endpoint_count'] ?? null);
+        $this->assertTrue((bool) ($payload['token_present'] ?? false));
+        $this->assertFalse((bool) ($payload['token_output'] ?? true));
+        $this->assertStringNotContainsString('release-secret', $rawOutput);
+        $this->assertStringNotContainsString('cache.example.test', $rawOutput);
+
+        Http::assertSent(function ($request): bool {
+            $paths = (array) data_get($request->data(), 'cache_signal.paths', []);
+
+            return $request->url() === 'https://cache.example.test/api/content-release/revalidate'
+                && $request->hasHeader('X-FM-Content-Release-Token', 'release-secret')
+                && in_array('/en/articles/content-release-article', $paths, true)
+                && in_array('/en/topics/big-five', $paths, true)
+                && in_array('/llms-full.txt', $paths, true);
+        });
+    }
+
+    public function test_execute_blocks_when_revalidation_token_or_endpoint_config_is_missing(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', []);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', '');
+        Http::fake();
+
+        $article = $this->articleWithSeoMeta('zh-CN');
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article',
+            '--article-id' => (string) $article->id,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput(Artisan::output());
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('cache_invalidation_urls_missing', $payload['issues'] ?? []);
+        $this->assertContains('cache_invalidation_secret_missing', $payload['issues'] ?? []);
+
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @param  array<string,mixed>  $editorialMetadata
+     */
+    private function articleWithSeoMeta(string $locale, array $editorialMetadata = []): Article
+    {
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'content-release-article',
+            'locale' => $locale,
+            'title' => 'Content Release Article',
+            'excerpt' => 'Release excerpt',
+            'content_md' => 'Release body',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => 'Release SEO title',
+            'seo_description' => 'Release SEO description',
+            'canonical_url' => 'https://fermatmind.com/'.(str_starts_with($locale, 'zh') ? 'zh' : 'en').'/articles/content-release-article',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => $editorialMetadata,
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['seoMeta']) ?? $article;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(string $rawOutput): array
+    {
+        $payload = json_decode(trim($rawOutput), true);
+        $this->assertIsArray($payload, $rawOutput);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -92,6 +92,71 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
     }
 
     #[Test]
+    public function eligible_backend_cms_article_url_can_be_written_to_queue_without_live_submission(): void
+    {
+        config([
+            'seo_intel.search_channel_queue.write_enabled' => true,
+            'seo_intel.search_channel.live_submission.enabled' => false,
+        ]);
+        $canonicalUrl = 'https://www.fermatmind.com/zh/articles/mbti-vs-holland-career-choice';
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => '37',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_source' => 'articles.updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertTrue((bool) ($output['writes_attempted'] ?? false));
+        $this->assertTrue((bool) ($output['writes_committed'] ?? false));
+        $this->assertTrue((bool) ($output['enqueue_attempted'] ?? false));
+        $this->assertTrue((bool) ($output['enqueue_committed'] ?? false));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertSame(['indexnow' => 1], $output['channel_breakdown'] ?? null);
+        $this->assertSame(['article' => 1], $output['page_type_breakdown'] ?? null);
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+
+        $item = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_items')
+            ->where('canonical_url', $canonicalUrl)
+            ->first();
+
+        $this->assertNotNull($item);
+        $this->assertSame('article', $item->page_entity_type);
+        $this->assertSame('article', $item->entity_type);
+        $this->assertSame('37', $item->entity_id);
+        $this->assertSame('backend_cms', $item->source_authority);
+        $this->assertSame('articles', $item->source_table);
+        $this->assertSame('indexnow', $item->channel);
+        $this->assertSame('eligible', $item->eligibility_state);
+        $this->assertSame('pending', $item->approval_state);
+        $this->assertSame('dry_run_ready', $item->execution_state);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_baidu_push_logs')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_indexnow_submissions')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_domestic_submission_logs')->count());
+    }
+
+    #[Test]
     public function unsafe_article_urls_remain_blocked(): void
     {
         $unsafeCases = [

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -646,6 +646,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_content_release_revalidate_automation_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ContentReleaseRevalidate.php',
             'backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php',
             'backend/app/Services/Cms/ContentReleasePathPlanner.php',
         ];
@@ -990,6 +991,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
+    public function test_runtime_freeze_classifier_ignores_daily_article_backend_pipeline_command_registration(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ContentReleaseRevalidate.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleEnsureSeoMetaBaseline;',
+            '+use App\\Console\\Commands\\ArticleUpdateExistingSeoContentPackage;',
+            '+use App\\Console\\Commands\\ContentReleaseRevalidate;',
+            '+use App\\Console\\Commands\\SeoIntelSearchChannelQueueCommand;',
+            '+use App\\Console\\Commands\\SeoIntelUrlTruthHandoffCommand;',
+            '+        ArticleEnsureSeoMetaBaseline::class,',
+            '+        ArticleUpdateExistingSeoContentPackage::class,',
+            '+        SeoIntelUrlTruthHandoffCommand::class,',
+            '+        SeoIntelSearchChannelQueueCommand::class,',
+            '+        ContentReleaseRevalidate::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
     public function test_runtime_freeze_classifier_ignores_seo_intel_mbti_url_truth_cleanup_runtime_files(): void
@@ -3745,6 +3768,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoImageBundleImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleImageMetadataUpdaterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleInlineImageUrlReplacerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsDailyArticleBackendPipelineOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -3928,6 +3952,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isContentReleaseRevalidateAutomationFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/ContentReleaseRevalidate.php',
             'backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php',
             'backend/app/Services/Cms/ContentReleasePathPlanner.php',
         ], true);
@@ -5721,6 +5746,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleReplaceInlineImageUrl\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsDailyArticleBackendPipelineOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleUpdateExistingSeoContentPackage|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
+++ b/backend/tests/Unit/Support/PublicMediaUrlGuardTest.php
@@ -46,6 +46,7 @@ final class PublicMediaUrlGuardTest extends TestCase
 
         foreach ([
             'https://assets.fermatmind.com/static/share/mbti_wide_1200x630.png',
+            'https://api.fermatmind.com/storage/media-library/variants/article-daily/hero_1600x900.jpg',
             'https://api.fermatmind.com/static/social/wechat-qr.jpg',
             'https://api.staging.fermatmind.com/static/articles/cover.png',
         ] as $allowedUrl) {


### PR DESCRIPTION
## What changed
- Explicitly register the daily article backend pipeline commands in the console kernel: article SEO meta baseline, existing article update writer, URL Truth handoff, Search Channel Queue, and safe content-release revalidation.
- Add `content-release:revalidate` for dry-run path planning and explicit `--execute` dispatch to configured frontend revalidation endpoints without outputting tokens or endpoint URLs.
- Add coverage for article Search Channel Queue writes staying pending/dry-run-ready with no live submission.
- Lock `api.fermatmind.com/storage/...` as an accepted public media fallback origin.

## Why
Daily SEO article operations need backend-authoritative URL Truth/Search Queue/revalidation paths that are production-callable, auditable, and safe by default. Queue writes are allowed, but GSC/Baidu/IndexNow live submit remains outside this PR and is not attempted.

## Validation
- `php artisan test tests/Feature/Console/ContentReleaseRevalidateCommandTest.php tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php tests/Feature/SeoIntel/EnParity01UrlTruthCanonicalBaselineTest.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php tests/Unit/Support/PublicMediaUrlGuardTest.php --no-ansi`
- `vendor/bin/pint --test app/Console/Commands/ContentReleaseRevalidate.php app/Console/Kernel.php tests/Feature/Console/ContentReleaseRevalidateCommandTest.php tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php tests/Unit/Support/PublicMediaUrlGuardTest.php`
- `php artisan route:list --no-ansi`
- `git diff --check`
- scoped changed-file validation

## Intentionally deferred
- Frontend LLMS route changes
- GSC Request Indexing
- Baidu live push
- Direct IndexNow provider calls
- Production env/secret changes
- Database migrations