### PR TITLE
feat(career): add salary asset staging preview importer

### DIFF
--- a/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\SalaryAssets\CareerSalaryAssetImportService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class CareerImportSalaryAssetsPreview extends Command
+{
+    protected $signature = 'career:salary-assets-import-preview
+        {--file= : Absolute path to PASS career_job_salary_assets_1046_v3_6 JSONL}
+        {--slugs= : Optional comma-separated preview slug subset}
+        {--dry-run : Validate only; this is the default when --force is not supplied}
+        {--force : Write staging_preview rows for allowlisted preview slugs only}
+        {--json : Emit machine-readable JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Dry-run or staging-preview import of PASS v3.6 career salary asset rows for the 10-slug allowlist.';
+
+    public function __construct(
+        private readonly CareerSalaryAssetImportService $importService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $file = trim((string) $this->option('file'));
+            if ($file === '') {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--file is required.'],
+                ], false);
+            }
+
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+            if ($force && $dryRun) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--dry-run and --force cannot be used together.'],
+                ], false);
+            }
+
+            $slugs = $this->requestedSlugs();
+            $report = $force
+                ? $this->importService->importStagingPreview($file, $slugs)
+                : $this->importService->validateFile($file, $slugs);
+
+            return $this->finish($report, ($report['decision'] ?? null) === 'pass');
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'decision' => 'fail',
+                'errors' => [$throwable->getMessage()],
+            ], false);
+        }
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function requestedSlugs(): ?array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            return null;
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (string $slug): string => strtolower(trim($slug)), explode(',', $raw)),
+            static fn (string $slug): bool => $slug !== ''
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $outputPath = trim((string) $this->option('output'));
+        if ($outputPath !== '') {
+            $directory = dirname($outputPath);
+            if (! is_dir($directory)) {
+                mkdir($directory, 0775, true);
+            }
+
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif ($success) {
+            $this->info('career salary asset preview import validation passed.');
+        } else {
+            $this->error('career salary asset preview import validation failed.');
+            foreach ((array) ($report['errors'] ?? []) as $error) {
+                $this->line('- '.(string) $error);
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerSalaryAssetPreviewController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerSalaryAssetPreviewController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\CareerJobSalaryAsset;
+use App\Services\Career\SalaryAssets\CareerSalaryAssetPreviewService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerSalaryAssetPreviewController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerSalaryAssetPreviewService $previewService,
+    ) {}
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $locale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $asset = $this->previewService->previewAsset($slug, $locale);
+
+        if (! $asset instanceof CareerJobSalaryAsset) {
+            return $this->notFoundResponse('career salary asset preview unavailable.');
+        }
+
+        return response()->json($this->previewService->publicPayload($asset));
+    }
+}

