### PR TITLE
Harden career salary asset import state machine

### DIFF
--- a/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
@@ -12,6 +12,7 @@ final class CareerImportSalaryAssetsPreview extends Command
 {
     protected $signature = 'career:salary-assets-import-preview
         {--file= : Absolute path to PASS career_job_salary_assets_1046_v3_6 JSONL}
+        {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
         {--slugs= : Optional comma-separated preview slug subset}
         {--dry-run : Validate only; this is the default when --force is not supplied}
         {--force : Write staging_preview rows for allowlisted preview slugs only}
@@ -47,9 +48,10 @@ final class CareerImportSalaryAssetsPreview extends Command
             }
 
             $slugs = $this->requestedSlugs();
+            $expectedSha256 = trim((string) $this->option('expected-sha256')) ?: null;
             $report = $force
-                ? $this->importService->importStagingPreview($file, $slugs)
-                : $this->importService->validateFile($file, $slugs);
+                ? $this->importService->importStagingPreview($file, $slugs, $expectedSha256)
+                : $this->importService->validateFile($file, $slugs, $expectedSha256);
 
             return $this->finish($report, ($report['decision'] ?? null) === 'pass');
         } catch (Throwable $throwable) {

--- a/backend/app/Models/CareerJobSalaryAsset.php
+++ b/backend/app/Models/CareerJobSalaryAsset.php
@@ -12,6 +12,12 @@ class CareerJobSalaryAsset extends CareerFoundationModel
 
     public const STATUS_STAGING_PREVIEW = 'staging_preview';
 
+    public const STATUS_EDITORIAL_REVIEW = 'editorial_review';
+
+    public const STATUS_APPROVED = 'approved';
+
+    public const STATUS_PRODUCTION_IMPORTED = 'production_imported';
+
     protected $table = 'career_job_salary_assets';
 
     protected $casts = [

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -21,13 +21,14 @@ final class CareerSalaryAssetImportService
         private readonly CareerSalaryAssetPreviewService $previewService,
         private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
         private readonly PublicCareerAuthorityResponseCache $authorityResponseCache,
+        private readonly CareerSalaryAssetImportStateMachine $stateMachine,
     ) {}
 
     /**
      * @param  list<string>|null  $requestedSlugs
      * @return array<string, mixed>
      */
-    public function validateFile(string $file, ?array $requestedSlugs = null): array
+    public function validateFile(string $file, ?array $requestedSlugs = null, ?string $expectedSha256 = null): array
     {
         $report = $this->baseReport($file, $requestedSlugs);
         $errors = [];
@@ -41,6 +42,7 @@ final class CareerSalaryAssetImportService
 
         $targetSlugs = $this->targetSlugs($requestedSlugs, $errors);
         $rowsByKey = [];
+        $duplicateKeys = [];
         $parseErrors = [];
         $totalLines = 0;
         $lineNumber = 0;
@@ -83,6 +85,7 @@ final class CareerSalaryAssetImportService
             $key = $slug.'|'.$locale;
             if (isset($rowsByKey[$key])) {
                 $errors[] = "{$slug}/{$locale}: duplicate asset row.";
+                $duplicateKeys[] = $key;
 
                 continue;
             }
@@ -97,6 +100,12 @@ final class CareerSalaryAssetImportService
 
         foreach ($parseErrors as $parseError) {
             $errors[] = $parseError;
+        }
+
+        $sourceFileSha256 = hash_file('sha256', $file) ?: null;
+        $expectedSha256 = $this->normalizeSha256($expectedSha256);
+        if ($expectedSha256 !== null && $sourceFileSha256 !== $expectedSha256) {
+            $errors[] = 'Source JSONL SHA-256 does not match expected artifact SHA.';
         }
 
         foreach ($targetSlugs as $slug) {
@@ -141,7 +150,14 @@ final class CareerSalaryAssetImportService
             'target_slug_count' => count($targetSlugs),
             'validated_preview_rows' => count($validatedRows),
             'expected_preview_rows' => count($targetSlugs) * 2,
-            'source_file_sha256' => hash_file('sha256', $file) ?: null,
+            'source_file_sha256' => $sourceFileSha256,
+            'expected_source_file_sha256' => $expectedSha256,
+            'source_file_sha256_match' => $expectedSha256 === null || $sourceFileSha256 === $expectedSha256,
+            'duplicate_key_count' => count(array_unique($duplicateKeys)),
+            'duplicate_keys' => array_values(array_unique($duplicateKeys)),
+            'idempotency' => $this->idempotencyReport($sourceFileSha256, $targetSlugs),
+            'rollback_policy' => $this->rollbackPolicy(),
+            'state_machine' => $this->stateMachine->report(),
             'target_slugs' => $targetSlugs,
             'career_job_bundle_authority' => $authorityReport,
             'editorial_quality_gate' => $editorialQualityReport,
@@ -403,9 +419,9 @@ final class CareerSalaryAssetImportService
      * @param  list<string>|null  $requestedSlugs
      * @return array<string, mixed>
      */
-    public function importStagingPreview(string $file, ?array $requestedSlugs = null): array
+    public function importStagingPreview(string $file, ?array $requestedSlugs = null, ?string $expectedSha256 = null): array
     {
-        $report = $this->validateFile($file, $requestedSlugs);
+        $report = $this->validateFile($file, $requestedSlugs, $expectedSha256);
         if (($report['decision'] ?? null) !== 'pass') {
             return $report;
         }
@@ -423,6 +439,15 @@ final class CareerSalaryAssetImportService
                 $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
                 $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
                 $auditFields = $this->arrayValue($row, 'audit_fields');
+                $existing = CareerJobSalaryAsset::query()
+                    ->where('career_job_slug', $slug)
+                    ->where('locale', $locale)
+                    ->where('asset_version', CareerJobSalaryAsset::ASSET_VERSION_V3_6)
+                    ->first();
+
+                if (! $this->stateMachine->canWriteStagingPreviewFrom($existing?->status)) {
+                    throw new \RuntimeException("{$slug}/{$locale}: cannot transition salary asset from {$existing?->status} to staging_preview.");
+                }
 
                 $asset = CareerJobSalaryAsset::query()->updateOrCreate(
                     [
@@ -452,6 +477,8 @@ final class CareerSalaryAssetImportService
                     'locale' => $locale,
                     'row_id' => $asset->id,
                     'created' => $asset->wasRecentlyCreated,
+                    'previous_status' => $existing?->status,
+                    'new_status' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
                 ];
             }
 
@@ -464,6 +491,7 @@ final class CareerSalaryAssetImportService
             'did_write' => count($written) > 0,
             'written_count' => count($written),
             'import_run_id' => $importRunId,
+            'rollback_policy' => $this->rollbackPolicy($importRunId),
             'written_assets' => $written,
         ]);
     }
@@ -479,6 +507,11 @@ final class CareerSalaryAssetImportService
             'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
             'status_policy' => CareerJobSalaryAsset::STATUS_STAGING_PREVIEW,
             'production_import_allowed' => false,
+            'production_import_gate' => [
+                'allowed' => false,
+                'required_from_status' => CareerJobSalaryAsset::STATUS_APPROVED,
+                'current_command_supports_production_import' => false,
+            ],
             'source_file' => $file,
             'requested_slugs' => $requestedSlugs,
         ];
