### PR TITLE
fix(cms): harden article media identity ops

### DIFF
--- a/backend/app/Console/Commands/ArticleUpdateTranslationGroupId.php
+++ b/backend/app/Console/Commands/ArticleUpdateTranslationGroupId.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class ArticleUpdateTranslationGroupId extends Command
+{
+    protected $signature = 'articles:update-translation-group-id
+        {--article-id= : Exact article id to lock}
+        {--expected-slug= : Expected existing article slug}
+        {--current-translation-group-id= : Expected current translation_group_id lock}
+        {--new-translation-group-id= : New stable translation_group_id to write}
+        {--dry-run : Validate and plan without writing DB rows}
+        {--execute : Apply the identity cleanup; omitted by default for dry-run safety}
+        {--json : Emit a JSON summary}
+        {--no-publish : Required execute-mode hold: do not publish}
+        {--no-schema : Required execute-mode hold: do not modify schema gates}
+        {--no-hreflang : Required execute-mode hold: do not modify hreflang gates}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-sitemap-llms-change : Required execute-mode hold: do not modify sitemap/llms eligibility}';
+
+    protected $description = 'Safely update one published article translation_group_id and its current revision pointers without publishing or search side effects.';
+
+    private const SAFETY_FLAGS = [
+        'no-publish',
+        'no-schema',
+        'no-hreflang',
+        'no-search',
+        'no-sitemap-llms-change',
+    ];
+
+    public function handle(): int
+    {
+        try {
+            $summary = $this->buildSummary();
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $errors = [];
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+        $currentTranslationGroupId = trim((string) $this->option('current-translation-group-id'));
+        $newTranslationGroupId = trim((string) $this->option('new-translation-group-id'));
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+        if ($execute) {
+            foreach (self::SAFETY_FLAGS as $flag) {
+                if ((bool) $this->option($flag) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        $this->validateInputs($articleId, $expectedSlug, $currentTranslationGroupId, $newTranslationGroupId, $errors);
+
+        $article = $articleId > 0 ? $this->article($articleId) : null;
+        if (! $article instanceof Article) {
+            $errors[] = $this->issue('article_id', 'article_not_found', 'Article was not found.');
+
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $currentTranslationGroupId, $newTranslationGroupId, null, null, $errors, []);
+        }
+
+        $before = $this->snapshot($article);
+        $after = $this->plannedSnapshot($article, $newTranslationGroupId);
+        $this->validateArticleLock($article, $expectedSlug, $currentTranslationGroupId, $newTranslationGroupId, $errors);
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $currentTranslationGroupId, $newTranslationGroupId, $before, $after, $errors, []);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_update_translation_group_id', $articleId, $currentTranslationGroupId, $newTranslationGroupId, $before, $after, [], []);
+        }
+
+        DB::transaction(function () use ($article, $newTranslationGroupId): void {
+            $article->forceFill([
+                'translation_group_id' => $newTranslationGroupId,
+            ])->saveQuietly();
+
+            $revisionIds = array_values(array_unique(array_filter([
+                (int) $article->working_revision_id,
+                (int) $article->published_revision_id,
+            ])));
+
+            ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->where('article_id', (int) $article->id)
+                ->whereIn('id', $revisionIds)
+                ->update([
+                    'translation_group_id' => $newTranslationGroupId,
+                ]);
+        });
+
+        $fresh = $this->article($articleId);
+
+        return $this->summary(
+            true,
+            false,
+            'updated_translation_group_id',
+            $articleId,
+            $currentTranslationGroupId,
+            $newTranslationGroupId,
+            $before,
+            $fresh instanceof Article ? $this->snapshot($fresh) : null,
+            [],
+            [],
+        );
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateInputs(int $articleId, string $expectedSlug, string $currentTranslationGroupId, string $newTranslationGroupId, array &$errors): void
+    {
+        if ($articleId <= 0) {
+            $errors[] = $this->issue('article_id', 'article_id_required', '--article-id is required.');
+        }
+        if ($expectedSlug === '') {
+            $errors[] = $this->issue('expected_slug', 'expected_slug_required', '--expected-slug is required.');
+        }
+        if ($currentTranslationGroupId === '') {
+            $errors[] = $this->issue('current_translation_group_id', 'current_translation_group_id_required', '--current-translation-group-id is required.');
+        }
+        if ($newTranslationGroupId === '') {
+            $errors[] = $this->issue('new_translation_group_id', 'new_translation_group_id_required', '--new-translation-group-id is required.');
+        }
+        if ($currentTranslationGroupId !== '' && $newTranslationGroupId !== '' && $currentTranslationGroupId === $newTranslationGroupId) {
+            $errors[] = $this->issue('new_translation_group_id', 'new_translation_group_id_same_as_current', 'New translation_group_id must differ from the current value.');
+        }
+        if ($newTranslationGroupId !== '' && ! preg_match('/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$/', $newTranslationGroupId)) {
+            $errors[] = $this->issue('new_translation_group_id', 'new_translation_group_id_invalid', 'New translation_group_id must be <=64 chars and contain only letters, numbers, underscore, dot, colon, or hyphen.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateArticleLock(Article $article, string $expectedSlug, string $currentTranslationGroupId, string $newTranslationGroupId, array &$errors): void
+    {
+        if ((string) $article->slug !== $expectedSlug) {
+            $errors[] = $this->issue('article.slug', 'slug_mismatch', 'Article slug does not match expected lock.');
+        }
+        if ((string) $article->translation_group_id !== $currentTranslationGroupId) {
+            $errors[] = $this->issue('article.translation_group_id', 'translation_group_id_mismatch', 'Article translation_group_id does not match expected current lock.');
+        }
+        if ((string) $article->status !== 'published' || ! (bool) $article->is_public || ! (int) $article->published_revision_id) {
+            $errors[] = $this->issue('article.status', 'article_not_published_public', 'Identity cleanup is limited to published public articles with a published revision.');
+        }
+        if (! $article->seoMeta instanceof ArticleSeoMeta) {
+            $errors[] = $this->issue('article.seo_meta', 'article_seo_meta_missing', 'Article SEO meta row is required so canonical/schema/hreflang locks can be verified.');
+        }
+        if (! $article->workingRevision instanceof ArticleTranslationRevision || ! $article->publishedRevision instanceof ArticleTranslationRevision) {
+            $errors[] = $this->issue('article.revision', 'current_revision_missing', 'Both working and published revisions are required for identity cleanup.');
+        }
+        if ($newTranslationGroupId !== '' && Article::query()
+            ->withoutGlobalScopes()
+            ->where('id', '<>', (int) $article->id)
+            ->where('translation_group_id', $newTranslationGroupId)
+            ->exists()) {
+            $errors[] = $this->issue('new_translation_group_id', 'translation_group_id_collision', 'Another article already uses the requested translation_group_id.');
+        }
+    }
+
+    private function article(int $articleId): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->find($articleId);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $article->loadMissing([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'slug' => (string) $article->slug,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'working_revision_translation_group_id' => $article->workingRevision instanceof ArticleTranslationRevision ? (string) $article->workingRevision->translation_group_id : null,
+            'published_revision_translation_group_id' => $article->publishedRevision instanceof ArticleTranslationRevision ? (string) $article->publishedRevision->translation_group_id : null,
+            'title_sha256' => hash('sha256', (string) $article->title),
+            'excerpt_sha256' => hash('sha256', (string) $article->excerpt),
+            'content_md_sha256' => hash('sha256', (string) $article->content_md),
+            'content_html_sha256' => hash('sha256', (string) $article->content_html),
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)) : null,
+            'revision_count' => ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function plannedSnapshot(Article $article, string $newTranslationGroupId): array
+    {
+        $snapshot = $this->snapshot($article);
+        $snapshot['translation_group_id'] = $newTranslationGroupId;
+        $snapshot['working_revision_translation_group_id'] = $newTranslationGroupId;
+        $snapshot['published_revision_translation_group_id'] = $newTranslationGroupId;
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, int $articleId, string $currentTranslationGroupId, string $newTranslationGroupId, ?array $before, ?array $after, array $errors, array $warnings): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'article_id' => $articleId,
+            'current_translation_group_id' => $currentTranslationGroupId,
+            'new_translation_group_id' => $newTranslationGroupId,
+            'updates_scope' => [
+                'article_fields' => ['translation_group_id'],
+                'article_translation_revision_fields' => ['translation_group_id'],
+            ],
+            'protected_holds' => [
+                'no_publish' => true,
+                'no_schema' => true,
+                'no_hreflang' => true,
+                'no_search' => true,
+                'no_sitemap_llms_change' => true,
+                'no_revision_create' => true,
+                'content_unchanged' => true,
+            ],
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => ! (bool) $this->option('execute'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'article_id' => (int) $this->option('article-id'),
+            'current_translation_group_id' => (string) $this->option('current-translation-group-id'),
+            'new_translation_group_id' => (string) $this->option('new-translation-group-id'),
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('article_id='.(string) ($summary['article_id'] ?? ''));
+        $this->line('current_translation_group_id='.(string) ($summary['current_translation_group_id'] ?? ''));
+        $this->line('new_translation_group_id='.(string) ($summary['new_translation_group_id'] ?? ''));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -15,6 +15,7 @@ use App\Console\Commands\ArticleSeoGateRollout;
 use App\Console\Commands\ArticleTaxonomyHygiene;
 use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
+use App\Console\Commands\ArticleUpdateTranslationGroupId;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
@@ -351,6 +352,7 @@ class Kernel extends ConsoleKernel
         ArticleReplaceInlineImageUrl::class,
         ArticleSeoGateRollout::class,
         ArticleTaxonomyHygiene::class,
+        ArticleUpdateTranslationGroupId::class,
         ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoIntelUrlTruthHandoffCommand::class,

--- a/backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php
+++ b/backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php
@@ -328,9 +328,11 @@ final class ArticleInlineImageUrlReplacer
         /** @var Article $article */
         $article = $plan['article'];
         $contentMd = (string) $plan['replacement_content_md'];
+        $sourceVersionHash = (string) data_get($plan, 'after.source_version_hash');
 
         $article->forceFill([
             'content_md' => $contentMd,
+            'source_version_hash' => $sourceVersionHash,
         ])->saveQuietly();
         $article->refresh();
 
@@ -345,7 +347,7 @@ final class ArticleInlineImageUrlReplacer
             ->whereIn('id', $revisionIds)
             ->update([
                 'content_md' => $contentMd,
-                'source_version_hash' => $article->source_version_hash,
+                'source_version_hash' => $sourceVersionHash,
                 'translated_from_version_hash' => $article->translated_from_version_hash,
             ]);
     }

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -1700,22 +1700,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1728,7 +1728,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1808,7 +1808,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -1824,7 +1824,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T22:11:48+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1912,16 +1912,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -2011,7 +2011,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -2027,7 +2027,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T21:50:11+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/backend/tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php
@@ -95,6 +95,9 @@ final class ArticleReplaceInlineImageUrlCommandTest extends TestCase
             $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->content_md);
             $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->workingRevision?->content_md);
             $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->publishedRevision?->content_md);
+            $this->assertSame($payload['after'][array_search((int) $article->id, array_column($payload['after'], 'article_id'), true)]['source_version_hash'], (string) $fresh->source_version_hash);
+            $this->assertSame((string) $fresh->source_version_hash, (string) $fresh->workingRevision?->source_version_hash);
+            $this->assertSame((string) $fresh->source_version_hash, (string) $fresh->publishedRevision?->source_version_hash);
             $this->assertSame($before[(int) $article->id], $this->protectedSnapshot($fresh));
         }
     }