--- a/backend/app/Models/CareerJobSalaryAsset.php
+++ b/backend/app/Models/CareerJobSalaryAsset.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerJobSalaryAsset extends CareerFoundationModel
+{
+    public const ASSET_VERSION_V3_6 = 'career_job_salary_asset_v3_6';
+
+    public const STATUS_STAGING_PREVIEW = 'staging_preview';
+
+    protected $table = 'career_job_salary_assets';
+
+    protected $casts = [
+        'preview_allowlisted' => 'boolean',
+        'asset_payload_json' => 'array',
+        'sources_json' => 'array',
+        'evidence_used_json' => 'array',
+        'derived_from_estimate_json' => 'array',
+        'audit_fields_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Models/Occupation.php
+++ b/backend/app/Models/Occupation.php
@@ -83,6 +83,11 @@ class Occupation extends CareerFoundationModel
         return $this->hasMany(CareerJobDisplayAsset::class, 'occupation_id', 'id');
     }
 
+    public function salaryAssets(): HasMany
+    {
+        return $this->hasMany(CareerJobSalaryAsset::class, 'occupation_id', 'id');
+    }
+
     public function sourceTraces(): HasMany
     {
         return $this->hasManyThrough(

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\SalaryAssets;
+
+use App\Models\CareerJobSalaryAsset;
+use App\Models\Occupation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+final class CareerSalaryAssetImportService
+{
+    public const IMPORTER_VERSION = 'career_salary_asset_v3_6_staging_preview_importer_v0.1';
+
+    public function __construct(
+        private readonly CareerSalaryAssetPreviewService $previewService,
+    ) {}
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function validateFile(string $file, ?array $requestedSlugs = null): array
+    {
+        $report = $this->baseReport($file, $requestedSlugs);
+        $errors = [];
+
+        if (! is_file($file) || ! is_readable($file)) {
+            return array_merge($report, [
+                'decision' => 'fail',
+                'errors' => ['Source JSONL file is missing or unreadable.'],
+            ]);
+        }
+
+        $targetSlugs = $this->targetSlugs($requestedSlugs, $errors);
+        $rowsByKey = [];
+        $parseErrors = [];
+        $totalLines = 0;
+        $lineNumber = 0;
+
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return array_merge($report, [
+                'decision' => 'fail',
+                'errors' => ['Source JSONL file could not be opened.'],
+            ]);
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $lineNumber++;
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $totalLines++;
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable $throwable) {
+                $parseErrors[] = "Line {$lineNumber}: invalid JSON.";
+
+                continue;
+            }
+
+            if (! is_array($row)) {
+                $parseErrors[] = "Line {$lineNumber}: row must be an object.";
+
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if ($slug === '' || ! in_array($slug, $targetSlugs, true)) {
+                continue;
+            }
+
+            $key = $slug.'|'.$locale;
+            if (isset($rowsByKey[$key])) {
+                $errors[] = "{$slug}/{$locale}: duplicate asset row.";
+
+                continue;
+            }
+
+            $rowsByKey[$key] = [
+                'line' => $lineNumber,
+                'row' => $row,
+            ];
+        }
+
+        fclose($handle);
+
+        foreach ($parseErrors as $parseError) {
+            $errors[] = $parseError;
+        }
+
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $key = $slug.'|'.$locale;
+                if (! isset($rowsByKey[$key])) {
+                    $errors[] = "{$slug}/{$locale}: required preview row missing.";
+
+                    continue;
+                }
+
+                foreach ($this->rowErrors($rowsByKey[$key]['row'], $slug, $locale) as $rowError) {
+                    $errors[] = "{$slug}/{$locale}: {$rowError}";
+                }
+            }
+        }
+
+        $missingOccupations = [];
+        foreach ($targetSlugs as $slug) {
+            $exists = Occupation::query()->where('canonical_slug', $slug)->exists();
+            if (! $exists) {
+                $missingOccupations[] = $slug;
+            }
+        }
+        foreach ($missingOccupations as $slug) {
+            $errors[] = "{$slug}: matching occupation row is missing.";
+        }
+
+        $validatedRows = array_values(array_map(
+            static fn (array $entry): array => $entry['row'],
+            $rowsByKey
+        ));
+
+        return array_merge($report, [
+            'mode' => 'dry_run',
+            'decision' => $errors === [] ? 'pass' : 'fail',
+            'total_jsonl_lines' => $totalLines,
+            'target_slug_count' => count($targetSlugs),
+            'validated_preview_rows' => count($validatedRows),
+            'expected_preview_rows' => count($targetSlugs) * 2,
+            'source_file_sha256' => hash_file('sha256', $file) ?: null,
+            'target_slugs' => $targetSlugs,
+            'errors' => $errors,
+            'rows' => $validatedRows,
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function importStagingPreview(string $file, ?array $requestedSlugs = null): array
+    {
+        $report = $this->validateFile($file, $requestedSlugs);
+        if (($report['decision'] ?? null) !== 'pass') {
+            return $report;
+        }
+
+        $importRunId = (string) Str::uuid();
+        $sourceSha = is_string($report['source_file_sha256'] ?? null) ? $report['source_file_sha256'] : null;
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = is_array($report['rows'] ?? null) ? $report['rows'] : [];
+        $written = DB::transaction(function () use ($rows, $sourceSha, $importRunId): array {
+            $written = [];
+
+            foreach ($rows as $row) {
+                $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+                $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+                $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
+                $auditFields = $this->arrayValue($row, 'audit_fields');
+
+                $asset = CareerJobSalaryAsset::query()->updateOrCreate(
+                    [
+                        'career_job_slug' => $slug,
+                        'locale' => $locale,
+                        'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+                        'preview_allowlisted' => true,
+                        'asset_payload_json' => $row,
+                        'sources_json' => $this->arrayValue($row, 'sources'),
+                        'evidence_used_json' => $this->arrayValue($row, 'evidence_used'),
+                        'derived_from_estimate_json' => $this->arrayValue($row, 'derived_from_estimate'),
+                        'audit_fields_json' => $auditFields,
+                        'asset_row_hash' => (string) ($auditFields['row_hash'] ?? ''),
+                        'source_artifact_sha256' => $sourceSha,
+                        'evidence_artifact_sha256' => null,
+                        'estimate_artifact_sha256' => null,
+                        'import_run_id' => $importRunId,
+                    ],
+                );
+
+                $written[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'row_id' => $asset->id,
+                    'created' => $asset->wasRecentlyCreated,
+                ];
+            }
+
+            return $written;
+        });
+
+        return array_merge($report, [
+            'mode' => 'force_staging_preview',
+            'decision' => 'pass',
+            'did_write' => count($written) > 0,
+            'written_count' => count($written),
+            'import_run_id' => $importRunId,
+            'written_assets' => $written,
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    private function baseReport(string $file, ?array $requestedSlugs): array
+    {
+        return [
+            'importer_version' => self::IMPORTER_VERSION,
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status_policy' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+            'production_import_allowed' => false,
+            'source_file' => $file,
+            'requested_slugs' => $requestedSlugs,
+        ];
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @param  list<string>  $errors
+     * @return list<string>
+     */
+    private function targetSlugs(?array $requestedSlugs, array &$errors): array
+    {
+        $allowlist = $this->previewService->previewSlugs();
+        $target = $requestedSlugs === null || $requestedSlugs === []
+            ? $allowlist
+            : array_values(array_unique(array_map(
+                fn (string $slug): string => $this->previewService->normalizeSlug($slug),
+                $requestedSlugs
+            )));
+
+        foreach ($target as $slug) {
+            if (! in_array($slug, $allowlist, true)) {
+                $errors[] = "{$slug}: slug is not in the staging preview allowlist.";
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function rowErrors(array $row, string $slug, string $locale): array
+    {
+        $errors = [];
+        if (($row['asset_type'] ?? null) !== 'career_job_salary_asset') {
+            $errors[] = 'asset_type must be career_job_salary_asset.';
+        }
+
+        if (($row['asset_version'] ?? null) !== CareerJobSalaryAsset::ASSET_VERSION_V3_6) {
+            $errors[] = 'asset_version must be career_job_salary_asset_v3_6.';
+        }
+
+        if ($this->previewService->normalizeSlug((string) ($row['slug'] ?? '')) !== $slug) {
+            $errors[] = 'slug mismatch.';
+        }
+
+        if ($this->previewService->normalizeLocale((string) ($row['locale'] ?? '')) !== $locale) {
+            $errors[] = 'locale mismatch.';
+        }
+
+        $auditFields = $this->arrayValue($row, 'audit_fields');
+        if (($auditFields['schema_version'] ?? null) !== 'career_job_salary_asset_v3_6') {
+            $errors[] = 'audit_fields.schema_version mismatch.';
+        }
+
+        if (($auditFields['ready_for_codex_audit'] ?? null) !== true) {
+            $errors[] = 'audit_fields.ready_for_codex_audit must be true.';
+        }
+
+        $rowHash = (string) ($auditFields['row_hash'] ?? '');
+        if (! preg_match('/^[a-f0-9]{64}$/', $rowHash)) {
+            $errors[] = 'audit_fields.row_hash must be a SHA-256 hex digest.';
+        }
+
+        $cn = $this->arrayValue($row, 'china_recruitment_reference');
+        $facts = $this->arrayValue($cn, 'facts');
+        foreach (['monthly_cny_p25', 'monthly_cny_median', 'monthly_cny_p75'] as $field) {
+            if (($facts[$field] ?? null) !== null) {
+                $errors[] = "China {$field} must stay null for v3.6 preview import.";
+            }
+        }
+
+        $boundary = strtolower((string) ($cn['data_boundary'] ?? ''));
+        $body = (string) ($cn['body'] ?? '');
+        if (! str_contains($boundary, 'not an official chinese single-occupation median wage')
+            && ! str_contains($body, '不是官方职业中位薪资')) {
+            $errors[] = 'China recruitment boundary must explicitly say it is not official wage.';
+        }
+
+        if (! is_array($row['sources'] ?? null) || count((array) $row['sources']) === 0) {
+            $errors[] = 'sources must be a non-empty array.';
+        }
+
+        $derived = $this->arrayValue($row, 'derived_from_estimate');
+        if (! preg_match('/^[a-f0-9]{64}$/', (string) ($derived['estimate_row_hash'] ?? ''))) {
+            $errors[] = 'derived_from_estimate.estimate_row_hash must be present.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function arrayValue(array $row, string $key): array
+    {
+        return is_array($row[$key] ?? null) ? $row[$key] : [];
+    }
+}

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\SalaryAssets;
+
+use App\Models\CareerJobSalaryAsset;
+
+final class CareerSalaryAssetPreviewService
+{
+    public function previewEnabled(): bool
+    {
+        return (bool) config('career_salary_assets.staging_preview_enabled', false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function previewSlugs(): array
+    {
+        $slugs = config('career_salary_assets.preview_slugs', []);
+        if (! is_array($slugs)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            array_map(fn (mixed $slug): string => $this->normalizeSlug((string) $slug), $slugs),
+            static fn (string $slug): bool => $slug !== ''
+        )));
+    }
+
+    public function previewAsset(string $slug, string $locale): ?CareerJobSalaryAsset
+    {
+        $normalizedSlug = $this->normalizeSlug($slug);
+        $normalizedLocale = $this->normalizeLocale($locale);
+
+        if (! $this->previewEnabled() || ! in_array($normalizedSlug, $this->previewSlugs(), true)) {
+            return null;
+        }
+
+        return CareerJobSalaryAsset::query()
+            ->where('career_job_slug', $normalizedSlug)
+            ->where('locale', $normalizedLocale)
+            ->where('asset_version', CareerJobSalaryAsset::ASSET_VERSION_V3_6)
+            ->where('status', CareerJobSalaryAsset::STATUS_STAGING_PREVIEW)
+            ->where('preview_allowlisted', true)
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function publicPayload(CareerJobSalaryAsset $asset): array
+    {
+        $payload = is_array($asset->asset_payload_json) ? $asset->asset_payload_json : [];
+
+        return [
+            'ok' => true,
+            'preview' => true,
+            'salary_asset_v1' => $payload,
+            'lineage' => [
+                'career_job_slug' => (string) $asset->career_job_slug,
+                'locale' => (string) $asset->locale,
+                'asset_version' => (string) $asset->asset_version,
+                'status' => (string) $asset->status,
+                'asset_row_hash' => (string) $asset->asset_row_hash,
+                'source_artifact_sha256' => $asset->source_artifact_sha256,
+                'evidence_artifact_sha256' => $asset->evidence_artifact_sha256,
+                'estimate_artifact_sha256' => $asset->estimate_artifact_sha256,
+                'import_run_id' => $asset->import_run_id,
+            ],
+        ];
+    }
+
+    public function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    public function normalizeLocale(string $locale): string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            default => 'zh-CN',
+        };
+    }
+}

--- a/backend/config/career_salary_assets.php
+++ b/backend/config/career_salary_assets.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'staging_preview_enabled' => env('CAREER_SALARY_ASSETS_STAGING_PREVIEW_ENABLED', false),
+
+    'preview_slugs' => [
+        'accountants-and-auditors',
+        'actuaries',
+        'computer-programmers',
+        'agents-and-business-managers-of-artists-performers-and-athletes',
+        'writers-and-authors',
+        'zoologists-and-wildlife-biologists',
+        'wind-turbine-technicians',
+        'woodworking-machine-setters-operators-and-tenders-except-sawing',
+        'air-traffic-controllers',
+        'athletes-and-sports-competitors',
+    ],
+];

--- a/backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php
+++ b/backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('career_job_salary_assets')) {
+            return;
+        }
+
+        Schema::create('career_job_salary_assets', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('career_job_slug', 160);
+            $table->string('locale', 16);
+            $table->string('asset_version', 64);
+            $table->string('status', 64);
+            $table->boolean('preview_allowlisted')->default(false);
+            $table->json('asset_payload_json');
+            $table->json('sources_json')->nullable();
+            $table->json('evidence_used_json')->nullable();
+            $table->json('derived_from_estimate_json')->nullable();
+            $table->json('audit_fields_json')->nullable();
+            $table->string('asset_row_hash', 64);
+            $table->string('source_artifact_sha256', 64)->nullable();
+            $table->string('evidence_artifact_sha256', 64)->nullable();
+            $table->string('estimate_artifact_sha256', 64)->nullable();
+            $table->uuid('import_run_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['career_job_slug', 'locale', 'asset_version'], 'career_salary_assets_slug_locale_version_unique');
+            $table->index(['status', 'preview_allowlisted'], 'career_salary_assets_status_preview_idx');
+            $table->index('asset_version', 'career_salary_assets_version_idx');
+            $table->index('import_run_id', 'career_salary_assets_import_run_idx');
+            $table->index('occupation_id', 'career_salary_assets_occupation_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2873,6 +2873,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/jobs/{slug}/salary-asset": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_salary_asset",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerSalaryAssetPreviewController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/launch-governance-closure": {
             "get": {
                 "operationId": "get_api_v0_5_career_launch_governance_closure",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -56,6 +56,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerRecommendationExplainabilityContr
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationFeedbackController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationIndexController;
 use App\Http\Controllers\API\V0_5\Career\CareerRuntimeConfigController;
+use App\Http\Controllers\API\V0_5\Career\CareerSalaryAssetPreviewController;
 use App\Http\Controllers\API\V0_5\Career\CareerSearchController;
 use App\Http\Controllers\API\V0_5\Career\CareerShortlistController;
 use App\Http\Controllers\API\V0_5\Career\CareerTransitionPreviewController;
@@ -488,6 +489,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/directory', [CareerDirectoryController::class, 'index']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/cn-proxy/{slug}', [CareerCnProxyPublicOwnerController::class, 'show']);
+    Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/jobs/{slug}/explainability', [CareerJobExplainabilityController::class, 'show']);
     Route::get('/career/recommendations/mbti', [CareerRecommendationIndexController::class, 'index']);

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Models\CareerJobSalaryAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class CareerSalaryAssetPreviewImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_salary_asset_sidecar_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('career_job_salary_assets'));
+        $this->assertTrue(Schema::hasColumn('career_job_salary_assets', 'asset_payload_json'));
+        $this->assertTrue(Schema::hasColumn('career_job_salary_assets', 'asset_row_hash'));
+        $this->assertTrue(Schema::hasColumn('career_job_salary_assets', 'preview_allowlisted'));
+    }
+
+    public function test_importer_dry_run_validates_preview_rows_without_writing(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-dry-run.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(2, $decoded['validated_preview_rows']);
+        $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
+    }
+
+    public function test_importer_force_writes_staging_preview_rows_only(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 2);
+        $this->assertDatabaseHas('career_job_salary_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+        ]);
+    }
+
+    public function test_preview_api_projects_allowlisted_staging_asset_when_enabled(): void
+    {
+        Config::set('career_salary_assets.staging_preview_enabled', true);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        CareerJobSalaryAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_estimate_json' => $row['derived_from_estimate'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('preview', true)
+            ->assertJsonPath('salary_asset_v1.slug', 'accountants-and-auditors')
+            ->assertJsonPath('salary_asset_v1.locale', 'zh-CN')
+            ->assertJsonPath('lineage.status', CareerJobSalaryAsset::STATUS_STAGING_PREVIEW);
+    }
+
+    public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
+    {
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        CareerJobSalaryAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_estimate_json' => $row['derived_from_estimate'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        Config::set('career_salary_assets.staging_preview_enabled', false);
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
+            ->assertNotFound();
+
+        Config::set('career_salary_assets.staging_preview_enabled', true);
+        Config::set('career_salary_assets.preview_slugs', ['actuaries']);
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
+            ->assertNotFound();
+    }
+
+    private function seedOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'salary-preview-'.$slug,
+            'title_en' => 'Salary Preview',
+            'title_zh' => '薪资预览',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Accountants and Auditors',
+            'canonical_title_zh' => '会计师和审计师',
+            'search_h1_zh' => '会计师和审计师',
+            'structural_stability' => 0.9,
+            'task_prototype_signature' => ['analysis' => 0.8],
+            'market_semantics_gap' => 0.1,
+            'regulatory_divergence' => 0.1,
+            'toolchain_divergence' => 0.1,
+            'skill_gap_threshold' => 0.4,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeJsonl(array $rows): string
+    {
+        $path = storage_path('framework/testing/salary-preview-'.bin2hex(random_bytes(4)).'.jsonl');
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        file_put_contents($path, implode('', array_map(
+            static fn (array $row): string => json_encode($row, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL,
+            $rows
+        )));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assetRow(string $slug, string $locale): array
+    {
+        $hash = hash('sha256', $slug.'|'.$locale);
+
+        return [
+            'asset_type' => 'career_job_salary_asset',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'slug' => $slug,
+            'locale' => $locale,
+            'occupation' => [
+                'title_en' => 'Accountants and Auditors',
+                'title_zh' => '会计师和审计师',
+                'soc_code' => '13-2011',
+                'onet_code' => '13-2011.00',
+            ],
+            'heading' => $locale === 'zh-CN' ? '会计师和审计师薪资与就业参考' : 'Accountants and Auditors salary reference',
+            'summary' => [
+                'headline' => 'Salary reference',
+                'short_answer' => 'China uses recruitment-market evidence, not official wage data.',
+                'confidence_label' => 'medium',
+            ],
+            'china_recruitment_reference' => [
+                'heading' => '中国招聘市场参考',
+                'evidence_status' => 'calculable',
+                'display_monthly_range_cny' => '约 ¥6,000–10,000/月',
+                'body' => $locale === 'zh-CN'
+                    ? '中国大陆部分只使用招聘市场证据，不是官方职业中位薪资，也不是个人收入预测。'
+                    : 'China salary content uses recruitment-market evidence and is not official Chinese wage data.',
+                'data_boundary' => 'This is a China recruitment-market reference; it is not an official Chinese single-occupation median wage.',
+                'facts' => [
+                    'monthly_cny_low_observed' => 6000,
+                    'monthly_cny_high_observed' => 10000,
+                    'monthly_cny_average_observed' => null,
+                    'monthly_cny_p25' => null,
+                    'monthly_cny_median' => null,
+                    'monthly_cny_p75' => null,
+                ],
+                'limitations' => ['Recruitment samples are not official wage statistics.'],
+            ],
+            'us_official_reference' => ['status' => 'available', 'facts' => ['median_annual_usd' => 81680]],
+            'uk_reference' => ['status' => 'available', 'facts' => ['starter_annual_gbp' => 25000]],
+            'eu_context_boundary' => ['status' => 'macro_context_only'],
+            'salary_drivers' => array_fill(0, 5, ['factor' => 'Scope', 'description' => 'Role boundary changes pay.']),
+            'reader_guidance' => array_fill(0, 4, 'Read China values as recruitment-market references only.'),
+            'forbidden_claims' => [],
+            'sources' => [[
+                'market' => 'CN',
+                'name' => 'JobUI',
+                'url' => 'https://example.test/salary',
+                'source_id' => 'cn_001',
+            ]],
+            'evidence_used' => ['cn_evidence_ids' => ['cn_001']],
+            'derived_from_estimate' => [
+                'source_estimate_file' => 'career_job_salary_estimates_1046_v3_6.jsonl',
+                'estimate_schema_version' => 'career_job_salary_estimate_v3_6',
+                'estimate_row_hash' => str_repeat('b', 64),
+            ],
+            'research_notes' => [],
+            'audit_fields' => [
+                'schema_version' => 'career_job_salary_asset_v3_6',
+                'generated_at' => '2026-06-15T18:10:45Z',
+                'ready_for_codex_audit' => true,
+                'row_hash' => $hash,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2391,6 +2391,30 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_salary_asset_staging_preview_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerSalaryAssetPreviewController.php',
+            'backend/app/Models/CareerJobSalaryAsset.php',
+            'backend/app/Models/Occupation.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php',
+            'backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerSalaryAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_asset_backed_bundle_changes(): void
     {
         $changed = [
@@ -3486,6 +3510,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerSalaryAssetStagingPreviewFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Services/Content/ContentPacksIndex.php'
                 && $this->contentPacksIndexDiffIsStreamingScanOnly(
@@ -3534,6 +3562,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerDirectoryAuthorityOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsCareerSalaryAssetStagingPreviewOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -5081,6 +5116,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isCareerSalaryAssetStagingPreviewFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerSalaryAssetPreviewController.php',
+            'backend/app/Models/CareerJobSalaryAsset.php',
+            'backend/app/Models/Occupation.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php',
+            'backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php',
+        ], true);
+    }
+
     private function isCareerPublicDistributionFile(string $file): bool
     {
         return in_array($file, [
@@ -6028,6 +6075,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowedLines = [
             '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerDirectoryController;',
             "+    Route::get('/career/directory', [CareerDirectoryController::class, 'index']);",
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsCareerSalaryAssetStagingPreviewOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerSalaryAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);",
         ];
 
         foreach ($changedLines as $line) {


### PR DESCRIPTION
## What changed
- Added `career_job_salary_assets` as a sidecar table for audited salary asset JSON payloads.
- Added `career:salary-assets-import-preview` for dry-run validation and explicit staging-preview import of the 10-slug allowlist.
- Added a fail-closed preview API: `GET /api/v0.5/career/jobs/{slug}/salary-asset?locale=zh-CN|en`.
- Added model relations, feature-flagged preview config, OpenAPI snapshot coverage, and feature tests.

## Why
This creates the backend receiving surface for the already audited career salary asset baseline without importing into production or changing public career pages. It lets us validate import shape and preview projection for 10 controlled slugs before any production import design decision.

## Validation commands
- `php artisan test --filter=CareerSalaryAssetPreviewImportTest`
- `php artisan route:list --path=salary-asset`
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend | rg "career_job_salary_assets|2026_06_16_000100"`
- `bash scripts/export_openapi.sh --check`
- `git diff --check`
- `bash scripts/ci_verify_mbti.sh`

## Operator examples
Dry-run only:
```bash
php artisan career:salary-assets-import-preview \
  --file=/path/to/career_job_salary_assets_1046_v3_6.jsonl \
  --slugs=accountants-and-auditors \
  --dry-run \
  --json
```

Staging preview import only:
```bash
php artisan career:salary-assets-import-preview \
  --file=/path/to/career_job_salary_assets_1046_v3_6.jsonl \
  --slugs=accountants-and-auditors \
  --force \
  --json
```

Preview API after enabling `CAREER_SALARY_ASSETS_STAGING_PREVIEW_ENABLED=true`:
```bash
curl "$API/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN"
```

## Intentionally deferred
- No production import.
- No CMS/public page publish.
- No frontend rendering changes.
- No salary asset generation or mutation.
- No default preview exposure; `CAREER_SALARY_ASSETS_STAGING_PREVIEW_ENABLED` remains fail-closed by default.

## Repository rule impact
Career salary assets are backend/CMS-authoritative sidecar content. This PR adds a backend baseline importer/preview projection surface only; it does not introduce frontend fallback content, local publishable assets, sitemap/LLMS enumeration, or public page rendering authority.
