### PR TITLE
PR 3: fap-api 1046 Staging Preview Import

### DIFF
--- a/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
@@ -15,6 +15,7 @@ final class CareerImportSalaryAssetsPreview extends Command
         {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
         {--slugs= : Optional comma-separated preview slug subset}
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
+        {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
         {--dry-run : Validate only; this is the default when --force is not supplied}
         {--force : Write staging_preview rows for allowlisted preview slugs only}
         {--json : Emit machine-readable JSON report}
@@ -48,17 +49,18 @@ final class CareerImportSalaryAssetsPreview extends Command
                 ], false);
             }
             $allSlugsFromFile = (bool) $this->option('all-slugs-from-file');
-            if ($force && $allSlugsFromFile) {
+            $confirmFullStagingPreview = (bool) $this->option('confirm-full-staging-preview');
+            if ($force && $allSlugsFromFile && ! $confirmFullStagingPreview) {
                 return $this->finish([
                     'decision' => 'fail',
-                    'errors' => ['--all-slugs-from-file is dry-run only; staging_preview writes must use an explicit allowlist.'],
+                    'errors' => ['--force --all-slugs-from-file requires --confirm-full-staging-preview.'],
                 ], false);
             }
 
             $slugs = $this->requestedSlugs();
             $expectedSha256 = trim((string) $this->option('expected-sha256')) ?: null;
             $report = $force
-                ? $this->importService->importStagingPreview($file, $slugs, $expectedSha256)
+                ? $this->importService->importStagingPreview($file, $slugs, $expectedSha256, $allSlugsFromFile)
                 : $this->importService->validateFile($file, $slugs, $expectedSha256, $allSlugsFromFile);
 
             return $this->finish($report, ($report['decision'] ?? null) === 'pass');

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -477,9 +477,9 @@ final class CareerSalaryAssetImportService
      * @param  list<string>|null  $requestedSlugs
      * @return array<string, mixed>
      */
-    public function importStagingPreview(string $file, ?array $requestedSlugs = null, ?string $expectedSha256 = null): array
+    public function importStagingPreview(string $file, ?array $requestedSlugs = null, ?string $expectedSha256 = null, bool $allSlugsFromFile = false): array
     {
-        $report = $this->validateFile($file, $requestedSlugs, $expectedSha256);
+        $report = $this->validateFile($file, $requestedSlugs, $expectedSha256, $allSlugsFromFile);
         if (($report['decision'] ?? null) !== 'pass') {
             return $report;
         }
@@ -487,8 +487,17 @@ final class CareerSalaryAssetImportService
         $importRunId = (string) Str::uuid();
         $sourceSha = is_string($report['source_file_sha256'] ?? null) ? $report['source_file_sha256'] : null;
 
+        /** @var list<string> $targetSlugs */
+        $targetSlugs = is_array($report['target_slugs'] ?? null) ? array_values(array_filter(
+            array_map(fn (mixed $slug): string => $this->previewService->normalizeSlug((string) $slug), $report['target_slugs']),
+            static fn (string $slug): bool => $slug !== ''
+        )) : [];
+
         /** @var list<array<string, mixed>> $rows */
-        $rows = is_array($report['rows'] ?? null) ? $report['rows'] : [];
+        $rows = $allSlugsFromFile
+            ? $this->rowsForTargetSlugs($file, $targetSlugs)
+            : (is_array($report['rows'] ?? null) ? $report['rows'] : []);
+
         $written = DB::transaction(function () use ($rows, $sourceSha, $importRunId): array {
             $written = [];
 
@@ -548,10 +557,45 @@ final class CareerSalaryAssetImportService
             'decision' => 'pass',
             'did_write' => count($written) > 0,
             'written_count' => count($written),
+            'full_staging_preview_confirmed' => $allSlugsFromFile,
             'import_run_id' => $importRunId,
             'rollback_policy' => $this->rollbackPolicy($importRunId),
             'written_assets' => $written,
         ]);
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return list<array<string, mixed>>
+     */
+    private function rowsForTargetSlugs(string $file, array $targetSlugs): array
+    {
+        $targetLookup = array_fill_keys($targetSlugs, true);
+        $rows = [];
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            throw new \RuntimeException('Source JSONL file could not be opened for staging_preview write.');
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            if (isset($targetLookup[$slug])) {
+                $rows[] = $row;
+            }
+        }
+
+        fclose($handle);
+
+        return $rows;
     }
 
     /**

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
@@ -34,7 +34,7 @@ final class CareerSalaryAssetPreviewService
         $normalizedSlug = $this->normalizeSlug($slug);
         $normalizedLocale = $this->normalizeLocale($locale);
 
-        if (! $this->previewEnabled() || ! in_array($normalizedSlug, $this->previewSlugs(), true)) {
+        if (! $this->previewEnabled()) {
             return null;
         }
 

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -183,6 +183,67 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         $this->assertSame($slugs, $decoded['target_slugs']);
     }
 
+    public function test_importer_force_all_slugs_from_file_requires_explicit_full_staging_confirmation(): void
+    {
+        Config::set('career_salary_assets.preview_slugs', ['not-in-source-file']);
+        $slugs = ['all-file-career-a', 'all-file-career-b'];
+        $this->seedCareerJobBundleAuthorities($slugs);
+
+        $file = $this->writeJsonl([
+            $this->assetRow('all-file-career-a', 'zh-CN'),
+            $this->assetRow('all-file-career-a', 'en'),
+            $this->assetRow('all-file-career-b', 'zh-CN'),
+            $this->assetRow('all-file-career-b', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-all-file-force-without-confirmation.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertStringContainsString('--confirm-full-staging-preview', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_force_can_write_all_slugs_from_file_when_confirmed(): void
+    {
+        Config::set('career_salary_assets.preview_slugs', ['not-in-source-file']);
+        $slugs = ['all-file-career-a', 'all-file-career-b'];
+        $this->seedCareerJobBundleAuthorities($slugs);
+
+        $file = $this->writeJsonl([
+            $this->assetRow('all-file-career-a', 'zh-CN'),
+            $this->assetRow('all-file-career-a', 'en'),
+            $this->assetRow('all-file-career-b', 'zh-CN'),
+            $this->assetRow('all-file-career-b', 'en'),
+        ]);
+        $report = storage_path('framework/testing/salary-preview-all-file-force-confirmed.json');
+
+        $exitCode = Artisan::call('career:salary-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--confirm-full-staging-preview' => true,
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_salary_assets', 4);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertTrue((bool) $decoded['all_slugs_from_file']);
+        $this->assertTrue((bool) $decoded['full_staging_preview_confirmed']);
+        $this->assertSame(4, $decoded['written_count']);
+        $this->assertSame($slugs, $decoded['target_slugs']);
+        $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
+    }
+
     public function test_importer_editorial_gate_uses_reader_safe_projection_for_source_labels(): void
     {
         $this->seedCareerJobBundleAuthority('accountants-and-auditors');
@@ -290,7 +351,6 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         $this->seedPreviewAsset('accountants-and-auditors', 'zh-CN');
         $this->seedPreviewAsset('actuaries', 'en');
         $this->seedPreviewAsset('computer-programmers', 'zh-CN');
-        $this->seedPreviewAsset('actors', 'en');
 
         $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
             ->assertOk()
@@ -504,6 +564,10 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         Config::set('career_salary_assets.staging_preview_enabled', true);
         Config::set('career_salary_assets.preview_slugs', ['actuaries']);
         $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/salary-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('salary_asset_v1.slug', 'accountants-and-auditors');
+
+        $this->getJson('/api/v0.5/career/jobs/actuaries/salary-asset?locale=zh-CN')
             ->assertNotFound();
     }
 

--- a/generated/career-salary-1046-staging-preview-import/pr3_staging_preview_import_contract_report.md
+++ b/generated/career-salary-1046-staging-preview-import/pr3_staging_preview_import_contract_report.md
@@ -1,0 +1,29 @@
+# Career Salary 1046 Staging Preview Import Contract
+
+Generated at: 2026-06-17T04:10:10Z
+
+## Scope
+
+This PR adds a guarded path for importing every slug present in the PASS v3.6 salary asset JSONL into `staging_preview`.
+
+It does not import production data, does not modify the salary asset artifact, and does not create new evidence or estimates.
+
+## Behavior
+
+- `--all-slugs-from-file` remains available for full-file dry-run validation.
+- `--force --all-slugs-from-file` is blocked unless `--confirm-full-staging-preview` is also supplied.
+- Confirmed full-file staging writes still use `status = staging_preview`, `production_import_allowed = false`, SHA/idempotency reporting, authority gates, and reader-safe projection gates.
+- Runtime preview reads are gated by `FAP_CAREER_SALARY_ASSET_PREVIEW_ENABLED` and stored `staging_preview` rows, rather than the static config preview slug list.
+- If the preview flag is disabled or no staging row exists, the salary asset endpoint fails closed.
+
+## Local Validation
+
+- `php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php` PASS, 18 tests.
+- `./vendor/bin/pint --dirty` PASS.
+- `php artisan route:list --path=api/v0.5/career/jobs` PASS, 4 routes.
+- `php artisan migrate --pretend` PASS, nothing to migrate.
+- `bash scripts/ci_verify_mbti.sh` PASS.
+
+## Deferred
+
+The actual 2092-row `--force --all-slugs-from-file --confirm-full-staging-preview` run must execute on staging after this PR is deployed, because local DB fixtures are not the staging career job bundle authority source.


### PR DESCRIPTION
## What changed
- Adds an explicit `--confirm-full-staging-preview` guard so `--force --all-slugs-from-file` can write every JSONL slug to `staging_preview` only when deliberately confirmed.
- Keeps production import unavailable from this command and preserves SHA/idempotency/authority/editorial gates before any staging write.
- Updates salary preview runtime lookup to serve stored `staging_preview` rows when the preview flag is enabled, instead of blocking on the static preview slug list after import.
- Adds feature coverage for full-file force confirmation, full-file staging writes, fail-closed behavior, and existing allowlist import regression.
- Adds a generated PR3 contract report.

## Why
PR2 made full 1046 JSONL validation possible. PR3 needs a controlled path for 2092-row staging preview writes and API smoke without widening to production import or modifying the salary asset artifact.

## Validation commands
- `php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `./vendor/bin/pint --dirty`
- `php artisan route:list --path=api/v0.5/career/jobs`
- `php artisan migrate --pretend`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production import.
- No salary asset JSONL content changes.
- The actual 2092-row staging run must execute after this PR is deployed to staging because the local test DB is not the staging career job bundle authority source.
- No frontend consumer changes; those remain PR4 scope.

## Repository rule impact
This keeps salary assets backend-authoritative. The frontend continues to consume API-rendered salary asset payloads and must not add fallback career salary content.