@@ -579,5 +612,46 @@ final class CareerSalaryAssetImportService
     private function arrayValue(array $row, string $key): array
     {
         return is_array($row[$key] ?? null) ? $row[$key] : [];
+    }
+
+    private function normalizeSha256(?string $sha256): ?string
+    {
+        $normalized = strtolower(trim((string) $sha256));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array<string, mixed>
+     */
+    private function idempotencyReport(?string $sourceFileSha256, array $targetSlugs): array
+    {
+        return [
+            'idempotency_key' => hash('sha256', implode('|', [
+                CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+                $sourceFileSha256 ?? 'unknown_source_sha',
+                implode(',', $targetSlugs),
+            ])),
+            'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+            'write_strategy' => 'update_or_create_by_target_key',
+            'duplicate_rows_allowed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rollbackPolicy(?string $importRunId = null): array
+    {
+        return [
+            'production_rollback_supported_by_this_command' => false,
+            'staging_preview_import_run_id' => $importRunId,
+            'staging_preview_rollback_boundary' => 'Rows written by a staging_preview import are scoped by import_run_id and must be rolled back before approval or production import.',
+            'production_import_requires_approved_status' => true,
+        ];
     }
 }

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportStateMachine.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportStateMachine.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\SalaryAssets;
+
+use App\Models\CareerJobSalaryAsset;
+
+final class CareerSalaryAssetImportStateMachine
+{
+    public const STATE_DRY_RUN = 'dry_run';
+
+    public const STATE_STAGING_PREVIEW = CareerJobSalaryAsset::STATUS_STAGING_PREVIEW;
+
+    public const STATE_EDITORIAL_REVIEW = CareerJobSalaryAsset::STATUS_EDITORIAL_REVIEW;
+
+    public const STATE_APPROVED = CareerJobSalaryAsset::STATUS_APPROVED;
+
+    public const STATE_PRODUCTION_IMPORTED = CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED;
+
+    /**
+     * @return list<string>
+     */
+    public function states(): array
+    {
+        return [
+            self::STATE_DRY_RUN,
+            self::STATE_STAGING_PREVIEW,
+            self::STATE_EDITORIAL_REVIEW,
+            self::STATE_APPROVED,
+            self::STATE_PRODUCTION_IMPORTED,
+        ];
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function transitions(): array
+    {
+        return [
+            self::STATE_DRY_RUN => [self::STATE_STAGING_PREVIEW],
+            self::STATE_STAGING_PREVIEW => [self::STATE_EDITORIAL_REVIEW],
+            self::STATE_EDITORIAL_REVIEW => [self::STATE_APPROVED, self::STATE_STAGING_PREVIEW],
+            self::STATE_APPROVED => [self::STATE_PRODUCTION_IMPORTED, self::STATE_EDITORIAL_REVIEW],
+            self::STATE_PRODUCTION_IMPORTED => [],
+        ];
+    }
+
+    public function canTransition(string $from, string $to): bool
+    {
+        return in_array($to, $this->transitions()[$from] ?? [], true);
+    }
+
+    public function canWriteStagingPreviewFrom(?string $currentStatus): bool
+    {
+        if ($currentStatus === null) {
+            return true;
+        }
+
+        return $currentStatus === self::STATE_STAGING_PREVIEW
+            || $this->canTransition($currentStatus, self::STATE_STAGING_PREVIEW);
+    }
+
+    public function canProductionImportFrom(?string $currentStatus): bool
+    {
+        return $currentStatus === self::STATE_APPROVED
+            && $this->canTransition(self::STATE_APPROVED, self::STATE_PRODUCTION_IMPORTED);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function report(): array
+    {
+        return [
+            'states' => $this->states(),
+            'transitions' => $this->transitions(),
+            'production_import_requires_from_status' => self::STATE_APPROVED,
+            'production_import_without_approved_allowed' => false,
+        ];
+    }
+}

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -8,9 +8,9 @@ use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerJobSalaryAsset;
 use App\Models\Occupation;
 use App\Models\OccupationFamily;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
 use App\Services\Career\SalaryAssets\CareerSalaryAssetImportService;
 use App\Services\Career\SalaryAssets\CareerSalaryAssetPreviewService;
-use App\Services\Career\PublicCareerAuthorityResponseCache;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -65,6 +65,93 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
     }
 
+    public function test_importer_dry_run_reports_state_machine_sha_idempotency_and_rollback_policy(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $sha = hash_file('sha256', $file);
+        $report = storage_path('framework/testing/salary-preview-state-machine-dry-run.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $sha,
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame($sha, $decoded['source_file_sha256']);
+        $this->assertTrue((bool) $decoded['source_file_sha256_match']);
+        $this->assertSame(0, $decoded['duplicate_key_count']);
+        $this->assertSame(['career_job_slug', 'locale', 'asset_version'], $decoded['idempotency']['target_key']);
+        $this->assertFalse((bool) $decoded['state_machine']['production_import_without_approved_allowed']);
+        $this->assertSame(CareerJobSalaryAsset::STATUS_APPROVED, $decoded['state_machine']['production_import_requires_from_status']);
+        $this->assertTrue((bool) $decoded['rollback_policy']['production_import_requires_approved_status']);
+    }
+
+    public function test_importer_dry_run_rejects_unexpected_source_sha(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-sha-mismatch.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => str_repeat('0', 64),
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertFalse((bool) $decoded['source_file_sha256_match']);
+        $this->assertStringContainsString('Source JSONL SHA-256 does not match expected artifact SHA', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_dry_run_validates_full_1046_contract_without_writing(): void
+    {
+        $slugs = array_map(static fn (int $index): string => 'contract-career-'.$index, range(1, 1046));
+        Config::set('career_salary_assets.preview_slugs', $slugs);
+        $this->seedCareerJobBundleAuthorities($slugs);
+
+        $rows = [];
+        foreach ($slugs as $slug) {
+            $rows[] = $this->assetRow($slug, 'zh-CN');
+            $rows[] = $this->assetRow($slug, 'en');
+        }
+        $file = $this->writeJsonl($rows);
+        $report = storage_path('framework/testing/salary-preview-full-1046-dry-run.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(1046, $decoded['target_slug_count']);
+        $this->assertSame(2092, $decoded['validated_preview_rows']);
+        $this->assertSame(2092, $decoded['expected_preview_rows']);
+        $this->assertSame(1046, $decoded['career_job_bundle_authority']['ready_slug_count']);
+        $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
+    }
+
     public function test_importer_force_writes_staging_preview_rows_only(): void
     {
         $this->seedOccupation('accountants-and-auditors');
@@ -91,6 +178,48 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         ]);
     }
 
+    public function test_importer_force_blocks_staging_preview_over_production_imported_rows(): void
+    {
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        CareerJobSalaryAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'status' => CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+            'preview_allowlisted' => false,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_estimate_json' => $row['derived_from_estimate'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+        $file = $this->writeJsonl([
+            $row,
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-production-row-blocked.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseHas('career_job_salary_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'status' => CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+        ]);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('cannot transition salary asset from production_imported to staging_preview', implode(' ', $decoded['errors']));
+    }
+
     public function test_preview_api_accepts_allowlisted_slug_samples_and_fail_closed_others(): void
     {
         Config::set('career_salary_assets.staging_preview_enabled', true);
@@ -100,10 +229,7 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
             'computer-programmers',
         ]);
 
-        foreach (['accountants-and-auditors', 'actuaries', 'computer-programmers', 'actors'] as $slug) {
-            $this->seedOccupation($slug);
-            $this->seedCareerJobBundleAuthority($slug);
-        }
+        $this->seedCareerJobBundleAuthorities(['accountants-and-auditors', 'actuaries', 'computer-programmers', 'actors']);
 
         $this->seedPreviewAsset('accountants-and-auditors', 'zh-CN');
         $this->seedPreviewAsset('actuaries', 'en');
@@ -139,10 +265,7 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         Config::set('career_salary_assets.staging_preview_enabled', true);
         Config::set('career_salary_assets.preview_slugs', ['accountants-and-auditors', 'actuaries']);
 
-        foreach (['accountants-and-auditors', 'actuaries', 'actors'] as $slug) {
-            $this->seedOccupation($slug);
-            $this->seedCareerJobBundleAuthority($slug);
-        }
+        $this->seedCareerJobBundleAuthorities(['accountants-and-auditors', 'actuaries', 'actors']);
 
         $file = $this->writeJsonl([
             $this->assetRow('accountants-and-auditors', 'zh-CN'),
@@ -369,14 +492,27 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
 
     private function seedCareerJobBundleAuthority(string $slug): void
     {
-        $this->seedRuntimeProjectionAuthority([$slug]);
-        app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'zh-CN');
-        app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'en');
+        $this->seedCareerJobBundleAuthorities([$slug]);
+    }
 
-        app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'zh-CN', true);
-        app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'en', true);
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedCareerJobBundleAuthorities(array $slugs): void
+    {
+        $this->seedRuntimeProjectionAuthority($slugs);
 
-        $this->app->forgetInstance(CareerRuntimePublishProjectionVisibility::class);
+        foreach ($slugs as $slug) {
+            if (! Occupation::query()->where('canonical_slug', $slug)->exists()) {
+                $this->seedOccupation($slug);
+            }
+            app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'zh-CN');
+            app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'en');
+
+            app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'zh-CN', true);
+            app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'en', true);
+        }
+
         $this->app->forgetInstance(CareerSalaryAssetImportService::class);
         $this->app->forgetInstance(CareerSalaryAssetPreviewService::class);
         $this->app->forgetInstance('App\\Console\\Commands\\CareerImportSalaryAssetsPreview');

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2398,6 +2398,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/CareerJobSalaryAsset.php',
             'backend/app/Models/Occupation.php',
             'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportStateMachine.php',
             'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php',
             'backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php',
             'backend/routes/api.php',
