### PR TITLE
feat(seo): add Baidu search queue retry reset

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelRetryResetCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelRetryResetCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueRetryResetter;
+use Illuminate\Console\Command;
+
+final class SeoIntelSearchChannelRetryResetCommand extends Command
+{
+    protected $signature = 'seo-intel:search-channel-retry-reset
+        {--queue-ids= : Comma-separated Search Channel Queue item ids}
+        {--channels=baidu_push : Comma-separated allowed channels; only baidu_push is supported}
+        {--reason=provider_quota_reset : Bounded retry reset reason}
+        {--approval-phrase= : Exact bounded retry reset approval phrase}
+        {--approval-token= : SHA-256 token for the exact bounded retry reset approval phrase}
+        {--actor=operator : Sanitized actor id for audit events}
+        {--execute : Commit retry reset; omitted means dry-run}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Reset Baidu Search Channel queue items from provider-quota submit_failed to dry_run_ready.';
+
+    public function handle(SearchChannelQueueRetryResetter $resetter): int
+    {
+        $queueIds = $this->positiveIntegerList($this->option('queue-ids'));
+        $channels = $this->stringList($this->option('channels'));
+        $execute = (bool) $this->option('execute');
+
+        $payload = $resetter->reset(
+            queueItemIds: $queueIds,
+            channels: $channels,
+            reason: $this->nullableOption('reason'),
+            approvalPhrase: $this->nullableOption('approval-phrase'),
+            approvalToken: $this->nullableOption('approval-token'),
+            actorId: $this->actor(),
+            dryRun: ! $execute,
+        );
+
+        return $this->finish($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_SLASHES));
+        } else {
+            foreach (['status', 'dry_run', 'queue_item_count', 'writes_attempted', 'writes_committed', 'external_calls_attempted', 'search_submission_attempted'] as $key) {
+                $this->line($key.'='.$this->stringValue($payload[$key] ?? null));
+            }
+        }
+
+        return ($payload['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function positiveIntegerList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): int => max(0, (int) trim($part)),
+            explode(',', (string) $value),
+        ), static fn (int $id): bool => $id > 0)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): string => strtolower(trim($part)),
+            explode(',', (string) $value),
+        ), static fn (string $part): bool => $part !== '')));
+    }
+
+    private function nullableOption(string $key): ?string
+    {
+        $value = $this->option($key);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function actor(): string
+    {
+        $actor = preg_replace('/[^A-Za-z0-9:_@.-]/', '_', (string) ($this->option('actor') ?: 'operator'));
+
+        return substr((string) $actor, 0, 128);
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return (string) json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+
+        return (string) $value;
+    }
+}

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueRetryResetter.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueRetryResetter.php
@@ -1,0 +1,452 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\SearchChannelQueue;
+
+use Illuminate\Support\Facades\DB;
+
+final class SearchChannelQueueRetryResetter
+{
+    public function __construct(
+        private readonly SearchChannelQueueAuditLogger $events,
+    ) {}
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return array<string, mixed>
+     */
+    public function reset(
+        array $queueItemIds,
+        array $channels,
+        ?string $reason,
+        ?string $approvalPhrase,
+        ?string $approvalToken,
+        string $actorId,
+        bool $dryRun,
+    ): array {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $allowedChannels = $this->allowedChannels($channels);
+        $reason = $this->normalizedReason($reason);
+        $expectedPhrase = $this->approvalPhrase($queueItemIds, $allowedChannels, $reason);
+        $expectedToken = hash('sha256', $expectedPhrase);
+        $setupIssues = $this->setupIssues($queueItemIds, $allowedChannels, $reason);
+
+        $items = $queueItemIds === []
+            ? collect()
+            : $connection->table('seo_search_channel_queue_items')
+                ->whereIn('id', $queueItemIds)
+                ->orderBy('id')
+                ->get();
+
+        $foundIds = $items->pluck('id')->map(static fn (mixed $id): int => (int) $id)->all();
+        $missingIds = array_values(array_diff($queueItemIds, $foundIds));
+        $itemResults = [];
+
+        foreach ($missingIds as $missingId) {
+            $itemResults[] = $this->blockedItem($missingId, null, null, ['queue_item_not_found'], $dryRun);
+        }
+
+        foreach ($items as $item) {
+            $latestFailure = $this->latestSubmissionFailure((int) $item->id);
+            $itemIssues = $this->validateItem($item, $allowedChannels, $latestFailure);
+            $itemResults[] = $itemIssues === []
+                ? $this->readyItem($item, $latestFailure, $dryRun)
+                : $this->blockedItem((int) $item->id, $item, $latestFailure, $itemIssues, $dryRun);
+        }
+
+        $approvalIssues = $dryRun ? [] : $this->approvalIssues($approvalPhrase, $approvalToken, $expectedPhrase, $expectedToken);
+        $issues = array_values(array_unique([
+            ...$setupIssues,
+            ...$approvalIssues,
+            ...$this->flattenItemIssues($itemResults),
+        ]));
+
+        if ($issues !== []) {
+            return $this->payload(
+                status: 'blocked',
+                dryRun: $dryRun,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                reason: $reason,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: $issues,
+                itemResults: $itemResults,
+            );
+        }
+
+        if ($dryRun) {
+            return $this->payload(
+                status: 'success',
+                dryRun: true,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                reason: $reason,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: [],
+                itemResults: $itemResults,
+            );
+        }
+
+        $resetResults = [];
+        foreach ($items as $item) {
+            $resetResults[] = $this->resetOne($item, $reason, $actorId, $expectedToken);
+        }
+
+        $resetIssues = $this->flattenItemIssues($resetResults);
+
+        return $this->payload(
+            status: $resetIssues === [] ? 'success' : 'failed',
+            dryRun: false,
+            queueItemIds: $queueItemIds,
+            channels: $allowedChannels,
+            reason: $reason,
+            expectedPhrase: $expectedPhrase,
+            expectedToken: $expectedToken,
+            issues: $resetIssues,
+            itemResults: $resetResults,
+            writesAttempted: true,
+            writesCommitted: $resetIssues === [],
+        );
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     */
+    public function approvalPhrase(array $queueItemIds, array $channels, string $reason): string
+    {
+        return sprintf(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-RETRY-RESET reset for queue items %s channels %s reason %s.',
+            implode(',', $queueItemIds),
+            implode(',', $channels),
+            $reason,
+        );
+    }
+
+    /**
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function allowedChannels(array $channels): array
+    {
+        $configured = array_values(config('seo_intel.search_channel_queue.live_submission.allowed_channels', []));
+        $requested = $channels === [] ? ['baidu_push'] : $channels;
+
+        return array_values(array_intersect($requested, $configured, ['baidu_push']));
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function setupIssues(array $queueItemIds, array $channels, string $reason): array
+    {
+        $issues = [];
+
+        if ($queueItemIds === []) {
+            $issues[] = 'queue_ids_required';
+        }
+
+        if ($channels !== ['baidu_push']) {
+            $issues[] = 'baidu_push_channel_required';
+        }
+
+        if ($reason !== 'provider_quota_reset') {
+            $issues[] = 'provider_quota_reset_reason_required';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function approvalIssues(?string $approvalPhrase, ?string $approvalToken, string $expectedPhrase, string $expectedToken): array
+    {
+        $phraseMatches = $approvalPhrase !== null && hash_equals($expectedPhrase, $approvalPhrase);
+        $tokenMatches = $approvalToken !== null && hash_equals($expectedToken, strtolower($approvalToken));
+
+        return $phraseMatches || $tokenMatches ? [] : ['bounded_retry_reset_approval_required'];
+    }
+
+    /**
+     * @param  list<string>  $allowedChannels
+     * @param  array<string, mixed>|null  $latestFailure
+     * @return list<string>
+     */
+    private function validateItem(object $item, array $allowedChannels, ?array $latestFailure): array
+    {
+        $issues = [];
+
+        if (! in_array((string) $item->channel, $allowedChannels, true)) {
+            $issues[] = 'channel_not_requested';
+        }
+
+        if ((string) $item->channel !== 'baidu_push') {
+            $issues[] = 'baidu_push_channel_required';
+        }
+
+        if ((string) $item->eligibility_state !== 'eligible') {
+            $issues[] = 'item_not_eligible';
+        }
+
+        if ((string) $item->approval_state !== 'approved') {
+            $issues[] = 'approval_state_not_approved';
+        }
+
+        if ((string) $item->execution_state !== 'submit_failed') {
+            $issues[] = 'execution_state_not_submit_failed';
+        }
+
+        if ((string) $item->indexability_state !== 'indexable') {
+            $issues[] = 'non_indexable_rejected';
+        }
+
+        if ((string) $item->claim_boundary_state !== 'claim_safe') {
+            $issues[] = 'claim_unsafe_rejected';
+        }
+
+        if ((bool) $item->private_flow) {
+            $issues[] = 'private_flow_rejected';
+        }
+
+        if ($latestFailure === null) {
+            $issues[] = 'latest_bounded_submission_failure_not_found';
+        } elseif (! $this->latestFailureWasOverQuota($latestFailure)) {
+            $issues[] = 'latest_failure_not_provider_quota_exhausted';
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function latestSubmissionFailure(int $queueItemId): ?array
+    {
+        $event = DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table('seo_search_channel_queue_events')
+            ->where('queue_item_id', $queueItemId)
+            ->where('event_type', 'bounded_live_submission_response')
+            ->orderByDesc('id')
+            ->first();
+
+        if ($event === null) {
+            return null;
+        }
+
+        $payload = json_decode((string) $event->event_payload, true);
+
+        return is_array($payload) ? $payload : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $latestFailure
+     */
+    private function latestFailureWasOverQuota(array $latestFailure): bool
+    {
+        $diagnostic = strtolower(trim(implode(' ', array_filter([
+            (string) ($latestFailure['provider_error_code'] ?? ''),
+            (string) ($latestFailure['provider_error_message'] ?? ''),
+        ]))));
+
+        return (int) ($latestFailure['http_status'] ?? 0) === 400
+            && str_contains($diagnostic, 'over quota');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resetOne(object $item, string $reason, string $actorId, string $approvalToken): array
+    {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $now = now();
+
+        $updated = $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->where('channel', 'baidu_push')
+            ->where('approval_state', 'approved')
+            ->where('execution_state', 'submit_failed')
+            ->update([
+                'execution_state' => 'dry_run_ready',
+                'updated_at' => $now,
+            ]);
+
+        if ($updated !== 1) {
+            $fresh = $connection->table('seo_search_channel_queue_items')->where('id', (int) $item->id)->first();
+
+            return $this->blockedItem((int) $item->id, $fresh ?? $item, null, ['queue_item_already_changed_requeue_required'], false);
+        }
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'search_channel_queue_retry_reset', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'from_execution_state' => 'submit_failed',
+            'to_execution_state' => 'dry_run_ready',
+            'reason' => $reason,
+            'approval_token_hash' => hash('sha256', $approvalToken),
+            'external_calls_attempted' => false,
+        ], 'operator', $actorId);
+
+        return [
+            ...$this->itemBase($item, false),
+            'status' => 'reset',
+            'issues' => [],
+            'execution_state' => 'dry_run_ready',
+            'writes_attempted' => true,
+            'writes_committed' => true,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return list<string>
+     */
+    private function flattenItemIssues(array $itemResults): array
+    {
+        $issues = [];
+
+        foreach ($itemResults as $result) {
+            foreach (($result['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $latestFailure
+     * @return array<string, mixed>
+     */
+    private function readyItem(object $item, ?array $latestFailure, bool $dryRun): array
+    {
+        return [
+            ...$this->itemBase($item, $dryRun),
+            'status' => 'ready_for_retry_reset',
+            'issues' => [],
+            'latest_failure' => $this->failureSummary($latestFailure),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $latestFailure
+     * @param  list<string>  $issues
+     * @return array<string, mixed>
+     */
+    private function blockedItem(int $queueItemId, ?object $item, ?array $latestFailure, array $issues, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => $queueItemId,
+            'channel' => $item === null ? null : (string) $item->channel,
+            'canonical_url' => $item === null ? null : (string) $item->canonical_url,
+            'url_hash' => $item === null ? null : (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'status' => 'blocked',
+            'issues' => array_values(array_unique($issues)),
+            'approval_state' => $item === null ? null : (string) $item->approval_state,
+            'execution_state' => $item === null ? null : (string) $item->execution_state,
+            'latest_failure' => $this->failureSummary($latestFailure),
+            'writes_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function itemBase(object $item, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => (int) $item->id,
+            'channel' => (string) $item->channel,
+            'canonical_url' => (string) $item->canonical_url,
+            'url_hash' => (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'approval_state' => (string) $item->approval_state,
+            'execution_state' => (string) $item->execution_state,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $latestFailure
+     * @return array<string, mixed>|null
+     */
+    private function failureSummary(?array $latestFailure): ?array
+    {
+        if ($latestFailure === null) {
+            return null;
+        }
+
+        return [
+            'http_status' => $latestFailure['http_status'] ?? null,
+            'execution_state' => $latestFailure['execution_state'] ?? null,
+            'provider_error_code' => $latestFailure['provider_error_code'] ?? null,
+            'provider_error_message' => $latestFailure['provider_error_message'] ?? null,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @param  list<string>  $issues
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return array<string, mixed>
+     */
+    private function payload(
+        string $status,
+        bool $dryRun,
+        array $queueItemIds,
+        array $channels,
+        string $reason,
+        string $expectedPhrase,
+        string $expectedToken,
+        array $issues,
+        array $itemResults,
+        bool $writesAttempted = false,
+        bool $writesCommitted = false,
+    ): array {
+        return [
+            'runtime' => 'search_channel_queue_retry_reset',
+            'status' => $status,
+            'dry_run' => $dryRun,
+            'queue_item_ids' => $queueItemIds,
+            'queue_item_count' => count($queueItemIds),
+            'channels' => $channels,
+            'reason' => $reason,
+            'approval_phrase' => $expectedPhrase,
+            'approval_token' => $expectedToken,
+            'issues' => $issues,
+            'items' => $itemResults,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => $writesAttempted,
+            'writes_committed' => $writesCommitted,
+            'safety_flags' => [
+                'baidu_push_only' => true,
+                'dry_run_default' => true,
+                'approved_queue_state_required' => true,
+                'submit_failed_state_required' => true,
+                'over_quota_failure_required' => true,
+                'external_api_calls' => false,
+                'search_submission_attempted' => false,
+                'cms_mutation' => false,
+                'schema_hreflang_mutation' => false,
+            ],
+        ];
+    }
+
+    private function normalizedReason(?string $reason): string
+    {
+        $reason = strtolower(trim((string) $reason));
+
+        return $reason === '' ? 'provider_quota_reset' : $reason;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelRetryResetCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelRetryResetCommandTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueRetryResetter;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelRetryResetCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function dry_run_accepts_only_approved_baidu_submit_failed_items_with_latest_over_quota_failure(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+        $this->seedBaiduFailureEvent($queueItemId, 'over quota');
+
+        [$exitCode, $payload] = $this->runRetryResetCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'baidu_push',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-RETRY-RESET reset for queue items '.$queueItemId.' channels baidu_push reason provider_quota_reset.',
+            $payload['approval_phrase'] ?? null,
+        );
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['approval_token'] ?? ''));
+        $this->assertSame('submit_failed', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('execution_state'));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_requires_exact_approval_and_resets_to_dry_run_ready_with_audit_event(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+        $this->seedBaiduFailureEvent($queueItemId, 'over quota');
+        $approvalPhrase = app(SearchChannelQueueRetryResetter::class)
+            ->approvalPhrase([$queueItemId], ['baidu_push'], 'provider_quota_reset');
+
+        [$exitCode, $payload] = $this->runRetryResetCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'baidu_push',
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['dry_run'] ?? true));
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertSame('dry_run_ready', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('execution_state'));
+
+        $event = DB::connection('seo_intel')->table('seo_search_channel_queue_events')->where('event_type', 'search_channel_queue_retry_reset')->first();
+        $this->assertNotNull($event);
+        $this->assertSame($queueItemId, (int) $event->queue_item_id);
+        $this->assertSame('operator', $event->actor_type);
+        $this->assertSame('seo-ops@example.com', $event->actor_id);
+        $this->assertStringContainsString('provider_quota_reset', (string) $event->event_payload);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_blocks_without_exact_approval_and_without_external_calls_or_writes(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+        $this->seedBaiduFailureEvent($queueItemId, 'over quota');
+
+        [$exitCode, $payload] = $this->runRetryResetCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'baidu_push',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('bounded_retry_reset_approval_required', $payload['issues'] ?? []);
+        $this->assertSame('submit_failed', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('execution_state'));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function dry_run_rejects_non_quota_failures_and_submitted_items(): void
+    {
+        Http::fake();
+        $siteInitId = $this->seedQueueItem();
+        $this->seedBaiduFailureEvent($siteInitId, 'site init fail');
+        $submittedId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/submitted',
+            'execution_state' => 'submitted',
+        ]);
+        $this->seedBaiduFailureEvent($submittedId, 'over quota');
+
+        [$exitCode, $payload] = $this->runRetryResetCommand([
+            '--queue-ids' => $siteInitId.','.$submittedId,
+            '--channels' => 'baidu_push',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('latest_failure_not_provider_quota_exhausted', $payload['issues'] ?? []);
+        $this->assertContains('execution_state_not_submit_failed', $payload['issues'] ?? []);
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runRetryResetCommand(array $arguments): array
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-retry-reset', $arguments);
+        $rawOutput = trim(Artisan::output());
+
+        $this->assertNotSame('', $rawOutput);
+        $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $rawOutput];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(array $overrides = []): int
+    {
+        $canonicalUrl = (string) ($overrides['canonical_url'] ?? 'https://fermatmind.com/zh/articles/iq-test-score-and-limits-explained');
+        $now = now();
+
+        return (int) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insertGetId([
+            'batch_id' => $overrides['batch_id'] ?? 1,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'zh',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'article',
+            'entity_type' => $overrides['entity_type'] ?? 'article',
+            'entity_id' => $overrides['entity_id'] ?? 'article:fixture',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'source_table' => $overrides['source_table'] ?? 'cms_articles',
+            'channel' => $overrides['channel'] ?? 'baidu_push',
+            'eligibility_state' => $overrides['eligibility_state'] ?? 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'approved',
+            'execution_state' => $overrides['execution_state'] ?? 'submit_failed',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'claim_boundary_state' => $overrides['claim_boundary_state'] ?? 'claim_safe',
+            'private_flow' => (bool) ($overrides['private_flow'] ?? false),
+            'reason_codes' => $overrides['reason_codes'] ?? null,
+            'lastmod' => $now,
+            'content_hash' => hash('sha256', $canonicalUrl),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.($overrides['channel'] ?? 'baidu_push')),
+            'approved_by' => $overrides['approved_by'] ?? 'operator',
+            'approved_at' => $overrides['approved_at'] ?? $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    private function seedBaiduFailureEvent(int $queueItemId, string $message): void
+    {
+        DB::connection('seo_intel')->table('seo_search_channel_queue_events')->insert([
+            'queue_item_id' => $queueItemId,
+            'batch_id' => 1,
+            'event_type' => 'bounded_live_submission_response',
+            'event_payload' => json_encode([
+                'channel' => 'baidu_push',
+                'url_hash' => hash('sha256', 'fixture'),
+                'endpoint_host' => 'data.zz.baidu.test',
+                'http_status' => 400,
+                'submission_status' => 'failed',
+                'execution_state' => 'submit_failed',
+                'exception_class' => null,
+                'provider_error_code' => '400',
+                'provider_error_message' => $message,
+            ], JSON_THROW_ON_ERROR),
+            'actor_type' => 'system',
+            'actor_id' => 'seo-intel:search-channel-submit-approved',
+            'created_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64);
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -993,6 +993,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelRetryResetCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
@@ -1004,6 +1005,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueRetryResetter.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueWriteService.php',
             'backend/database/migrations/seo_intel/2026_05_20_220000_create_seo_search_channel_queue_tables.php',
         ];
@@ -4363,6 +4365,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelRetryResetCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
@@ -4374,6 +4377,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueRetryResetter.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueWriteService.php',
             'backend/database/migrations/seo_intel/2026_05_20_220000_create_seo_search_channel_queue_tables.php',
         ], true);


### PR DESCRIPTION
## What changed
- Adds `seo-intel:search-channel-retry-reset` for Baidu Search Channel queue retry preparation.
- Adds `SearchChannelQueueRetryResetter` with dry-run by default, exact approval phrase/token enforcement, Baidu-only channel gating, and over-quota latest-failure validation.
- Adds focused feature coverage for dry-run, approval blocking, execution reset, audit logging, and rejection of non-quota/submitted items.

## Why
Baidu accepted only queue items 47 and 48; queue items 49, 51, 53, and 55 are in `submit_failed` after HTTP 400 `over quota`. The existing bounded live executor correctly refuses to retry non-`dry_run_ready` queue items. This PR adds the missing stable operations tool to reset only approved Baidu queue items whose latest bounded provider response was explicitly over quota, after platform quota is believed to have reset and an operator gives exact approval.

## Validation
- `php artisan test tests/Feature/SeoIntel/SeoIntelSearchChannelRetryResetCommandTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php`
- `./vendor/bin/pint app/Console/Commands/SeoIntelSearchChannelRetryResetCommand.php app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueRetryResetter.php tests/Feature/SeoIntel/SeoIntelSearchChannelRetryResetCommandTest.php --test`
- `php artisan list seo-intel | rg "search-channel-(retry-reset|submit-approved|approve|queue)"`
- `php artisan route:list --no-ansi | head -n 20`
- `git diff --check`

## Intentionally deferred
- No live Baidu push in this PR.
- No CMS content mutation, publish, schema, hreflang, sitemap, llms, IndexNow, GSC, or revalidation changes.
- Production retry should run only after this deploys and after exact operator approval.

## Deployment follow-up commands
Dry-run after deploy:
```bash
php artisan seo-intel:search-channel-retry-reset --queue-ids=49,51,53,55 --channels=baidu_push --reason=provider_quota_reset --json --no-ansi
```

Exact approval phrase for reset execution:
```text
I explicitly approve SEARCH-CHANNEL-QUEUE-RETRY-RESET reset for queue items 49,51,53,55 channels baidu_push reason provider_quota_reset.
```

Reset execution after dry-run passes and exact approval is provided:
```bash
php artisan seo-intel:search-channel-retry-reset --queue-ids=49,51,53,55 --channels=baidu_push --reason=provider_quota_reset --approval-phrase="I explicitly approve SEARCH-CHANNEL-QUEUE-RETRY-RESET reset for queue items 49,51,53,55 channels baidu_push reason provider_quota_reset." --execute --json --no-ansi
```

Then rerun bounded live executor dry-run:
```bash
php artisan seo-intel:search-channel-submit-approved --queue-ids=49,51,53,55 --channels=baidu_push --json --no-ansi
```

Exact approval phrase for live Baidu retry, only if dry-run passes:
```text
I explicitly approve SEARCH-CHANNEL-BOUNDED-LIVE-EXECUTOR live submission for queue items 49,51,53,55 channels baidu_push.
```

Live executor command after dry-run passes and exact approval is provided:
```bash
php artisan seo-intel:search-channel-submit-approved --queue-ids=49,51,53,55 --channels=baidu_push --approval-phrase="I explicitly approve SEARCH-CHANNEL-BOUNDED-LIVE-EXECUTOR live submission for queue items 49,51,53,55 channels baidu_push." --live --json --no-ansi
```