### PR TITLE
feat(career): harden salary preview authority gate

### DIFF
--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Career\SalaryAssets;
 
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerJobSalaryAsset;
 use App\Models\Occupation;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Throwable;
@@ -16,6 +19,8 @@ final class CareerSalaryAssetImportService
 
     public function __construct(
         private readonly CareerSalaryAssetPreviewService $previewService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
+        private readonly PublicCareerAuthorityResponseCache $authorityResponseCache,
     ) {}
 
     /**
@@ -109,15 +114,12 @@ final class CareerSalaryAssetImportService
             }
         }
 
-        $missingOccupations = [];
-        foreach ($targetSlugs as $slug) {
-            $exists = Occupation::query()->where('canonical_slug', $slug)->exists();
-            if (! $exists) {
-                $missingOccupations[] = $slug;
+        $authorityReport = $this->careerJobBundleAuthorityReport($targetSlugs);
+        foreach ($authorityReport['rows'] as $authorityRow) {
+            $authorityErrors = is_array($authorityRow['errors'] ?? null) ? $authorityRow['errors'] : [];
+            foreach ($authorityErrors as $authorityError) {
+                $errors[] = ((string) ($authorityRow['slug'] ?? 'unknown')).': missing_career_job_bundle_authority: '.(string) $authorityError;
             }
-        }
-        foreach ($missingOccupations as $slug) {
-            $errors[] = "{$slug}: matching occupation row is missing.";
         }
 
         $validatedRows = array_values(array_map(
@@ -134,9 +136,86 @@ final class CareerSalaryAssetImportService
             'expected_preview_rows' => count($targetSlugs) * 2,
             'source_file_sha256' => hash_file('sha256', $file) ?: null,
             'target_slugs' => $targetSlugs,
+            'career_job_bundle_authority' => $authorityReport,
             'errors' => $errors,
             'rows' => $validatedRows,
         ]);
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array{checked_slug_count: int, ready_slug_count: int, rows: list<array<string, mixed>>}
+     */
+    private function careerJobBundleAuthorityReport(array $targetSlugs): array
+    {
+        $rows = [];
+        $readyCount = 0;
+
+        foreach ($targetSlugs as $slug) {
+            $occupationExists = Occupation::query()->where('canonical_slug', $slug)->exists();
+            $enItem = $this->runtimeProjection->itemForSlug($slug, 'en');
+            $zhItem = $this->runtimeProjection->itemForSlug($slug, 'zh-CN');
+            $projectionItem = is_array($enItem) ? $enItem : (is_array($zhItem) ? $zhItem : null);
+            $projectionExists = is_array($projectionItem);
+            $publicResolutionType = $projectionExists ? (string) ($projectionItem['public_resolution_type'] ?? '') : null;
+            $detailRouteEnabled = $projectionExists ? (($projectionItem['detail_route_enabled'] ?? false) === true) : false;
+            $releaseGatePass = $projectionExists ? (($projectionItem['release_gate_pass'] ?? false) === true) : false;
+            $detailApiZh = $this->authorityResponseCache->jobDetailPayload($slug, 'zh-CN') !== null;
+            $detailApiEn = $this->authorityResponseCache->jobDetailPayload($slug, 'en') !== null;
+            $errors = [];
+
+            if (! $occupationExists) {
+                $errors[] = 'occupation row is missing.';
+            }
+
+            if (! $projectionExists) {
+                $errors[] = 'runtime publish projection item is missing.';
+            }
+
+            if ($projectionExists && $publicResolutionType !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $errors[] = 'public_resolution_type must be public_canonical_job.';
+            }
+
+            if ($projectionExists && ! $detailRouteEnabled) {
+                $errors[] = 'detail_route_enabled must be true.';
+            }
+
+            if ($projectionExists && ! $releaseGatePass) {
+                $errors[] = 'release_gate_pass must be true.';
+            }
+
+            if (! $detailApiZh) {
+                $errors[] = 'zh-CN career job detail API is not ready.';
+            }
+
+            if (! $detailApiEn) {
+                $errors[] = 'en career job detail API is not ready.';
+            }
+
+            if ($errors === []) {
+                $readyCount++;
+            }
+
+            $rows[] = [
+                'slug' => $slug,
+                'occupation_row_exists' => $occupationExists,
+                'runtime_publish_projection_item_exists' => $projectionExists,
+                'public_resolution_type' => $publicResolutionType,
+                'public_resolution_type_pass' => $publicResolutionType === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'detail_route_enabled' => $detailRouteEnabled,
+                'release_gate_pass' => $releaseGatePass,
+                'detail_api_zh_CN_200' => $detailApiZh,
+                'detail_api_en_200' => $detailApiEn,
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_slug_count' => count($targetSlugs),
+            'ready_slug_count' => $readyCount,
+            'rows' => $rows,
+        ];
     }
 
     /**

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -4,18 +4,30 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Career;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerJobSalaryAsset;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 final class CareerSalaryAssetPreviewImportTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        $this->seedRuntimeProjectionAuthority([]);
+    }
 
     public function test_salary_asset_sidecar_table_exists(): void
     {
@@ -28,6 +40,7 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
     public function test_importer_dry_run_validates_preview_rows_without_writing(): void
     {
         $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
         $file = $this->writeJsonl([
             $this->assetRow('accountants-and-auditors', 'zh-CN'),
             $this->assetRow('accountants-and-auditors', 'en'),
@@ -53,6 +66,7 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
     public function test_importer_force_writes_staging_preview_rows_only(): void
     {
         $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
         $file = $this->writeJsonl([
             $this->assetRow('accountants-and-auditors', 'zh-CN'),
             $this->assetRow('accountants-and-auditors', 'en'),
@@ -73,6 +87,31 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
             'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
             'preview_allowlisted' => true,
         ]);
+    }
+
+    public function test_importer_force_blocks_when_career_job_bundle_authority_is_missing(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-authority-fail.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertStringContainsString('missing_career_job_bundle_authority', implode(' ', $decoded['errors']));
+        $this->assertSame(0, $decoded['career_job_bundle_authority']['ready_slug_count']);
     }
 
     public function test_preview_api_projects_allowlisted_staging_asset_when_enabled(): void
@@ -130,6 +169,63 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         Config::set('career_salary_assets.preview_slugs', ['actuaries']);
         $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
             ->assertNotFound();
+    }
+
+    private function seedCareerJobBundleAuthority(string $slug): void
+    {
+        $this->seedRuntimeProjectionAuthority([$slug]);
+        app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'zh-CN');
+        app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'en');
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedRuntimeProjectionAuthority(array $slugs): void
+    {
+        $detailRouteEnabled = [];
+        $robotsIndexable = [];
+        $releaseGatePass = [];
+        $items = [];
+
+        foreach ($slugs as $slug) {
+            $normalizedSlug = strtolower(trim($slug));
+            if ($normalizedSlug === '') {
+                continue;
+            }
+
+            $detailRouteEnabled[$normalizedSlug] = true;
+            $robotsIndexable[$normalizedSlug] = true;
+            $releaseGatePass[$normalizedSlug] = true;
+            foreach (['en', 'zh'] as $locale) {
+                $items[$normalizedSlug.'|'.$locale] = [
+                    'slug' => $normalizedSlug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'runtime_publish_state' => 'published',
+                ];
+            }
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                detailRouteEnabled: $detailRouteEnabled,
+                robotsIndexable: $robotsIndexable,
+                releaseGatePass: $releaseGatePass,
+                items: $items,
+            ),
+        );
     }
 
     private function seedOccupation(string $slug): Occupation


### PR DESCRIPTION
## Summary
- Add a career job bundle authority gate to the salary asset preview importer dry-run path.
- Require each preview slug to have occupation authority, runtime publish projection authority, `public_canonical_job`, enabled detail route, passed release gate, and zh-CN/en job detail payload readiness before `--force` can write staging preview rows.
- Add feature coverage proving `--force` fails closed with `missing_career_job_bundle_authority` and writes nothing when authority is missing.

## Why
The salary preview importer should not allow staging preview rows for slugs whose career job bundle authority is incomplete. This keeps salary preview content behind the same backend career job authority layer used by runtime job detail pages.

## Validation
- `cd backend && php artisan test --filter=CareerSalaryAssetPreviewImportTest`
- `cd backend && php artisan test tests/Feature/Career/CareerJobDetailApiTest.php`
- `cd backend && ./vendor/bin/pint --test app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/career/jobs`
- `git diff --check`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production import.
- No new salary asset generation.
- No frontend fallback changes.
- No sitemap, llms, canonical, or noindex changes.
