### PR TITLE
Add career salary 1046 production import ops gate

### DIFF
--- a/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportSalaryAssetsPreview.php
@@ -20,6 +20,9 @@ final class CareerImportSalaryAssetsPreview extends Command
         {--approval-manifest= : Absolute path to the editorial approval manifest JSON}
         {--expected-approval-manifest-sha256= : Optional expected SHA-256 for the approval manifest artifact}
         {--confirm-approval-transition : Explicitly confirm that --approve-staging-preview may update rows to approved}
+        {--production-import : Validate or transition approved salary asset rows to production_imported using the approval manifest and exact operator approval}
+        {--operator-approval= : Exact operator approval text required for --production-import}
+        {--confirm-production-import : Explicitly confirm that --production-import may update approved rows to production_imported}
         {--dry-run : Validate only; this is the default when --force is not supplied}
         {--force : Write staging_preview rows for allowlisted preview slugs only}
         {--json : Emit machine-readable JSON report}
@@ -36,6 +39,32 @@ final class CareerImportSalaryAssetsPreview extends Command
     public function handle(): int
     {
         try {
+            if ((bool) $this->option('production-import')) {
+                if ((bool) $this->option('force') || (bool) $this->option('approve-staging-preview')) {
+                    return $this->finish([
+                        'decision' => 'fail',
+                        'errors' => ['--production-import cannot be combined with --force or --approve-staging-preview.'],
+                    ], false);
+                }
+
+                $manifest = trim((string) $this->option('approval-manifest'));
+                if ($manifest === '') {
+                    return $this->finish([
+                        'decision' => 'fail',
+                        'errors' => ['--approval-manifest is required with --production-import.'],
+                    ], false);
+                }
+
+                $report = $this->importService->productionImportApproved(
+                    $manifest,
+                    trim((string) $this->option('expected-approval-manifest-sha256')) ?: null,
+                    trim((string) $this->option('operator-approval')),
+                    (bool) $this->option('confirm-production-import'),
+                );
+
+                return $this->finish($report, ($report['decision'] ?? null) === 'pass');
+            }
+
             if ((bool) $this->option('approve-staging-preview')) {
                 if ((bool) $this->option('force')) {
                     return $this->finish([

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetImportService.php
@@ -742,6 +742,222 @@ final class CareerSalaryAssetImportService
     /**
      * @return array<string, mixed>
      */
+    public function productionImportApproved(string $approvalManifestFile, ?string $expectedApprovalManifestSha256 = null, string $operatorApproval = '', bool $apply = false): array
+    {
+        $approvalManifestSha256 = is_file($approvalManifestFile) ? (hash_file('sha256', $approvalManifestFile) ?: null) : null;
+        $rawExpectedApprovalManifestSha256 = trim((string) $expectedApprovalManifestSha256);
+        $expectedApprovalManifestSha256 = $this->normalizeSha256($expectedApprovalManifestSha256);
+        $errors = [];
+
+        if ($rawExpectedApprovalManifestSha256 !== '' && $expectedApprovalManifestSha256 === null) {
+            $errors[] = 'Expected approval manifest SHA-256 must be a 64-character hex digest.';
+        }
+
+        if (! is_file($approvalManifestFile) || ! is_readable($approvalManifestFile)) {
+            return $this->productionImportReport($approvalManifestFile, $approvalManifestSha256, $expectedApprovalManifestSha256, null, false, $apply, [
+                'Approval manifest file is missing or unreadable.',
+            ]);
+        }
+
+        if ($expectedApprovalManifestSha256 !== null && $approvalManifestSha256 !== $expectedApprovalManifestSha256) {
+            $errors[] = 'Approval manifest SHA-256 does not match expected artifact SHA.';
+        }
+
+        try {
+            $manifest = json_decode((string) file_get_contents($approvalManifestFile), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return $this->productionImportReport($approvalManifestFile, $approvalManifestSha256, $expectedApprovalManifestSha256, null, false, $apply, [
+                'Approval manifest is not valid JSON.',
+            ]);
+        }
+
+        if (! is_array($manifest)) {
+            return $this->productionImportReport($approvalManifestFile, $approvalManifestSha256, $expectedApprovalManifestSha256, null, false, $apply, [
+                'Approval manifest root must be an object.',
+            ]);
+        }
+
+        $sourceAsset = $this->arrayValue($manifest, 'source_asset');
+        $sourceAudits = $this->arrayValue($manifest, 'source_audits');
+        $gateResults = $this->arrayValue($manifest, 'gate_results');
+        $editorialReview = $this->arrayValue($manifest, 'editorial_review');
+        $approvedSlugs = is_array($manifest['approved_slugs'] ?? null) ? array_values(array_filter(
+            array_map(fn (mixed $slug): string => $this->previewService->normalizeSlug((string) $slug), $manifest['approved_slugs']),
+            static fn (string $slug): bool => $slug !== ''
+        )) : [];
+        $approvedSlugSet = array_values(array_unique($approvedSlugs));
+
+        if (($manifest['artifact_type'] ?? null) !== 'career_salary_1046_editorial_review_approval_manifest') {
+            $errors[] = 'approval_manifest.artifact_type mismatch.';
+        }
+        if (($sourceAsset['row_count'] ?? null) !== 2092) {
+            $errors[] = 'approval_manifest.source_asset.row_count must be 2092.';
+        }
+        if (($sourceAsset['slug_count'] ?? null) !== 1046) {
+            $errors[] = 'approval_manifest.source_asset.slug_count must be 1046.';
+        }
+        $localeCounts = is_array($sourceAsset['locale_counts'] ?? null) ? $sourceAsset['locale_counts'] : [];
+        if (($localeCounts['zh-CN'] ?? null) !== 1046 || ($localeCounts['en'] ?? null) !== 1046) {
+            $errors[] = 'approval_manifest.source_asset.locale_counts must contain zh-CN=1046 and en=1046.';
+        }
+
+        $sourceAssetSha256 = $this->normalizeSha256(is_string($sourceAsset['sha256'] ?? null) ? $sourceAsset['sha256'] : null);
+        if ($sourceAssetSha256 === null) {
+            $errors[] = 'approval_manifest.source_asset.sha256 must be a SHA-256 digest.';
+        }
+        foreach ([
+            'independent_qa_sha256',
+            'staging_api_smoke_sha256',
+            'staging_summary_sha256',
+        ] as $shaField) {
+            if ($this->normalizeSha256(is_string($sourceAudits[$shaField] ?? null) ? $sourceAudits[$shaField] : null) === null) {
+                $errors[] = "approval_manifest.source_audits.{$shaField} must be a SHA-256 digest.";
+            }
+        }
+        if (($gateResults['independent_qa_conclusion'] ?? null) !== 'READY_FOR_EXPANDED_STAGING_PREVIEW') {
+            $errors[] = 'approval_manifest.gate_results.independent_qa_conclusion must be READY_FOR_EXPANDED_STAGING_PREVIEW.';
+        }
+        if (($gateResults['known_good_10slug_pass'] ?? null) !== true) {
+            $errors[] = 'approval_manifest.gate_results.known_good_10slug_pass must be true.';
+        }
+        if (($gateResults['projection_ready_rows'] ?? null) !== 2092 || ($gateResults['projection_blocked_rows'] ?? null) !== 0) {
+            $errors[] = 'approval_manifest.gate_results projection counts must be ready=2092 and blocked=0.';
+        }
+        if (($gateResults['staging_api_smoke_status'] ?? null) !== 'pass'
+            || ($gateResults['staging_api_ready_rows'] ?? null) !== 2092
+            || ($gateResults['staging_api_failed_rows'] ?? null) !== 0) {
+            $errors[] = 'approval_manifest.gate_results staging API smoke must pass 2092/2092.';
+        }
+        if (($editorialReview['status'] ?? null) !== 'editorial_review_pass') {
+            $errors[] = 'approval_manifest.editorial_review.status must be editorial_review_pass.';
+        }
+        if (($editorialReview['approved_for_next_state'] ?? null) !== CareerJobSalaryAsset::STATUS_APPROVED) {
+            $errors[] = 'approval_manifest.editorial_review.approved_for_next_state must be approved.';
+        }
+        if (($editorialReview['production_import_approved'] ?? null) !== false) {
+            $errors[] = 'approval_manifest.editorial_review.production_import_approved must be false; production approval must come from the operator command text.';
+        }
+        if (($editorialReview['manual_approval_required_for_production_import'] ?? null) !== true) {
+            $errors[] = 'approval_manifest.editorial_review.manual_approval_required_for_production_import must be true.';
+        }
+        if (($editorialReview['rejected_count'] ?? null) !== 0 || (is_array($editorialReview['rejected_slugs'] ?? null) && count($editorialReview['rejected_slugs']) > 0)) {
+            $errors[] = 'approval_manifest.editorial_review must have rejected_count=0 and no rejected_slugs.';
+        }
+        if (count($approvedSlugSet) !== 1046 || count($approvedSlugs) !== 1046) {
+            $errors[] = 'approval_manifest.approved_slugs must contain 1046 unique slugs.';
+        }
+
+        $requiredApprovalText = $sourceAssetSha256 === null ? null : $this->requiredProductionApprovalText($sourceAssetSha256);
+        $operatorApprovalMatches = $requiredApprovalText !== null && trim($operatorApproval) === $requiredApprovalText;
+        if (! $operatorApprovalMatches) {
+            $errors[] = 'Operator approval text does not exactly match the required production import approval.';
+        }
+
+        $dbReport = $sourceAssetSha256 === null ? $this->emptyProductionDbReport() : $this->productionDatabaseReport($approvedSlugSet, $sourceAssetSha256);
+        foreach ($dbReport['errors'] as $dbError) {
+            $errors[] = $dbError;
+        }
+
+        $productionImportRunId = (string) Str::uuid();
+        $updated = [];
+        if ($errors === [] && $apply) {
+            $updated = DB::transaction(function () use ($approvedSlugSet, $sourceAssetSha256, $approvalManifestSha256, $sourceAudits, $productionImportRunId, $operatorApproval): array {
+                $assets = CareerJobSalaryAsset::query()
+                    ->where('asset_version', CareerJobSalaryAsset::ASSET_VERSION_V3_6)
+                    ->whereIn('career_job_slug', $approvedSlugSet)
+                    ->where('source_artifact_sha256', $sourceAssetSha256)
+                    ->where('status', CareerJobSalaryAsset::STATUS_APPROVED)
+                    ->lockForUpdate()
+                    ->get();
+                $updated = [];
+
+                foreach ($assets as $asset) {
+                    if (! $this->stateMachine->canProductionImportFrom($asset->status)) {
+                        throw new \RuntimeException("{$asset->career_job_slug}/{$asset->locale}: cannot transition salary asset from {$asset->status} to production_imported.");
+                    }
+
+                    $auditFields = is_array($asset->audit_fields_json) ? $asset->audit_fields_json : [];
+                    $auditFields['production_import_gate'] = [
+                        'status' => CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+                        'approval_manifest_sha256' => $approvalManifestSha256,
+                        'source_asset_sha256' => $sourceAssetSha256,
+                        'independent_qa_sha256' => $sourceAudits['independent_qa_sha256'] ?? null,
+                        'staging_api_smoke_sha256' => $sourceAudits['staging_api_smoke_sha256'] ?? null,
+                        'operator_approval_sha256' => hash('sha256', trim($operatorApproval)),
+                        'production_import_run_id' => $productionImportRunId,
+                    ];
+                    $previousStatus = $asset->status;
+                    $asset->status = CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED;
+                    $asset->preview_allowlisted = false;
+                    $asset->audit_fields_json = $auditFields;
+                    $asset->import_run_id = $productionImportRunId;
+                    $asset->save();
+
+                    $updated[] = [
+                        'slug' => $asset->career_job_slug,
+                        'locale' => $asset->locale,
+                        'row_id' => $asset->id,
+                        'previous_status' => $previousStatus,
+                        'new_status' => CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+                    ];
+                }
+
+                return $updated;
+            });
+        }
+
+        return array_merge($this->productionImportReport($approvalManifestFile, $approvalManifestSha256, $expectedApprovalManifestSha256, $requiredApprovalText, $operatorApprovalMatches, $apply, $errors), [
+            'source_asset_sha256' => $sourceAssetSha256,
+            'independent_qa_sha256' => $sourceAudits['independent_qa_sha256'] ?? null,
+            'staging_api_smoke_sha256' => $sourceAudits['staging_api_smoke_sha256'] ?? null,
+            'approved_slug_count' => count($approvedSlugSet),
+            'expected_row_count' => 2092,
+            'database_gate' => $dbReport,
+            'did_write' => $apply && $errors === [] && count($updated) > 0,
+            'updated_count' => count($updated),
+            'production_import_run_id' => $apply && $errors === [] ? $productionImportRunId : null,
+            'updated_assets' => $updated,
+            'rollback_report' => [
+                'production_import_run_id' => $apply && $errors === [] ? $productionImportRunId : null,
+                'rollback_boundary' => 'Rows production-imported by this command are scoped by production_import_run_id/import_run_id and source_asset_sha256.',
+                'restore_target_status' => CareerJobSalaryAsset::STATUS_APPROVED,
+                'production_rows_touched' => $apply && $errors === [] ? count($updated) : 0,
+            ],
+        ]);
+    }
+
+    private function requiredProductionApprovalText(string $sourceAssetSha256): string
+    {
+        return "批准 production import 1046 salary assets, using SHA {$sourceAssetSha256}";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function productionImportReport(string $approvalManifestFile, ?string $approvalManifestSha256, ?string $expectedApprovalManifestSha256, ?string $requiredApprovalText, bool $operatorApprovalMatches, bool $apply, array $errors): array
+    {
+        return [
+            'importer_version' => self::IMPORTER_VERSION,
+            'mode' => $apply ? 'production_import' : 'production_import_dry_run',
+            'asset_version' => CareerJobSalaryAsset::ASSET_VERSION_V3_6,
+            'decision' => $errors === [] ? 'pass' : 'fail',
+            'status_policy' => CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+            'production_import_allowed' => $errors === [],
+            'production_rows_touched' => 0,
+            'approval_manifest_file' => $approvalManifestFile,
+            'approval_manifest_sha256' => $approvalManifestSha256,
+            'expected_approval_manifest_sha256' => $expectedApprovalManifestSha256,
+            'approval_manifest_sha256_match' => $expectedApprovalManifestSha256 === null || $approvalManifestSha256 === $expectedApprovalManifestSha256,
+            'required_operator_approval' => $requiredApprovalText,
+            'operator_approval_matches' => $operatorApprovalMatches,
+            'state_machine' => $this->stateMachine->report(),
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     private function approvalReport(string $approvalManifestFile, ?string $approvalManifestSha256, ?string $expectedApprovalManifestSha256, bool $apply, array $errors): array
     {
         return [
@@ -803,6 +1019,57 @@ final class CareerSalaryAssetImportService
     }
 
     /**
+     * @param  list<string>  $approvedSlugs
+     * @return array<string, mixed>
+     */
+    private function productionDatabaseReport(array $approvedSlugs, string $sourceAssetSha256): array
+    {
+        $assets = CareerJobSalaryAsset::query()
+            ->where('asset_version', CareerJobSalaryAsset::ASSET_VERSION_V3_6)
+            ->whereIn('career_job_slug', $approvedSlugs)
+            ->where('source_artifact_sha256', $sourceAssetSha256)
+            ->get(['career_job_slug', 'locale', 'status', 'source_artifact_sha256']);
+        $rowsByKey = [];
+        $statusCounts = [];
+        $errors = [];
+
+        foreach ($assets as $asset) {
+            $rowsByKey[$asset->career_job_slug.'|'.$asset->locale] = true;
+            $statusCounts[$asset->status] = ($statusCounts[$asset->status] ?? 0) + 1;
+            if ($asset->status === CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED) {
+                continue;
+            }
+
+            if (! $this->stateMachine->canProductionImportFrom($asset->status)) {
+                $errors[] = "{$asset->career_job_slug}/{$asset->locale}: cannot transition from {$asset->status} to production_imported.";
+            }
+        }
+
+        foreach ($approvedSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                if (! isset($rowsByKey[$slug.'|'.$locale])) {
+                    $errors[] = "{$slug}/{$locale}: approved row with matching source asset SHA is missing.";
+                }
+            }
+        }
+
+        $approvedCount = (int) ($statusCounts[CareerJobSalaryAsset::STATUS_APPROVED] ?? 0);
+        $alreadyImportedCount = (int) ($statusCounts[CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED] ?? 0);
+        $expectedRowCount = count($approvedSlugs) * 2;
+
+        return [
+            'checked_slug_count' => count($approvedSlugs),
+            'expected_row_count' => $expectedRowCount,
+            'matching_row_count' => count($rowsByKey),
+            'status_counts' => $statusCounts,
+            'approved_source_row_count' => $approvedCount,
+            'already_production_imported_row_count' => $alreadyImportedCount,
+            'ready_for_production_import' => $errors === [] && count($rowsByKey) === $expectedRowCount && ($approvedCount + $alreadyImportedCount) === $expectedRowCount,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function emptyApprovalDbReport(): array
@@ -813,6 +1080,23 @@ final class CareerSalaryAssetImportService
             'matching_row_count' => 0,
             'status_counts' => [],
             'ready_for_approval' => false,
+            'errors' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyProductionDbReport(): array
+    {
+        return [
+            'checked_slug_count' => 0,
+            'expected_row_count' => 0,
+            'matching_row_count' => 0,
+            'status_counts' => [],
+            'approved_source_row_count' => 0,
+            'already_production_imported_row_count' => 0,
+            'ready_for_production_import' => false,
             'errors' => [],
         ];
     }

--- a/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
+++ b/backend/app/Services/Career/SalaryAssets/CareerSalaryAssetPreviewService.php
@@ -34,6 +34,17 @@ final class CareerSalaryAssetPreviewService
         $normalizedSlug = $this->normalizeSlug($slug);
         $normalizedLocale = $this->normalizeLocale($locale);
 
+        $productionAsset = CareerJobSalaryAsset::query()
+            ->where('career_job_slug', $normalizedSlug)
+            ->where('locale', $normalizedLocale)
+            ->where('asset_version', CareerJobSalaryAsset::ASSET_VERSION_V3_6)
+            ->where('status', CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED)
+            ->first();
+
+        if ($productionAsset instanceof CareerJobSalaryAsset) {
+            return $productionAsset;
+        }
+
         if (! $this->previewEnabled()) {
             return null;
         }
@@ -56,7 +67,8 @@ final class CareerSalaryAssetPreviewService
 
         return [
             'ok' => true,
-            'preview' => true,
+            'preview' => $asset->status !== CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED,
+            'status' => $asset->status,
             'salary_asset_v1' => $this->readerSafePayload($payload),
         ];
     }

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -8,29 +8,28 @@
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
-            "version": "1.3.5",
+            "version": "1.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AnourValar/eloquent-serialize.git",
-                "reference": "1a7dead8d532657e5358f8f27c0349373517681e"
+                "reference": "da1b8c8fa5cd9bdfc5dd19a2a92a0e16f6bf1bca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/1a7dead8d532657e5358f8f27c0349373517681e",
-                "reference": "1a7dead8d532657e5358f8f27c0349373517681e",
+                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/da1b8c8fa5cd9bdfc5dd19a2a92a0e16f6bf1bca",
+                "reference": "da1b8c8fa5cd9bdfc5dd19a2a92a0e16f6bf1bca",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0",
-                "php": "^7.4|^8.0"
+                "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.26",
                 "laravel/legacy-factories": "^1.1",
-                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^9.5|^10.5|^11.0",
-                "psalm/plugin-laravel": "^2.8|^3.0",
                 "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "library",
@@ -68,9 +67,9 @@
             ],
             "support": {
                 "issues": "https://github.com/AnourValar/eloquent-serialize/issues",
-                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.5"
+                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.9"
             },
-            "time": "2025-12-04T13:38:21+00:00"
+            "time": "2026-06-12T13:35:57+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -225,26 +224,26 @@
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/driesvints/blade-heroicons.git",
-                "reference": "4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19"
+                "reference": "66fa8ba09dba12e0cdb410b8cb94f3b890eca440"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/driesvints/blade-heroicons/zipball/4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19",
-                "reference": "4553b2a1f6c76f0ac7f3bc0de4c0cfa06a097d19",
+                "url": "https://api.github.com/repos/driesvints/blade-heroicons/zipball/66fa8ba09dba12e0cdb410b8cb94f3b890eca440",
+                "reference": "66fa8ba09dba12e0cdb410b8cb94f3b890eca440",
                 "shasum": ""
             },
             "require": {
                 "blade-ui-kit/blade-icons": "^1.6",
-                "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-                "phpunit/phpunit": "^9.0|^10.5|^11.0"
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.0|^10.5|^11.0|^12.0"
             },
             "type": "library",
             "extra": {
@@ -270,7 +269,7 @@
                 }
             ],
             "description": "A package to easily make use of Heroicons in your Laravel Blade views.",
-            "homepage": "https://github.com/blade-ui-kit/blade-heroicons",
+            "homepage": "https://github.com/driesvints/blade-heroicons",
             "keywords": [
                 "Heroicons",
                 "blade",
@@ -278,7 +277,7 @@
             ],
             "support": {
                 "issues": "https://github.com/driesvints/blade-heroicons/issues",
-                "source": "https://github.com/driesvints/blade-heroicons/tree/2.6.0"
+                "source": "https://github.com/driesvints/blade-heroicons/tree/2.7.0"
             },
             "funding": [
                 {
@@ -290,34 +289,34 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2025-02-13T20:53:33+00:00"
+            "time": "2026-03-16T13:00:23+00:00"
         },
         {
             "name": "blade-ui-kit/blade-icons",
-            "version": "1.8.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/driesvints/blade-icons.git",
-                "reference": "47e7b6f43250e6404e4224db8229219cd42b543c"
+                "reference": "74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/driesvints/blade-icons/zipball/47e7b6f43250e6404e4224db8229219cd42b543c",
-                "reference": "47e7b6f43250e6404e4224db8229219cd42b543c",
+                "url": "https://api.github.com/repos/driesvints/blade-icons/zipball/74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a",
+                "reference": "74189a80bbaa4966aebaee54fec3a3c2ef0a5f3a",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/view": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/view": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "php": "^7.4|^8.0",
-                "symfony/console": "^5.3|^6.0|^7.0",
-                "symfony/finder": "^5.3|^6.0|^7.0"
+                "symfony/console": "^5.3|^6.0|^7.0|^8.0",
+                "symfony/finder": "^5.3|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.5.1",
-                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
                 "phpunit/phpunit": "^9.0|^10.5|^11.0"
             },
             "bin": [
@@ -371,7 +370,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-01-20T09:46:32+00:00"
+            "time": "2026-04-23T19:03:45+00:00"
         },
         {
             "name": "brick/math",
@@ -555,27 +554,27 @@
         },
         {
             "name": "danharrin/livewire-rate-limiting",
-            "version": "v2.1.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/danharrin/livewire-rate-limiting.git",
-                "reference": "14dde653a9ae8f38af07a0ba4921dc046235e1a0"
+                "reference": "c03e649220089f6e5a52d422e24e3f98c73e456d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danharrin/livewire-rate-limiting/zipball/14dde653a9ae8f38af07a0ba4921dc046235e1a0",
-                "reference": "14dde653a9ae8f38af07a0ba4921dc046235e1a0",
+                "url": "https://api.github.com/repos/danharrin/livewire-rate-limiting/zipball/c03e649220089f6e5a52d422e24e3f98c73e456d",
+                "reference": "c03e649220089f6e5a52d422e24e3f98c73e456d",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+                "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0"
             },
             "require-dev": {
                 "livewire/livewire": "^3.0",
                 "livewire/volt": "^1.3",
-                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-                "phpunit/phpunit": "^9.0|^10.0|^11.5.3"
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.0|^10.0|^11.5.3|^12.5.12"
             },
             "type": "library",
             "autoload": {
@@ -605,7 +604,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-21T08:52:11+00:00"
+            "time": "2026-03-16T11:29:23+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -684,16 +683,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "4.4.1",
+            "version": "4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "3d544473fb93f5c25b483ea4f4ce99f8c4d9d44c"
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/3d544473fb93f5c25b483ea4f4ce99f8c4d9d44c",
-                "reference": "3d544473fb93f5c25b483ea4f4ce99f8c4d9d44c",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
                 "shasum": ""
             },
             "require": {
@@ -709,9 +708,9 @@
                 "phpstan/phpstan": "2.1.30",
                 "phpstan/phpstan-phpunit": "2.0.7",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "11.5.23",
-                "slevomat/coding-standard": "8.24.0",
-                "squizlabs/php_codesniffer": "4.0.0",
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
                 "symfony/cache": "^6.3.8|^7.0|^8.0",
                 "symfony/console": "^5.4|^6.3|^7.0|^8.0"
             },
@@ -770,7 +769,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/4.4.1"
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
             },
             "funding": [
                 {
@@ -786,7 +785,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-04T10:11:03+00:00"
+            "time": "2026-03-20T08:52:12+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1136,16 +1135,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "3cb3e1f9094ed3b4bc102616966c365138c908bc"
+                "reference": "74bf94a5ba0d3f5ec432734ed42afa0c880812fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/3cb3e1f9094ed3b4bc102616966c365138c908bc",
-                "reference": "3cb3e1f9094ed3b4bc102616966c365138c908bc",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/74bf94a5ba0d3f5ec432734ed42afa0c880812fa",
+                "reference": "74bf94a5ba0d3f5ec432734ed42afa0c880812fa",
                 "shasum": ""
             },
             "require": {
@@ -1154,9 +1153,9 @@
                 "filament/infolists": "self.version",
                 "filament/notifications": "self.version",
                 "filament/support": "self.version",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/database": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
                 "league/csv": "^9.16",
                 "openspout/openspout": "^4.23",
                 "php": "^8.1",
@@ -1185,20 +1184,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-02-07T21:52:11+00:00"
+            "time": "2026-06-12T16:57:07+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "073e41c0abe78bc2cfcde3a186a40cbed328a6a7"
+                "reference": "04e29df86858bf42bb8c07895c35703be8bdd6e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/073e41c0abe78bc2cfcde3a186a40cbed328a6a7",
-                "reference": "073e41c0abe78bc2cfcde3a186a40cbed328a6a7",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/04e29df86858bf42bb8c07895c35703be8bdd6e5",
+                "reference": "04e29df86858bf42bb8c07895c35703be8bdd6e5",
                 "shasum": ""
             },
             "require": {
@@ -1210,16 +1209,16 @@
                 "filament/support": "self.version",
                 "filament/tables": "self.version",
                 "filament/widgets": "self.version",
-                "illuminate/auth": "^10.45|^11.0|^12.0",
-                "illuminate/console": "^10.45|^11.0|^12.0",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/cookie": "^10.45|^11.0|^12.0",
-                "illuminate/database": "^10.45|^11.0|^12.0",
-                "illuminate/http": "^10.45|^11.0|^12.0",
-                "illuminate/routing": "^10.45|^11.0|^12.0",
-                "illuminate/session": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
-                "illuminate/view": "^10.45|^11.0|^12.0",
+                "illuminate/auth": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/console": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/cookie": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/session": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.45|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9"
             },
@@ -1250,33 +1249,33 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-05-21T17:50:14+00:00"
+            "time": "2026-06-12T16:57:16+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "67b6dc4cef99d2a9eda916a4202f63985b54ccf2"
+                "reference": "e99a612ff07892f5a85ea38b8425269aa4fbee12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/67b6dc4cef99d2a9eda916a4202f63985b54ccf2",
-                "reference": "67b6dc4cef99d2a9eda916a4202f63985b54ccf2",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/e99a612ff07892f5a85ea38b8425269aa4fbee12",
+                "reference": "e99a612ff07892f5a85ea38b8425269aa4fbee12",
                 "shasum": ""
             },
             "require": {
                 "danharrin/date-format-converter": "^0.3",
                 "filament/actions": "self.version",
                 "filament/support": "self.version",
-                "illuminate/console": "^10.45|^11.0|^12.0",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/database": "^10.45|^11.0|^12.0",
-                "illuminate/filesystem": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
-                "illuminate/validation": "^10.45|^11.0|^12.0",
-                "illuminate/view": "^10.45|^11.0|^12.0",
+                "illuminate/console": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.45|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9"
             },
@@ -1306,31 +1305,31 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-05-21T17:51:59+00:00"
+            "time": "2026-06-12T16:57:19+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "9cef7bf9f46756a8adf762ced62952e8c239b840"
+                "reference": "e86e1332093856731abe9d71f93d95e2b873cbd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/9cef7bf9f46756a8adf762ced62952e8c239b840",
-                "reference": "9cef7bf9f46756a8adf762ced62952e8c239b840",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/e86e1332093856731abe9d71f93d95e2b873cbd7",
+                "reference": "e86e1332093856731abe9d71f93d95e2b873cbd7",
                 "shasum": ""
             },
             "require": {
                 "filament/actions": "self.version",
                 "filament/support": "self.version",
-                "illuminate/console": "^10.45|^11.0|^12.0",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/database": "^10.45|^11.0|^12.0",
-                "illuminate/filesystem": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
-                "illuminate/view": "^10.45|^11.0|^12.0",
+                "illuminate/console": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.45|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9"
             },
@@ -1357,29 +1356,29 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-02-07T21:51:54+00:00"
+            "time": "2026-06-12T16:57:28+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
-                "reference": "3a6ef54b6a8cefc79858e7033e4d6b65fb2d859b"
+                "reference": "c9b6b1f1d06b9c64d7378c945bec21f8802d554f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/3a6ef54b6a8cefc79858e7033e4d6b65fb2d859b",
-                "reference": "3a6ef54b6a8cefc79858e7033e4d6b65fb2d859b",
+                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/c9b6b1f1d06b9c64d7378c945bec21f8802d554f",
+                "reference": "c9b6b1f1d06b9c64d7378c945bec21f8802d554f",
                 "shasum": ""
             },
             "require": {
                 "filament/actions": "self.version",
                 "filament/support": "self.version",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/filesystem": "^10.45|^11.0|^12.0",
-                "illuminate/notifications": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/notifications": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9"
             },
@@ -1409,29 +1408,29 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:16+00:00"
+            "time": "2026-06-12T16:57:50+00:00"
         },
         {
             "name": "filament/support",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "493bd79d4f4ae7b9256c317af742354318a6f4e0"
+                "reference": "a9889ea4cdec47c365af47f344a8acd9917ed4c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/493bd79d4f4ae7b9256c317af742354318a6f4e0",
-                "reference": "493bd79d4f4ae7b9256c317af742354318a6f4e0",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/a9889ea4cdec47c365af47f344a8acd9917ed4c5",
+                "reference": "a9889ea4cdec47c365af47f344a8acd9917ed4c5",
                 "shasum": ""
             },
             "require": {
                 "blade-ui-kit/blade-heroicons": "^2.5",
                 "doctrine/dbal": "^3.2|^4.0",
                 "ext-intl": "*",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
-                "illuminate/view": "^10.45|^11.0|^12.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.45|^11.0|^12.0|^13.0",
                 "kirschbaum-development/eloquent-power-joins": "^3.0|^4.0",
                 "livewire/livewire": "^3.5",
                 "php": "^8.1",
@@ -1468,32 +1467,32 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-02-07T21:51:58+00:00"
+            "time": "2026-06-12T16:57:05+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937"
+                "reference": "2160b7ac8bc6d11cc12ae608417b6eb22d18a5d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937",
-                "reference": "6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/2160b7ac8bc6d11cc12ae608417b6eb22d18a5d7",
+                "reference": "2160b7ac8bc6d11cc12ae608417b6eb22d18a5d7",
                 "shasum": ""
             },
             "require": {
                 "filament/actions": "self.version",
                 "filament/forms": "self.version",
                 "filament/support": "self.version",
-                "illuminate/console": "^10.45|^11.0|^12.0",
-                "illuminate/contracts": "^10.45|^11.0|^12.0",
-                "illuminate/database": "^10.45|^11.0|^12.0",
-                "illuminate/filesystem": "^10.45|^11.0|^12.0",
-                "illuminate/support": "^10.45|^11.0|^12.0",
-                "illuminate/view": "^10.45|^11.0|^12.0",
+                "illuminate/console": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.45|^11.0|^12.0|^13.0",
+                "illuminate/view": "^10.45|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9"
             },
@@ -1520,20 +1519,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-05-20T15:37:01+00:00"
+            "time": "2026-06-12T16:57:06+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v3.3.52",
+            "version": "v3.3.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "f58ff26e81ca2557205e3111e1d9d05c258cc206"
+                "reference": "db41ce3846560cb87bd0933742d762e23a9b5cd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/f58ff26e81ca2557205e3111e1d9d05c258cc206",
-                "reference": "f58ff26e81ca2557205e3111e1d9d05c258cc206",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/db41ce3846560cb87bd0933742d762e23a9b5cd8",
+                "reference": "db41ce3846560cb87bd0933742d762e23a9b5cd8",
                 "shasum": ""
             },
             "require": {
@@ -1564,7 +1563,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-02-07T21:51:58+00:00"
+            "time": "2026-06-12T16:57:28+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -1701,25 +1700,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
+                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1728,8 +1728,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1807,7 +1808,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
             },
             "funding": [
                 {
@@ -1823,28 +1824,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-16T22:11:48+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1890,7 +1892,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1906,27 +1908,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.2",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
+                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -2007,7 +2011,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
             },
             "funding": [
                 {
@@ -2023,20 +2027,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T22:58:15+00:00"
+            "time": "2026-06-16T21:50:11+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.6",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946"
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/eef7f87bab6f204eba3c39224d8075c70c637946",
-                "reference": "eef7f87bab6f204eba3c39224d8075c70c637946",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
                 "shasum": ""
             },
             "require": {
@@ -2093,7 +2097,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.6"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -2109,7 +2113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T22:00:21+00:00"
+            "time": "2026-06-12T21:33:43+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -2173,28 +2177,28 @@
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",
-            "version": "4.2.11",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kirschbaum-development/eloquent-power-joins.git",
-                "reference": "0e3e3372992e4bf82391b3c7b84b435c3db73588"
+                "reference": "33c189bd51a510c1ceba67222395ead08a29863a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kirschbaum-development/eloquent-power-joins/zipball/0e3e3372992e4bf82391b3c7b84b435c3db73588",
-                "reference": "0e3e3372992e4bf82391b3c7b84b435c3db73588",
+                "url": "https://api.github.com/repos/kirschbaum-development/eloquent-power-joins/zipball/33c189bd51a510c1ceba67222395ead08a29863a",
+                "reference": "33c189bd51a510c1ceba67222395ead08a29863a",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^11.42|^12.0",
-                "illuminate/support": "^11.42|^12.0",
+                "illuminate/database": "^11.42|^12.0|^13.0",
+                "illuminate/support": "^11.42|^12.0|^13.0",
                 "php": "^8.2"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "dev-master",
-                "laravel/legacy-factories": "^1.0@dev",
-                "orchestra/testbench": "^9.0|^10.0",
-                "phpunit/phpunit": "^10.0|^11.0"
+                "laravel/legacy-factories": "^1.0@dev|dev-master",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^10.0|^11.0|^12.0"
             },
             "type": "library",
             "extra": {
@@ -2230,22 +2234,22 @@
             ],
             "support": {
                 "issues": "https://github.com/kirschbaum-development/eloquent-power-joins/issues",
-                "source": "https://github.com/kirschbaum-development/eloquent-power-joins/tree/4.2.11"
+                "source": "https://github.com/kirschbaum-development/eloquent-power-joins/tree/4.3.2"
             },
-            "time": "2025-12-17T00:37:48+00:00"
+            "time": "2026-05-28T20:35:55+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.61.0",
+            "version": "v12.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf"
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/1124062a1ca92d290c8bcb9b7f649920fa6816bf",
-                "reference": "1124062a1ca92d290c8bcb9b7f649920fa6816bf",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/f7e61eb1e0e06a38996802b769bce9127aec227c",
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c",
                 "shasum": ""
             },
             "require": {
@@ -2454,7 +2458,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-26T23:41:33+00:00"
+            "time": "2026-06-09T13:50:13+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -3349,36 +3353,36 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v3.7.6",
+            "version": "v3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "276ac156f6ae414990784854a2673e3d23c68b24"
+                "reference": "0a7c2ec6c5c958cab32870ce5a7836a2fca0b459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/276ac156f6ae414990784854a2673e3d23c68b24",
-                "reference": "276ac156f6ae414990784854a2673e3d23c68b24",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/0a7c2ec6c5c958cab32870ce5a7836a2fca0b459",
+                "reference": "0a7c2ec6c5c958cab32870ce5a7836a2fca0b459",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^10.0|^11.0|^12.0",
-                "illuminate/routing": "^10.0|^11.0|^12.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
-                "illuminate/validation": "^10.0|^11.0|^12.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
                 "laravel/prompts": "^0.1.24|^0.2|^0.3",
                 "league/mime-type-detection": "^1.9",
                 "php": "^8.1",
-                "symfony/console": "^6.0|^7.0",
-                "symfony/http-kernel": "^6.2|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
             },
             "require-dev": {
                 "calebporzio/sushi": "^2.1",
-                "laravel/framework": "^10.15.0|^11.0|^12.0",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
                 "mockery/mockery": "^1.3.1",
-                "orchestra/testbench": "^8.21.0|^9.0|^10.0",
-                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0",
-                "phpunit/phpunit": "^10.4|^11.5",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
                 "psy/psysh": "^0.11.22|^0.12"
             },
             "type": "library",
@@ -3413,7 +3417,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v3.7.6"
+                "source": "https://github.com/livewire/livewire/tree/v3.8.1"
             },
             "funding": [
                 {
@@ -3421,7 +3425,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-23T05:41:38+00:00"
+            "time": "2026-06-02T08:18:44+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -3595,16 +3599,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -3613,7 +3617,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -3621,7 +3625,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -3655,22 +3659,22 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6e7853a668c3107294aff38d42bf760ec02126b6",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6",
                 "shasum": ""
             },
             "require": {
@@ -3762,7 +3766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-06-14T20:41:42+00:00"
         },
         {
             "name": "nette/schema",
@@ -5053,33 +5057,33 @@
         },
         {
             "name": "ryangjchandler/blade-capture-directive",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ryangjchandler/blade-capture-directive.git",
-                "reference": "bbb1513dfd89eaec87a47fe0c449a7e3d4a1976d"
+                "reference": "3f9e80b56ff60b78755ef320e3e16d88850101d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ryangjchandler/blade-capture-directive/zipball/bbb1513dfd89eaec87a47fe0c449a7e3d4a1976d",
-                "reference": "bbb1513dfd89eaec87a47fe0c449a7e3d4a1976d",
+                "url": "https://api.github.com/repos/ryangjchandler/blade-capture-directive/zipball/3f9e80b56ff60b78755ef320e3e16d88850101d6",
+                "reference": "3f9e80b56ff60b78755ef320e3e16d88850101d6",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.1",
                 "spatie/laravel-package-tools": "^1.9.2"
             },
             "require-dev": {
                 "nunomaduro/collision": "^7.0|^8.0",
                 "nunomaduro/larastan": "^2.0|^3.0",
-                "orchestra/testbench": "^8.0|^9.0|^10.0",
-                "pestphp/pest": "^2.0|^3.7",
-                "pestphp/pest-plugin-laravel": "^2.0|^3.1",
+                "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.0|^3.7|^4.1",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.1|^v4.1.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
                 "phpstan/phpstan-phpunit": "^1.0|^2.0",
-                "phpunit/phpunit": "^10.0|^11.5.3",
+                "phpunit/phpunit": "^10.0|^11.5.3|^12.0",
                 "spatie/laravel-ray": "^1.26"
             },
             "type": "library",
@@ -5119,7 +5123,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ryangjchandler/blade-capture-directive/issues",
-                "source": "https://github.com/ryangjchandler/blade-capture-directive/tree/v1.1.0"
+                "source": "https://github.com/ryangjchandler/blade-capture-directive/tree/v1.1.1"
             },
             "funding": [
                 {
@@ -5127,7 +5131,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-25T09:09:36+00:00"
+            "time": "2026-03-19T10:36:26+00:00"
         },
         {
             "name": "sentry/sentry",
@@ -5427,29 +5431,29 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.92.7",
+            "version": "1.93.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5"
+                "reference": "d5552849801f2642aea710557463234b59ef65eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/f09a799850b1ed765103a4f0b4355006360c49a5",
-                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/d5552849801f2642aea710557463234b59ef65eb",
+                "reference": "d5552849801f2642aea710557463234b59ef65eb",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
-                "php": "^8.0"
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.5",
-                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
-                "pestphp/pest": "^1.23|^2.1|^3.1",
-                "phpunit/php-code-coverage": "^9.0|^10.0|^11.0",
-                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
-                "spatie/pest-plugin-test-time": "^1.1|^2.2"
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "pestphp/pest": "^2.1|^3.1|^4.0",
+                "phpunit/php-code-coverage": "^10.0|^11.0|^12.0",
+                "phpunit/phpunit": "^10.5|^11.5|^12.5",
+                "spatie/pest-plugin-test-time": "^2.2|^3.0"
             },
             "type": "library",
             "autoload": {
@@ -5476,7 +5480,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.7"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.1"
             },
             "funding": [
                 {
@@ -5484,7 +5488,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T15:46:43+00:00"
+            "time": "2026-05-19T14:06:37+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7044,16 +7048,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -7105,7 +7109,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -7125,7 +7129,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -7213,16 +7217,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
-                "reference": "8339098cae28673c15cce00d80734af0453054e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -7269,7 +7273,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -7289,7 +7293,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php
@@ -337,7 +337,7 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
         $this->assertStringContainsString('cannot transition salary asset from production_imported to staging_preview', implode(' ', $decoded['errors']));
     }
 
-    public function test_importer_approval_gate_promotes_1046_staging_rows_to_approved_only_after_manifest_confirmation(): void
+    public function test_importer_approval_and_production_gates_promote_1046_rows_only_after_explicit_confirmations(): void
     {
         $slugs = array_map(static fn (int $index): string => 'approved-career-'.$index, range(1, 1046));
         Config::set('career_salary_assets.preview_slugs', $slugs);
@@ -409,6 +409,77 @@ final class CareerSalaryAssetPreviewImportTest extends TestCase
             ->firstOrFail();
         $this->assertSame(CareerJobSalaryAsset::STATUS_APPROVED, $approved->status);
         $this->assertSame($approvalManifestSha, $approved->audit_fields_json['approval_gate']['approval_manifest_sha256'] ?? null);
+
+        $missingOperatorApprovalReport = storage_path('framework/testing/salary-preview-production-gate-missing-operator-approval.json');
+        $missingOperatorApprovalCode = Artisan::call('career:salary-assets-import-preview', [
+            '--production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--expected-approval-manifest-sha256' => $approvalManifestSha,
+            '--confirm-production-import' => true,
+            '--output' => $missingOperatorApprovalReport,
+        ]);
+
+        $this->assertSame(1, $missingOperatorApprovalCode);
+        $this->assertSame(2092, CareerJobSalaryAsset::query()->where('status', CareerJobSalaryAsset::STATUS_APPROVED)->count());
+        $missingOperatorApproval = json_decode((string) file_get_contents($missingOperatorApprovalReport), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $missingOperatorApproval['decision']);
+        $this->assertFalse((bool) $missingOperatorApproval['operator_approval_matches']);
+        $this->assertStringContainsString('Operator approval text does not exactly match', implode(' ', $missingOperatorApproval['errors']));
+
+        $operatorApproval = '批准 production import 1046 salary assets, using SHA '.$sourceSha;
+        $productionDryRunReport = storage_path('framework/testing/salary-preview-production-gate-dry-run.json');
+        $productionDryRunCode = Artisan::call('career:salary-assets-import-preview', [
+            '--production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--expected-approval-manifest-sha256' => $approvalManifestSha,
+            '--operator-approval' => $operatorApproval,
+            '--output' => $productionDryRunReport,
+        ]);
+
+        $this->assertSame(0, $productionDryRunCode);
+        $this->assertSame(2092, CareerJobSalaryAsset::query()->where('status', CareerJobSalaryAsset::STATUS_APPROVED)->count());
+        $productionDryRun = json_decode((string) file_get_contents($productionDryRunReport), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $productionDryRun['decision']);
+        $this->assertSame('production_import_dry_run', $productionDryRun['mode']);
+        $this->assertTrue((bool) $productionDryRun['operator_approval_matches']);
+        $this->assertTrue((bool) $productionDryRun['production_import_allowed']);
+        $this->assertSame(2092, $productionDryRun['database_gate']['approved_source_row_count']);
+        $this->assertSame(0, $productionDryRun['production_rows_touched']);
+
+        $productionApplyReport = storage_path('framework/testing/salary-preview-production-gate-apply.json');
+        $productionApplyCode = Artisan::call('career:salary-assets-import-preview', [
+            '--production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--expected-approval-manifest-sha256' => $approvalManifestSha,
+            '--operator-approval' => $operatorApproval,
+            '--confirm-production-import' => true,
+            '--output' => $productionApplyReport,
+        ]);
+
+        $this->assertSame(0, $productionApplyCode);
+        $this->assertSame(2092, CareerJobSalaryAsset::query()->where('status', CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED)->count());
+        $this->assertSame(0, CareerJobSalaryAsset::query()->where('status', CareerJobSalaryAsset::STATUS_APPROVED)->count());
+        $productionApply = json_decode((string) file_get_contents($productionApplyReport), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $productionApply['decision']);
+        $this->assertSame('production_import', $productionApply['mode']);
+        $this->assertSame(2092, $productionApply['updated_count']);
+        $this->assertSame(2092, $productionApply['rollback_report']['production_rows_touched']);
+
+        $productionAsset = CareerJobSalaryAsset::query()
+            ->where('career_job_slug', 'approved-career-1')
+            ->where('locale', 'en')
+            ->firstOrFail();
+        $this->assertSame(CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED, $productionAsset->status);
+        $this->assertFalse((bool) $productionAsset->preview_allowlisted);
+        $this->assertSame($approvalManifestSha, $productionAsset->audit_fields_json['production_import_gate']['approval_manifest_sha256'] ?? null);
+
+        Config::set('career_salary_assets.staging_preview_enabled', false);
+        $this->getJson('/api/v0.5/career/jobs/approved-career-1/salary-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('preview', false)
+            ->assertJsonPath('status', CareerJobSalaryAsset::STATUS_PRODUCTION_IMPORTED)
+            ->assertJsonPath('salary_asset_v1.slug', 'approved-career-1')
+            ->assertJsonPath('salary_asset_v1.locale', 'en');
     }
 
     public function test_importer_approval_gate_rejects_missing_or_unconfirmed_manifest_inputs(): void


### PR DESCRIPTION
## What changed
- Added explicit `--production-import` mode to the career salary asset importer.
- Requires the editorial approval manifest, optional manifest SHA check, exact operator approval text, and `--confirm-production-import` before approved rows can move to `production_imported`.
- Keeps production import idempotent by accepting already `production_imported` rows with the same source SHA during validation.
- Records production import lineage in `audit_fields.production_import_gate` without storing the raw approval text.
- Exposes `production_imported` salary assets through the salary asset API without requiring the staging preview flag, while staging preview rows remain gated.

## Why
PR7 established the readiness and manual approval gate. This PR adds the executable ops gate needed to perform the approved 1046 production import safely after deployment.

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Career/CareerSalaryAssetPreviewImportTest.php`
- `php artisan route:list --path=api/v0.5/career/jobs`
- `git diff --check`

## Operator approval received
`批准 production import 1046 salary assets, using SHA c62c3c5b515034cebcec1a7429b82309092664d6615b01ce64cd02e798ff9dd4`

## Intentionally deferred
- No production command was executed from this local PR branch.
- Production import should run only after this PR is merged and deployed to the target backend environment.
- No salary asset JSONL, evidence ledger, estimate ledger, sitemap, llms.txt, canonical, noindex, or frontend content changes.


CI follow-up after GitHub supply-chain failure:
- `composer update filament/filament filament/forms laravel/framework mtdowling/jmespath.php --with-all-dependencies --no-interaction`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `bash scripts/ci_verify_mbti.sh`
