### PR TITLE
SEO-OPS-SIX-PILLAR: support article URL Truth handoff

### DIFF
--- a/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
@@ -23,7 +23,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
         {--confirm-artifact-sha256= : Required SHA256 confirmation for write mode}
         {--json : Output safe machine-readable JSON}';
 
-    protected $description = 'Export or validate bounded Research URL Truth handoff artifacts without cross-cloud direct writes.';
+    protected $description = 'Export or validate bounded URL Truth handoff artifacts without cross-cloud direct writes.';
 
     public function handle(UrlTruthHandoffArtifact $artifact): int
     {
@@ -43,23 +43,23 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
             ]);
         }
 
-        if ($pageType !== ResearchReport::PAGE_ENTITY_TYPE) {
+        if (! $artifact->supportsPageEntityType($pageType)) {
             return $this->finish([
                 'status' => 'blocked',
-                'issues' => ['only_research_report_page_type_supported'],
+                'issues' => ['unsupported_page_entity_type'],
                 'dry_run' => true,
                 'writes_committed' => false,
-            ]);
+            ], $pageType);
         }
 
         if ($exportPath !== null) {
-            return $this->export($artifact, $exportPath, $limit);
+            return $this->export($artifact, $exportPath, $limit, $pageType);
         }
 
-        return $this->import($artifact, (string) $importPath, $limit, $dryRun, $write);
+        return $this->import($artifact, (string) $importPath, $limit, $dryRun, $write, $pageType);
     }
 
-    private function export(UrlTruthHandoffArtifact $artifact, string $path, int $limit): int
+    private function export(UrlTruthHandoffArtifact $artifact, string $path, int $limit, string $pageType): int
     {
         $pathSafetyIssue = $artifact->artifactPathSafetyIssue($path, forWrite: true);
         if ($pathSafetyIssue !== null) {
@@ -69,13 +69,13 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'issues' => [$pathSafetyIssue],
                 'dry_run' => true,
                 'writes_committed' => false,
-            ]);
+            ], $pageType);
         }
 
         $source = new BackendAuthorityUrlTruthSource;
         $records = array_values(array_filter(
             $source->candidates(),
-            static fn (UrlTruthInventoryRecord $record): bool => $record->pageEntityType === ResearchReport::PAGE_ENTITY_TYPE
+            static fn (UrlTruthInventoryRecord $record): bool => $record->pageEntityType === $pageType
                 && $record->sourceAuthority === UrlTruthHandoffArtifact::SOURCE_AUTHORITY
         ));
 
@@ -84,8 +84,8 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
             $b->canonicalUrlHash(),
         ));
 
-        $payload = $artifact->fromRecords($records, $source->metadata(), $limit);
-        $validation = $artifact->validate($payload, $limit);
+        $payload = $artifact->fromRecords($records, $source->metadata(), $limit, $pageType);
+        $validation = $artifact->validate($payload, $limit, $pageType);
 
         if ($validation['status'] === 'blocked') {
             return $this->finish([
@@ -94,7 +94,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'issues' => $validation['issues'],
                 'dry_run' => true,
                 'writes_committed' => false,
-            ]);
+            ], $pageType);
         }
 
         $artifact->writeJson($path, $payload);
@@ -114,10 +114,10 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
             'search_url_submission' => false,
             'crawler_log_read' => false,
             'issues' => [],
-        ]);
+        ], $pageType);
     }
 
-    private function import(UrlTruthHandoffArtifact $artifact, string $path, int $limit, bool $dryRun, bool $write): int
+    private function import(UrlTruthHandoffArtifact $artifact, string $path, int $limit, bool $dryRun, bool $write, string $pageType): int
     {
         $pathSafetyIssue = $artifact->artifactPathSafetyIssue($path, forWrite: false);
         if ($pathSafetyIssue !== null) {
@@ -128,7 +128,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => true,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         if (! is_file($path)) {
@@ -138,12 +138,12 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'issues' => ['handoff_artifact_missing'],
                 'dry_run' => true,
                 'writes_committed' => false,
-            ]);
+            ], $pageType);
         }
 
         $sha256 = $artifact->sha256($path);
         $payload = $artifact->readJson($path);
