### PR TITLE
feat(career): harden salary preview projection

### DIFF
--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -126,6 +126,13 @@ final class CareerSalaryAssetImportService
             static fn (array $entry): array => $entry['row'],
             $rowsByKey
         ));
+        $editorialQualityReport = $this->editorialQualityReport($validatedRows);
+        foreach ($editorialQualityReport['rows'] as $editorialRow) {
+            $editorialErrors = is_array($editorialRow['errors'] ?? null) ? $editorialRow['errors'] : [];
+            foreach ($editorialErrors as $editorialError) {
+                $errors[] = ((string) ($editorialRow['slug'] ?? 'unknown')).'/'.((string) ($editorialRow['locale'] ?? 'unknown')).': salary_preview_editorial_gate: '.(string) $editorialError;
+            }
+        }
 
         return array_merge($report, [
             'mode' => 'dry_run',
@@ -137,6 +144,7 @@ final class CareerSalaryAssetImportService
             'source_file_sha256' => hash_file('sha256', $file) ?: null,
             'target_slugs' => $targetSlugs,
             'career_job_bundle_authority' => $authorityReport,
+            'editorial_quality_gate' => $editorialQualityReport,
             'errors' => $errors,
             'rows' => $validatedRows,
         ]);
@@ -216,6 +224,179 @@ final class CareerSalaryAssetImportService
             'ready_slug_count' => $readyCount,
             'rows' => $rows,
         ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array{checked_row_count: int, ready_row_count: int, rows: list<array<string, mixed>>}
