### PR TITLE
fix(article-seo): project public schema gates

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -1106,6 +1106,7 @@ class ArticleController extends Controller
         $seoMeta['seo_description'] = $revision->seo_description;
         $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
         if (is_array($seoMeta['schema_json'] ?? null)) {
+            $this->projectPublicSeoGateMetadata($seoMeta, $seoMeta['schema_json']);
             $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
                 CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
             );
@@ -1291,12 +1292,54 @@ class ArticleController extends Controller
 
         $seoMeta['canonical_url'] = CanonicalFrontendUrl::normalizeAbsoluteUrl($seoMeta['canonical_url'] ?? null);
         if (is_array($seoMeta['schema_json'] ?? null)) {
+            $this->projectPublicSeoGateMetadata($seoMeta, $seoMeta['schema_json']);
             $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
                 CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
             );
+            unset($seoMeta['schema_json']['editorial_package_v1']);
         }
 
         return $seoMeta;
+    }
+
+    /**
+     * @param  array<string,mixed>  $seoMeta
+     * @param  array<string,mixed>  $schemaJson
+     */
+    private function projectPublicSeoGateMetadata(array &$seoMeta, array $schemaJson): void
+    {
+        $editorialPackage = $schemaJson['editorial_package_v1'] ?? null;
+        if (! is_array($editorialPackage)) {
+            return;
+        }
+
+        $schemaGates = [];
+        foreach ([
+            'article_schema_enabled' => 'article_schema_gate_v1',
+            'breadcrumb_schema_enabled' => 'breadcrumb_schema_gate_v1',
+            'faq_schema_enabled' => 'faq_schema_gate_v1',
+        ] as $sourceKey => $targetKey) {
+            if (is_bool($editorialPackage[$sourceKey] ?? null)) {
+                $schemaGates[$targetKey] = ['enabled' => (bool) $editorialPackage[$sourceKey]];
+            }
+        }
+
+        if ($schemaGates !== []) {
+            $seoMeta['schema_gates_v1'] = $schemaGates;
+        }
+
+        $hreflangGate = $editorialPackage['hreflang_gate_v1'] ?? null;
+        if (is_array($hreflangGate) && is_bool($hreflangGate['enabled'] ?? null)) {
+            $publicHreflangGate = ['enabled' => (bool) $hreflangGate['enabled']];
+
+            foreach (['policy', 'reason'] as $key) {
+                if (is_string($hreflangGate[$key] ?? null) && trim((string) $hreflangGate[$key]) !== '') {
+                    $publicHreflangGate[$key] = trim((string) $hreflangGate[$key]);
+                }
+            }
+
+            $seoMeta['hreflang_gate_v1'] = $publicHreflangGate;
+        }
     }
 
     private function invalidArgument(InvalidArgumentException $e): JsonResponse

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -322,6 +322,49 @@ final class ArticlePublicApiTest extends TestCase
         $this->assertStringStartsWith('## Legacy duplicate title', (string) $response->json('article.content_md'));
     }
 
+    public function test_article_detail_projects_public_schema_and_hreflang_gates_without_editorial_package(): void
+    {
+        $article = $this->createArticle([
+            'slug' => 'schema-gated-article',
+            'locale' => 'en',
+            'title' => 'Schema Gated Article',
+            'excerpt' => 'Article with controlled public schema gates.',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => [
+                '@type' => 'Article',
+                'url' => 'https://www.fermatmind.com/en/articles/schema-gated-article',
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                        'policy' => 'no_hreflang',
+                        'reason' => 'no_direct_english_counterpart_approved',
+                        'recorded_by' => 'articles:seo-gate-rollout',
+                    ],
+                    'private_operator_note' => 'do not expose this package field',
+                ],
+            ],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/articles/schema-gated-article?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('article.seo_meta.schema_json.@type', 'Article')
+            ->assertJsonPath('article.seo_meta.schema_gates_v1.article_schema_gate_v1.enabled', true)
+            ->assertJsonPath('article.seo_meta.schema_gates_v1.breadcrumb_schema_gate_v1.enabled', true)
+            ->assertJsonPath('article.seo_meta.schema_gates_v1.faq_schema_gate_v1.enabled', false)
+            ->assertJsonPath('article.seo_meta.hreflang_gate_v1.enabled', false)
+            ->assertJsonPath('article.seo_meta.hreflang_gate_v1.policy', 'no_hreflang')
+            ->assertJsonPath('article.seo_meta.hreflang_gate_v1.reason', 'no_direct_english_counterpart_approved')
+            ->assertJsonMissingPath('article.seo_meta.hreflang_gate_v1.recorded_by')
+            ->assertJsonMissingPath('article.seo_meta.schema_json.editorial_package_v1');
+
+        $this->assertStringNotContainsString('private_operator_note', (string) $response->getContent());
+    }
+
     public function test_article_detail_projects_cms_cta_slots_and_visible_faq_without_private_targets(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);


### PR DESCRIPTION
## What changed
- Project a safe `schema_gates_v1` payload from article SEO `schema_json.editorial_package_v1` into the public article detail API.
- Project a safe `hreflang_gate_v1` payload with only public `enabled`, `policy`, and `reason` fields.
- Continue removing the raw `editorial_package_v1` package from public API responses.
- Cover the contract with a focused Article public API test.

## Why
After `articles:seo-gate-rollout`, the SEO endpoint exposed Article JSON-LD, but article detail responses still stripped the entire editorial package without projecting the gate fields the frontend reads. Public HTML for MBTI / Big Five / EQ therefore remained schema-held after revalidation. This keeps backend CMS as the authority while exposing only the controlled public gate contract.

## Validation
- `cd backend && php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=projects_public_schema_and_hreflang_gates`
- `cd backend && php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php`
- `cd backend && ./vendor/bin/pint --test app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Feature/V0_5/ArticlePublicApiTest.php`
- `git diff --check`

## Intentionally deferred
- No CMS writes.
- No article publish.
- No search submission.
- No deployment.
- No content-release revalidation.

## Repository rule impact
This is a backend public API projection fix for CMS-owned SEO gate metadata. It does not change content ownership or introduce a new content surface.