-        $validation = $artifact->validate($payload, $limit);
+        $validation = $artifact->validate($payload, $limit, $pageType);
 
         if ($validation['status'] === 'blocked') {
             return $this->finish([
@@ -154,7 +154,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => true,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         if ($write && $dryRun) {
@@ -166,7 +166,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => true,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         if (! $write) {
@@ -184,7 +184,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'search_url_submission' => false,
                 'crawler_log_read' => false,
                 'issues' => [],
-            ]);
+            ], $pageType);
         }
 
         if ($validation['records'] === []) {
@@ -196,7 +196,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => false,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         $confirmation = $this->stringOption($this->option('confirm-artifact-sha256'));
@@ -209,7 +209,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => false,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         if (! (bool) config('seo_intel.enabled', false) || ! (bool) config('seo_intel.write_enabled', false)) {
@@ -221,7 +221,7 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
                 'dry_run' => false,
                 'writes_committed' => false,
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-            ]);
+            ], $pageType);
         }
 
         $written = (new UrlTruthInventoryRecordWriter)->write($validation['records']);
@@ -241,18 +241,18 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
             'search_url_submission' => false,
             'crawler_log_read' => false,
             'issues' => [],
-        ]);
+        ], $pageType);
     }
 
     /**
      * @param  array<string, mixed>  $payload
      */
