### PR TITLE
Add controlled article SEO gate rollout command

### DIFF
--- a/backend/app/Console/Commands/ArticleSeoGateRollout.php
+++ b/backend/app/Console/Commands/ArticleSeoGateRollout.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ArticleSeoGateRollout as RolloutService;
+use Illuminate\Console\Command;
+
+final class ArticleSeoGateRollout extends Command
+{
+    protected $signature = 'articles:seo-gate-rollout
+        {--article-ids= : Comma-separated article ids to lock}
+        {--translation-group-id= : Expected current translation_group_id for the locked articles}
+        {--expected-slugs= : Comma-separated expected slugs in article-id order}
+        {--set-translation-group-id= : Optional replacement translation_group_id for identity cleanup}
+        {--enable-article-schema : Enable the Article JSON-LD render gate}
+        {--enable-breadcrumb-schema : Enable the Breadcrumb JSON-LD render gate}
+        {--enable-faq-schema : Enable FAQ schema gate after explicit review}
+        {--hold-faq-schema : Explicitly hold FAQ schema gate}
+        {--enable-hreflang : Enable hreflang gate after reciprocal validation}
+        {--no-hreflang-policy : Record an explicit no-hreflang policy}
+        {--hreflang-policy-reason= : Reason for no-hreflang policy}
+        {--dry-run : Force dry-run mode}
+        {--execute : Execute the bounded write}
+        {--json : Emit JSON}
+        {--no-publish : Required for execute; confirms no publish action}
+        {--no-search : Required for execute; confirms no search submission}
+        {--no-sitemap-llms-change : Required for execute; confirms no sitemap/llms mutation}
+        {--no-content-change : Required for execute; confirms no editorial content mutation}
+        {--no-revalidation : Required for execute; confirms no cache revalidation}';
+
+    protected $description = 'Controlled rollout for article SEO gates with identity locks, JSON-LD guards, hreflang validation, and audit logging.';
+
+    public function handle(RolloutService $rollout): int
+    {
+        $payload = $rollout->run([
+            'article_ids' => $this->option('article-ids'),
+            'translation_group_id' => $this->option('translation-group-id'),
+            'expected_slugs' => $this->option('expected-slugs'),
+            'set_translation_group_id' => $this->option('set-translation-group-id'),
+            'enable_article_schema' => (bool) $this->option('enable-article-schema'),
+            'enable_breadcrumb_schema' => (bool) $this->option('enable-breadcrumb-schema'),
+            'enable_faq_schema' => (bool) $this->option('enable-faq-schema'),
+            'hold_faq_schema' => (bool) $this->option('hold-faq-schema'),
+            'enable_hreflang' => (bool) $this->option('enable-hreflang'),
+            'no_hreflang_policy' => (bool) $this->option('no-hreflang-policy'),
+            'hreflang_policy_reason' => $this->option('hreflang-policy-reason'),
+            'dry_run' => (bool) $this->option('dry-run'),
+            'execute' => (bool) $this->option('execute'),
+            'json' => (bool) $this->option('json'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_search' => (bool) $this->option('no-search'),
+            'no_sitemap_llms_change' => (bool) $this->option('no-sitemap-llms-change'),
+            'no_content_change' => (bool) $this->option('no-content-change'),
+            'no_revalidation' => (bool) $this->option('no-revalidation'),
+        ]);
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } elseif ((bool) ($payload['ok'] ?? false)) {
+            $this->info((string) ($payload['action'] ?? 'ok'));
+        } else {
+            $this->error((string) ($payload['action'] ?? 'failed'));
+        }
+
+        return (bool) ($payload['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -10,6 +10,7 @@ use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 use App\Console\Commands\ArticleReplaceInlineImageUrl;
+use App\Console\Commands\ArticleSeoGateRollout;
 use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\Big5AttemptPurge;
@@ -337,6 +338,7 @@ class Kernel extends ConsoleKernel
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
         ArticleReplaceInlineImageUrl::class,
+        ArticleSeoGateRollout::class,
         ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoIntelUrlTruthHandoffCommand::class,

--- a/backend/app/Services/Cms/ArticleSeoGateRollout.php
+++ b/backend/app/Services/Cms/ArticleSeoGateRollout.php
@@ -1,0 +1,588 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\AuditLog;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ArticleSeoGateRollout
+{
+    private const EXECUTE_SAFETY_FLAGS = [
+        'no_publish',
+        'no_search',
+        'no_sitemap_llms_change',
+        'no_content_change',
+        'no_revalidation',
+    ];
+
+    public function __construct(
+        private readonly ArticleSeoService $seoService,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options): array
+    {
+        $execute = (bool) ($options['execute'] ?? false);
+        $dryRun = ! $execute;
+        $errors = [];
+        $warnings = [];
+        $articleIds = $this->articleIds((string) ($options['article_ids'] ?? ''), $errors);
+        $expectedSlugs = $this->expectedSlugs((string) ($options['expected_slugs'] ?? ''), $errors);
+        $translationGroupId = trim((string) ($options['translation_group_id'] ?? ''));
+        $setTranslationGroupId = trim((string) ($options['set_translation_group_id'] ?? ''));
+        $schemaRequested = (bool) ($options['enable_article_schema'] ?? false)
+            || (bool) ($options['enable_breadcrumb_schema'] ?? false)
+            || (bool) ($options['enable_faq_schema'] ?? false)
+            || (bool) ($options['hold_faq_schema'] ?? false);
+        $hreflangRequested = (bool) ($options['enable_hreflang'] ?? false)
+            || (bool) ($options['no_hreflang_policy'] ?? false);
+
+        if ($translationGroupId === '') {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_required', 'Expected translation_group_id lock is required.');
+        }
+
+        if ((bool) ($options['dry_run'] ?? false) && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+
+        if ($articleIds !== [] && $expectedSlugs !== [] && count($expectedSlugs) !== count($articleIds)) {
+            $errors[] = $this->issue('expected_slugs', 'expected_slug_count_mismatch', 'expected-slugs must match article-ids count.');
+        }
+
+        if ($schemaRequested === false && $hreflangRequested === false && $setTranslationGroupId === '') {
+            $errors[] = $this->issue('change_set', 'change_set_required', 'At least one schema, hreflang policy, or translation_group_id change is required.');
+        }
+
+        if ((bool) ($options['enable_hreflang'] ?? false) && (bool) ($options['no_hreflang_policy'] ?? false)) {
+            $errors[] = $this->issue('hreflang', 'hreflang_policy_conflict', '--enable-hreflang cannot be combined with --no-hreflang-policy.');
+        }
+
+        if ($execute) {
+            foreach (self::EXECUTE_SAFETY_FLAGS as $flag) {
+                if ((bool) ($options[$flag] ?? false) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        $articles = $this->resolveArticles($articleIds);
+        $this->validateLocks($articles, $articleIds, $expectedSlugs, $translationGroupId, $errors);
+        $this->validateRequestedGates($articles, $options, $errors, $warnings);
+
+        $before = array_map(fn (Article $article): array => $this->snapshot($article), $articles);
+        $after = array_map(fn (Article $article): array => $this->plannedSnapshot($article, $options), $articles);
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleIds, $translationGroupId, $before, $after, $errors, $warnings);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_rollout_article_seo_gates', $articleIds, $translationGroupId, $before, $after, [], $warnings);
+        }
+
+        DB::transaction(function () use ($articleIds, $expectedSlugs, $translationGroupId, $options, &$after): void {
+            $locked = $this->resolveArticles($articleIds, true);
+            $errors = [];
+            $warnings = [];
+            $this->validateLocks($locked, $articleIds, $expectedSlugs, $translationGroupId, $errors);
+            $this->validateRequestedGates($locked, $options, $errors, $warnings);
+
+            if ($errors !== []) {
+                throw new \RuntimeException('Article SEO gate rollout lock changed during execute.');
+            }
+
+            foreach ($locked as $article) {
+                $this->apply($article, $options);
+            }
+
+            $fresh = $this->resolveArticles($articleIds);
+            $after = array_map(fn (Article $article): array => $this->snapshot($article), $fresh);
+            $this->writeAudit($fresh, $options, $translationGroupId);
+        });
+
+        return $this->summary(true, false, 'rolled_out_article_seo_gates', $articleIds, $translationGroupId, $before, $after, [], $warnings);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<Article>
+     */
+    private function resolveArticles(array $ids, bool $lock = false): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $query = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->whereIn('id', $ids);
+
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        /** @var list<Article> $articles */
+        $articles = $query->get()
+            ->sortBy(static fn (Article $article): int => array_search((int) $article->id, $ids, true))
+            ->values()
+            ->all();
+
+        return $articles;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  list<int>  $articleIds
+     * @param  list<string>  $expectedSlugs
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateLocks(array $articles, array $articleIds, array $expectedSlugs, string $translationGroupId, array &$errors): void
+    {
+        $foundIds = array_map(static fn (Article $article): int => (int) $article->id, $articles);
+        foreach ($articleIds as $id) {
+            if (! in_array($id, $foundIds, true)) {
+                $errors[] = $this->issue('article_ids', 'article_not_found', 'Requested article id was not found.', ['article_id' => $id]);
+            }
+        }
+
+        foreach ($articles as $index => $article) {
+            if ((string) $article->translation_group_id !== $translationGroupId) {
+                $errors[] = $this->issue('article.'.$article->id.'.translation_group_id', 'translation_group_id_mismatch', 'Article translation_group_id does not match expected lock.', [
+                    'article_id' => (int) $article->id,
+                    'actual' => (string) $article->translation_group_id,
+                    'expected' => $translationGroupId,
+                ]);
+            }
+
+            $expectedSlug = $expectedSlugs[$index] ?? null;
+            if ($expectedSlug !== null && (string) $article->slug !== $expectedSlug) {
+                $errors[] = $this->issue('article.'.$article->id.'.slug', 'expected_slug_mismatch', 'Article slug does not match expected identity lock.', [
+                    'article_id' => (int) $article->id,
+                    'actual' => (string) $article->slug,
+                    'expected' => $expectedSlug,
+                ]);
+            }
+
+            if ((string) $article->status !== 'published' || ! (bool) $article->is_public || (int) $article->published_revision_id <= 0) {
+                $errors[] = $this->issue('article.'.$article->id.'.status', 'article_not_published_public', 'SEO gate rollout is limited to published public articles with a published revision.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+
+            if (! $article->seoMeta instanceof ArticleSeoMeta) {
+                $errors[] = $this->issue('article.'.$article->id.'.seo_meta', 'article_seo_meta_missing', 'Article SEO meta row is required before SEO gate rollout.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  array<string,mixed>  $options
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function validateRequestedGates(array $articles, array $options, array &$errors, array &$warnings): void
+    {
+        foreach ($articles as $article) {
+            if (! $article->seoMeta instanceof ArticleSeoMeta) {
+                continue;
+            }
+
+            $types = $this->jsonLdTypes($this->seoService->generateJsonLd($article, $article->publishedRevision));
+            $articleSchemaRequested = (bool) ($options['enable_article_schema'] ?? false)
+                || (bool) ($options['enable_breadcrumb_schema'] ?? false);
+
+            if ($articleSchemaRequested && ! in_array('Article', $types, true)) {
+                $errors[] = $this->issue('article.'.$article->id.'.jsonld', 'json_ld_article_missing', 'Generated JSON-LD must contain Article before enabling Article schema.', [
+                    'article_id' => (int) $article->id,
+                    'json_ld_types' => $types,
+                ]);
+            }
+
+            if ($articleSchemaRequested && ! (bool) ($options['enable_faq_schema'] ?? false) && in_array('FAQPage', $types, true)) {
+                $errors[] = $this->issue('article.'.$article->id.'.jsonld', 'json_ld_faq_gate_blocked', 'Generated JSON-LD contains FAQPage while FAQ schema gate is not explicitly enabled.', [
+                    'article_id' => (int) $article->id,
+                    'json_ld_types' => $types,
+                ]);
+            }
+
+            if ((bool) ($options['enable_faq_schema'] ?? false) && ! in_array('FAQPage', $types, true)) {
+                $warnings[] = $this->issue('article.'.$article->id.'.jsonld', 'faq_schema_enabled_without_faqpage', 'FAQ schema gate was requested but generated JSON-LD has no FAQPage.', [
+                    'article_id' => (int) $article->id,
+                    'json_ld_types' => $types,
+                ]);
+            }
+        }
+
+        if ((bool) ($options['enable_hreflang'] ?? false)) {
+            $this->validateReciprocalHreflang($articles, $errors);
+        }
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateReciprocalHreflang(array $articles, array &$errors): void
+    {
+        foreach ($articles as $article) {
+            $payload = $this->seoService->buildSeoPayload($article, $article->publishedRevision);
+            $alternates = is_array($payload['alternates'] ?? null) ? $payload['alternates'] : [];
+            $canonical = (string) ($payload['canonical'] ?? '');
+
+            if ($canonical === '' || ! isset($alternates['en'], $alternates['zh-CN'])) {
+                $errors[] = $this->issue('article.'.$article->id.'.hreflang', 'hreflang_missing_counterpart', 'Hreflang enable requires both en and zh-CN public indexable alternates.', [
+                    'article_id' => (int) $article->id,
+                    'alternates' => $alternates,
+                ]);
+
+                continue;
+            }
+
+            foreach (['en', 'zh-CN'] as $locale) {
+                $sibling = Article::query()
+                    ->withoutGlobalScopes()
+                    ->where('org_id', (int) $article->org_id)
+                    ->where('translation_group_id', (string) $article->translation_group_id)
+                    ->where('locale', $locale)
+                    ->publiclyIndexable()
+                    ->first();
+
+                if (! $sibling instanceof Article) {
+                    $errors[] = $this->issue('article.'.$article->id.'.hreflang', 'hreflang_counterpart_not_found', 'Hreflang counterpart article was not found.', [
+                        'article_id' => (int) $article->id,
+                        'locale' => $locale,
+                    ]);
+
+                    continue;
+                }
+
+                $siblingPayload = $this->seoService->buildSeoPayload($sibling, $sibling->publishedRevision);
+                $siblingAlternates = is_array($siblingPayload['alternates'] ?? null) ? $siblingPayload['alternates'] : [];
+                if (($siblingAlternates[(string) $article->locale] ?? null) !== $canonical) {
+                    $errors[] = $this->issue('article.'.$article->id.'.hreflang', 'hreflang_reciprocal_mismatch', 'Hreflang counterpart does not reciprocate this article canonical.', [
+                        'article_id' => (int) $article->id,
+                        'counterpart_article_id' => (int) $sibling->id,
+                        'counterpart_locale' => $locale,
+                        'expected' => $canonical,
+                        'actual' => $siblingAlternates[(string) $article->locale] ?? null,
+                    ]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function apply(Article $article, array $options): void
+    {
+        $setTranslationGroupId = trim((string) ($options['set_translation_group_id'] ?? ''));
+        if ($setTranslationGroupId !== '') {
+            $article->forceFill(['translation_group_id' => $setTranslationGroupId])->saveQuietly();
+        }
+
+        /** @var ArticleSeoMeta $seoMeta */
+        $seoMeta = $article->seoMeta;
+        $schema = is_array($seoMeta->schema_json) ? $seoMeta->schema_json : [];
+        $package = is_array($schema['editorial_package_v1'] ?? null) ? $schema['editorial_package_v1'] : [];
+
+        if ((bool) ($options['enable_article_schema'] ?? false)) {
+            $package['article_schema_enabled'] = true;
+        }
+        if ((bool) ($options['enable_breadcrumb_schema'] ?? false)) {
+            $package['breadcrumb_schema_enabled'] = true;
+        }
+        if ((bool) ($options['enable_faq_schema'] ?? false)) {
+            $package['faq_schema_enabled'] = true;
+        } elseif ((bool) ($options['hold_faq_schema'] ?? false)) {
+            $package['faq_schema_enabled'] = false;
+        }
+
+        if ((bool) ($options['enable_hreflang'] ?? false)) {
+            $package['hreflang_gate_v1'] = [
+                'enabled' => true,
+                'policy' => 'reciprocal_counterparts_verified',
+                'verified_by' => 'articles:seo-gate-rollout',
+                'verified_at' => now()->toIso8601String(),
+            ];
+        } elseif ((bool) ($options['no_hreflang_policy'] ?? false)) {
+            $package['hreflang_gate_v1'] = [
+                'enabled' => false,
+                'policy' => 'no_hreflang',
+                'reason' => trim((string) ($options['hreflang_policy_reason'] ?? 'no_verified_reciprocal_counterpart')),
+                'recorded_by' => 'articles:seo-gate-rollout',
+                'recorded_at' => now()->toIso8601String(),
+            ];
+        }
+
+        $schema['editorial_package_v1'] = $package;
+        $seoMeta->forceFill(['schema_json' => $schema])->saveQuietly();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $article->loadMissing([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+
+        $seoMeta = $article->seoMeta;
+        $schema = $seoMeta instanceof ArticleSeoMeta && is_array($seoMeta->schema_json) ? $seoMeta->schema_json : null;
+        $package = is_array($schema['editorial_package_v1'] ?? null) ? $schema['editorial_package_v1'] : [];
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'slug' => (string) $article->slug,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'seo_meta_exists' => $seoMeta instanceof ArticleSeoMeta,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)) : null,
+            'schema_gates' => [
+                'article_schema_enabled' => $package['article_schema_enabled'] ?? null,
+                'breadcrumb_schema_enabled' => $package['breadcrumb_schema_enabled'] ?? null,
+                'faq_schema_enabled' => $package['faq_schema_enabled'] ?? null,
+                'hreflang_gate_v1' => $package['hreflang_gate_v1'] ?? null,
+            ],
+            'json_ld_types' => $seoMeta instanceof ArticleSeoMeta
+                ? $this->jsonLdTypes($this->seoService->generateJsonLd($article, $article->publishedRevision))
+                : [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function plannedSnapshot(Article $article, array $options): array
+    {
+        $snapshot = $this->snapshot($article);
+        $setTranslationGroupId = trim((string) ($options['set_translation_group_id'] ?? ''));
+        if ($setTranslationGroupId !== '') {
+            $snapshot['translation_group_id'] = $setTranslationGroupId;
+        }
+
+        if ((bool) ($options['enable_article_schema'] ?? false)) {
+            $snapshot['schema_gates']['article_schema_enabled'] = true;
+        }
+        if ((bool) ($options['enable_breadcrumb_schema'] ?? false)) {
+            $snapshot['schema_gates']['breadcrumb_schema_enabled'] = true;
+        }
+        if ((bool) ($options['enable_faq_schema'] ?? false)) {
+            $snapshot['schema_gates']['faq_schema_enabled'] = true;
+        } elseif ((bool) ($options['hold_faq_schema'] ?? false)) {
+            $snapshot['schema_gates']['faq_schema_enabled'] = false;
+        }
+        if ((bool) ($options['enable_hreflang'] ?? false)) {
+            $snapshot['schema_gates']['hreflang_gate_v1'] = [
+                'enabled' => true,
+                'policy' => 'reciprocal_counterparts_verified',
+            ];
+        } elseif ((bool) ($options['no_hreflang_policy'] ?? false)) {
+            $snapshot['schema_gates']['hreflang_gate_v1'] = [
+                'enabled' => false,
+                'policy' => 'no_hreflang',
+                'reason' => trim((string) ($options['hreflang_policy_reason'] ?? 'no_verified_reciprocal_counterpart')),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  array<string,mixed>  $options
+     */
+    private function writeAudit(array $articles, array $options, string $translationGroupId): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        foreach ($articles as $article) {
+            AuditLog::query()->withoutGlobalScopes()->create([
+                'org_id' => (int) $article->org_id,
+                'actor_admin_id' => null,
+                'action' => 'articles_seo_gate_rollout',
+                'target_type' => 'article',
+                'target_id' => (string) $article->id,
+                'meta_json' => [
+                    'command' => 'articles:seo-gate-rollout',
+                    'article_id' => (int) $article->id,
+                    'slug' => (string) $article->slug,
+                    'locale' => (string) $article->locale,
+                    'translation_group_id_lock' => $translationGroupId,
+                    'requested_options' => $this->auditOptions($options),
+                    'no_publish' => true,
+                    'no_search' => true,
+                    'no_sitemap_llms_change' => true,
+                    'no_content_change' => true,
+                    'no_revalidation' => true,
+                ],
+                'ip' => null,
+                'user_agent' => 'artisan',
+                'request_id' => '',
+                'reason' => 'controlled_article_seo_gate_rollout',
+                'result' => 'success',
+                'created_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function auditOptions(array $options): array
+    {
+        return [
+            'enable_article_schema' => (bool) ($options['enable_article_schema'] ?? false),
+            'enable_breadcrumb_schema' => (bool) ($options['enable_breadcrumb_schema'] ?? false),
+            'enable_faq_schema' => (bool) ($options['enable_faq_schema'] ?? false),
+            'hold_faq_schema' => (bool) ($options['hold_faq_schema'] ?? false),
+            'enable_hreflang' => (bool) ($options['enable_hreflang'] ?? false),
+            'no_hreflang_policy' => (bool) ($options['no_hreflang_policy'] ?? false),
+            'set_translation_group_id_present' => trim((string) ($options['set_translation_group_id'] ?? '')) !== '',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $jsonLd
+     * @return list<string>
+     */
+    private function jsonLdTypes(array $jsonLd): array
+    {
+        $types = [];
+        $walk = function (mixed $value) use (&$walk, &$types): void {
+            if (! is_array($value)) {
+                return;
+            }
+
+            $type = $value['@type'] ?? null;
+            if (is_string($type) && trim($type) !== '') {
+                $types[] = trim($type);
+            } elseif (is_array($type)) {
+                foreach ($type as $item) {
+                    if (is_string($item) && trim($item) !== '') {
+                        $types[] = trim($item);
+                    }
+                }
+            }
+
+            foreach ($value as $nested) {
+                $walk($nested);
+            }
+        };
+        $walk($jsonLd);
+
+        return array_values(array_unique($types));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<int>
+     */
+    private function articleIds(string $raw, array &$errors): array
+    {
+        $ids = array_values(array_unique(array_filter(array_map(
+            static fn (string $value): int => is_numeric(trim($value)) ? (int) trim($value) : 0,
+            explode(',', $raw)
+        ))));
+
+        if ($ids === []) {
+            $errors[] = $this->issue('article_ids', 'article_ids_required', 'At least one article id is required.');
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<string>
+     */
+    private function expectedSlugs(string $raw, array &$errors): array
+    {
+        $slugs = array_values(array_filter(array_map(
+            static fn (string $value): string => trim($value),
+            explode(',', $raw)
+        ), static fn (string $value): bool => $value !== ''));
+
+        if ($slugs === []) {
+            $errors[] = $this->issue('expected_slugs', 'expected_slugs_required', 'Expected slug identity lock is required.');
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_filter([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context,
+        ], static fn (mixed $value): bool => $value !== []);
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(
+        bool $ok,
+        bool $dryRun,
+        string $action,
+        array $articleIds,
+        string $translationGroupId,
+        array $before,
+        array $after,
+        array $errors,
+        array $warnings
+    ): array {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && $dryRun,
+            'article_ids' => $articleIds,
+            'translation_group_id_lock' => $translationGroupId,
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ArticleSeoGateRolloutCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered_for_production_artisan_path(): void
+    {
+        $this->assertArrayHasKey('articles:seo-gate-rollout', Artisan::all());
+    }
+
+    public function test_dry_run_plans_article_breadcrumb_and_no_hreflang_policy_without_writing(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 8,
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-8',
+            'title' => 'MBTI 基础',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => false,
+                    'breadcrumb_schema_enabled' => false,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => ['enabled' => false],
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'article-8',
+            '--expected-slugs' => 'mbti-basics',
+            '--enable-article-schema' => true,
+            '--enable-breadcrumb-schema' => true,
+            '--hold-faq-schema' => true,
+            '--no-hreflang-policy' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertTrue($payload['would_write']);
+        $this->assertFalse((bool) data_get($payload, 'before.0.schema_gates.article_schema_enabled'));
+        $this->assertTrue((bool) data_get($payload, 'after.0.schema_gates.article_schema_enabled'));
+        $this->assertTrue((bool) data_get($payload, 'after.0.schema_gates.breadcrumb_schema_enabled'));
+        $this->assertFalse((bool) data_get($payload, 'after.0.schema_gates.faq_schema_enabled'));
+        $this->assertSame('no_hreflang', data_get($payload, 'after.0.schema_gates.hreflang_gate_v1.policy'));
+
+        $fresh = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->firstOrFail();
+        $this->assertFalse((bool) data_get($fresh->schema_json, 'editorial_package_v1.article_schema_enabled'));
+        $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_seo_gate_rollout')->count());
+    }
+
+    public function test_execute_writes_schema_policy_identity_cleanup_and_audit_without_revision_or_content_change(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 50,
+            'slug' => 'iq-test-score-and-limits-explained',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'unknown_until_cms_import',
+            'title' => '在线 IQ 测试准吗？',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => false,
+                ],
+            ],
+        ]);
+        $revisionCount = ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count();
+        $contentMd = (string) $article->content_md;
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'unknown_until_cms_import',
+            '--expected-slugs' => 'iq-test-score-and-limits-explained',
+            '--set-translation-group-id' => 'tg_article_iq_test_score_and_limits_explained_2026v1',
+            '--no-hreflang-policy' => true,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+            '--no-content-change' => true,
+            '--no-revalidation' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('rolled_out_article_seo_gates', $payload['action']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+        $this->assertSame('tg_article_iq_test_score_and_limits_explained_2026v1', (string) $fresh->translation_group_id);
+        $this->assertSame($contentMd, (string) $fresh->content_md);
+        $this->assertSame($revisionCount, ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count());
+        $this->assertSame('no_hreflang', data_get($fresh->seoMeta?->schema_json, 'editorial_package_v1.hreflang_gate_v1.policy'));
+
+        $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_seo_gate_rollout')->first();
+        $this->assertInstanceOf(AuditLog::class, $audit);
+        $this->assertSame((string) $article->id, (string) $audit->target_id);
+        $this->assertSame('articles:seo-gate-rollout', data_get($audit->meta_json, 'command'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_content_change'));
+    }
+
+    public function test_article_schema_enable_blocks_when_generated_jsonld_contains_faqpage_and_faq_gate_is_held(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 51,
+            'slug' => 'enneagram-personality-test-explained',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_enneagram_personality_test_explained_2026v1',
+            'title' => '九型人格测试准吗？',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'answer_surface_policy' => 'editor_supplied',
+                    'answer_surface_visibility' => 'below_intro',
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            ['question' => '九型人格能诊断人格吗？', 'answer' => '不能，它只能用于自我理解。'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'tg_article_enneagram_personality_test_explained_2026v1',
+            '--expected-slugs' => 'enneagram-personality-test-explained',
+            '--enable-article-schema' => true,
+            '--enable-breadcrumb-schema' => true,
+            '--hold-faq-schema' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertErrorCode($payload, 'json_ld_faq_gate_blocked');
+        $this->assertContains('FAQPage', data_get($payload, 'before.0.json_ld_types'));
+    }
+
+    public function test_enable_hreflang_requires_reciprocal_counterpart(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 4,
+            'slug' => 'eq-test-tool-guide',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-4',
+            'title' => '情商测试指南',
+        ]);
+        $this->createSeoMeta($article);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'article-4',
+            '--expected-slugs' => 'eq-test-tool-guide',
+            '--enable-hreflang' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'hreflang_missing_counterpart');
+    }
+
+    public function test_enable_hreflang_passes_for_reciprocal_public_counterparts(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $groupId = 'tg_article_eq_test_tool_guide_2026v1';
+        $zh = $this->createArticle([
+            'id' => 4,
+            'slug' => 'eq-test-tool-guide',
+            'locale' => 'zh-CN',
+            'translation_group_id' => $groupId,
+            'title' => '情商测试指南',
+        ]);
+        $en = $this->createArticle([
+            'id' => 40,
+            'slug' => 'eq-test-tool-guide',
+            'locale' => 'en',
+            'translation_group_id' => $groupId,
+            'title' => 'EQ Test Tool Guide',
+        ]);
+        $this->createSeoMeta($zh);
+        $this->createSeoMeta($en);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => $zh->id.','.$en->id,
+            '--translation-group-id' => $groupId,
+            '--expected-slugs' => 'eq-test-tool-guide,eq-test-tool-guide',
+            '--enable-hreflang' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('reciprocal_counterparts_verified', data_get($payload, 'after.0.schema_gates.hreflang_gate_v1.policy'));
+        $this->assertSame('reciprocal_counterparts_verified', data_get($payload, 'after.1.schema_gates.hreflang_gate_v1.policy'));
+    }
+
+    public function test_execute_requires_all_safety_flags(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 3,
+            'slug' => 'big-five-tool-guide',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-3',
+        ]);
+        $this->createSeoMeta($article);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'article-3',
+            '--expected-slugs' => 'big-five-tool-guide',
+            '--enable-article-schema' => true,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        $fresh = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->firstOrFail();
+        $this->assertNull($fresh->schema_json);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'translation_group_id' => 'article-group',
+            'source_locale' => 'en',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => 'Article Title',
+            'excerpt' => 'Article excerpt.',
+            'content_md' => '# Article body',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => Carbon::create(2026, 6, 14, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ], $overrides));
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) ($article->translated_from_version_hash ?: $article->source_version_hash),
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
+        ]);
+
+        $article->forceFill(['published_revision_id' => $revision->id])->save();
+
+        return $article->fresh(['publishedRevision']) ?? $article;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createSeoMeta(Article $article, array $overrides = []): ArticleSeoMeta
+    {
+        /** @var ArticleSeoMeta */
+        return ArticleSeoMeta::query()->withoutGlobalScopes()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) ($article->excerpt ?? ''),
+            'canonical_url' => 'https://fermatmind.com/'.((string) $article->locale === 'zh-CN' ? 'zh' : 'en').'/articles/'.$article->slug,
+            'og_title' => (string) $article->title,
+            'og_description' => (string) ($article->excerpt ?? ''),
+            'og_image_url' => null,
+            'robots' => 'index,follow',
+            'schema_json' => null,
+            'is_indexable' => true,
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['errors'] ?? [])
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1734,6 +1734,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_seo_gate_rollout_tooling_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleSeoGateRollout.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/ArticleSeoGateRollout.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleSeoGateRollout;',
+            '+        ArticleSeoGateRollout::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -3170,6 +3185,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleSeoGateRolloutFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -4141,6 +4160,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php',
             'backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php',
+        ], true);
+    }
+
+    private function isArticleSeoGateRolloutFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleSeoGateRollout.php',
+            'backend/app/Services/Cms/ArticleSeoGateRollout.php',
         ], true);
     }
 
@@ -5804,7 +5831,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleUpdateExistingSeoContentPackage|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `articles:seo-gate-rollout` as a controlled Artisan command for article SEO gate rollout work.
- Added identity locks for article ids, expected slugs, and current `translation_group_id`.
- Added guarded dry-run/execute behavior, execute safety flags, JSON-LD type checks, FAQ schema gate separation, hreflang reciprocal validation, no-hreflang policy writes, and audit logging.
- Added focused feature coverage for registration, dry-run, execute, IQ-style identity cleanup, FAQ blocking, reciprocal hreflang, and execute safety flags.

## Why
This provides a bounded production tool for the next six-pillar cleanup phase without using ad hoc DB writes. It lets operators dry-run first, then execute only after explicit approval and deploy.

## Validation
- `php artisan test tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php`
- `php artisan test tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php tests/Feature/V0_5/ArticlePublicApiTest.php`
- `./vendor/bin/pint --dirty`
- `php artisan list --raw | rg "articles:seo-gate-rollout|articles:ensure-seo-meta-baseline|content-release:revalidate"`
- `git diff --check`

## Intentionally deferred
- No production CMS writes in this PR.
- No deploy, publish, revalidation, sitemap/llms/search submission, IndexNow/Baidu/GSC action, schema execute, or hreflang execute.
- Post-deploy dry-runs must be run first; production execute requires separate exact approval.