### PR TITLE
fix(cms): support zh-only SEO package drafts

### DIFF
--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -122,10 +122,6 @@ final class SeoContentPackageDraftImporter
         if ($expectedTranslationGroupId === '') {
             $errors[] = $this->issue('translation_group_id', 'missing_expected_translation_group_id', '--translation-group-id is required.');
         }
-        if ($locales !== ['zh-CN', 'en']) {
-            $errors[] = $this->issue('locales', 'unsupported_locale_set', '--locales must resolve to zh-CN,en.');
-        }
-
         $manifest = [];
         $packageItems = [];
         $guardScans = [
@@ -136,7 +132,8 @@ final class SeoContentPackageDraftImporter
             $this->validateRequiredFiles($packageRoot, $errors);
             $manifest = $this->readJson($packageRoot.'/manifest.json', 'manifest.json', $errors);
             $guardScans = $this->validatePackageGuardScopes($packageRoot, $errors);
-            $packageItems = $this->buildPackageItems($packageRoot, $manifest, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
+            $locales = $this->validatedLocales($locales, $manifest, $errors);
+            $packageItems = $this->buildPackageItems($packageRoot, $manifest, $locales, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
             $this->validateJsonFieldSerialization($packageItems, $errors, $warnings);
         }
 
@@ -195,7 +192,7 @@ final class SeoContentPackageDraftImporter
             'cover_image_width' => (int) $item['cover_image_width'],
             'cover_image_height' => (int) $item['cover_image_height'],
             'cover_image_variants' => $metadata,
-            'related_test_slug' => 'holland-career-interest-test-riasec',
+            'related_test_slug' => (string) $item['related_test_slug'],
             'status' => 'draft',
             'is_public' => false,
             'is_indexable' => false,
@@ -385,10 +382,11 @@ final class SeoContentPackageDraftImporter
         if (preg_match(self::OLD_BIG_FIVE_ROUTE_PATTERN, $activeSurfaceText) === 1) {
             $errors[] = $this->issue('active_surface_guard_scan.big_five_route', 'old_big_five_route_found_in_active_surface', 'Old Big Five route is forbidden in active import surfaces.');
         }
-        if (! str_contains($packageText, self::CANONICAL_BIG_FIVE_ROUTE)) {
+        if (preg_match(self::OLD_BIG_FIVE_ROUTE_PATTERN, $packageText) === 1
+            && ! str_contains($packageText, self::CANONICAL_BIG_FIVE_ROUTE)) {
             $errors[] = $this->issue('big_five_route', 'required_big_five_route_missing', 'Canonical Big Five route is required.');
         }
-        if (str_contains($packageText, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
+        if (str_contains($activeSurfaceText, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
             $errors[] = $this->issue('social_image', 'media_placeholder_found', 'CMS media placeholder marker is forbidden.');
         }
         if (preg_match(self::PRIVATE_ROUTE_PATTERN, $activeSurfaceText) === 1) {
@@ -605,6 +603,7 @@ final class SeoContentPackageDraftImporter
             'forbidden_private_routes',
             'forbidden_query_keys',
             'forbidden_sensitive_query_keys',
+            'forbidden_substrings',
             'sensitive_query_keys',
         ], true);
 
@@ -646,7 +645,12 @@ final class SeoContentPackageDraftImporter
     private function collectDynamicCtaSensitiveKeyViolations(mixed $value, array $path, bool $allowedForbiddenParamContext, array &$invalidPaths): void
     {
         $key = strtolower((string) end($path));
-        $allowed = $allowedForbiddenParamContext || $key === 'forbidden_tracking_params';
+        $allowed = $allowedForbiddenParamContext || in_array($key, [
+            'forbidden_tracking_params',
+            'forbidden_parameters',
+            'forbidden_query_keys',
+            'forbidden_sensitive_query_keys',
+        ], true);
 
         if (is_array($value)) {
             foreach ($value as $childKey => $child) {
@@ -676,18 +680,19 @@ final class SeoContentPackageDraftImporter
     private function buildPackageItems(
         string $root,
         array $manifest,
+        array $locales,
         string $expectedTranslationGroupId,
         array $expectedSlugs,
         array &$errors,
         array &$warnings
     ): array {
         $manifestTranslationGroupId = trim((string) ($manifest['translation_group_id'] ?? ''));
-        if ($manifestTranslationGroupId !== $expectedTranslationGroupId) {
+        if ($manifestTranslationGroupId !== '' && $manifestTranslationGroupId !== $expectedTranslationGroupId) {
             $errors[] = $this->issue('manifest.translation_group_id', 'translation_group_id_mismatch', 'manifest translation_group_id does not match expected value.');
         }
 
         $items = [];
-        foreach (['zh-CN', 'en'] as $locale) {
+        foreach ($locales as $locale) {
             $import = $this->readFirstJson($root.'/cms/CMS_IMPORT_DRAFT_'.$locale.'_*.json', 'cms import '.$locale, $errors);
             $fields = $this->readFirstJson($root.'/cms/CMS_FIELDS_'.$locale.'_*.json', 'cms fields '.$locale, $errors);
             $pagePath = $this->pagePathFor($root, $locale, $import, $manifest, $errors);
@@ -697,6 +702,9 @@ final class SeoContentPackageDraftImporter
             $expectedSlug = trim((string) ($expectedSlugs[$locale] ?? ''));
             if ($expectedSlug !== '' && (string) ($item['slug'] ?? '') !== $expectedSlug) {
                 $errors[] = $this->issue($locale.'.slug', 'expected_slug_mismatch', 'Package slug does not match expected slug.');
+            }
+            if ($item !== [] && (string) ($item['translation_group_id'] ?? '') !== $expectedTranslationGroupId) {
+                $errors[] = $this->issue($locale.'.translation_group_id', 'translation_group_id_mismatch', 'Package translation_group_id does not match expected value.');
             }
 
             if ($item !== []) {
@@ -836,11 +844,12 @@ final class SeoContentPackageDraftImporter
         $translationGroupId = $this->firstString($import['translation_group_id'] ?? null, $fields['translation_group_id'] ?? null, $frontmatter['translation_group_id'] ?? null, $manifest['translation_group_id'] ?? null);
         $slug = Str::slug($this->firstString($import['slug'] ?? null, $fields['slug'] ?? null, $frontmatter['slug'] ?? null, $manifestPage['slug'] ?? null));
         $title = $this->firstString($import['title'] ?? null, $fields['title'] ?? null, $frontmatter['title'] ?? null, $manifestPage['title'] ?? null);
-        $metaTitle = $this->firstString($import['meta_title'] ?? null, $fields['meta_title'] ?? null, $frontmatter['meta_title_draft'] ?? null, $manifestPage['meta_title_draft'] ?? null, $title);
-        $metaDescription = $this->firstString($import['meta_description'] ?? null, $fields['meta_description'] ?? null, $frontmatter['meta_description_draft'] ?? null, $manifestPage['meta_description_draft'] ?? null);
-        $canonical = $this->firstString($import['canonical_url'] ?? null, $fields['canonical_url'] ?? null, $frontmatter['canonical_url_draft'] ?? null, $manifestPage['canonical_url_draft'] ?? null);
+        $metaTitle = $this->firstString($import['meta_title'] ?? null, $import['meta_title_draft'] ?? null, $fields['meta_title'] ?? null, $fields['meta_title_draft'] ?? null, $frontmatter['meta_title_draft'] ?? null, $manifestPage['meta_title_draft'] ?? null, $title);
+        $metaDescription = $this->firstString($import['meta_description'] ?? null, $import['meta_description_draft'] ?? null, $fields['meta_description'] ?? null, $fields['meta_description_draft'] ?? null, $frontmatter['meta_description_draft'] ?? null, $manifestPage['meta_description_draft'] ?? null);
+        $canonical = $this->firstString($import['canonical_url'] ?? null, $import['canonical_url_draft'] ?? null, $fields['canonical_url'] ?? null, $fields['canonical_url_draft'] ?? null, $frontmatter['canonical_url_draft'] ?? null, $manifestPage['canonical_url_draft'] ?? null);
         $claimGateStatus = $this->firstString($import['claim_gate_status'] ?? null, $fields['claim_gate_status'] ?? null, $frontmatter['claim_gate_status'] ?? null, 'not_reviewed');
         $social = is_array($import['social_image_metadata'] ?? null) ? $import['social_image_metadata'] : (is_array($fields['social_image_metadata'] ?? null) ? $fields['social_image_metadata'] : []);
+        $primaryCtaPath = $this->firstString(data_get($import, 'primary_cta.href'), data_get($fields, 'primary_cta.href'), $import['primary_cta'] ?? null, $fields['primary_cta'] ?? null, $frontmatter['primary_cta'] ?? null, $import['primary_hub_url'] ?? null, $fields['primary_hub_url'] ?? null, $frontmatter['primary_hub_url'] ?? null);
 
         $item = [
             'locale' => $locale,
@@ -868,6 +877,8 @@ final class SeoContentPackageDraftImporter
             'og_image_url' => $this->firstString($import['og_image_url'] ?? null, $fields['og_image_url'] ?? null, data_get($social, 'og_1200x630_variant.url'), $social['twitter_image_url'] ?? null),
             'twitter_image_url' => $this->firstString($import['twitter_image_url'] ?? null, $fields['twitter_image_url'] ?? null, $social['twitter_image_url'] ?? null),
             'social_image_metadata' => $social,
+            'primary_cta_path' => $primaryCtaPath,
+            'related_test_slug' => $this->testSlugFromPath($primaryCtaPath),
             'source_package_root' => $root,
         ];
 
@@ -1071,8 +1082,11 @@ final class SeoContentPackageDraftImporter
                 'og_image_url' => (string) $item['og_image_url'],
             ],
             'article_editorial_package_import.graph_json' => [
-                'primary_cta' => '/tests/holland-career-interest-test-riasec',
-                'big_five_route' => '/tests/big-five-personality-test-ocean-model',
+                'primary_cta' => (string) ($item['primary_cta_path'] ?? ''),
+                'related_test_slug' => (string) ($item['related_test_slug'] ?? ''),
+                'big_five_route' => str_contains((string) ($item['body_markdown'] ?? ''), self::CANONICAL_BIG_FIVE_ROUTE)
+                    ? self::CANONICAL_BIG_FIVE_ROUTE
+                    : null,
             ],
             'article_editorial_package_import.answer_surface_json' => ['status' => 'visible_only'],
             'article_editorial_package_import.heading_sequence_json' => $this->headingSequence((string) $item['body_markdown']),
@@ -1156,6 +1170,55 @@ final class SeoContentPackageDraftImporter
         }
 
         return array_values(array_map(static fn (mixed $locale): string => (string) $locale, $value));
+    }
+
+    /**
+     * @param  list<string>  $requestedLocales
+     * @param  array<string,mixed>  $manifest
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<string>
+     */
+    private function validatedLocales(array $requestedLocales, array $manifest, array &$errors): array
+    {
+        $locales = array_values(array_filter($requestedLocales, static fn (string $locale): bool => $locale !== ''));
+        $allowedSets = [
+            ['zh-CN', 'en'],
+            ['zh-CN'],
+        ];
+
+        if (! in_array($locales, $allowedSets, true)) {
+            $errors[] = $this->issue('locales', 'unsupported_locale_set', '--locales must resolve to zh-CN,en or zh-CN.');
+
+            return $locales;
+        }
+
+        $manifestLocales = array_values(array_filter(array_map(
+            static fn (mixed $locale): string => (string) $locale,
+            (array) ($manifest['locale_scope'] ?? [])
+        ), static fn (string $locale): bool => $locale !== ''));
+
+        if ($manifestLocales !== []) {
+            foreach ($locales as $locale) {
+                if (! in_array($locale, $manifestLocales, true)) {
+                    $errors[] = $this->issue('locales', 'locale_not_in_manifest_scope', 'Requested locale is not present in manifest locale_scope.');
+                }
+            }
+        }
+
+        return $locales;
+    }
+
+    private function testSlugFromPath(string $path): string
+    {
+        if (preg_match('~/(?:zh|en)/tests/([^/?#]+)~', $path, $matches) === 1) {
+            return (string) $matches[1];
+        }
+
+        if (preg_match('~/tests/([^/?#]+)~', $path, $matches) === 1) {
+            return (string) $matches[1];
+        }
+
+        return '';
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -46,6 +46,43 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
     }
 
+    public function test_dry_run_accepts_valid_zh_only_package_without_english_files(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['manifest.json']['locale_scope'] = ['zh-CN'];
+            $files['manifest.json']['translation_group_id'] = null;
+            $files['manifest.json']['pages'] = array_values(array_filter(
+                $files['manifest.json']['pages'],
+                static fn (array $page): bool => (string) ($page['locale'] ?? '') === 'zh-CN'
+            ));
+            unset(
+                $files['pages/en-career-interest-test-vs-personality-test.md'],
+                $files['cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json'],
+                $files['cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json']
+            );
+            $files['cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json']['meta_description_draft'] =
+                $files['cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json']['meta_description'];
+            unset($files['cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json']['meta_description']);
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--locales' => 'zh-CN',
+            '--expected-en-slug' => '',
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('would_create_draft', $payload['action']);
+        $this->assertSame('passed', $payload['active_surface_guard_scan']['status']);
+        $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
+        $this->assertCount(1, $payload['articles']);
+        $this->assertSame('zh-CN', $payload['articles'][0]['locale']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
     public function test_dry_run_accepts_old_big_five_alias_key_with_canonical_value(): void
     {
         $package = $this->writeModeCPackage(static function (array &$files): void {
@@ -292,6 +329,27 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $payload = $this->jsonOutput();
         $this->assertSame(1, $exitCode);
         $this->assertErrorCode($payload, 'media_placeholder_found');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_accepts_cms_media_placeholder_marker_in_guard_contract_forbidden_list(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json']['forbidden'] = [
+                '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+                'fake image URL',
+            ];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['active_surface_guard_scan']['status']);
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 


### PR DESCRIPTION
## What changed
- Allow `articles:import-seo-content-package-draft` to validate zh-CN-only Mode C packages while preserving bilingual support.
- Keep translation group locking strict at the locale item level when `manifest.translation_group_id` is intentionally empty for new article packages.
- Scope Big Five route, media placeholder, private URL, and dynamic CTA contract scans to active surfaces or allowed guard-list contexts.
- Derive draft SEO fields, primary CTA path, and related test slug from CMS import/fields payloads instead of hardcoding RIASEC defaults.
- Add feature coverage for zh-CN-only packages and media placeholder text inside guard contract forbidden lists.

## Why
The IQ pillar zh-CN-only release package is valid Mode C input, but the importer was still assuming bilingual-only packages and scanning non-active guard-contract text as if it were article content. This blocked draft import before the normal Media Library resolution step.

## Validation
- `composer install --no-interaction --prefer-dist`
- `./vendor/bin/pint --dirty`
- `php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest`
- `php -l backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php`
- `php -l backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
- `git diff --check`
- `php artisan route:list --no-ansi`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-zh-only-importer-migrate.sqlite php artisan migrate --pretend --no-interaction --no-ansi`
- IQ package dry-run on temp sqlite: importer now reports only unresolved `zh-CN.social_image_metadata` media fields, with active surface and contract scans passing.

## Intentionally deferred
- No CMS writes, no article publish, no sitemap/llms/schema/hreflang/search release.
- Media Library import/resolution remains the next release dependency before restoring the IQ article release.
- Production deploy is deferred until this PR is merge-ready and an exact target SHA/release is approved.

## Repository rule impact
This keeps article content CMS/backend-authoritative and changes only the backend draft importer/readiness path. It does not introduce frontend content fallback or public editorial assets.