### PR TITLE
PERSONALITY-COMPARISON-PAGES-01: feat(personality): add backend A/T comparison authority

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -183,6 +183,590 @@ class PersonalityController extends Controller
         ]);
     }
 
+    public function comparison(Request $request, string $comparison): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $baseTypeCode = $this->comparisonBaseTypeCode($comparison);
+        if ($baseTypeCode === null) {
+            return $this->notFoundResponse('personality comparison not found.');
+        }
+
+        $assertiveRoute = $this->personalityProfileService->getPublicDetailRouteProfileByType(
+            strtolower($baseTypeCode).'-a',
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+        $turbulentRoute = $this->personalityProfileService->getPublicDetailRouteProfileByType(
+            strtolower($baseTypeCode).'-t',
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+
+        if (! is_array($assertiveRoute) || ! is_array($turbulentRoute)) {
+            return $this->notFoundResponse('personality comparison not found.');
+        }
+
+        /** @var PersonalityProfile $assertiveProfile */
+        $assertiveProfile = $assertiveRoute['profile'];
+        /** @var PersonalityProfile $turbulentProfile */
+        $turbulentProfile = $turbulentRoute['profile'];
+        /** @var PersonalityProfileVariant|null $assertiveVariant */
+        $assertiveVariant = $assertiveRoute['variant'];
+        /** @var PersonalityProfileVariant|null $turbulentVariant */
+        $turbulentVariant = $turbulentRoute['variant'];
+
+        if (
+            ! $assertiveVariant instanceof PersonalityProfileVariant
+            || ! $turbulentVariant instanceof PersonalityProfileVariant
+            || ! $this->isMbtiProfile($assertiveProfile)
+            || ! $this->isMbtiProfile($turbulentProfile)
+        ) {
+            return $this->notFoundResponse('personality comparison not found.');
+        }
+
+        $assertiveProjection = $this->personalityProfileService->buildPublicProjection($assertiveProfile, $assertiveVariant);
+        $turbulentProjection = $this->personalityProfileService->buildPublicProjection($turbulentProfile, $turbulentVariant);
+        $assertiveSections = $this->publicSectionPayloads($assertiveProfile, $assertiveVariant);
+        $turbulentSections = $this->publicSectionPayloads($turbulentProfile, $turbulentVariant);
+        $meta = $this->comparisonMeta($baseTypeCode, $validated['locale']);
+        $jsonLd = $this->comparisonJsonLd($baseTypeCode, $validated['locale'], $meta);
+        $comparisonProjection = $this->comparisonProjectionPayload(
+            $baseTypeCode,
+            $validated['locale'],
+            $assertiveProfile,
+            $assertiveVariant,
+            $assertiveProjection,
+            $assertiveSections,
+            $turbulentProfile,
+            $turbulentVariant,
+            $turbulentProjection,
+            $turbulentSections,
+            $meta
+        );
+        $seoSurface = $this->buildSeoSurface($meta, $jsonLd, 'mbti_personality_at_comparison');
+        $landingSurface = $this->buildComparisonLandingSurface($baseTypeCode, $validated['locale'], $meta);
+
+        return response()->json([
+            'ok' => true,
+            'comparison' => $comparisonProjection,
+            'comparison_public_projection_v1' => $comparisonProjection,
+            'seo_meta' => $this->comparisonSeoMetaPayload($meta),
+            'jsonld' => $jsonLd,
+            'seo_surface_v1' => $seoSurface,
+            'landing_surface_v1' => $landingSurface,
+            'answer_surface_v1' => $this->buildComparisonAnswerSurface(
+                $baseTypeCode,
+                $validated['locale'],
+                $comparisonProjection,
+                $seoSurface,
+                $landingSurface
+            ),
+        ]);
+    }
+
+    private function comparisonBaseTypeCode(string $comparison): ?string
+    {
+        $normalized = strtolower(trim($comparison));
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (preg_match('/^(?<base>[a-z]{4})(?:-a-vs-\k<base>-t)?$/', $normalized, $matches) !== 1) {
+            return null;
+        }
+
+        $baseTypeCode = strtoupper($matches['base']);
+
+        return in_array($baseTypeCode, PersonalityProfile::BASE_TYPE_CODES, true) ? $baseTypeCode : null;
+    }
+
+    private function comparisonSlug(string $baseTypeCode): string
+    {
+        $baseSlug = strtolower($baseTypeCode);
+
+        return $baseSlug.'-a-vs-'.$baseSlug.'-t';
+    }
+
+    private function comparisonCanonicalUrl(string $baseTypeCode, string $locale): ?string
+    {
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->frontendLocaleSegment($locale)
+            .'/personality/'
+            .$this->comparisonSlug($baseTypeCode);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function comparisonMeta(string $baseTypeCode, string $locale): array
+    {
+        $title = $locale === 'zh-CN'
+            ? $baseTypeCode.'-A 和 '.$baseTypeCode.'-T 区别：特点、职业、爱情与稀有度'
+            : $baseTypeCode.'-A vs '.$baseTypeCode.'-T: Traits, Careers, Love & Rarity';
+        $description = $locale === 'zh-CN'
+            ? '对比 '.$baseTypeCode.'-A 与 '.$baseTypeCode.'-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。'
+            : 'Compare '.$baseTypeCode.'-A and '.$baseTypeCode.'-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.';
+        $canonical = $this->comparisonCanonicalUrl($baseTypeCode, $locale);
+        $alternates = [
+            'en' => $this->comparisonCanonicalUrl($baseTypeCode, 'en'),
+            'zh-CN' => $this->comparisonCanonicalUrl($baseTypeCode, 'zh-CN'),
+        ];
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'alternates' => $alternates,
+            'og' => [
+                'title' => $title,
+                'description' => $description,
+                'image' => null,
+                'type' => 'article',
+                'url' => $canonical,
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $title,
+                'description' => $description,
+                'image' => null,
+            ],
+            'robots' => 'index,follow',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function comparisonJsonLd(string $baseTypeCode, string $locale, array $meta): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
+        $hubUrl = $baseUrl !== '' ? $baseUrl.'/'.$segment.'/personality' : null;
+        $canonicalUrl = is_string($meta['canonical'] ?? null) ? $meta['canonical'] : null;
+        $variantUrls = [
+            'A' => $baseUrl !== '' ? $baseUrl.'/'.$segment.'/personality/'.strtolower($baseTypeCode).'-a' : null,
+            'T' => $baseUrl !== '' ? $baseUrl.'/'.$segment.'/personality/'.strtolower($baseTypeCode).'-t' : null,
+        ];
+
+        return CanonicalFrontendUrl::normalizeNestedUrls([
+            '@context' => 'https://schema.org',
+            '@type' => 'CollectionPage',
+            'name' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'url' => $canonicalUrl,
+            'mainEntity' => [
+                '@type' => 'ItemList',
+                'itemListElement' => [
+                    [
+                        '@type' => 'ListItem',
+                        'position' => 1,
+                        'name' => $baseTypeCode.'-A',
+                        'url' => $variantUrls['A'],
+                    ],
+                    [
+                        '@type' => 'ListItem',
+                        'position' => 2,
+                        'name' => $baseTypeCode.'-T',
+                        'url' => $variantUrls['T'],
+                    ],
+                ],
+            ],
+            'breadcrumb' => [
+                '@type' => 'BreadcrumbList',
+                'itemListElement' => [
+                    [
+                        '@type' => 'ListItem',
+                        'position' => 1,
+                        'name' => $locale === 'zh-CN' ? '人格类型' : 'Personality types',
+                        'item' => $hubUrl,
+                    ],
+                    [
+                        '@type' => 'ListItem',
+                        'position' => 2,
+                        'name' => $baseTypeCode.'-A vs '.$baseTypeCode.'-T',
+                        'item' => $canonicalUrl,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $assertiveProjection
+     * @param  list<array<string,mixed>>  $assertiveSections
+     * @param  array<string,mixed>  $turbulentProjection
+     * @param  list<array<string,mixed>>  $turbulentSections
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function comparisonProjectionPayload(
+        string $baseTypeCode,
+        string $locale,
+        PersonalityProfile $assertiveProfile,
+        PersonalityProfileVariant $assertiveVariant,
+        array $assertiveProjection,
+        array $assertiveSections,
+        PersonalityProfile $turbulentProfile,
+        PersonalityProfileVariant $turbulentVariant,
+        array $turbulentProjection,
+        array $turbulentSections,
+        array $meta
+    ): array {
+        return [
+            'comparison_contract_version' => 'mbti.at_comparison.v1',
+            'comparison_slug' => $this->comparisonSlug($baseTypeCode),
+            'base_type_code' => $baseTypeCode,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'locale' => $locale,
+            'public_route_type' => 'at-comparison',
+            'title' => $meta['title'] ?? null,
+            'description' => $meta['description'] ?? null,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'alternates' => $meta['alternates'] ?? [],
+            'variants' => [
+                'a' => $this->comparisonVariantPayload($assertiveProfile, $assertiveVariant, $assertiveProjection, $locale),
+                't' => $this->comparisonVariantPayload($turbulentProfile, $turbulentVariant, $turbulentProjection, $locale),
+            ],
+            'comparison_blocks' => $this->comparisonBlocks(
+                $baseTypeCode,
+                $locale,
+                $assertiveSections,
+                $turbulentSections,
+                $assertiveProjection,
+                $turbulentProjection
+            ),
+            'source_refs' => [
+                'personality_public_projection_v1',
+                'mbti_public_projection_v1',
+                'personality_variant_sections',
+                'personality_variant_seo_meta',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @return array<string,mixed>
+     */
+    private function comparisonVariantPayload(
+        PersonalityProfile $profile,
+        PersonalityProfileVariant $variant,
+        array $projection,
+        string $locale
+    ): array {
+        $routeSlug = $this->resolveRouteSlug($profile, $variant);
+        $baseUrl = CanonicalFrontendUrl::fromConfig();
+        $publicUrl = $baseUrl !== '' ? $baseUrl.'/'.$this->frontendLocaleSegment($locale).'/personality/'.$routeSlug : null;
+
+        return [
+            'profile_id' => (int) $profile->id,
+            'variant_id' => (int) $variant->id,
+            'base_type_code' => (string) data_get($projection, 'canonical_type_code', $profile->type_code),
+            'runtime_type_code' => (string) data_get($projection, 'runtime_type_code', $variant->runtime_type_code),
+            'variant_code' => (string) $variant->variant_code,
+            'public_route_slug' => $routeSlug,
+            'public_url' => $publicUrl,
+            'display_type' => data_get($projection, 'display_type'),
+            'type_name' => data_get($projection, 'profile.type_name'),
+            'nickname' => data_get($projection, 'profile.nickname'),
+            'rarity' => data_get($projection, 'profile.rarity'),
+            'keywords' => is_array(data_get($projection, 'profile.keywords'))
+                ? array_values(data_get($projection, 'profile.keywords'))
+                : [],
+            'hero_summary' => data_get($projection, 'profile.hero_summary'),
+            'summary_card' => is_array(data_get($projection, 'summary_card')) ? data_get($projection, 'summary_card') : [],
+            'seo' => is_array(data_get($projection, 'seo')) ? data_get($projection, 'seo') : [],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $assertiveSections
+     * @param  list<array<string,mixed>>  $turbulentSections
+     * @param  array<string,mixed>  $assertiveProjection
+     * @param  array<string,mixed>  $turbulentProjection
+     * @return list<array<string,mixed>>
+     */
+    private function comparisonBlocks(
+        string $baseTypeCode,
+        string $locale,
+        array $assertiveSections,
+        array $turbulentSections,
+        array $assertiveProjection,
+        array $turbulentProjection
+    ): array {
+        return array_values(array_filter([
+            $this->comparisonBlock(
+                'at_difference',
+                $locale === 'zh-CN'
+                    ? $baseTypeCode.'-A 和 '.$baseTypeCode.'-T 有什么区别？'
+                    : $baseTypeCode.'-A vs '.$baseTypeCode.'-T: what is the difference?',
+                $this->sectionBody($assertiveSections, 'traits.at_difference'),
+                $this->sectionBody($turbulentSections, 'traits.at_difference'),
+                'section_pair'
+            ),
+            $this->comparisonBlock(
+                'traits',
+                $locale === 'zh-CN' ? '核心特点对比' : 'Core traits comparison',
+                (string) data_get($assertiveProjection, 'summary_card.summary', ''),
+                (string) data_get($turbulentProjection, 'summary_card.summary', ''),
+                'summary_pair'
+            ),
+            $this->comparisonBlock(
+                'career',
+                $locale === 'zh-CN' ? '适合职业与工作风格' : 'Career fit and work style',
+                $this->sectionBody($assertiveSections, 'career.summary', 'career.fit'),
+                $this->sectionBody($turbulentSections, 'career.summary', 'career.fit'),
+                'section_pair'
+            ),
+            $this->comparisonBlock(
+                'relationships',
+                $locale === 'zh-CN' ? '爱情关系与相处方式' : 'Relationships and love style',
+                $this->sectionBody($assertiveSections, 'relationships.summary', 'relationships'),
+                $this->sectionBody($turbulentSections, 'relationships.summary', 'relationships'),
+                'section_pair'
+            ),
+            $this->comparisonBlock(
+                'rarity',
+                $locale === 'zh-CN' ? '稀有度与识别线索' : 'Rarity and identification cues',
+                (string) data_get($assertiveProjection, 'profile.rarity', ''),
+                (string) data_get($turbulentProjection, 'profile.rarity', ''),
+                'profile_field_pair'
+            ),
+        ]));
+    }
+
+    private function comparisonBlock(
+        string $key,
+        string $title,
+        ?string $assertiveBody,
+        ?string $turbulentBody,
+        string $source
+    ): ?array {
+        $assertiveBody = trim((string) $assertiveBody);
+        $turbulentBody = trim((string) $turbulentBody);
+        if ($assertiveBody === '' && $turbulentBody === '') {
+            return null;
+        }
+
+        return [
+            'key' => $key,
+            'title' => $title,
+            'source' => $source,
+            'variants' => [
+                'a' => $assertiveBody,
+                't' => $turbulentBody,
+            ],
+            'body_md' => implode("\n\n", array_values(array_filter([
+                $assertiveBody !== '' ? 'A: '.$assertiveBody : null,
+                $turbulentBody !== '' ? 'T: '.$turbulentBody : null,
+            ]))),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $sections
+     */
+    private function sectionBody(array $sections, string ...$keys): ?string
+    {
+        foreach ($keys as $key) {
+            foreach ($sections as $section) {
+                if (! is_array($section) || (string) ($section['section_key'] ?? '') !== $key) {
+                    continue;
+                }
+
+                $body = trim((string) ($section['body_md'] ?? ''));
+                if ($body !== '') {
+                    return $body;
+                }
+
+                $items = data_get($section, 'payload_json.items');
+                if (is_array($items) && $items !== []) {
+                    $text = collect($items)
+                        ->map(static function (mixed $item): string {
+                            if (is_string($item)) {
+                                return trim($item);
+                            }
+
+                            if (! is_array($item)) {
+                                return '';
+                            }
+
+                            return trim(implode(' ', array_filter([
+                                (string) ($item['title'] ?? ''),
+                                (string) ($item['body'] ?? $item['summary'] ?? $item['description'] ?? ''),
+                            ])));
+                        })
+                        ->filter(static fn (string $value): bool => $value !== '')
+                        ->implode(' ');
+                    if ($text !== '') {
+                        return $text;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function comparisonSeoMetaPayload(array $meta): array
+    {
+        return [
+            'seo_title' => $meta['title'] ?? null,
+            'seo_description' => $meta['description'] ?? null,
+            'canonical_url' => $meta['canonical'] ?? null,
+            'og_title' => data_get($meta, 'og.title'),
+            'og_description' => data_get($meta, 'og.description'),
+            'og_image_url' => data_get($meta, 'og.image'),
+            'twitter_title' => data_get($meta, 'twitter.title'),
+            'twitter_description' => data_get($meta, 'twitter.description'),
+            'twitter_image_url' => data_get($meta, 'twitter.image'),
+            'robots' => $meta['robots'] ?? null,
+            'jsonld_overrides_json' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function buildComparisonLandingSurface(string $baseTypeCode, string $locale, array $meta): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        $baseSlug = strtolower($baseTypeCode);
+        $startTestPath = '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+
+        return $this->landingSurfaceContractService->build([
+            'landing_scope' => 'public_indexable_detail',
+            'entry_surface' => 'personality_comparison',
+            'entry_type' => 'mbti_at_pair',
+            'summary_blocks' => [
+                [
+                    'key' => 'hero',
+                    'title' => (string) ($meta['title'] ?? ''),
+                    'body' => (string) ($meta['description'] ?? ''),
+                    'kind' => 'answer_first',
+                ],
+            ],
+            'discoverability_keys' => ['personality_comparison', 'personality_detail', 'start_test'],
+            'continue_reading_keys' => ['personality_detail', 'topic_cluster'],
+            'start_test_target' => $startTestPath,
+            'content_continue_target' => '/'.$segment.'/personality/'.$baseSlug.'-a',
+            'cta_bundle' => [
+                [
+                    'key' => 'assertive_detail',
+                    'label' => $baseTypeCode.'-A',
+                    'href' => '/'.$segment.'/personality/'.$baseSlug.'-a',
+                    'kind' => 'content_continue',
+                ],
+                [
+                    'key' => 'turbulent_detail',
+                    'label' => $baseTypeCode.'-T',
+                    'href' => '/'.$segment.'/personality/'.$baseSlug.'-t',
+                    'kind' => 'content_continue',
+                ],
+                [
+                    'key' => 'start_test',
+                    'label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+                    'href' => $startTestPath,
+                    'kind' => 'start_test',
+                ],
+            ],
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_personality_landing',
+            'seo_surface_ref' => $this->comparisonSlug($baseTypeCode),
+            'surface_family' => 'personality',
+            'primary_content_ref' => $baseTypeCode.':A:T',
+            'related_surface_keys' => ['personality_detail', 'topic_cluster', 'start_test'],
+            'fingerprint_seed' => [
+                'comparison_slug' => $this->comparisonSlug($baseTypeCode),
+                'locale' => $locale,
+                'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     * @param  array<string,mixed>  $seoSurface
+     * @param  array<string,mixed>  $landingSurface
+     * @return array<string,mixed>
+     */
+    private function buildComparisonAnswerSurface(
+        string $baseTypeCode,
+        string $locale,
+        array $projection,
+        array $seoSurface,
+        array $landingSurface
+    ): array {
+        $summaryBlocks = [
+            [
+                'key' => 'comparison_summary',
+                'title' => (string) ($projection['title'] ?? ''),
+                'body' => (string) ($projection['description'] ?? ''),
+                'kind' => 'answer_first',
+            ],
+        ];
+        $compareBlocks = collect((array) ($projection['comparison_blocks'] ?? []))
+            ->map(static fn (array $block): array => [
+                'key' => (string) ($block['key'] ?? ''),
+                'title' => (string) ($block['title'] ?? ''),
+                'body' => (string) ($block['body_md'] ?? ''),
+                'kind' => (string) ($block['source'] ?? 'comparison_pair'),
+            ])
+            ->values()
+            ->all();
+
+        return $this->answerSurfaceContractService->build([
+            'answer_scope' => 'public_indexable_detail',
+            'surface_type' => 'personality_comparison_public_detail',
+            'summary_blocks' => $summaryBlocks,
+            'compare_blocks' => $compareBlocks,
+            'next_step_blocks' => $this->answerSurfaceContractService->buildNextStepBlocksFromCtas(
+                is_array($landingSurface['cta_bundle'] ?? null) ? $landingSurface['cta_bundle'] : [],
+                3
+            ),
+            'answer_bundle' => [
+                ['key' => 'summary', 'title' => 'summary', 'count' => count($summaryBlocks)],
+                ['key' => 'compare', 'title' => 'compare', 'count' => count($compareBlocks)],
+            ],
+            'evidence_refs' => array_values(array_filter([
+                (string) ($seoSurface['metadata_fingerprint'] ?? ''),
+                (string) ($landingSurface['landing_fingerprint'] ?? ''),
+                'comparison_public_projection_v1',
+                'personality_variant_sections',
+                'personality_variant_seo_meta',
+            ])),
+            'public_safety_state' => 'public_indexable',
+            'indexability_state' => 'indexable',
+            'attribution_scope' => 'public_personality_answer',
+            'seo_surface_ref' => (string) ($seoSurface['metadata_fingerprint'] ?? ''),
+            'landing_surface_ref' => (string) ($landingSurface['landing_fingerprint'] ?? ''),
+            'primary_content_ref' => $baseTypeCode.':A:T',
+            'related_surface_keys' => ['personality_detail', 'topic_cluster', 'start_test'],
+            'fingerprint_seed' => [
+                'comparison_slug' => $this->comparisonSlug($baseTypeCode),
+                'locale' => $locale,
+                'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            ],
+        ]);
+    }
+
     /**
      * @param  array<string,mixed>  $meta
      * @return array<string,mixed>

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -4120,6 +4120,23 @@
                 ]
             }
         },
+        "/api/v0.5/personality/comparisons/{comparison}": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_comparisons_comparison_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@comparison",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/personality/{type}": {
             "get": {
                 "operationId": "get_api_v0_5_personality_type_",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -600,6 +600,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);
     Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);
     Route::get('/personality', [PersonalityController::class, 'index']);
+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);
     Route::get('/personality/{type}/desktop-clone', [PersonalityDesktopCloneController::class, 'show']);
     Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
     Route::get('/personality/{type}', [PersonalityController::class, 'show']);

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -612,6 +612,164 @@ final class PersonalityPublicApiTest extends TestCase
         );
     }
 
+    public function test_personality_comparison_endpoint_returns_backend_authoritative_at_pair(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'type_name' => 'Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'INTJ Personality Type',
+            'seo_description' => 'Explore INTJ traits.',
+            'robots' => 'index,follow',
+        ]);
+
+        $assertive = $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 2%',
+            'hero_summary_md' => 'INTJ-A keeps a calmer long-range plan under pressure.',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($assertive, [
+            'seo_title' => 'INTJ-A Architect Personality: Traits, Careers, Love & Rarity',
+            'seo_description' => 'Explore INTJ-A Architect traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.',
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $assertive->id,
+            'section_key' => 'traits.at_difference',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ-A usually trusts the plan sooner and spends less energy second-guessing the decision.',
+            'payload_json' => ['runtime_type_code' => 'INTJ-A', 'sibling_runtime_type_code' => 'INTJ-T'],
+            'sort_order' => 31,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $assertive->id,
+            'section_key' => 'career.summary',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ-A often fits roles that reward independent strategy and calm ownership.',
+            'sort_order' => 50,
+            'is_enabled' => true,
+        ]);
+
+        $turbulent = $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect Turbulent',
+            'nickname' => 'Self-auditing strategist',
+            'rarity_text' => 'About 1%',
+            'hero_summary_md' => 'INTJ-T keeps checking weak points before committing.',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($turbulent, [
+            'seo_title' => 'INTJ-T Architect Personality: Traits, Careers, Love & Rarity',
+            'seo_description' => 'Explore INTJ-T Architect traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.',
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $turbulent->id,
+            'section_key' => 'traits.at_difference',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ-T usually stress-tests the plan longer and notices risks earlier.',
+            'payload_json' => ['runtime_type_code' => 'INTJ-T', 'sibling_runtime_type_code' => 'INTJ-A'],
+            'sort_order' => 31,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $turbulent->id,
+            'section_key' => 'relationships.summary',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ-T often needs explicit trust signals before relaxing in close relationships.',
+            'sort_order' => 60,
+            'is_enabled' => true,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons/intj-a-vs-intj-t?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('comparison_public_projection_v1.comparison_contract_version', 'mbti.at_comparison.v1')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_slug', 'intj-a-vs-intj-t')
+            ->assertJsonPath('comparison_public_projection_v1.base_type_code', 'INTJ')
+            ->assertJsonPath('comparison_public_projection_v1.public_route_type', 'at-comparison')
+            ->assertJsonPath('comparison_public_projection_v1.variants.a.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('comparison_public_projection_v1.variants.a.public_route_slug', 'intj-a')
+            ->assertJsonPath('comparison_public_projection_v1.variants.t.runtime_type_code', 'INTJ-T')
+            ->assertJsonPath('comparison_public_projection_v1.variants.t.public_route_slug', 'intj-t')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_blocks.0.key', 'at_difference')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_blocks.0.variants.a', 'INTJ-A usually trusts the plan sooner and spends less energy second-guessing the decision.')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_blocks.0.variants.t', 'INTJ-T usually stress-tests the plan longer and notices risks earlier.')
+            ->assertJsonPath('seo_meta.seo_title', 'INTJ-A vs INTJ-T: Traits, Careers, Love & Rarity')
+            ->assertJsonPath('seo_meta.canonical_url', 'https://fermatmind.com/en/personality/intj-a-vs-intj-t')
+            ->assertJsonPath('seo_surface_v1.surface_type', 'mbti_personality_at_comparison')
+            ->assertJsonPath('seo_surface_v1.canonical_url', 'https://fermatmind.com/en/personality/intj-a-vs-intj-t')
+            ->assertJsonPath('seo_surface_v1.alternates.zh-CN', 'https://fermatmind.com/zh/personality/intj-a-vs-intj-t')
+            ->assertJsonPath('landing_surface_v1.entry_surface', 'personality_comparison')
+            ->assertJsonPath('landing_surface_v1.entry_type', 'mbti_at_pair')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.0.href', '/en/personality/intj-a')
+            ->assertJsonPath('answer_surface_v1.surface_type', 'personality_comparison_public_detail')
+            ->assertJsonPath('answer_surface_v1.compare_blocks.0.key', 'at_difference')
+            ->assertJsonPath('jsonld.@type', 'CollectionPage')
+            ->assertJsonPath('jsonld.mainEntity.@type', 'ItemList');
+
+        self::assertContains('BreadcrumbList', (array) $response->json('seo_surface_v1.structured_data_keys'));
+        self::assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
+
+        $this->getJson('/api/v0.5/personality/comparisons/intj?locale=en')
+            ->assertOk()
+            ->assertJsonPath('comparison_public_projection_v1.comparison_slug', 'intj-a-vs-intj-t');
+    }
+
+    public function test_personality_comparison_endpoint_requires_complete_published_pair(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'is_published' => false,
+            'published_at' => null,
+        ]);
+
+        $this->getJson('/api/v0.5/personality/comparisons/intj-a-vs-intj-t?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/comparisons/invalid-a-vs-invalid-t?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
     public function test_detail_accepts_published_public_variants_after_canonical_cutover(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -250,6 +250,24 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_personality_comparison_api_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            "+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_variant_seo_metadata_refresh_files(): void
     {
         $changed = [
@@ -3517,6 +3535,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsPersonalityComparisonApiContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
             if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
@@ -6045,6 +6070,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             "+    Route::get('/personality-content-assets', [PersonalityPublicContentAssetController::class, 'index']);",
             "+    Route::get('/personality-content-assets/{framework}/{entityType}/{code}', [PersonalityPublicContentAssetController::class, 'showByCode']);",
             "+    Route::get('/personality-content-assets/{framework}/{slug}', [PersonalityPublicContentAssetController::class, 'show']);",
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsPersonalityComparisonApiContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            "+    Route::get('/personality/comparisons/{comparison}', [PersonalityController::class, 'comparison']);",
         ];
 
         foreach ($changedLines as $line) {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26434,7 +26434,7 @@
   "INDEXNOW-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/indexnow-live-00-readiness-contract",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "BAIDU-LIVE-00"
     ],
@@ -54740,11 +54740,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "4c5513baf5391290e2c5a9a2618ed2954a034458",
+    "commit_sha": "1b9074549211fe15b257a9595a88782cef118616",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2087",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-13T20:22:14Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-14T04:02:59+08:00",
@@ -54770,6 +54770,79 @@
         "at": "2026-06-14T04:45:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed and pre-merge scope validation showed only the 7 declared PR files changed."
+      },
+      {
+        "at": "2026-06-14T04:42:00+08:00",
+        "status": "merged",
+        "note": "Reconciled GitHub PR #2087 as merged; origin/main contains merge commit 1b9074549211fe15b257a9595a88782cef118616 and the remote branch is deleted."
+      }
+    ]
+  },
+  "PERSONALITY-COMPARISON-PAGES-01": {
+    "id": "PERSONALITY-COMPARISON-PAGES-01",
+    "branch": "codex/personality-comparison-pages-01-backend",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "personality_seo",
+    "title": "PERSONALITY-COMPARISON-PAGES-01: feat(personality): add backend A/T comparison authority",
+    "depends_on": [
+      "PERSONALITY-SEO-TITLE-METADATA-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing the fap-api comparison backend PR-train item."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PERSONALITY-SEO-TITLE-METADATA-01 is reconciled as merged in fap-api PR #2087 with merge commit 1b9074549211fe15b257a9595a88782cef118616."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the backend personality public API route/controller contract, OpenAPI snapshot, focused personality comparison tests, Big Five runtime-freeze classifier coverage, and docs/codex PR-train metadata. No fap-web, sitemap, llms, frontend rendering, production CMS mutation, publish-state mutation, or deploy is in scope."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter personality_comparison --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_comparison --no-ansi",
+          "cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-comparison-pages.sqlite php artisan migrate --force --no-ansi",
+          "cd backend && APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash scripts/export_openapi.sh --check",
+          "cd backend && bash scripts/ci_verify_mbti.sh",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "After synchronizing backend/docs/contracts/openapi.snapshot.json for the new public comparison route, all required local checks passed: focused personality_comparison API test passed with 2 warnings / 34 assertions; Big Five runtime-freeze classifier filter passed with 1 warning / 1 assertion; Pint passed for 4 files; route-list showed the api/v0.5/personality comparison route among 8 personality routes; sqlite migrate passed; OpenAPI snapshot check passed; full scripts/ci_verify_mbti.sh passed through OpenAPI, auth, order security, migration, Big Five, MBTI, and webhook/attempt gates; JSON/YAML parse and git diff --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-14T04:42:00+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit user authorization and started backend-only MBTI A/T comparison authority implementation."
+      },
+      {
+        "at": "2026-06-14T05:00:00+08:00",
+        "status": "local_checks_failed",
+        "note": "Full ci_verify_mbti.sh reached the OpenAPI diff gate and failed because the new public comparison route required backend/docs/contracts/openapi.snapshot.json to be synchronized. No PR was opened before fixing the contract snapshot in scope."
+      },
+      {
+        "at": "2026-06-14T05:02:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Synchronized the OpenAPI snapshot, restored validation-generated Big Five compiled artifacts outside this PR scope, reran the required full ci_verify_mbti.sh gate successfully, and verified the remaining diff is confined to the declared backend comparison authority scope."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -54782,7 +54782,7 @@
     "id": "PERSONALITY-COMPARISON-PAGES-01",
     "branch": "codex/personality-comparison-pages-01-backend",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "committed",
     "train_scope": "personality_seo",
     "title": "PERSONALITY-COMPARISON-PAGES-01: feat(personality): add backend A/T comparison authority",
     "depends_on": [
@@ -54823,7 +54823,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "c3e8eea1555dfed503fe9e8243edc2a0758a7aed",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -54843,6 +54843,11 @@
         "at": "2026-06-14T05:02:00+08:00",
         "status": "local_checks_passed",
         "note": "Synchronized the OpenAPI snapshot, restored validation-generated Big Five compiled artifacts outside this PR scope, reran the required full ci_verify_mbti.sh gate successfully, and verified the remaining diff is confined to the declared backend comparison authority scope."
+      },
+      {
+        "at": "2026-06-14T05:03:00+08:00",
+        "status": "committed",
+        "note": "Recorded scoped implementation commit c3e8eea1555dfed503fe9e8243edc2a0758a7aed after local checks and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -54782,7 +54782,7 @@
     "id": "PERSONALITY-COMPARISON-PAGES-01",
     "branch": "codex/personality-comparison-pages-01-backend",
     "base": "origin/main",
-    "status": "committed",
+    "status": "pr_open",
     "train_scope": "personality_seo",
     "title": "PERSONALITY-COMPARISON-PAGES-01: feat(personality): add backend A/T comparison authority",
     "depends_on": [
@@ -54824,7 +54824,7 @@
     },
     "failure_reason": null,
     "commit_sha": "c3e8eea1555dfed503fe9e8243edc2a0758a7aed",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2089",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -54848,6 +54848,11 @@
         "at": "2026-06-14T05:03:00+08:00",
         "status": "committed",
         "note": "Recorded scoped implementation commit c3e8eea1555dfed503fe9e8243edc2a0758a7aed after local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-14T05:04:00+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2089 from head 52d796503aac62740f85535e344dfc0d7fe87e11."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38349,7 +38349,7 @@
     "merge_commit": "42a8caacb4f4bfa0fb5a83ecd69c25e3b5e83973"
   },
   "AUDIT-SEC-TRAIN-LEDGER-CLOSEOUT-01": {
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "branch": "audit/sec-train-ledger-closeout-01",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1804",
     "base": "main",
@@ -54818,8 +54818,8 @@
         "evidence": "After synchronizing backend/docs/contracts/openapi.snapshot.json for the new public comparison route, all required local checks passed: focused personality_comparison API test passed with 2 warnings / 34 assertions; Big Five runtime-freeze classifier filter passed with 1 warning / 1 assertion; Pint passed for 4 files; route-list showed the api/v0.5/personality comparison route among 8 personality routes; sqlite migrate passed; OpenAPI snapshot check passed; full scripts/ci_verify_mbti.sh passed through OpenAPI, auth, order security, migration, Big Five, MBTI, and webhook/attempt gates; JSON/YAML parse and git diff --check passed."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2089 GitHub checks passed on head 3af2d882cd424069e8250fa2a49a7c815a7d80a8: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload. Pre-merge PR state was CLEAN."
       }
     },
     "failure_reason": null,
@@ -54853,6 +54853,11 @@
         "at": "2026-06-14T05:04:00+08:00",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2089 from head 52d796503aac62740f85535e344dfc0d7fe87e11."
+      },
+      {
+        "at": "2026-06-14T05:10:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2089 and pre-merge scope validation showed only the 7 declared PR files changed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24005,6 +24005,53 @@ prs:
     content_authority: backend
     next_task: PERSONALITY-SEO-TITLE-METADATA-01 fap-web consumer after this backend PR is merged
 
+  - id: PERSONALITY-COMPARISON-PAGES-01
+    repo: fap-api
+    depends_on:
+      - PERSONALITY-SEO-TITLE-METADATA-01
+    branch: codex/personality-comparison-pages-01-backend
+    title: "PERSONALITY-COMPARISON-PAGES-01: feat(personality): add backend A/T comparison authority"
+    train_scope: personality_seo
+    status: user_authorized
+    scope:
+      - Add a backend public MBTI A/T comparison endpoint for 16 base type pairs, keyed by the frontend comparison slug such as intj-a-vs-intj-t.
+      - Return backend-authoritative comparison projection, SEO surface, landing surface, answer surface, canonical URL, alternates, and structured data for each complete A/T pair.
+      - Require both published public A and T variants before returning a comparison page payload.
+      - Add contracts proving fap-web can render comparison pages without inferring editorial or SEO content client-side.
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+      - backend/docs/contracts/openapi.snapshot.json
+      - backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Add frontend pages, sitemap changes, llms changes, CMS production writes, baseline content rewrites, deploys, or publish-state mutations.
+      - Generate comparison content in frontend code or make fap-web infer A/T authority.
+      - Add new 32 distinct media assets or alter existing personality media handling.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter personality_comparison --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_comparison --no-ansi
+      - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-comparison-pages.sqlite php artisan migrate --force --no-ansi
+      - cd backend && APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash scripts/export_openapi.sh --check
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+    next_task: PERSONALITY-COMPARISON-PAGES-01 fap-web consumer after this backend PR is merged
+
   - id: ARTICLE-H1-02
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the backend PR-train manifest/state item for PERSONALITY-COMPARISON-PAGES-01.
- Added a public `GET /api/v0.5/personality/comparisons/{comparison}` contract for MBTI A/T pairs such as `intj-a-vs-intj-t` and base aliases such as `intj`.
- Projects backend-authoritative comparison, SEO, JSON-LD, landing, and answer surfaces from published A/T variant content.
- Synced the OpenAPI snapshot and added focused API/runtime-freeze contract coverage.

## Why
This gives fap-web a backend-owned source for 16 A-vs-T comparison pages without making the frontend infer editorial, SEO, canonical, alternate, or answer content.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter personality_comparison --no-ansi`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter mbti_personality_comparison --no-ansi`\n- `cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan route:list --path=api/v0.5/personality --no-ansi`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-personality-comparison-pages.sqlite php artisan migrate --force --no-ansi`\n- `cd backend && APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash scripts/export_openapi.sh --check`\n- `cd backend && bash scripts/ci_verify_mbti.sh`\n- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`\n- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n\n## Intentionally deferred\n- No fap-web route/rendering work in this backend PR.\n- No sitemap, llms.txt, hub, frontend JSON-LD, or comparison page UI changes.\n- No production CMS mutation, publish-state mutation, deploy, or content generation beyond projecting existing backend A/T variant content.\n\n## Repository rule impact\nBackend remains the authority for personality comparison content, SEO metadata, canonical/alternate URLs, landing surfaces, answer surfaces, and structured data. This PR adds an API contract for a new backend-authoritative public content surface; frontend consumers must render this contract rather than infer comparison content locally.