-    private function finish(array $payload): int
+    private function finish(array $payload, ?string $pageType = null): int
     {
         $output = [
             'task' => 'SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00',
             'collector' => UrlTruthHandoffArtifact::COLLECTOR,
-            'page_entity_type' => UrlTruthHandoffArtifact::PAGE_ENTITY_TYPE,
+            'page_entity_type' => $pageType ?? UrlTruthHandoffArtifact::PAGE_ENTITY_TYPE,
             'source_authority' => UrlTruthHandoffArtifact::SOURCE_AUTHORITY,
             'target_tables' => ['seo_urls', 'seo_url_entities'],
             'external_api_calls' => false,

--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -148,6 +148,7 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
                 ],
                 attributes: [
                     'source_authority' => 'backend_cms',
+                    'claim_safe' => true,
                     'article_id_hash' => hash('sha256', (string) $article->id),
                     'translation_group_hash' => hash('sha256', (string) $article->translation_group_id),
                 ],

--- a/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+++ b/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
@@ -16,30 +16,71 @@ final class UrlTruthHandoffArtifact
 
     public const PAGE_ENTITY_TYPE = 'research_report';
 
+    public const ARTICLE_PAGE_ENTITY_TYPE = 'article';
+
     public const SOURCE_AUTHORITY = 'backend_cms';
+
+    /**
+     * @var array<string, array{
+     *     mode:string,
+     *     route_regex:string,
+     *     entity_source:string,
+     *     route_fragment:string,
+     *     forbidden_route_fragments:list<string>,
+     *     type_issue:string,
+     *     entity_source_issue:string,
+     *     route_issue:string,
+     *     entity_identity_issue:string
+     * }>
+     */
+    private const PAGE_TYPE_POLICIES = [
+        self::PAGE_ENTITY_TYPE => [
+            'mode' => 'two_stage_research_report_url_truth_handoff',
+            'route_regex' => '^/(en|zh)/research/[a-z0-9][a-z0-9-]*$',
+            'entity_source' => 'research_reports',
+            'route_fragment' => '/research/',
+            'forbidden_route_fragments' => ['/articles', '/reports', 'turnover-rate-report'],
+            'type_issue' => 'candidate_not_research_report',
+            'entity_source_issue' => 'candidate_entity_source_not_research_reports',
+            'route_issue' => 'candidate_route_not_research',
+            'entity_identity_issue' => 'candidate_research_path_slug_mismatch',
+        ],
+        self::ARTICLE_PAGE_ENTITY_TYPE => [
+            'mode' => 'two_stage_article_url_truth_handoff',
+            'route_regex' => '^/(en|zh)/articles/[a-z0-9][a-z0-9-]*$',
+            'entity_source' => 'articles',
+            'route_fragment' => '/articles/',
+            'forbidden_route_fragments' => ['/research', '/reports', 'turnover-rate-report'],
+            'type_issue' => 'candidate_not_article',
+            'entity_source_issue' => 'candidate_entity_source_not_articles',
+            'route_issue' => 'candidate_route_not_article',
+            'entity_identity_issue' => 'candidate_article_entity_id_invalid',
+        ],
+    ];
 
     /**
      * @param  list<UrlTruthInventoryRecord>  $records
      * @param  array<string, mixed>  $sourceMetadata
      * @return array<string, mixed>
      */
-    public function fromRecords(array $records, array $sourceMetadata = [], ?int $limit = null): array
+    public function fromRecords(array $records, array $sourceMetadata = [], ?int $limit = null, string $pageEntityType = self::PAGE_ENTITY_TYPE): array
     {
+        $policy = $this->policyFor($pageEntityType);
         $boundedRecords = $limit === null ? $records : array_slice($records, 0, max(0, $limit));
 
         return [
             'schema_version' => self::SCHEMA_VERSION,
             'collector' => self::COLLECTOR,
-            'mode' => 'two_stage_research_report_url_truth_handoff',
+            'mode' => $policy['mode'],
             'generated_at' => now()->toIso8601String(),
             'dry_run_required_on_source' => true,
             'source_environment_role' => 'candidate_export_only',
             'runner_environment_role' => 'validate_then_bounded_write_only',
             'constraints' => [
-                'allowed_page_entity_type' => self::PAGE_ENTITY_TYPE,
+                'allowed_page_entity_type' => $pageEntityType,
                 'allowed_source_authority' => self::SOURCE_AUTHORITY,
-                'allowed_route_regex' => '^/(en|zh)/research/[a-z0-9][a-z0-9-]*$',
-                'forbidden_route_fragments' => ['/articles', '/reports', 'turnover-rate-report'],
+                'allowed_route_regex' => $policy['route_regex'],
+                'forbidden_route_fragments' => $policy['forbidden_route_fragments'],
                 'forbidden_states' => ['private', 'draft', 'noindex', 'claim_unsafe'],
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
                 'no_external_api' => true,
@@ -57,10 +98,22 @@ final class UrlTruthHandoffArtifact
      * @param  array<string, mixed>  $artifact
      * @return array{status:string, issues:list<string>, records:list<UrlTruthInventoryRecord>, metadata:array<string, mixed>}
      */
-    public function validate(array $artifact, ?int $limit = null): array
+    public function validate(array $artifact, ?int $limit = null, ?string $expectedPageEntityType = null): array
     {
         $issues = [];
         $records = [];
+        $pageEntityType = (string) data_get($artifact, 'constraints.allowed_page_entity_type', self::PAGE_ENTITY_TYPE);
+
+        if ($expectedPageEntityType !== null && $expectedPageEntityType !== $pageEntityType) {
+            $issues[] = 'artifact_page_entity_type_mismatch';
+        }
+
+        if (! $this->supportsPageEntityType($pageEntityType)) {
+            $issues[] = 'unsupported_page_entity_type';
+            $pageEntityType = self::PAGE_ENTITY_TYPE;
+        }
+
+        $policy = $this->policyFor($pageEntityType);
 
         if (($artifact['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
             $issues[] = 'invalid_schema_version';
@@ -72,6 +125,18 @@ final class UrlTruthHandoffArtifact
 
         if (($artifact['target_tables'] ?? null) !== ['seo_urls', 'seo_url_entities']) {
             $issues[] = 'invalid_target_tables';
+        }
+
+        if (data_get($artifact, 'constraints.allowed_page_entity_type') !== $pageEntityType) {
+            $issues[] = 'invalid_allowed_page_entity_type';
+        }
+
+        if (data_get($artifact, 'constraints.allowed_source_authority') !== self::SOURCE_AUTHORITY) {
+            $issues[] = 'invalid_allowed_source_authority';
+        }
+
+        if (data_get($artifact, 'constraints.allowed_route_regex') !== $policy['route_regex']) {
+            $issues[] = 'invalid_allowed_route_regex';
         }
 
         foreach (['no_external_api', 'no_search_submission', 'no_crawler_log_read'] as $flag) {
@@ -95,7 +160,7 @@ final class UrlTruthHandoffArtifact
                 continue;
             }
 
-            $recordIssues = $this->validateCandidate($candidate, $index);
+            $recordIssues = $this->validateCandidate($candidate, $index, $pageEntityType, $policy);
             if ($recordIssues !== []) {
                 array_push($issues, ...$recordIssues);
 
@@ -113,7 +178,7 @@ final class UrlTruthHandoffArtifact
                 'planned_url_count' => count($records),
                 'planned_entity_count' => count($records),
                 'target_tables' => ['seo_urls', 'seo_url_entities'],
-                'page_entity_type' => self::PAGE_ENTITY_TYPE,
+                'page_entity_type' => $pageEntityType,
                 'source_authority' => self::SOURCE_AUTHORITY,
                 'limit' => $limit,
             ],
@@ -243,9 +308,20 @@ final class UrlTruthHandoffArtifact
 
     /**
      * @param  array<string, mixed>  $candidate
+     * @param  array{
+     *     mode:string,
+     *     route_regex:string,
+     *     entity_source:string,
+     *     route_fragment:string,
+     *     forbidden_route_fragments:list<string>,
+     *     type_issue:string,
+     *     entity_source_issue:string,
+     *     route_issue:string,
+     *     entity_identity_issue:string
+     * }  $policy
      * @return list<string>
      */
-    private function validateCandidate(array $candidate, int $index): array
+    private function validateCandidate(array $candidate, int $index, string $pageEntityType, array $policy): array
     {
         $issues = [];
         $url = (string) ($candidate['canonical_url'] ?? '');
@@ -253,19 +329,19 @@ final class UrlTruthHandoffArtifact
         $host = Str::lower((string) parse_url($url, PHP_URL_HOST));
         $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
         $pathLocale = Str::before(Str::after($path, '/'), '/');
-        $pathSlug = Str::after($path, '/research/');
+        $pathSlug = Str::after($path, $policy['route_fragment']);
         $locale = (string) ($candidate['locale'] ?? '');
 
-        if (($candidate['page_entity_type'] ?? null) !== self::PAGE_ENTITY_TYPE) {
-            $issues[] = 'candidate_not_research_report:'.$index;
+        if (($candidate['page_entity_type'] ?? null) !== $pageEntityType) {
+            $issues[] = $policy['type_issue'].':'.$index;
         }
 
         if (($candidate['source_authority'] ?? null) !== self::SOURCE_AUTHORITY) {
             $issues[] = 'candidate_source_authority_not_backend_cms:'.$index;
         }
 
-        if (($candidate['entity_source'] ?? null) !== 'research_reports') {
-            $issues[] = 'candidate_entity_source_not_research_reports:'.$index;
+        if (($candidate['entity_source'] ?? null) !== $policy['entity_source']) {
+            $issues[] = $policy['entity_source_issue'].':'.$index;
         }
 
         if (($candidate['authority_status'] ?? null) !== 'published_approved') {
@@ -284,16 +360,16 @@ final class UrlTruthHandoffArtifact
             $issues[] = 'candidate_claim_unsafe:'.$index;
         }
 
-        if (! preg_match('#^/(en|zh)/research/[a-z0-9][a-z0-9-]*$#', $path)) {
-            $issues[] = 'candidate_route_not_research:'.$index;
+        if (! preg_match('#'.$policy['route_regex'].'#', $path)) {
+            $issues[] = $policy['route_issue'].':'.$index;
         }
 
         if ($scheme !== 'https' || ! in_array($host, $this->trustedTenantHosts(), true)) {
             $issues[] = 'candidate_untrusted_tenant_host:'.$index;
         }
 
-        if ($pathSlug === '' || ($candidate['entity_id_or_slug'] ?? null) !== $pathSlug) {
-            $issues[] = 'candidate_research_path_slug_mismatch:'.$index;
+        if ($this->entityIdentityInvalid($candidate, $pageEntityType, $pathSlug)) {
+            $issues[] = $policy['entity_identity_issue'].':'.$index;
         }
 
         $canonicalPathHash = data_get($candidate, 'metadata.canonical_path_hash');
@@ -301,7 +377,7 @@ final class UrlTruthHandoffArtifact
             $issues[] = 'candidate_canonical_path_hash_mismatch:'.$index;
         }
 
-        foreach (['/articles', '/reports', 'turnover-rate-report'] as $fragment) {
+        foreach ($policy['forbidden_route_fragments'] as $fragment) {
             if (str_contains($path, $fragment)) {
                 $issues[] = 'candidate_forbidden_route_fragment:'.$fragment.':'.$index;
             }
@@ -332,6 +408,59 @@ final class UrlTruthHandoffArtifact
         }
 
         return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedPageEntityTypes(): array
+    {
+        return array_keys(self::PAGE_TYPE_POLICIES);
+    }
+
+    public function supportsPageEntityType(string $pageEntityType): bool
+    {
+        return array_key_exists($pageEntityType, self::PAGE_TYPE_POLICIES);
+    }
+
+    /**
+     * @return array{
+     *     mode:string,
+     *     route_regex:string,
+     *     entity_source:string,
+     *     route_fragment:string,
+     *     forbidden_route_fragments:list<string>,
+     *     type_issue:string,
+     *     entity_source_issue:string,
+     *     route_issue:string,
+     *     entity_identity_issue:string
+     * }
+     */
+    private function policyFor(string $pageEntityType): array
+    {
+        if (! $this->supportsPageEntityType($pageEntityType)) {
+            throw new InvalidArgumentException('unsupported_page_entity_type');
+        }
+
+        return self::PAGE_TYPE_POLICIES[$pageEntityType];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function entityIdentityInvalid(array $candidate, string $pageEntityType, string $pathSlug): bool
+    {
+        $entityIdOrSlug = (string) ($candidate['entity_id_or_slug'] ?? '');
+
+        if ($pageEntityType === self::PAGE_ENTITY_TYPE) {
+            return $pathSlug === '' || $entityIdOrSlug !== $pathSlug;
+        }
+
+        if ($pageEntityType === self::ARTICLE_PAGE_ENTITY_TYPE) {
+            return $entityIdOrSlug === '' || ! ctype_digit($entityIdOrSlug);
+        }
+
+        return true;
     }
 
     /**

--- a/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
+++ b/backend/docs/seo/seo-intel-two-stage-url-truth-handoff.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-`SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00` defines a controlled handoff path for Research URL Truth observation while `fap-api` production and the verified `seo_intel` RDS remain split across clouds.
+`SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00` defines a controlled handoff path for backend-authoritative URL Truth observation while `fap-api` production and the verified `seo_intel` RDS remain split across clouds.
 
 The current MVP policy is:
 
@@ -27,6 +27,17 @@ php artisan seo-intel:url-truth-handoff \
   --page-type=research_report
 ```
 
+For published CMS articles, use the same no-write handoff path with `page-type=article`:
+
+```bash
+php artisan seo-intel:url-truth-handoff \
+  --export=/secure/path/article-url-truth-handoff.json \
+  --dry-run \
+  --json \
+  --limit=20 \
+  --page-type=article
+```
+
 The export is candidate-only. It does not write to `seo_intel`, does not call external search APIs, does not read crawler logs, and does not submit URLs.
 
 The artifact path must be an absolute `.json` path in an existing non-symlink directory. Export refuses to overwrite an existing file or symlink.
@@ -40,10 +51,22 @@ php artisan seo-intel:url-truth-handoff \
   --import=/secure/path/research-url-truth-handoff.json \
   --dry-run \
   --json \
+  --page-type=research_report \
   --limit=20
 ```
 
-Validation is fail-closed. The artifact is accepted only when every candidate is:
+For article artifacts:
+
+```bash
+php artisan seo-intel:url-truth-handoff \
+  --import=/secure/path/article-url-truth-handoff.json \
+  --dry-run \
+  --json \
+  --page-type=article \
+  --limit=20
+```
+
+Validation is fail-closed. Research artifacts are accepted only when every candidate is:
 
 - `page_entity_type = research_report`
 - `source_authority = backend_cms`
@@ -55,6 +78,20 @@ Validation is fail-closed. The artifact is accepted only when every candidate is
 - routed under `/en/research/{slug}` or `/zh/research/{slug}`
 
 Validation rejects `/articles`, `/reports`, stale `turnover-rate-report` slugs, draft/private/noindex/claim-unsafe candidates, and sensitive metadata keys.
+
+Article artifacts are accepted only when every candidate is:
+
+- `page_entity_type = article`
+- `source_authority = backend_cms`
+- `entity_source = articles`
+- `authority_status = published_approved`
+- `indexability_state = indexable`
+- non-private
+- claim-safe
+- routed under `/en/articles/{slug}` or `/zh/articles/{slug}`
+- backed by a numeric article entity id from backend CMS authority
+
+Article validation rejects `/research`, `/reports`, stale `turnover-rate-report` slugs, draft/private/noindex/claim-unsafe candidates, and sensitive metadata keys.
 
 Import validates artifact path safety before reading. It accepts only regular `.json` files under an existing non-symlink directory and rejects stream wrappers, relative paths, missing files, symlinks, and oversized artifacts.
 
@@ -70,6 +107,7 @@ php artisan seo-intel:url-truth-handoff \
   --write \
   --confirm-artifact-sha256=<artifact_sha256> \
   --json \
+  --page-type=research_report \
   --limit=20
 ```
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\SeoIntel;
 
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
 use App\Models\ResearchReport;
 use App\Services\SeoIntel\UrlTruthHandoffArtifact;
 use App\Services\SeoIntel\UrlTruthInventoryRecord;
@@ -39,7 +42,7 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
         ]);
         $exportOutput = json_decode(trim(Artisan::output()), true);
 
-        $this->assertSame(0, $exportExitCode);
+        $this->assertSame(0, $exportExitCode, json_encode($exportOutput, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
         $this->assertSame('success', $exportOutput['status'] ?? null);
         $this->assertTrue((bool) ($exportOutput['dry_run'] ?? false));
         $this->assertFalse((bool) ($exportOutput['writes_committed'] ?? true));
@@ -66,6 +69,79 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
         $this->assertSame('import_dry_run', $importOutput['mode'] ?? null);
         $this->assertSame(1, $importOutput['planned_url_count'] ?? null);
         $this->assertFalse((bool) ($importOutput['writes_committed'] ?? true));
+    }
+
+    #[Test]
+    public function command_exports_and_validates_article_handoff_artifact_without_writes_or_search_submission(): void
+    {
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
+
+        $article = $this->createPublishedArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 基础指南',
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $article->id,
+            'locale' => 'zh-CN',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/mbti-basics',
+            'is_indexable' => true,
+        ]);
+
+        $path = sys_get_temp_dir().'/article-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+
+        $exportExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--export' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+            '--page-type' => 'article',
+        ]);
+        $exportOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exportExitCode, json_encode($exportOutput, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $this->assertSame('success', $exportOutput['status'] ?? null);
+        $this->assertSame('article', $exportOutput['page_entity_type'] ?? null);
+        $this->assertTrue((bool) ($exportOutput['dry_run'] ?? false));
+        $this->assertFalse((bool) ($exportOutput['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($exportOutput['external_api_calls'] ?? true));
+        $this->assertFalse((bool) ($exportOutput['search_url_submission'] ?? true));
+        $this->assertSame(1, $exportOutput['planned_url_count'] ?? null);
+        $this->assertFileExists($path);
+
+        $artifact = json_decode((string) file_get_contents($path), true);
+        $this->assertSame(UrlTruthHandoffArtifact::SCHEMA_VERSION, $artifact['schema_version'] ?? null);
+        $this->assertSame('two_stage_article_url_truth_handoff', $artifact['mode'] ?? null);
+        $this->assertSame('article', data_get($artifact, 'constraints.allowed_page_entity_type'));
+        $this->assertSame('^/(en|zh)/articles/[a-z0-9][a-z0-9-]*$', data_get($artifact, 'constraints.allowed_route_regex'));
+        $this->assertSame('article', data_get($artifact, 'candidates.0.page_entity_type'));
+        $this->assertSame('backend_cms', data_get($artifact, 'candidates.0.source_authority'));
+        $this->assertSame('articles', data_get($artifact, 'candidates.0.entity_source'));
+        $this->assertSame((string) $article->id, data_get($artifact, 'candidates.0.entity_id_or_slug'));
+        $this->assertSame('/zh/articles/mbti-basics', parse_url((string) data_get($artifact, 'candidates.0.canonical_url'), PHP_URL_PATH));
+
+        $importExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+            '--page-type' => 'article',
+        ]);
+        $importOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $importExitCode);
+        $this->assertSame('success', $importOutput['status'] ?? null);
+        $this->assertSame('article', $importOutput['page_entity_type'] ?? null);
+        $this->assertSame('import_dry_run', $importOutput['mode'] ?? null);
+        $this->assertSame(1, $importOutput['planned_url_count'] ?? null);
+        $this->assertFalse((bool) ($importOutput['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($importOutput['external_api_calls'] ?? true));
+        $this->assertFalse((bool) ($importOutput['search_url_submission'] ?? true));
     }
 
     #[Test]
@@ -161,6 +237,81 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
         $this->assertContains('candidate_claim_unsafe:0', $output['issues'] ?? []);
         $this->assertContains('candidate_route_not_research:0', $output['issues'] ?? []);
         $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+    }
+
+    #[Test]
+    public function import_validation_rejects_wrong_article_source_route_or_entity_identity(): void
+    {
+        $artifact = new UrlTruthHandoffArtifact;
+        $payload = $artifact->fromRecords([
+            new UrlTruthInventoryRecord(
+                canonicalUrl: 'https://www.fermatmind.com/zh/research/mbti-basics',
+                locale: 'zh-CN',
+                pageEntityType: 'article',
+                entityIdOrSlug: '8',
+                sourceAuthority: 'backend_cms',
+                indexabilityState: 'indexable',
+                lastmodAt: now()->subHour(),
+                lastmodSource: 'articles.updated_at',
+                cluster: 'articles',
+                entitySource: 'research_reports',
+                authorityStatus: 'published_approved',
+                sourceUpdatedAt: now()->subHour(),
+                isPrivateFlow: false,
+                metadata: [
+                    'source_table_hash' => hash('sha256', 'articles'),
+                    'canonical_path_hash' => hash('sha256', '/zh/research/mbti-basics'),
+                ],
+                attributes: [
+                    'source_authority' => 'backend_cms',
+                    'claim_safe' => true,
+                ],
+            ),
+            new UrlTruthInventoryRecord(
+                canonicalUrl: 'https://www.fermatmind.com/zh/articles/big-five-tool-guide',
+                locale: 'zh-CN',
+                pageEntityType: 'article',
+                entityIdOrSlug: 'big-five-tool-guide',
+                sourceAuthority: 'backend_cms',
+                indexabilityState: 'indexable',
+                lastmodAt: now()->subHour(),
+                lastmodSource: 'articles.updated_at',
+                cluster: 'articles',
+                entitySource: 'articles',
+                authorityStatus: 'published_approved',
+                sourceUpdatedAt: now()->subHour(),
+                isPrivateFlow: false,
+                metadata: [
+                    'source_table_hash' => hash('sha256', 'articles'),
+                    'canonical_path_hash' => hash('sha256', '/zh/articles/big-five-tool-guide'),
+                ],
+                attributes: [
+                    'source_authority' => 'backend_cms',
+                    'claim_safe' => true,
+                ],
+            ),
+        ], pageEntityType: 'article');
+
+        $path = sys_get_temp_dir().'/invalid-article-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+        $artifact->writeJson($path, $payload);
+
+        $exitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 20,
+            '--page-type' => 'article',
+        ]);
+        $output = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertContains('candidate_entity_source_not_articles:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_route_not_article:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_forbidden_route_fragment:/research:0', $output['issues'] ?? []);
+        $this->assertContains('candidate_article_entity_id_invalid:1', $output['issues'] ?? []);
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($output['search_url_submission'] ?? true));
     }
 
     #[Test]
@@ -338,6 +489,57 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
             'seo_description' => 'Safe Research Report description.',
             'canonical_path' => '/'.$localeSegment.'/research/'.$slug,
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPublishedArticle(array $overrides = []): Article
+    {
+        /** @var Article $article */
+        $article = Article::unguarded(fn (): Article => Article::query()->create($overrides + [
+            'org_id' => 0,
+            'slug' => 'safe-article',
+            'locale' => 'en',
+            'translation_group_id' => 'article-test-group',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => 'Safe Article',
+            'excerpt' => 'Safe article excerpt.',
+            'content_md' => 'Safe article body.',
+            'content_html' => '<p>Safe article body.</p>',
+            'status' => 'published',
+            'lifecycle_state' => Article::LIFECYCLE_ACTIVE,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subHour(),
+        ]));
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => $article->id,
+            'source_article_id' => null,
+            'locale' => $article->locale,
+            'source_locale' => $article->locale,
+            'translation_group_id' => $article->translation_group_id,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => $article->content_md,
+            'source_version_hash' => $article->source_version_hash,
+            'published_at' => now()->subHour(),
+            'created_by' => null,
+        ]);
+
+        $article->forceFill([
+            'published_revision_id' => $revision->id,
+            'working_revision_id' => $revision->id,
+        ])->save();
+
+        return $article->refresh();
     }
 
     private function prepareSeoIntelSqliteConnection(): void


### PR DESCRIPTION
## What changed
- Allows `seo-intel:url-truth-handoff` to export and validate bounded `page-type=article` URL Truth artifacts.
- Keeps existing `research_report` behavior intact while adding article-specific route/entity validation.
- Emits `claim_safe=true` in article URL Truth source attributes so article candidates satisfy the existing fail-closed claim gate.
- Documents safe article export/import dry-run commands.

## Why
Released SEO pillar articles can be public, indexable, sitemap eligible, and llms eligible but still unable to move through the URL Truth handoff because the handoff path was hard-coded to `research_report`. Search Channel queue dry-run/write paths depend on URL Truth rows, so article handoff needs to support backend CMS article authority first.

## Validation
- `vendor/bin/pint --test app/Services/SeoIntel app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php`
- `php artisan test tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php`
- `php artisan test tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php`
- `git diff --check`
- `php artisan seo-intel:url-truth-handoff --export=/private/tmp/article-url-truth-handoff-local-dry-run.json --dry-run --json --limit=20 --page-type=article`
- `php artisan seo-intel:url-truth-handoff --import=/private/tmp/article-url-truth-handoff-local-dry-run.json --dry-run --json --limit=20 --page-type=article`
- `php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --canonical-url=https://fermatmind.com/zh/articles/mbti-basics --page-type=article --limit=20`
- `php artisan seo-intel:search-channel-queue --dry-run --no-write --json --channel=indexnow --canonical-url=https://fermatmind.com/zh/articles/big-five-tool-guide --page-type=article --limit=20`

## Intentionally deferred
- No CMS mutation.
- No production env change.
- No Search Channel enqueue/write.
- No IndexNow/Baidu/GSC/provider submission.
- No deploy in this PR.
- Approval-based batch enqueue remains a separate operator action after this is merged and deployed.

## Repository rule impact
This keeps CMS/backend as the source of truth for article URL Truth. It does not introduce frontend fallback content or change publishing authority.
