### PR TITLE
Sanitize English CN salary preview source names

### DIFF
--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
@@ -143,11 +143,10 @@ final class CareerSalaryAssetPreviewService
     private function readerSafeSourceName(string $name, string $url, string $market, string $locale): string
     {
         $normalized = trim($name, " \t\n\r\0\x0B/");
-        if ($normalized !== '') {
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        if ($normalized !== '' && ! ($locale === 'en' && $market === 'CN' && $this->containsCjk($normalized))) {
             return $normalized;
         }
-
-        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
 
         if (str_contains($host, 'jobui.com')) {
             return $locale === 'zh-CN' ? '职友集/JobUI' : 'JobUI';
@@ -176,6 +175,11 @@ final class CareerSalaryAssetPreviewService
             'EU' => 'EU macro context source',
             default => 'Source',
         };
+    }
+
+    private function containsCjk(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
     }
 
     private function readerSafeSourceUse(string $market, string $locale): string

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -264,6 +264,41 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         $this->assertArrayNotHasKey('source_id', $asset['eu_context_boundary']);
     }
 
+    public function test_preview_api_sanitizes_english_cn_source_display_names(): void
+    {
+        Config::set('career_salary_assets.staging_preview_enabled', true);
+        Config::set('career_salary_assets.preview_slugs', ['zoologists-and-wildlife-biologists']);
+        $occupation = $this->seedOccupation('zoologists-and-wildlife-biologists');
+        $row = $this->assetRow('zoologists-and-wildlife-biologists', 'en');
+        $row['sources'][0]['market'] = 'CN';
+        $row['sources'][0]['name'] = '猎聘';
+        $row['sources'][0]['url'] = 'https://www.liepin.com/zpshengwuxingyeyanjiuyuan/xinzi/';
+        CareerJobSalaryAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'zoologists-and-wildlife-biologists',
+            'locale' => 'en',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_estimate_json' => $row['derived_from_estimate'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $asset = $this->getJson('/api/v0.5/career/jobs/zoologists-and-wildlife-biologists/salary-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('salary_asset_v1.locale', 'en')
+            ->json('salary_asset_v1');
+
+        $this->assertSame('Liepin', $asset['sources'][0]['name']);
+        $this->assertSame('China recruitment-market reference', $asset['sources'][0]['used_for']);
+        $this->assertDoesNotMatchRegularExpression('/\p{Han}/u', $asset['sources'][0]['name']);
+        $this->assertArrayNotHasKey('source_id', $asset['sources'][0]);
+    }
+
     public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
     {
         $occupation = $this->seedOccupation('accountants-and-auditors');


### PR DESCRIPTION
## What changed
- Sanitizes CN source display names for English salary preview API payloads when the stored source name contains Chinese characters.
- Keeps zh-CN source labels unchanged and continues using host-based reader-safe labels such as Liepin, JobUI, Zhaopin, Kanzhun, and BOSS Zhipin.
- Adds a preview API regression test for an English CN source label that previously leaked Chinese text.

## Why
The 50-slug staging editorial QA found six English salary preview rows where CN source names such as 猎聘 were still exposed in reader-facing English API payloads. This is a projection-layer display issue, not an asset/evidence/estimate content change.

## Validation
- php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php

## Intentionally deferred
- No salary asset JSONL changes.
- No evidence or estimate changes.
- No staging or production import.
- Re-run of the 50-slug staging editorial QA should happen after this backend change is merged and deployed to staging.