+     */
+    private function editorialQualityReport(array $rows): array
+    {
+        $reportRows = [];
+        $readyCount = 0;
+
+        foreach ($rows as $row) {
+            $errors = $this->editorialQualityErrors($row);
+            if ($errors === []) {
+                $readyCount++;
+            }
+
+            $reportRows[] = [
+                'slug' => $this->previewService->normalizeSlug((string) ($row['slug'] ?? '')),
+                'locale' => $this->previewService->normalizeLocale((string) ($row['locale'] ?? '')),
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_row_count' => count($rows),
+            'ready_row_count' => $readyCount,
+            'rows' => $reportRows,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function editorialQualityErrors(array $row): array
+    {
+        return array_values(array_merge(
+            $this->sourceLabelErrors($row),
+            $this->salaryDriverErrors($row),
+            $this->readerGuidanceErrors($row),
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function sourceLabelErrors(array $row): array
+    {
+        $sources = is_array($row['sources'] ?? null) ? $row['sources'] : [];
+        $errors = [];
+
+        foreach ($sources as $index => $source) {
+            if (! is_array($source)) {
+                $errors[] = "sources[{$index}] must be an object.";
+
+                continue;
+            }
+
+            $name = trim((string) ($source['name'] ?? ''), " \t\n\r\0\x0B/");
+            if ($name === '') {
+                $errors[] = "sources[{$index}].name must be a reader-safe source label.";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function salaryDriverErrors(array $row): array
+    {
+        $drivers = is_array($row['salary_drivers'] ?? null) ? $row['salary_drivers'] : [];
+        $errors = [];
+
+        if (count($drivers) < 5) {
+            $errors[] = 'salary_drivers must contain at least five items.';
+
+            return $errors;
+        }
+
+        $descriptions = [];
+        foreach ($drivers as $driver) {
+            if (! is_array($driver)) {
+                continue;
+            }
+
+            $descriptions[] = trim((string) ($driver['description'] ?? ''));
+        }
+
+        $uniqueDescriptions = array_values(array_unique(array_filter($descriptions)));
+        if (count($uniqueDescriptions) < 3) {
+            $errors[] = 'salary_drivers must not reuse the same generic description across the row.';
+        }
+
+        if ($this->matchesKnownTemplate($descriptions, [
+            '薪资会随具体岗位标题、职责范围和相邻岗位口径变化',
+            '城市、机构类型、企业规模和预算来源会明显影响招聘报价',
+            '初级、独立承担、带团队或负责关键结果时',
+            '岗位相关证书、设备、软件、合规或客户责任',
+            '排班、现场工作、旺季、风险和交付压力',
+            'pay changes when the exact title, responsibility scope, or adjacent role cluster changes',
+            'City, employer type, organization size, and budget source can materially change offers',
+            'Entry, independent, senior, lead, or accountable roles are priced differently',
+            'Relevant licenses, equipment, software, compliance, or client responsibility can change compensation',
+            'Shift work, field work, seasonal pressure, risk, and delivery demands can affect bonuses or upper ranges',
+        ], 4)) {
+            $errors[] = 'salary_drivers still match the default template and need occupation-specific wording.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function readerGuidanceErrors(array $row): array
+    {
+        $guidance = is_array($row['reader_guidance'] ?? null) ? array_values(array_map(
+            static fn (mixed $item): string => trim((string) $item),
+            $row['reader_guidance'],
+        )) : [];
+        $errors = [];
+
+        if (count($guidance) < 4) {
+            $errors[] = 'reader_guidance must contain at least four items.';
+
+            return $errors;
+        }
+
+        if (count(array_values(array_unique(array_filter($guidance)))) < 3) {
+            $errors[] = 'reader_guidance must not reuse the same generic sentence across the row.';
+        }
+
+        if ($this->matchesKnownTemplate($guidance, [
+            '先确认你看的是否真的是',
+            '中国薪资只读作招聘市场样本信号',
+            '美国、英国和欧盟来源各有统计口径',
+            '比较 offer 时同时看城市、经验、雇主类型',
+            'First confirm whether the source is the exact',
+            'Read China pay only as recruitment-market evidence',
+            'US, UK, and EU references use different source boundaries',
+            'Compare offers by location, experience, employer type',
+        ], 3)) {
+            $errors[] = 'reader_guidance still matches the default template and needs occupation-specific wording.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @param  list<string>  $fragments
+     */
+    private function matchesKnownTemplate(array $values, array $fragments, int $threshold): bool
+    {
+        $matchCount = 0;
+        foreach ($values as $value) {
+            foreach ($fragments as $fragment) {
+                if ($fragment !== '' && str_contains($value, $fragment)) {
+                    $matchCount++;
+
+                    break;
+                }
+            }
+        }
+
+        return $matchCount >= $threshold;
     }
 
     /**

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
@@ -57,19 +57,146 @@ final class CareerSalaryAssetPreviewService
         return [
             'ok' => true,
             'preview' => true,
-            'salary_asset_v1' => $payload,
-            'lineage' => [
-                'career_job_slug' => (string) $asset->career_job_slug,
-                'locale' => (string) $asset->locale,
-                'asset_version' => (string) $asset->asset_version,
-                'status' => (string) $asset->status,
-                'asset_row_hash' => (string) $asset->asset_row_hash,
-                'source_artifact_sha256' => $asset->source_artifact_sha256,
-                'evidence_artifact_sha256' => $asset->evidence_artifact_sha256,
-                'estimate_artifact_sha256' => $asset->estimate_artifact_sha256,
-                'import_run_id' => $asset->import_run_id,
-            ],
+            'salary_asset_v1' => $this->readerSafePayload($payload),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function readerSafePayload(array $payload): array
+    {
+        foreach ([
+            'research_notes',
+            'audit_fields',
+            'evidence_used',
+            'derived_from_estimate',
+            'forbidden_claims',
+        ] as $internalKey) {
+            unset($payload[$internalKey]);
+        }
+
+        $payload['sources'] = $this->readerSafeSources(
+            is_array($payload['sources'] ?? null) ? $payload['sources'] : [],
+            $this->normalizeLocale((string) ($payload['locale'] ?? 'zh-CN')),
+        );
+
+        return $this->withoutInternalReferenceIds($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function withoutInternalReferenceIds(array $payload): array
+    {
+        if (is_array($payload['china_recruitment_reference']['facts'] ?? null)) {
+            unset($payload['china_recruitment_reference']['facts']['range_source_evidence_ids']);
+        }
+
+        if (is_array($payload['us_official_reference'] ?? null)) {
+            unset($payload['us_official_reference']['source_ids']);
+        }
+
+        if (is_array($payload['uk_reference'] ?? null)) {
+            unset($payload['uk_reference']['source_id']);
+        }
+
+        if (is_array($payload['eu_context_boundary'] ?? null)) {
+            unset($payload['eu_context_boundary']['source_id']);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sources
+     * @return list<array<string, string>>
+     */
+    private function readerSafeSources(array $sources, string $locale): array
+    {
+        $safeSources = [];
+
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $market = strtoupper(trim((string) ($source['market'] ?? '')));
+            $url = trim((string) ($source['url'] ?? ''));
+            if ($market === '' || $url === '') {
+                continue;
+            }
+
+            $safeSources[] = [
+                'market' => $market,
+                'name' => $this->readerSafeSourceName((string) ($source['name'] ?? ''), $url, $market, $locale),
+                'url' => $url,
+                'used_for' => $this->readerSafeSourceUse($market, $locale),
+            ];
+        }
+
+        return $safeSources;
+    }
+
+    private function readerSafeSourceName(string $name, string $url, string $market, string $locale): string
+    {
+        $normalized = trim($name, " \t\n\r\0\x0B/");
+        if ($normalized !== '') {
+            return $normalized;
+        }
+
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+
+        if (str_contains($host, 'jobui.com')) {
+            return $locale === 'zh-CN' ? '职友集/JobUI' : 'JobUI';
+        }
+
+        if (str_contains($host, 'liepin.com')) {
+            return $locale === 'zh-CN' ? '猎聘' : 'Liepin';
+        }
+
+        if (str_contains($host, 'zhaopin.com')) {
+            return $locale === 'zh-CN' ? '智联招聘' : 'Zhaopin';
+        }
+
+        if (str_contains($host, 'kanzhun.com')) {
+            return $locale === 'zh-CN' ? '看准' : 'Kanzhun';
+        }
+
+        if (str_contains($host, 'zhipin.com')) {
+            return 'BOSS Zhipin';
+        }
+
+        return match ($market) {
+            'CN' => $locale === 'zh-CN' ? '中国招聘市场来源' : 'China recruitment source',
+            'US' => 'US official source',
+            'UK' => 'UK career source',
+            'EU' => 'EU macro context source',
+            default => 'Source',
+        };
+    }
+
+    private function readerSafeSourceUse(string $market, string $locale): string
+    {
+        if ($locale === 'zh-CN') {
+            return match ($market) {
+                'CN' => '中国招聘市场参考',
+                'US' => '美国官方薪资或就业参考',
+                'UK' => '英国职业参考',
+                'EU' => '欧盟宏观语境边界',
+                default => '薪资参考来源',
+            };
+        }
+
+        return match ($market) {
+            'CN' => 'China recruitment-market reference',
+            'US' => 'US official salary or outlook reference',
+            'UK' => 'UK career reference',
+            'EU' => 'EU macro context boundary',
+            default => 'Salary reference source',
+        };
     }
 
     public function normalizeSlug(string $slug): string

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -119,6 +119,13 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         Config::set('career_salary_assets.staging_preview_enabled', true);
         $occupation = $this->seedOccupation('accountants-and-auditors');
         $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $row['sources'][0]['name'] = '//';
+        $row['sources'][0]['url'] = 'https://www.jobui.com/salary/quanguo-kuaiji/';
+        $row['sources'][0]['used_for'] = 'CN evidence cn_001: internal ledger wording must not be reader-facing.';
+        $row['china_recruitment_reference']['facts']['range_source_evidence_ids'] = ['cn_001'];
+        $row['us_official_reference']['source_ids'] = ['us_001'];
+        $row['uk_reference']['source_id'] = 'uk_001';
+        $row['eu_context_boundary']['source_id'] = 'eu_001';
         CareerJobSalaryAsset::query()->create([
             'occupation_id' => $occupation->id,
             'career_job_slug' => 'accountants-and-auditors',
@@ -134,12 +141,26 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
             'asset_row_hash' => $row['audit_fields']['row_hash'],
         ]);
 
-        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
+        $response = $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
             ->assertOk()
             ->assertJsonPath('preview', true)
             ->assertJsonPath('salary_asset_v1.slug', 'accountants-and-auditors')
-            ->assertJsonPath('salary_asset_v1.locale', 'zh-CN')
-            ->assertJsonPath('lineage.status', CareerJobSalaryAsset::STATUS_STAGING_PREVIEW);
+            ->assertJsonPath('salary_asset_v1.locale', 'zh-CN');
+
+        $payload = $response->json();
+        $this->assertArrayNotHasKey('lineage', $payload);
+        $asset = $payload['salary_asset_v1'];
+        foreach (['research_notes', 'audit_fields', 'evidence_used', 'derived_from_estimate', 'forbidden_claims'] as $internalKey) {
+            $this->assertArrayNotHasKey($internalKey, $asset);
+        }
+
+        $this->assertSame('职友集/JobUI', $asset['sources'][0]['name']);
+        $this->assertSame('中国招聘市场参考', $asset['sources'][0]['used_for']);
+        $this->assertArrayNotHasKey('source_id', $asset['sources'][0]);
+        $this->assertArrayNotHasKey('range_source_evidence_ids', $asset['china_recruitment_reference']['facts']);
+        $this->assertArrayNotHasKey('source_ids', $asset['us_official_reference']);
+        $this->assertArrayNotHasKey('source_id', $asset['uk_reference']);
+        $this->assertArrayNotHasKey('source_id', $asset['eu_context_boundary']);
     }
 
     public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
@@ -169,6 +190,45 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         Config::set('career_salary_assets.preview_slugs', ['actuaries']);
         $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
             ->assertNotFound();
+    }
+
+    public function test_importer_blocks_reader_facing_editorial_quality_failures(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $zh = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $en = $this->assetRow('accountants-and-auditors', 'en');
+        foreach ([&$zh, &$en] as &$row) {
+            $row['sources'][0]['name'] = '//';
+            $row['salary_drivers'] = array_fill(0, 5, [
+                'factor' => '岗位边界',
+                'description' => '会计师和审计师 的薪资会随具体岗位标题、职责范围和相邻岗位口径变化。',
+            ]);
+            $row['reader_guidance'] = array_fill(0, 4, '中国薪资只读作招聘市场样本信号，不读作官方全国职业工资。');
+        }
+        unset($row);
+
+        $file = $this->writeJsonl([$zh, $en]);
+        $report = storage_path('framework/testing/salary-preview-editorial-gate-fail.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertSame(0, $decoded['editorial_quality_gate']['ready_row_count']);
+        $errors = implode(' ', $decoded['errors']);
+        $this->assertStringContainsString('salary_preview_editorial_gate', $errors);
+        $this->assertStringContainsString('reader-safe source label', $errors);
+        $this->assertStringContainsString('generic description', $errors);
+        $this->assertStringContainsString('generic sentence', $errors);
     }
 
     private function seedCareerJobBundleAuthority(string $slug): void
@@ -320,8 +380,34 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
             'us_official_reference' => ['status' => 'available', 'facts' => ['median_annual_usd' => 81680]],
             'uk_reference' => ['status' => 'available', 'facts' => ['starter_annual_gbp' => 25000]],
             'eu_context_boundary' => ['status' => 'macro_context_only'],
-            'salary_drivers' => array_fill(0, 5, ['factor' => 'Scope', 'description' => 'Role boundary changes pay.']),
-            'reader_guidance' => array_fill(0, 4, 'Read China values as recruitment-market references only.'),
+            'salary_drivers' => $locale === 'zh-CN'
+                ? [
+                    ['factor' => '审计季节性', 'description' => '审计旺季的加班、出差和项目密度会影响总收入与补贴结构。'],
+                    ['factor' => '证书与签字责任', 'description' => 'CPA、税务经验和是否承担签字或复核责任会改变岗位定价。'],
+                    ['factor' => '行业账务复杂度', 'description' => '制造、金融、互联网或跨境业务的准则复杂度不同，薪酬带宽也不同。'],
+                    ['factor' => '系统能力', 'description' => '熟悉 ERP、合并报表、成本核算和数据分析工具的候选人通常更有议价空间。'],
+                    ['factor' => '机构类型', 'description' => '事务所、企业财务、内审和咨询岗位的绩效奖金与晋升节奏不同。'],
+                ]
+                : [
+                    ['factor' => 'Audit season load', 'description' => 'Busy-season overtime, travel, and project density can change total compensation and allowances.'],
+                    ['factor' => 'Licensure and sign-off responsibility', 'description' => 'CPA status, tax exposure, and review or sign-off accountability materially affect pay.'],
+                    ['factor' => 'Industry accounting complexity', 'description' => 'Manufacturing, finance, internet, and cross-border reporting roles price accounting complexity differently.'],
+                    ['factor' => 'Systems capability', 'description' => 'ERP, consolidation, cost accounting, and analytics skills can improve negotiation leverage.'],
+                    ['factor' => 'Employer setting', 'description' => 'Public accounting, corporate finance, internal audit, and advisory roles use different bonus and promotion models.'],
+                ],
+            'reader_guidance' => $locale === 'zh-CN'
+                ? [
+                    '先分清样本是审计、税务、企业财务还是内审岗位，再比较薪资。',
+                    '中国区间只代表招聘市场样本，不代表官方职业工资或个人收入预测。',
+                    '美国和英国数据要按 SOC、职业 profile 和统计年份边界阅读。',
+                    '比较 offer 时同时看忙季强度、证书要求、出差、奖金和晋升路径。',
+                ]
+                : [
+                    'Separate audit, tax, corporate accounting, and internal-audit roles before comparing pay.',
+                    'Read the China range only as recruitment-market evidence, not an official wage or personal prediction.',
+                    'Read US and UK figures within their SOC, profile, source-year, and coverage boundaries.',
+                    'Compare offers alongside busy-season load, certification requirements, travel, bonuses, and promotion path.',
+                ],
             'forbidden_claims' => [],
             'sources' => [[
                 'market' => 'CN',


### PR DESCRIPTION
## What changed
- Hardened the career salary preview API projection so reader-facing responses no longer expose internal lineage fields such as `research_notes`, `audit_fields`, `evidence_used`, `derived_from_estimate`, or top-level `lineage`.
- Sanitized preview API source projection to return reader-safe source labels and purpose text, without source IDs or evidence-ledger wording.
- Added importer dry-run editorial quality gate for preview rows: placeholder source labels and default-template driver/guidance copy now block `--force` writes.
- Expanded feature coverage for projection sanitization, fail-closed preview behavior, authority gating, and editorial gate failures.

## Why
The 10-slug staging preview technically rendered, but editorial QA found reader-facing leakage and placeholder/source-template issues. This PR keeps the asset payload as internal storage while making the public preview projection and importer gate safer before any wider 1046 import design work.

## Validation commands
- `cd backend && ./vendor/bin/pint app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `cd backend && php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/career/jobs | rg -n "salary-asset|career/jobs"`
- `cd backend && bash scripts/ci_verify_mbti.sh`

Note: `cd backend && php artisan migrate:status --no-interaction` was attempted but the local default MySQL connection is not configured (`root@localhost` access denied). The CI chain rebuilt the SQLite baseline and ran migrations successfully.

## Intentionally deferred
- No production import.
- No new salary evidence, estimate, or asset generation.
- No frontend rendering changes.
- No sitemap, llms, canonical, or noindex changes.
- Full 1046 import state-machine implementation remains a follow-up after preview projection hardening lands.

## Repository rule impact
Career salary preview remains backend-authoritative. This PR narrows the public projection and importer gates; it does not move salary content authority into frontend fallback or local static content.
