### PR TITLE
Fix legacy /api/user auth guard

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -38,8 +38,7 @@
                 },
                 "x-laravel-action": "Closure",
                 "x-laravel-middleware": [
-                    "api",
-                    "Illuminate\\Auth\\Middleware\\Authenticate:sanctum"
+                    "api"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -96,6 +96,7 @@ use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Http\Request;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 
 /*
 |--------------------------------------------------------------------------
@@ -106,8 +107,24 @@ use Illuminate\Support\Facades\Route;
 |--------------------------------------------------------------------------
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::get('/user', static function (Request $request) {
+    $requestId = trim((string) $request->header('X-Request-Id', ''));
+    if ($requestId === '') {
+        $requestId = trim((string) $request->header('X-Request-ID', ''));
+    }
+    if ($requestId === '') {
+        $requestId = (string) Str::uuid();
+    }
+
+    return response()->json([
+        'ok' => false,
+        'error_code' => 'UNAUTHENTICATED',
+        'message' => 'Missing or invalid fm_token. Please login.',
+        'details' => (object) [],
+        'request_id' => $requestId,
+    ], 401)->withHeaders([
+        'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',
+    ]);
 });
 
 Route::middleware([HealthzAccessControl::class, 'throttle:api_public'])

--- a/backend/tests/Feature/LegacyApiUserRouteTest.php
+++ b/backend/tests/Feature/LegacyApiUserRouteTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class LegacyApiUserRouteTest extends TestCase
+{
+    public function test_legacy_api_user_route_does_not_depend_on_sanctum_guard(): void
+    {
+        $route = app('router')->getRoutes()->match(Request::create('/api/user', 'GET'));
+        $this->assertNotNull($route);
+
+        $middlewares = implode(',', $route->gatherMiddleware());
+        $this->assertStringNotContainsString('auth:sanctum', $middlewares);
+
+        $response = $this->withHeader('X-Request-Id', 'legacy-user-route-test')
+            ->getJson('/api/user');
+
+        $this->assertNotSame(500, $response->getStatusCode());
+        $response->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Bearer realm="Fermat API", error="invalid_token"')
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'UNAUTHENTICATED')
+            ->assertJsonPath('message', 'Missing or invalid fm_token. Please login.')
+            ->assertJsonPath('request_id', 'legacy-user-route-test')
+            ->assertJsonMissingPath('error');
+
+        $decoded = json_decode((string) $response->getContent());
+        $this->assertIsObject($decoded);
+        $this->assertEquals((object) [], $decoded->details ?? null);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2335,6 +2335,44 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_legacy_api_user_auth_guard_hardening(): void
+    {
+        $changed = [
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use Illuminate\Support\\Str;',
+            "-Route::middleware('auth:sanctum')->get('/user', function (Request \$request) {",
+            '-    return $request->user();',
+            "+Route::get('/user', static function (Request \$request) {",
+            "+    \$requestId = trim((string) \$request->header('X-Request-Id', ''));",
+            '+    if ($requestId === \'\') {',
+            "+        \$requestId = trim((string) \$request->header('X-Request-ID', ''));",
+            '+    }',
+            '+    if ($requestId === \'\') {',
+            '+        $requestId = (string) Str::uuid();',
+            '+    }',
+            '+',
+            '+    return response()->json([',
+            '+        \'ok\' => false,',
+            '+        \'error_code\' => \'UNAUTHENTICATED\',',
+            '+        \'message\' => \'Missing or invalid fm_token. Please login.\',',
+            '+        \'details\' => (object) [],',
+            '+        \'request_id\' => $requestId,',
+            '+    ], 401)->withHeaders([',
+            '+        \'WWW-Authenticate\' => \'Bearer realm="Fermat API", error="invalid_token"\',',
+            '+    ]);',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            null,
+            $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_surface_builder_changes(): void
     {
         $changed = [
@@ -3823,6 +3861,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCiAuthBypassHardeningOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsLegacyApiUserAuthGuardOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -6368,6 +6413,38 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsLegacyApiUserAuthGuardOnly(array $changedLines): bool
+    {
+        $allowedLines = [
+            '+use Illuminate\Support\\Str;',
+            "-Route::middleware('auth:sanctum')->get('/user', function (Request \$request) {",
+            '-    return $request->user();',
+            "+Route::get('/user', static function (Request \$request) {",
+            "+    \$requestId = trim((string) \$request->header('X-Request-Id', ''));",
+            '+    if ($requestId === \'\') {',
+            "+        \$requestId = trim((string) \$request->header('X-Request-ID', ''));",
+            '+    }',
+            '+    if ($requestId === \'\') {',
+            '+        $requestId = (string) Str::uuid();',
+            '+    }',
+            '+',
+            '+    return response()->json([',
+            '+        \'ok\' => false,',
+            '+        \'error_code\' => \'UNAUTHENTICATED\',',
+            '+        \'message\' => \'Missing or invalid fm_token. Please login.\',',
+            '+        \'details\' => (object) [],',
+            '+        \'request_id\' => $requestId,',
+            '+    ], 401)->withHeaders([',
+            '+        \'WWW-Authenticate\' => \'Bearer realm="Fermat API", error="invalid_token"\',',
+            '+    ]);',
+        ];
+
+        return $changedLines !== [] && array_values($changedLines) === $allowedLines;
     }
 
     /**


### PR DESCRIPTION
## What changed
- Removed the legacy `/api/user` route dependency on the undefined `auth:sanctum` guard.
- Made `/api/user` return a controlled JSON `401 UNAUTHENTICATED` response with the Fermat bearer challenge.
- Added a regression test to ensure the route does not depend on Sanctum and does not return 500.
- Updated the OpenAPI route snapshot for the middleware contract change.
- Updated the Big Five runtime freeze classifier to explicitly ignore this non-Big-Five legacy auth guard hardening diff.

## Why
Production still logged `Auth guard [sanctum] is not defined` for `/api/user`. This endpoint is a legacy Laravel template route, while Fermat auth uses `/api/v0.3/auth/guest` plus `FmTokenAuth`; the fix prevents accidental probes or calls from producing 500s without expanding the auth surface.

## Validation
- `php -l backend/routes/api.php && php -l backend/tests/Feature/LegacyApiUserRouteTest.php`
- `php artisan route:list --path=user`
- `php artisan migrate --pretend`
- `vendor/bin/pint --test routes/api.php tests/Feature/LegacyApiUserRouteTest.php docs/contracts/openapi.snapshot.json`
- `bash scripts/export_openapi.sh --check`
- `php artisan test --filter='LegacyApiUserRouteTest|AuthGuestRouteWiringTest|OpenApiDiffTest'`
- `php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_legacy_api_user_auth_guard_hardening'`
- `bash scripts/ci/verify_big5_norms.sh && php -d memory_limit=1024M artisan content:lint --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan content:compile --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`

## Curl examples
```bash
curl -i https://api.fermatmind.com/api/user
curl -i -H "X-Request-Id: legacy-user-route-test" https://api.fermatmind.com/api/user
```
Expected after deploy: HTTP 401 JSON with `error_code: UNAUTHENTICATED`, not HTTP 500.

## Intentionally deferred
- No production backend deploy in this PR creation step.
- No Sanctum installation/configuration, because this endpoint is not the active Fermat auth surface.
- No changes to `/api/v0.3/auth/guest` or `FmTokenAuth`.

## Repository rule impact
No content authority or publishing workflow changes. This is a backend route/auth contract hardening change only.