--- a/backend/tests/Feature/Console/ArticleUpdateTranslationGroupIdCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateTranslationGroupIdCommandTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ArticleUpdateTranslationGroupIdCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const CURRENT_GROUP_ID = 'unknown_until_cms_import';
+
+    private const NEW_GROUP_ID = 'tg_article_iq_test_score_and_limits_explained_2026v1';
+
+    public function test_default_invocation_is_dry_run_and_does_not_write(): void
+    {
+        $article = $this->createPublishedArticle();
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'iq-test-score-and-limits-explained',
+            '--current-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--new-translation-group-id' => self::NEW_GROUP_ID,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_update_translation_group_id', $payload['action']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertSame(self::CURRENT_GROUP_ID, $payload['before']['translation_group_id']);
+        $this->assertSame(self::NEW_GROUP_ID, $payload['after']['translation_group_id']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with([
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ])->findOrFail((int) $article->id);
+        $this->assertSame(self::CURRENT_GROUP_ID, (string) $fresh->translation_group_id);
+        $this->assertSame(self::CURRENT_GROUP_ID, (string) $fresh->workingRevision?->translation_group_id);
+        $this->assertSame(self::CURRENT_GROUP_ID, (string) $fresh->publishedRevision?->translation_group_id);
+    }
+
+    public function test_execute_updates_article_and_current_revision_translation_group_ids_only(): void
+    {
+        $article = $this->createPublishedArticle();
+        $before = $this->protectedSnapshot($article);
+        $revisionCountBefore = ArticleTranslationRevision::query()->withoutGlobalScopes()->count();
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'iq-test-score-and-limits-explained',
+            '--current-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--new-translation-group-id' => self::NEW_GROUP_ID,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-schema' => true,
+            '--no-hreflang' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('updated_translation_group_id', $payload['action']);
+        $this->assertSame($revisionCountBefore, ArticleTranslationRevision::query()->withoutGlobalScopes()->count());
+
+        $fresh = Article::query()->withoutGlobalScopes()->with([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ])->findOrFail((int) $article->id);
+
+        $this->assertSame(self::NEW_GROUP_ID, (string) $fresh->translation_group_id);
+        $this->assertSame(self::NEW_GROUP_ID, (string) $fresh->workingRevision?->translation_group_id);
+        $this->assertSame(self::NEW_GROUP_ID, (string) $fresh->publishedRevision?->translation_group_id);
+
+        $after = $this->protectedSnapshot($fresh);
+        $before['translation_group_id'] = self::NEW_GROUP_ID;
+        $before['working_revision_translation_group_id'] = self::NEW_GROUP_ID;
+        $before['published_revision_translation_group_id'] = self::NEW_GROUP_ID;
+        $this->assertSame($before, $after);
+    }
+
+    public function test_execute_requires_all_no_side_effect_flags(): void
+    {
+        $article = $this->createPublishedArticle();
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'iq-test-score-and-limits-explained',
+            '--current-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--new-translation-group-id' => self::NEW_GROUP_ID,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        $this->assertSame(self::CURRENT_GROUP_ID, (string) Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id)->translation_group_id);
+    }
+
+    public function test_locks_reject_wrong_slug_current_group_or_collision(): void
+    {
+        $article = $this->createPublishedArticle();
+        $this->createPublishedArticle(id: 51, slug: 'enneagram-personality-test-explained', translationGroupId: self::NEW_GROUP_ID);
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'wrong-slug',
+            '--current-translation-group-id' => 'wrong-current',
+            '--new-translation-group-id' => self::NEW_GROUP_ID,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'slug_mismatch');
+        $this->assertErrorCode($payload, 'translation_group_id_mismatch');
+        $this->assertErrorCode($payload, 'translation_group_id_collision');
+    }
+
+    public function test_rejects_invalid_or_same_new_translation_group_id(): void
+    {
+        $article = $this->createPublishedArticle();
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'iq-test-score-and-limits-explained',
+            '--current-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--new-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'new_translation_group_id_same_as_current');
+
+        $exitCode = Artisan::call('articles:update-translation-group-id', [
+            '--article-id' => (int) $article->id,
+            '--expected-slug' => 'iq-test-score-and-limits-explained',
+            '--current-translation-group-id' => self::CURRENT_GROUP_ID,
+            '--new-translation-group-id' => str_repeat('x', 65),
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'new_translation_group_id_invalid');
+    }
+
+    private function createPublishedArticle(int $id = 50, string $slug = 'iq-test-score-and-limits-explained', string $translationGroupId = self::CURRENT_GROUP_ID): Article
+    {
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'id' => $id,
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'translation_group_id' => $translationGroupId,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '在线 IQ 测试准吗？',
+            'excerpt' => 'A safe IQ score interpretation guide.',
+            'content_md' => '# Body',
+            'content_html' => '<h1>Body</h1>',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleiqscorelimitspillarcoverv1/hero_1600x900.jpg',
+            'cover_image_alt' => '在线 IQ 测试中矩阵推理、模式识别与抽象问题解决示意图',
+            'related_test_slug' => 'iq-test',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => $translationGroupId,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => now(),
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => 'https://fermatmind.com/zh/articles/'.$slug,
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleiqscorelimitspillarcoverv1/og_1200x630.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                    ],
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->refresh();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function protectedSnapshot(Article $article): array
+    {
+        $article->refresh();
+        $article->load([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'working_revision_translation_group_id' => (string) $article->workingRevision?->translation_group_id,
+            'published_revision_translation_group_id' => (string) $article->publishedRevision?->translation_group_id,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash,
+            'cover_image_url' => (string) $article->cover_image_url,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'canonical_url' => (string) $article->seoMeta?->canonical_url,
+            'robots' => (string) $article->seoMeta?->robots,
+            'seo_is_indexable' => (bool) $article->seoMeta?->is_indexable,
+            'schema_json' => $article->seoMeta?->schema_json,
+            'og_image_url' => (string) $article->seoMeta?->og_image_url,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1808,6 +1808,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_translation_group_id_cleanup_command_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleUpdateTranslationGroupId.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleUpdateTranslationGroupId;',
+            '+        ArticleUpdateTranslationGroupId::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -3354,6 +3368,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleTranslationGroupIdCleanupFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -4008,6 +4026,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoImageBundleImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleImageMetadataUpdaterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleInlineImageUrlReplacerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsArticleTranslationGroupIdCleanupOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsDailyArticleBackendPipelineOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -4402,6 +4421,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isArticleDiscoverabilityReleaseFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/ArticleDiscoverabilityRelease.php';
+    }
+
+    private function isArticleTranslationGroupIdCleanupFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/ArticleUpdateTranslationGroupId.php';
     }
 
     private function isArticleBodyH1GuardFile(string $file): bool
@@ -6071,6 +6095,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleReplaceInlineImageUrl\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsArticleTranslationGroupIdCleanupOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleUpdateTranslationGroupId\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Fix `articles:replace-inline-image-url` so execute mode writes the planned `source_version_hash` to the article and current working/published revisions after a content markdown URL replacement.
- Add `articles:update-translation-group-id`, a locked dry-run/execute command for one published article identity cleanup.
- Register the new command and add focused feature tests for hash sync, safety flags, slug/current-group locks, collision checks, and invalid target IDs.

## Why
The six-pillar image repair exposed two operational gaps:
- Inline body visual URL replacement could change `content_md` while leaving `source_version_hash` stale because `saveQuietly()` bypassed the model saving hook.
- Article identity cleanup, such as replacing `unknown_until_cms_import`, needed a reusable bounded command instead of ad hoc production DB edits.

## Validation commands
- `php -l app/Console/Commands/ArticleUpdateTranslationGroupId.php && php -l app/Services/Cms/ArticleInlineImageUrlReplacer.php && php -l tests/Feature/Console/ArticleUpdateTranslationGroupIdCommandTest.php && php -l tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php`
- `php artisan test tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php tests/Feature/Console/ArticleUpdateTranslationGroupIdCommandTest.php --no-ansi`
- `./vendor/bin/pint app/Console/Commands/ArticleUpdateTranslationGroupId.php app/Services/Cms/ArticleInlineImageUrlReplacer.php app/Console/Kernel.php tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php tests/Feature/Console/ArticleUpdateTranslationGroupIdCommandTest.php --dirty`
- `php artisan list --no-ansi | grep -E 'articles:(replace-inline-image-url|update-translation-group-id)'`
- `git diff --check`

## Intentionally deferred
- No production CMS/DB cleanup is executed in this PR.
- IQ article 50 translation_group_id cleanup should run only after this PR is merged and deployed, using the bounded dry-run/execute command with exact operator approval.
- No publish, schema, hreflang, sitemap/llms, search submission, revalidation, migration, or deploy is included.

## Repository rule impact
This PR adds backend-owned CMS operational tooling only. It preserves CMS/backend authority for article identity and mutable article metadata; it does not move content authority to frontend code or add fallback content.

- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter 'runtime_paths_have_no_uncommitted_diff|runtime_freeze_classifier_ignores_article_translation_group_id_cleanup_command_changes' --no-ansi`
