### PR TITLE
fix(article-seo): filter held FAQ JSON-LD

### DIFF
--- a/backend/app/Services/Cms/ArticleSeoGateRollout.php
+++ b/backend/app/Services/Cms/ArticleSeoGateRollout.php
@@ -202,9 +202,15 @@ final class ArticleSeoGateRollout
                 continue;
             }
 
-            $types = $this->jsonLdTypes($this->seoService->generateJsonLd($article, $article->publishedRevision));
+            $types = $this->jsonLdTypes($this->seoService->generateJsonLd(
+                $article,
+                $article->publishedRevision,
+                $this->plannedFaqSchemaOverride($options)
+            ));
             $articleSchemaRequested = (bool) ($options['enable_article_schema'] ?? false)
                 || (bool) ($options['enable_breadcrumb_schema'] ?? false);
+            $faqSchemaRequested = (bool) ($options['enable_faq_schema'] ?? false);
+            $faqSchemaHeld = (bool) ($options['hold_faq_schema'] ?? false);
 
             if ($articleSchemaRequested && ! in_array('Article', $types, true)) {
                 $errors[] = $this->issue('article.'.$article->id.'.jsonld', 'json_ld_article_missing', 'Generated JSON-LD must contain Article before enabling Article schema.', [
@@ -213,7 +219,7 @@ final class ArticleSeoGateRollout
                 ]);
             }
 