@@ -5123,6 +5124,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Models/CareerJobSalaryAsset.php',
             'backend/app/Models/Occupation.php',
             'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php',
+            'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportStateMachine.php',
             'backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php',
             'backend/database/migrations/2026_06_16_000100_create_career_job_salary_assets_table.php',
         ], true);


### PR DESCRIPTION
## What changed
- Added a dedicated career salary asset import state machine with the states `dry_run`, `staging_preview`, `editorial_review`, `approved`, and `production_imported`.
- Added SHA-256, duplicate row, idempotency, rollback, and production-import gate metadata to the importer dry-run report.
- Added `--expected-sha256` to the salary asset preview importer command.
- Blocked staging preview writes over rows already marked `production_imported`.
- Added 1046-slug / 2092-row dry-run contract coverage and transition regression tests.

## Why
This fixes the formal import contract before any 1046 salary asset staging or production path work. Production import remains unsupported by this command and requires the future `approved` gate.

## Validation
- `php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `php artisan route:list --path=api/v0.5/career/jobs`
- `bash scripts/ci_verify_mbti.sh`
- `php artisan migrate --pretend` attempted locally, but local MySQL credentials block it with `Access denied for user 'root'@'localhost'`; sqlite migrations passed inside `ci_verify_mbti.sh`.

## Intentionally deferred
- No production import.
- No salary asset JSONL, evidence, or estimate changes.
- No frontend changes.
- No sitemap, llms.txt, canonical, or noindex changes.