-            if ($articleSchemaRequested && ! (bool) ($options['enable_faq_schema'] ?? false) && in_array('FAQPage', $types, true)) {
+            if ($articleSchemaRequested && ! $faqSchemaRequested && ! $faqSchemaHeld && in_array('FAQPage', $types, true)) {
                 $errors[] = $this->issue('article.'.$article->id.'.jsonld', 'json_ld_faq_gate_blocked', 'Generated JSON-LD contains FAQPage while FAQ schema gate is not explicitly enabled.', [
                     'article_id' => (int) $article->id,
                     'json_ld_types' => $types,
@@ -231,6 +237,22 @@ final class ArticleSeoGateRollout
         if ((bool) ($options['enable_hreflang'] ?? false)) {
             $this->validateReciprocalHreflang($articles, $errors);
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function plannedFaqSchemaOverride(array $options): ?bool
+    {
+        if ((bool) ($options['enable_faq_schema'] ?? false)) {
+            return true;
+        }
+
+        if ((bool) ($options['hold_faq_schema'] ?? false)) {
+            return false;
+        }
+
+        return null;
     }
 
     /**
@@ -397,6 +419,14 @@ final class ArticleSeoGateRollout
             $snapshot['schema_gates']['faq_schema_enabled'] = true;
         } elseif ((bool) ($options['hold_faq_schema'] ?? false)) {
             $snapshot['schema_gates']['faq_schema_enabled'] = false;
+        }
+        $plannedFaqSchemaOverride = $this->plannedFaqSchemaOverride($options);
+        if ($plannedFaqSchemaOverride !== null) {
+            $snapshot['json_ld_types'] = $this->jsonLdTypes($this->seoService->generateJsonLd(
+                $article,
+                $article->publishedRevision,
+                $plannedFaqSchemaOverride
+            ));
         }
         if ((bool) ($options['enable_hreflang'] ?? false)) {
             $snapshot['schema_gates']['hreflang_gate_v1'] = [

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -120,7 +120,7 @@ final class ArticleSeoService
     /**
      * @return array<string,mixed>
      */
-    public function generateJsonLd(Article $article, ?ArticleTranslationRevision $revision = null): array
+    public function generateJsonLd(Article $article, ?ArticleTranslationRevision $revision = null, ?bool $faqSchemaEnabledOverride = null): array
     {
         $locale = $this->normalizeLocale((string) $article->locale);
         $seo = $this->resolveSeoMeta($article, $locale);
@@ -156,9 +156,13 @@ final class ArticleSeoService
 
         $faqPage = $this->buildVisibleFaqPage($article, $seo, $canonical);
         if ($faqPage !== null) {
-            $hasPart = is_array($jsonLd['hasPart'] ?? null) ? $jsonLd['hasPart'] : [];
-            $hasPart[] = $faqPage;
-            $jsonLd['hasPart'] = array_values($hasPart);
+            if ($this->shouldExposeFaqJsonLd($article, $seo, $faqSchemaEnabledOverride)) {
+                $hasPart = is_array($jsonLd['hasPart'] ?? null) ? $jsonLd['hasPart'] : [];
+                $hasPart[] = $faqPage;
+                $jsonLd['hasPart'] = array_values($hasPart);
+            } else {
+                $jsonLd = $this->removeFaqPageFromJsonLd($jsonLd);
+            }
         }
 
         return PublicMediaUrlGuard::sanitizeJsonLdImageFields(
@@ -317,6 +321,56 @@ final class ArticleSeoService
             '@id' => $canonical !== null ? $canonical.'#faq' : null,
             'mainEntity' => $mainEntity,
         ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    private function shouldExposeFaqJsonLd(Article $article, ?ArticleSeoMeta $seo, ?bool $faqSchemaEnabledOverride): bool
+    {
+        if ($faqSchemaEnabledOverride !== null) {
+            return $faqSchemaEnabledOverride;
+        }
+
+        $metadata = $this->editorialPackageMetadata($article, $seo);
+        if (array_key_exists('faq_schema_enabled', $metadata) && is_bool($metadata['faq_schema_enabled'])) {
+            return (bool) $metadata['faq_schema_enabled'];
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string,mixed>  $jsonLd
+     * @return array<string,mixed>
+     */
+    private function removeFaqPageFromJsonLd(array $jsonLd): array
+    {
+        if (($jsonLd['@type'] ?? null) === 'FAQPage') {
+            return [];
+        }
+
+        if (is_array($jsonLd['@type'] ?? null) && in_array('FAQPage', $jsonLd['@type'], true)) {
+            $jsonLd['@type'] = array_values(array_filter(
+                $jsonLd['@type'],
+                static fn (mixed $type): bool => $type !== 'FAQPage'
+            ));
+        }
+
+        if (is_array($jsonLd['hasPart'] ?? null)) {
+            $hasPart = [];
+            foreach ($jsonLd['hasPart'] as $part) {
+                if (is_array($part) && ($part['@type'] ?? null) === 'FAQPage') {
+                    continue;
+                }
+                $hasPart[] = $part;
+            }
+
+            if ($hasPart === []) {
+                unset($jsonLd['hasPart']);
+            } else {
+                $jsonLd['hasPart'] = array_values($hasPart);
+            }
+        }
+
+        return $jsonLd;
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php
@@ -125,7 +125,7 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
         $this->assertTrue((bool) data_get($audit->meta_json, 'no_content_change'));
     }
 
-    public function test_article_schema_enable_blocks_when_generated_jsonld_contains_faqpage_and_faq_gate_is_held(): void
+    public function test_article_schema_enable_filters_generated_faqpage_when_faq_gate_is_held(): void
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);
         $article = $this->createArticle([
@@ -156,6 +156,49 @@ final class ArticleSeoGateRolloutCommandTest extends TestCase
             '--enable-article-schema' => true,
             '--enable-breadcrumb-schema' => true,
             '--hold-faq-schema' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertContains('FAQPage', data_get($payload, 'before.0.json_ld_types'));
+        $this->assertNotContains('FAQPage', data_get($payload, 'after.0.json_ld_types'));
+        $this->assertFalse((bool) data_get($payload, 'after.0.schema_gates.faq_schema_enabled'));
+    }
+
+    public function test_article_schema_enable_blocks_when_generated_jsonld_contains_faqpage_without_faq_gate_decision(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle([
+            'id' => 51,
+            'slug' => 'enneagram-personality-test-explained',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_enneagram_personality_test_explained_2026v1',
+            'title' => '九型人格测试准吗？',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'answer_surface_policy' => 'editor_supplied',
+                    'answer_surface_visibility' => 'below_intro',
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            ['question' => '九型人格能诊断人格吗？', 'answer' => '不能，它只能用于自我理解。'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:seo-gate-rollout', [
+            '--article-ids' => (string) $article->id,
+            '--translation-group-id' => 'tg_article_enneagram_personality_test_explained_2026v1',
+            '--expected-slugs' => 'enneagram-personality-test-explained',
+            '--enable-article-schema' => true,
+            '--enable-breadcrumb-schema' => true,
             '--dry-run' => true,
             '--json' => true,
         ]);

--- a/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
@@ -89,4 +89,57 @@ final class ArticleSeoServiceTest extends TestCase
         $this->assertStringNotContainsString('www.fermatmind.com', json_encode($payload, JSON_THROW_ON_ERROR));
         $this->assertStringNotContainsString('www.fermatmind.com', json_encode($jsonLd, JSON_THROW_ON_ERROR));
     }
+
+    public function test_generate_json_ld_filters_visible_faq_when_faq_schema_gate_is_held(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'enneagram-personality-test-explained',
+            'locale' => 'zh-CN',
+            'title' => '九型人格测试准吗？',
+            'excerpt' => '了解九型人格测试的边界。',
+            'content_md' => '# 九型人格测试准吗？',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 6, 14, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 6, 14, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 6, 14, 9, 0, 0, 'UTC'),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '九型人格测试准吗？',
+            'seo_description' => '了解九型人格测试的边界。',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/enneagram-personality-test-explained',
+            'og_title' => '九型人格测试准吗？',
+            'og_description' => '了解九型人格测试的边界。',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'faq_schema_enabled' => false,
+                    'answer_surface_policy' => 'editor_supplied',
+                    'answer_surface_visibility' => 'below_intro',
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            ['question' => '九型人格能诊断人格吗？', 'answer' => '不能，它只能用于自我理解。'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $service = app(ArticleSeoService::class);
+        $heldJsonLd = $service->generateJsonLd($article);
+        $enabledJsonLd = $service->generateJsonLd($article, null, true);
+
+        $this->assertStringNotContainsString('FAQPage', json_encode($heldJsonLd, JSON_THROW_ON_ERROR));
+        $this->assertSame('FAQPage', data_get($enabledJsonLd, 'hasPart.0.@type'));
+    }
 }


### PR DESCRIPTION
## What changed
- Added a gate-aware FAQ JSON-LD filter to ArticleSeoService so visible FAQ content can remain renderable while FAQ schema is held.
- Updated articles:seo-gate-rollout validation and planned snapshots to simulate --hold-faq-schema before checking JSON-LD types.
- Added focused tests covering the Enneagram-style hold path and the existing blocker when no FAQ gate decision is provided.

## Why
Enneagram needs Article + Breadcrumb schema enabled while FAQ schema remains held. The prior preflight saw generated FAQPage JSON-LD and blocked Article/Breadcrumb rollout even when --hold-faq-schema was requested.

## Validation
- php artisan test tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php tests/Feature/SEO/ArticleSeoServiceTest.php
- ./vendor/bin/pint --test app/Services/Cms/ArticleSeoService.php app/Services/Cms/ArticleSeoGateRollout.php tests/Feature/Console/ArticleSeoGateRolloutCommandTest.php tests/Feature/SEO/ArticleSeoServiceTest.php
- php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter='schema|faq|seo'
- git diff --check

## Intentionally deferred
- No production deploy in this PR.
- No CMS writes, publish, search submission, sitemap/llms changes, schema/hreflang production writes, or revalidation.
- Enneagram Article/Breadcrumb rollout remains a separate post-deploy gated production operation.