### PR TITLE
MBTI64-BACKEND-IMPORT-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php
+++ b/backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\Mbti64BackendImportContractPlanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbti64BackendImportContract extends Command
+{
+    protected $signature = 'personality:mbti64-backend-import-contract
+        {--package= : Path to the MBTI64 pilot V2.1 JSON package}
+        {--dry-run : Required; validate and plan without database writes}
+        {--write : Unsupported in this PR; fails closed}
+        {--json : Emit the full JSON contract plan}
+        {--output= : Optional path to write the JSON contract plan}';
+
+    protected $description = 'Validate the MBTI64 pilot V2.1 backend import contract as a no-write dry run.';
+
+    public function handle(Mbti64BackendImportContractPlanner $planner): int
+    {
+        try {
+            $summary = $this->guardedPlan($planner);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary($exception->getMessage(), 'unexpected_error');
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardedPlan(Mbti64BackendImportContractPlanner $planner): array
+    {
+        if ((bool) $this->option('write')) {
+            throw new RuntimeException('--write is intentionally unsupported in MBTI64-BACKEND-IMPORT-CONTRACT-PATCH-01.');
+        }
+
+        if (! (bool) $this->option('dry-run')) {
+            throw new RuntimeException('--dry-run is required so this command cannot be mistaken for a write/import command.');
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = $this->resolvePath($packagePath);
+        $decoded = json_decode((string) File::get($resolved), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        return array_merge($planner->plan($decoded), [
+            'package_path' => $resolved,
+            'command' => 'personality:mbti64-backend-import-contract',
+        ]);
+    }
+
+    private function resolvePath(string $path): string
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run_only='.(($summary['dry_run_only'] ?? false) ? '1' : '0'));
+        $this->line('write_supported_in_this_pr='.(($summary['write_supported_in_this_pr'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('publish_attempted='.(($summary['publish_attempted'] ?? false) ? '1' : '0'));
+        $this->line('search_release_attempted='.(($summary['search_release_attempted'] ?? false) ? '1' : '0'));
+        $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
+        $this->line('variant_row_count='.(string) ($summary['variant_row_count'] ?? 0));
+        $this->line('comparison_row_count='.(string) ($summary['comparison_row_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message, string $code = 'runtime_error'): array
+    {
+        return [
+            'artifact' => 'MBTI64-BACKEND-IMPORT-CONTRACT-PATCH-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'publish_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -155,6 +155,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
+use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
@@ -188,6 +189,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
+        PersonalityMbti64BackendImportContract::class,
         MetricsWeeklyValidity::class,
         MbtiPrewarm::class,
         MbtiUpgradeLegacyPartialUnlocks::class,

--- a/backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php
+++ b/backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+final class Mbti64BackendImportContractPlanner
+{
+    private const EXPECTED_URLS = [
+        '/en/personality/intj-a-vs-intj-t',
+        '/zh/personality/istj-a',
+        '/en/personality/intp-a-vs-intp-t',
+        '/zh/personality/infp-t',
+        '/en/personality/intj-a',
+        '/en/personality/intj-t',
+        '/zh/personality/intj-a',
+        '/zh/personality/intj-t',
+    ];
+
+    private const FORBIDDEN_PUBLIC_ROUTE_PATTERN =
+        '~(?:^|["\'\s(])/(?:result|results|orders|order|share|pay|payment|history|private|account)(?:/|[?#\s)"\']|$)~i';
+
+    private const FORBIDDEN_QUERY_PATTERN =
+        '/(?:[?&]|^)(?:token|session|user|result_id|report_id|order_no)=/i';
+
+    private const FIRST_CLASS_VARIANT_FIELDS = [
+        'url',
+        'locale',
+        'page_type',
+        'canonical_target',
+        'seo.seo_title',
+        'seo.seo_description',
+        'seo.breadcrumb_title',
+        'seo.h1',
+        'seo.quick_answer_summary',
+        'content',
+        'faq',
+        'internal_links',
+    ];
+
+    private const STRUCTURED_METADATA_FIELDS = [
+        'primary_query',
+        'secondary_queries',
+        'excluded_queries',
+        'target_intent',
+        'target_test_route',
+        'method_boundary',
+        'trademark_boundary',
+        'information_gain',
+        'claim_risk_notes',
+        'qa_flags_for_codex',
+        'route_safety',
+        'v2_optimization',
+        'above_the_fold_module',
+        'serp_ctr_package_v2',
+        'status',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function plan(array $package): array
+    {
+        $errors = [];
+        $warnings = [];
+        $rows = $this->rows($package, $errors);
+        $rowPlans = [];
+
+        $this->validateTopLevel($package, $warnings);
+        $this->validateRowOrder($rows, $errors);
+        $this->validateForbiddenRoutes($package, $errors);
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                $errors[] = $this->issue('rows.'.(string) $index, 'row_not_object', 'Each package row must be a JSON object.');
+
+                continue;
+            }
+
+            $rowPlans[] = $this->rowPlan($row, $index, $errors, $warnings);
+        }
+
+        $variantPlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant'
+        ));
+        $comparisonPlans = array_values(array_filter(
+            $rowPlans,
+            static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison'
+        ));
+
+        return [
+            'artifact' => 'MBTI64-BACKEND-IMPORT-CONTRACT-PATCH-01',
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'ok' => $errors === [],
+            'dry_run_only' => true,
+            'write_supported_in_this_pr' => false,
+            'writes_committed' => false,
+            'publish_attempted' => false,
+            'search_release_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'expected_row_count' => count(self::EXPECTED_URLS),
+            'row_count' => count($rows),
+            'variant_row_count' => count($variantPlans),
+            'comparison_row_count' => count($comparisonPlans),
+            'row_order_locked' => $this->actualUrls($rows) === self::EXPECTED_URLS,
+            'expected_urls' => self::EXPECTED_URLS,
+            'cms_revision_draft_contract' => $this->cmsRevisionDraftContract(),
+            'comparison_storage_contract' => $this->comparisonStorageContract(),
+            'field_mapping_contract' => $this->fieldMappingContract(),
+            'dry_run_write_guard_contract' => $this->dryRunWriteGuardContract(),
+            'rows' => $rowPlans,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     * @return list<mixed>
+     */
+    private function rows(array $package, array &$errors): array
+    {
+        $rows = $package['rows'] ?? null;
+        if (! is_array($rows)) {
+            $errors[] = $this->issue('rows', 'rows_missing_or_not_array', 'V2.1 package must contain rows as an array.');
+
+            return [];
+        }
+
+        return array_values($rows);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $warnings
+     */
+    private function validateTopLevel(array $package, array &$warnings): void
+    {
+        $version = trim((string) ($package['version'] ?? ''));
+        if ($version !== 'pilot-v2.1') {
+            $warnings[] = $this->issue('version', 'unexpected_package_version', 'Expected pilot-v2.1; keep this as a human review warning.');
+        }
+
+        $status = trim((string) ($package['status'] ?? ''));
+        if ($status === '') {
+            $warnings[] = $this->issue('status', 'missing_package_status', 'Package status was not provided.');
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateRowOrder(array $rows, array &$errors): void
+    {
+        $actual = $this->actualUrls($rows);
+        if (count($actual) !== count(self::EXPECTED_URLS)) {
+            $errors[] = $this->issue('rows', 'unexpected_row_count', 'V2.1 pilot package must contain exactly 8 rows.');
+
+            return;
+        }
+
+        if ($actual !== self::EXPECTED_URLS) {
+            $errors[] = $this->issue('rows', 'pilot_queue_order_mismatch', 'V2.1 pilot package row order must match the locked 8-page queue.');
+        }
+    }
+
+    /**
+     * @param  list<mixed>  $rows
+     * @return list<string>
+     */
+    private function actualUrls(array $rows): array
+    {
+        $urls = [];
+        foreach ($rows as $row) {
+            $urls[] = is_array($row) ? $this->normalizePath((string) ($row['url'] ?? '')) : '';
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     */
+    private function validateForbiddenRoutes(array $package, array &$errors): void
+    {
+        $json = json_encode($package, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($json)) {
+            $errors[] = $this->issue('package', 'json_encode_failed', 'Package could not be normalized for route safety scanning.');
+
+            return;
+        }
+
+        if (preg_match(self::FORBIDDEN_PUBLIC_ROUTE_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_public_route_pattern_present', 'Package active payload must not contain result/order/share/payment/history/private/account routes.');
+        }
+
+        if (preg_match(self::FORBIDDEN_QUERY_PATTERN, $json) === 1) {
+            $errors[] = $this->issue('package', 'forbidden_query_pattern_present', 'Package active payload must not contain sensitive query keys.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  list<array<string,string>>  $errors
+     * @param  list<array<string,string>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function rowPlan(array $row, int $index, array &$errors, array &$warnings): array
+    {
+        $url = $this->normalizePath((string) ($row['url'] ?? ''));
+        $locale = (string) ($row['locale'] ?? '');
+        $pageType = (string) ($row['page_type'] ?? '');
+        $identity = $this->parseIdentity($url, $locale, $pageType, $errors, $index);
+        $content = is_array($row['content'] ?? null) ? $row['content'] : [];
+        $seo = is_array($row['seo'] ?? null) ? $row['seo'] : [];
+
+        return [
+            'position' => $index + 1,
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'canonical_target' => $this->normalizePath((string) ($row['canonical_target'] ?? '')),
+            'identity' => $identity,
+            'target' => $this->targetFor($identity, $pageType),
+            'draft_revision' => $this->draftRevisionFor($identity, $pageType, $url),
+            'first_class_field_destinations' => $this->firstClassDestinations($pageType),
+            'structured_metadata_snapshot_path' => $pageType === 'comparison'
+                ? 'personality_profile_revisions.snapshot_json.mbti64_comparison_draft_v2_1.structured_metadata'
+                : 'personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata',
+            'content_section_keys' => array_keys($content),
+            'seo_keys' => array_keys($seo),
+            'faq_count' => is_array($row['faq'] ?? null) ? count((array) $row['faq']) : 0,
+            'internal_link_count' => is_array($row['internal_links'] ?? null) ? count((array) $row['internal_links']) : 0,
+            'publish_state_after_import' => [
+                'status' => 'draft',
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'published_at' => null,
+            ],
+            'write_mode_in_this_pr' => 'not_supported',
+        ];
+    }
+
+    /**
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function parseIdentity(string $url, string $locale, string $pageType, array &$errors, int $index): array
+    {
+        if (! in_array($locale, ['en', 'zh-CN'], true)) {
+            $errors[] = $this->issue('rows.'.(string) $index.'.locale', 'unsupported_locale', 'Only en and zh-CN are supported.');
+        }
+
+        if ($pageType === 'variant') {
+            if (preg_match('~^/(?:en|zh)/personality/(?<type>[a-z]{4})-(?<variant>[at])$~', $url, $matches) !== 1) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.url', 'invalid_variant_url', 'Variant URL must look like /en/personality/intj-a or /zh/personality/intj-t.');
+
+                return [];
+            }
+
+            $baseType = strtoupper((string) $matches['type']);
+            $variant = strtoupper((string) $matches['variant']);
+
+            return [
+                'canonical_type_code' => $baseType,
+                'variant_code' => $variant,
+                'runtime_type_code' => $baseType.'-'.$variant,
+            ];
+        }
+
+        if ($pageType === 'comparison') {
+            if (preg_match('~^/(?:en|zh)/personality/(?<type>[a-z]{4})-a-vs-(?<type2>[a-z]{4})-t$~', $url, $matches) !== 1) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.url', 'invalid_comparison_url', 'Comparison URL must look like /en/personality/intj-a-vs-intj-t.');
+
+                return [];
+            }
+
+            $baseType = strtoupper((string) $matches['type']);
+            if ($baseType !== strtoupper((string) $matches['type2'])) {
+                $errors[] = $this->issue('rows.'.(string) $index.'.url', 'comparison_base_type_mismatch', 'Comparison URL must compare A/T variants of the same base type.');
+            }
+
+            return [
+                'canonical_type_code' => $baseType,
+                'variant_pair' => [$baseType.'-A', $baseType.'-T'],
+            ];
+        }
+
+        $errors[] = $this->issue('rows.'.(string) $index.'.page_type', 'unsupported_page_type', 'Only variant and comparison rows are supported.');
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     * @return array<string,mixed>
+     */
+    private function targetFor(array $identity, string $pageType): array
+    {
+        if ($pageType === 'comparison') {
+            return [
+                'target_model' => 'App\\Models\\PersonalityProfileRevision',
+                'target_table' => 'personality_profile_revisions',
+                'lookup' => [
+                    'org_id' => 0,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'row.locale',
+                    'canonical_type_code' => (string) ($identity['canonical_type_code'] ?? ''),
+                ],
+                'standalone_comparison_model' => false,
+            ];
+        }
+
+        return [
+            'target_model' => 'App\\Models\\PersonalityProfileVariantRevision',
+            'target_table' => 'personality_profile_variant_revisions',
+            'lookup' => [
+                'org_id' => 0,
+                'scale_code' => 'MBTI',
+                'locale' => 'row.locale',
+                'runtime_type_code' => (string) ($identity['runtime_type_code'] ?? ''),
+            ],
+            'companion_tables_for_future_promotion' => [
+                'personality_profile_variant_sections',
+                'personality_profile_variant_seo_meta',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $identity
+     * @return array<string,mixed>
+     */
+    private function draftRevisionFor(array $identity, string $pageType, string $url): array
+    {
+        if ($pageType === 'comparison') {
+            return [
+                'revision_note' => 'mbti64 pilot-v2.1 comparison draft overlay: '.$url,
+                'snapshot_key' => 'mbti64_comparison_draft_v2_1',
+                'snapshot_owner' => 'base PersonalityProfile revision',
+                'publish_visibility' => 'not_public_until_separate_publish_gate',
+                'search_visibility' => 'not_search_released_until_separate_search_gate',
+            ];
+        }
+
+        return [
+            'revision_note' => 'mbti64 pilot-v2.1 variant draft: '.$url,
+            'snapshot_key' => 'mbti64_variant_content_package_v2_1',
+            'snapshot_owner' => 'PersonalityProfileVariant revision',
+            'runtime_type_code' => (string) ($identity['runtime_type_code'] ?? ''),
+            'publish_visibility' => 'not_public_until_separate_publish_gate',
+            'search_visibility' => 'not_search_released_until_separate_search_gate',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function firstClassDestinations(string $pageType): array
+    {
+        if ($pageType === 'comparison') {
+            return [
+                'identity' => 'personality_profiles lookup + personality_profile_revisions profile_id/revision_no/note',
+                'body_and_seo' => 'stored as structured draft overlay in snapshot_json until a comparison-specific first-class model exists',
+            ];
+        }
+
+        return [
+            'identity' => 'personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note',
+            'seo' => 'planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR',
+            'sections' => 'planned destination: personality_profile_variant_sections after a separate approved promotion/write PR',
+            'draft_payload' => 'current PR stores the complete importable draft only in revision snapshot contract output, not in DB',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function cmsRevisionDraftContract(): array
+    {
+        return [
+            'variant_pages' => [
+                'storage' => 'PersonalityProfileVariantRevision snapshot_json.mbti64_variant_content_package_v2_1',
+                'draft_identity' => 'org_id=0 + MBTI + locale + runtime_type_code',
+                'future_write_behavior' => 'create a draft revision only; do not promote live sections/SEO or publish in the same command',
+            ],
+            'comparison_pages' => [
+                'storage' => 'PersonalityProfileRevision snapshot_json.mbti64_comparison_draft_v2_1',
+                'draft_identity' => 'org_id=0 + MBTI + locale + canonical_type_code',
+                'future_write_behavior' => 'create a base-profile draft overlay; do not create a standalone comparison route/model in this patch',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function comparisonStorageContract(): array
+    {
+        return [
+            'current_runtime_truth' => 'comparison pages are not stored in a standalone CMS table in this patch',
+            'storage_decision' => 'store each comparison row as a draft overlay under the base PersonalityProfile revision snapshot',
+            'snapshot_key' => 'mbti64_comparison_draft_v2_1',
+            'why' => 'preserves exact comparison content without inventing runtime rendering behavior or schema migrations in this contract PR',
+            'promotion_requirement' => 'a later PR must add/confirm comparison read API/render contract before any publish/search release',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fieldMappingContract(): array
+    {
+        return [
+            'first_class_fields_for_variant_promotion' => self::FIRST_CLASS_VARIANT_FIELDS,
+            'structured_metadata_fields' => self::STRUCTURED_METADATA_FIELDS,
+            'unsupported_field_policy' => [
+                'decision' => 'structured_metadata_not_dropped',
+                'storage' => [
+                    'variant' => 'personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata',
+                    'comparison' => 'personality_profile_revisions.snapshot_json.mbti64_comparison_draft_v2_1.structured_metadata',
+                ],
+                'first_class_promotion_rule' => 'promote only through a later migration/model/API PR; do not silently map unsupported fields to unrelated columns',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function dryRunWriteGuardContract(): array
+    {
+        return [
+            'this_command_requires' => '--dry-run',
+            'this_command_refuses' => '--write',
+            'write_mode_available_in_this_pr' => false,
+            'future_write_minimum_required_flags' => [
+                '--write',
+                '--draft-only',
+                '--no-publish',
+                '--no-index',
+                '--no-sitemap',
+                '--no-llms',
+                '--no-search-release',
+                '--operator-approved',
+            ],
+            'hard_guards' => [
+                'writes_committed=false in this PR',
+                'publish_attempted=false',
+                'search_release_attempted=false',
+                'sitemap_llms_release_attempted=false',
+                'no published_at mutation',
+                'no public/indexable/sitemap/llms flags enabled',
+            ],
+        ];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $normalized = trim($path);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $parsedPath = (string) (parse_url($normalized, PHP_URL_PATH) ?: $normalized);
+        $parsedPath = '/'.ltrim($parsedPath, '/');
+
+        return $parsedPath !== '/' ? rtrim($parsedPath, '/') : $parsedPath;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json
+++ b/backend/docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json
@@ -1,0 +1,665 @@
+{
+    "artifact": "MBTI64-BACKEND-IMPORT-CONTRACT-PATCH-01",
+    "status": "pass",
+    "ok": true,
+    "dry_run_only": true,
+    "write_supported_in_this_pr": false,
+    "writes_committed": false,
+    "publish_attempted": false,
+    "search_release_attempted": false,
+    "sitemap_llms_release_attempted": false,
+    "source_version": "pilot-v2.1",
+    "source_status": "draft_for_codex_qa",
+    "expected_row_count": 8,
+    "row_count": 8,
+    "variant_row_count": 6,
+    "comparison_row_count": 2,
+    "row_order_locked": true,
+    "expected_urls": [
+        "/en/personality/intj-a-vs-intj-t",
+        "/zh/personality/istj-a",
+        "/en/personality/intp-a-vs-intp-t",
+        "/zh/personality/infp-t",
+        "/en/personality/intj-a",
+        "/en/personality/intj-t",
+        "/zh/personality/intj-a",
+        "/zh/personality/intj-t"
+    ],
+    "cms_revision_draft_contract": {
+        "variant_pages": {
+            "storage": "PersonalityProfileVariantRevision snapshot_json.mbti64_variant_content_package_v2_1",
+            "draft_identity": "org_id=0 + MBTI + locale + runtime_type_code",
+            "future_write_behavior": "create a draft revision only; do not promote live sections/SEO or publish in the same command"
+        },
+        "comparison_pages": {
+            "storage": "PersonalityProfileRevision snapshot_json.mbti64_comparison_draft_v2_1",
+            "draft_identity": "org_id=0 + MBTI + locale + canonical_type_code",
+            "future_write_behavior": "create a base-profile draft overlay; do not create a standalone comparison route/model in this patch"
+        }
+    },
+    "comparison_storage_contract": {
+        "current_runtime_truth": "comparison pages are not stored in a standalone CMS table in this patch",
+        "storage_decision": "store each comparison row as a draft overlay under the base PersonalityProfile revision snapshot",
+        "snapshot_key": "mbti64_comparison_draft_v2_1",
+        "why": "preserves exact comparison content without inventing runtime rendering behavior or schema migrations in this contract PR",
+        "promotion_requirement": "a later PR must add/confirm comparison read API/render contract before any publish/search release"
+    },
+    "field_mapping_contract": {
+        "first_class_fields_for_variant_promotion": [
+            "url",
+            "locale",
+            "page_type",
+            "canonical_target",
+            "seo.seo_title",
+            "seo.seo_description",
+            "seo.breadcrumb_title",
+            "seo.h1",
+            "seo.quick_answer_summary",
+            "content",
+            "faq",
+            "internal_links"
+        ],
+        "structured_metadata_fields": [
+            "primary_query",
+            "secondary_queries",
+            "excluded_queries",
+            "target_intent",
+            "target_test_route",
+            "method_boundary",
+            "trademark_boundary",
+            "information_gain",
+            "claim_risk_notes",
+            "qa_flags_for_codex",
+            "route_safety",
+            "v2_optimization",
+            "above_the_fold_module",
+            "serp_ctr_package_v2",
+            "status"
+        ],
+        "unsupported_field_policy": {
+            "decision": "structured_metadata_not_dropped",
+            "storage": {
+                "variant": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+                "comparison": "personality_profile_revisions.snapshot_json.mbti64_comparison_draft_v2_1.structured_metadata"
+            },
+            "first_class_promotion_rule": "promote only through a later migration/model/API PR; do not silently map unsupported fields to unrelated columns"
+        }
+    },
+    "dry_run_write_guard_contract": {
+        "this_command_requires": "--dry-run",
+        "this_command_refuses": "--write",
+        "write_mode_available_in_this_pr": false,
+        "future_write_minimum_required_flags": [
+            "--write",
+            "--draft-only",
+            "--no-publish",
+            "--no-index",
+            "--no-sitemap",
+            "--no-llms",
+            "--no-search-release",
+            "--operator-approved"
+        ],
+        "hard_guards": [
+            "writes_committed=false in this PR",
+            "publish_attempted=false",
+            "search_release_attempted=false",
+            "sitemap_llms_release_attempted=false",
+            "no published_at mutation",
+            "no public/indexable/sitemap/llms flags enabled"
+        ]
+    },
+    "rows": [
+        {
+            "position": 1,
+            "url": "/en/personality/intj-a-vs-intj-t",
+            "locale": "en",
+            "page_type": "comparison",
+            "canonical_target": "/en/personality/intj-a-vs-intj-t",
+            "identity": {
+                "canonical_type_code": "INTJ",
+                "variant_pair": [
+                    "INTJ-A",
+                    "INTJ-T"
+                ]
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileRevision",
+                "target_table": "personality_profile_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "canonical_type_code": "INTJ"
+                },
+                "standalone_comparison_model": false
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 comparison draft overlay: /en/personality/intj-a-vs-intj-t",
+                "snapshot_key": "mbti64_comparison_draft_v2_1",
+                "snapshot_owner": "base PersonalityProfile revision",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profiles lookup + personality_profile_revisions profile_id/revision_no/note",
+                "body_and_seo": "stored as structured draft overlay in snapshot_json until a comparison-specific first-class model exists"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_revisions.snapshot_json.mbti64_comparison_draft_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "side_by_side_summary",
+                "core_traits_comparison",
+                "stress_confidence",
+                "career_work_style",
+                "relationships_love",
+                "which_one_fits"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 2,
+            "url": "/zh/personality/istj-a",
+            "locale": "zh-CN",
+            "page_type": "variant",
+            "canonical_target": "/zh/personality/istj-a",
+            "identity": {
+                "canonical_type_code": "ISTJ",
+                "variant_code": "A",
+                "runtime_type_code": "ISTJ-A"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "ISTJ-A"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /zh/personality/istj-a",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "ISTJ-A",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 3,
+            "url": "/en/personality/intp-a-vs-intp-t",
+            "locale": "en",
+            "page_type": "comparison",
+            "canonical_target": "/en/personality/intp-a-vs-intp-t",
+            "identity": {
+                "canonical_type_code": "INTP",
+                "variant_pair": [
+                    "INTP-A",
+                    "INTP-T"
+                ]
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileRevision",
+                "target_table": "personality_profile_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "canonical_type_code": "INTP"
+                },
+                "standalone_comparison_model": false
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 comparison draft overlay: /en/personality/intp-a-vs-intp-t",
+                "snapshot_key": "mbti64_comparison_draft_v2_1",
+                "snapshot_owner": "base PersonalityProfile revision",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profiles lookup + personality_profile_revisions profile_id/revision_no/note",
+                "body_and_seo": "stored as structured draft overlay in snapshot_json until a comparison-specific first-class model exists"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_revisions.snapshot_json.mbti64_comparison_draft_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "side_by_side_summary",
+                "core_traits_comparison",
+                "stress_confidence",
+                "career_work_style",
+                "relationships_love",
+                "which_one_fits"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 4,
+            "url": "/zh/personality/infp-t",
+            "locale": "zh-CN",
+            "page_type": "variant",
+            "canonical_target": "/zh/personality/infp-t",
+            "identity": {
+                "canonical_type_code": "INFP",
+                "variant_code": "T",
+                "runtime_type_code": "INFP-T"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "INFP-T"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /zh/personality/infp-t",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "INFP-T",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 5,
+            "url": "/en/personality/intj-a",
+            "locale": "en",
+            "page_type": "variant",
+            "canonical_target": "/en/personality/intj-a",
+            "identity": {
+                "canonical_type_code": "INTJ",
+                "variant_code": "A",
+                "runtime_type_code": "INTJ-A"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "INTJ-A"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /en/personality/intj-a",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "INTJ-A",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 6,
+            "url": "/en/personality/intj-t",
+            "locale": "en",
+            "page_type": "variant",
+            "canonical_target": "/en/personality/intj-t",
+            "identity": {
+                "canonical_type_code": "INTJ",
+                "variant_code": "T",
+                "runtime_type_code": "INTJ-T"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "INTJ-T"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /en/personality/intj-t",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "INTJ-T",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 7,
+            "url": "/zh/personality/intj-a",
+            "locale": "zh-CN",
+            "page_type": "variant",
+            "canonical_target": "/zh/personality/intj-a",
+            "identity": {
+                "canonical_type_code": "INTJ",
+                "variant_code": "A",
+                "runtime_type_code": "INTJ-A"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "INTJ-A"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /zh/personality/intj-a",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "INTJ-A",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        },
+        {
+            "position": 8,
+            "url": "/zh/personality/intj-t",
+            "locale": "zh-CN",
+            "page_type": "variant",
+            "canonical_target": "/zh/personality/intj-t",
+            "identity": {
+                "canonical_type_code": "INTJ",
+                "variant_code": "T",
+                "runtime_type_code": "INTJ-T"
+            },
+            "target": {
+                "target_model": "App\\Models\\PersonalityProfileVariantRevision",
+                "target_table": "personality_profile_variant_revisions",
+                "lookup": {
+                    "org_id": 0,
+                    "scale_code": "MBTI",
+                    "locale": "row.locale",
+                    "runtime_type_code": "INTJ-T"
+                },
+                "companion_tables_for_future_promotion": [
+                    "personality_profile_variant_sections",
+                    "personality_profile_variant_seo_meta"
+                ]
+            },
+            "draft_revision": {
+                "revision_note": "mbti64 pilot-v2.1 variant draft: /zh/personality/intj-t",
+                "snapshot_key": "mbti64_variant_content_package_v2_1",
+                "snapshot_owner": "PersonalityProfileVariant revision",
+                "runtime_type_code": "INTJ-T",
+                "publish_visibility": "not_public_until_separate_publish_gate",
+                "search_visibility": "not_search_released_until_separate_search_gate"
+            },
+            "first_class_field_destinations": {
+                "identity": "personality_profile_variants lookup + personality_profile_variant_revisions personality_profile_variant_id/revision_no/note",
+                "seo": "planned destination: personality_profile_variant_seo_meta after a separate approved promotion/write PR",
+                "sections": "planned destination: personality_profile_variant_sections after a separate approved promotion/write PR",
+                "draft_payload": "current PR stores the complete importable draft only in revision snapshot contract output, not in DB"
+            },
+            "structured_metadata_snapshot_path": "personality_profile_variant_revisions.snapshot_json.mbti64_variant_content_package_v2_1.structured_metadata",
+            "content_section_keys": [
+                "quick_answer",
+                "meaning",
+                "a_t_difference",
+                "core_traits",
+                "strengths_blind_spots",
+                "careers_work_style",
+                "relationships_communication",
+                "common_misreads",
+                "similar_types"
+            ],
+            "seo_keys": [
+                "seo_title",
+                "seo_description",
+                "breadcrumb_title",
+                "h1",
+                "quick_answer_summary"
+            ],
+            "faq_count": 7,
+            "internal_link_count": 7,
+            "publish_state_after_import": {
+                "status": "draft",
+                "is_public": false,
+                "is_indexable": false,
+                "sitemap_eligible": false,
+                "llms_eligible": false,
+                "published_at": null
+            },
+            "write_mode_in_this_pr": "not_supported"
+        }
+    ],
+    "errors": [],
+    "warnings": [],
+    "package_path": "/Users/rainie/Desktop/mbti64-content-package-pilot-v2.1.json",
+    "command": "personality:mbti64-backend-import-contract"
+}

--- a/backend/docs/seo/mbti64-backend-import-contract-patch-01.md
+++ b/backend/docs/seo/mbti64-backend-import-contract-patch-01.md
@@ -1,0 +1,131 @@
+# MBTI64 Backend Import Contract Patch 01
+
+Date: 2026-06-18
+
+Status: PASS
+
+This PR is backend contract-only. It does not import CMS rows, publish pages,
+change sitemap/LLMS generation, or submit search surfaces.
+
+## Source Package
+
+- Input artifact: `mbti64-content-package-pilot-v2.1.json`
+- Rows validated: 8
+- Variant rows: 6
+- Comparison rows: 2
+- Row order: locked to the V2.1 8-page pilot queue
+- Generated contract artifact:
+  `backend/docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json`
+
+## CMS Draft Mapping
+
+### Variant Pages
+
+Variant pages map to `PersonalityProfileVariantRevision` draft snapshots:
+
+- Lookup identity: `org_id=0 + MBTI + locale + runtime_type_code`
+- Snapshot key: `mbti64_variant_content_package_v2_1`
+- Future promotion targets:
+  - `personality_profile_variant_sections`
+  - `personality_profile_variant_seo_meta`
+
+The current PR does not create revisions and does not promote live sections or
+SEO metadata.
+
+### Comparison Pages
+
+Comparison pages do not get a new standalone backend model in this PR.
+
+They map to a base `PersonalityProfileRevision` draft overlay:
+
+- Lookup identity: `org_id=0 + MBTI + locale + canonical_type_code`
+- Snapshot key: `mbti64_comparison_draft_v2_1`
+- Example: `/en/personality/intj-a-vs-intj-t` attaches to the `INTJ` base
+  profile revision as comparison draft metadata.
+
+A later runtime/API PR must explicitly consume this overlay before any
+comparison page can be published or search-released.
+
+## Field Policy
+
+Variant first-class promotion candidates:
+
+- `url`
+- `locale`
+- `page_type`
+- `canonical_target`
+- `seo.seo_title`
+- `seo.seo_description`
+- `seo.breadcrumb_title`
+- `seo.h1`
+- `seo.quick_answer_summary`
+- `content`
+- `faq`
+- `internal_links`
+
+Structured metadata fields:
+
+- `primary_query`
+- `secondary_queries`
+- `excluded_queries`
+- `target_intent`
+- `target_test_route`
+- `method_boundary`
+- `trademark_boundary`
+- `information_gain`
+- `claim_risk_notes`
+- `qa_flags_for_codex`
+- `route_safety`
+- `v2_optimization`
+- `above_the_fold_module`
+- `serp_ctr_package_v2`
+- `status`
+
+Unsupported fields are not dropped and are not silently mapped to unrelated
+columns. They remain under the row revision snapshot structured metadata until
+a later migration/model/API PR promotes them to first-class fields.
+
+## Write Guard
+
+The command introduced by this PR is:
+
+```bash
+php artisan personality:mbti64-backend-import-contract \
+  --package=/path/to/mbti64-content-package-pilot-v2.1.json \
+  --dry-run \
+  --json
+```
+
+Safety behavior:
+
+- `--dry-run` is required.
+- `--write` is intentionally unsupported and fails closed.
+- `writes_committed=false`
+- `publish_attempted=false`
+- `search_release_attempted=false`
+- `sitemap_llms_release_attempted=false`
+- no `published_at` mutation
+- no public/indexable/sitemap/llms flags enabled
+
+A later real write/import PR must require a separate operator-approved command
+with explicit draft-only and no-release flags.
+
+## Validation
+
+Commands run:
+
+```bash
+php -l backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php
+php -l backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php
+php -l backend/tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php
+php artisan test tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php --display-warnings
+php artisan personality:mbti64-backend-import-contract --package=/Users/rainie/Desktop/mbti64-content-package-pilot-v2.1.json --dry-run --json --output=docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json
+```
+
+Result:
+
+- Contract status: `pass`
+- Errors: 0
+- Warnings: 0
+- CMS writes: 0
+- Publish/search release: 0

--- a/backend/tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbti64BackendImportContractCommandTest extends TestCase
+{
+    public function test_dry_run_plans_exact_eight_row_v21_package_without_writes(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-backend-import-contract', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertTrue($payload['dry_run_only']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(8, $payload['row_count']);
+        $this->assertSame(6, $payload['variant_row_count']);
+        $this->assertSame(2, $payload['comparison_row_count']);
+        $this->assertTrue($payload['row_order_locked']);
+        $this->assertSame([], $payload['errors']);
+    }
+
+    public function test_comparison_rows_are_profile_revision_draft_overlays_not_standalone_models(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-backend-import-contract', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $comparison = $payload['rows'][0] ?? [];
+        $variant = $payload['rows'][1] ?? [];
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('comparison', $comparison['page_type'] ?? null);
+        $this->assertSame('App\\Models\\PersonalityProfileRevision', $comparison['target']['target_model'] ?? null);
+        $this->assertSame('mbti64_comparison_draft_v2_1', $comparison['draft_revision']['snapshot_key'] ?? null);
+        $this->assertFalse($comparison['target']['standalone_comparison_model'] ?? true);
+        $this->assertSame('variant', $variant['page_type'] ?? null);
+        $this->assertSame('App\\Models\\PersonalityProfileVariantRevision', $variant['target']['target_model'] ?? null);
+        $this->assertSame('mbti64_variant_content_package_v2_1', $variant['draft_revision']['snapshot_key'] ?? null);
+    }
+
+    public function test_command_requires_explicit_dry_run(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-backend-import-contract', [
+            '--package' => $packagePath,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('runtime_error', $payload['errors'][0]['code'] ?? null);
+        $this->assertStringContainsString('--dry-run is required', (string) ($payload['errors'][0]['message'] ?? ''));
+    }
+
+    public function test_command_refuses_write_mode(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-backend-import-contract', [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['write_supported_in_this_pr']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('--write is intentionally unsupported', (string) ($payload['errors'][0]['message'] ?? ''));
+    }
+
+    public function test_row_order_mismatch_blocks_contract_plan(): void
+    {
+        $package = $this->validPackage();
+        $package['rows'] = array_reverse($package['rows']);
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-backend-import-contract', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['row_order_locked']);
+        $this->assertSame('pilot_queue_order_mismatch', $payload['errors'][0]['code'] ?? null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $urls = [
+            ['/en/personality/intj-a-vs-intj-t', 'en', 'comparison'],
+            ['/zh/personality/istj-a', 'zh-CN', 'variant'],
+            ['/en/personality/intp-a-vs-intp-t', 'en', 'comparison'],
+            ['/zh/personality/infp-t', 'zh-CN', 'variant'],
+            ['/en/personality/intj-a', 'en', 'variant'],
+            ['/en/personality/intj-t', 'en', 'variant'],
+            ['/zh/personality/intj-a', 'zh-CN', 'variant'],
+            ['/zh/personality/intj-t', 'zh-CN', 'variant'],
+        ];
+
+        return [
+            'artifact' => 'mbti64-content-package-pilot-v2.1',
+            'version' => 'pilot-v2.1',
+            'status' => 'pass',
+            'rows' => array_map(fn (array $row): array => $this->row($row[0], $row[1], $row[2]), $urls),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function row(string $url, string $locale, string $pageType): array
+    {
+        return [
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'primary_query' => 'fixture query',
+            'secondary_queries' => ['fixture secondary'],
+            'excluded_queries' => ['fixture excluded'],
+            'target_intent' => 'fixture intent',
+            'target_test_route' => str_starts_with($url, '/zh/')
+                ? '/zh/tests/mbti-personality-test-16-personality-types'
+                : '/en/tests/mbti-personality-test-16-personality-types',
+            'canonical_target' => $url,
+            'seo' => [
+                'seo_title' => 'Fixture title',
+                'seo_description' => 'Fixture description.',
+                'breadcrumb_title' => 'Fixture',
+                'h1' => 'Fixture H1',
+                'quick_answer_summary' => 'Fixture summary.',
+            ],
+            'content' => [
+                'quick_answer' => 'Fixture answer.',
+                'method_boundary' => ['h2' => 'Method boundary', 'body' => 'Fixture boundary.'],
+            ],
+            'faq' => [
+                ['question' => 'Fixture question?', 'answer' => 'Fixture answer.'],
+            ],
+            'internal_links' => [
+                [
+                    'href' => str_starts_with($url, '/zh/') ? '/zh/personality' : '/en/personality',
+                    'anchor_text' => 'Personality hub',
+                    'role' => 'hub',
+                    'safe_public_route' => true,
+                ],
+            ],
+            'method_boundary' => 'Fixture method boundary.',
+            'trademark_boundary' => 'Fixture trademark boundary.',
+            'information_gain' => ['unique_user_value' => 'fixture'],
+            'claim_risk_notes' => ['No deterministic claims.'],
+            'qa_flags_for_codex' => ['Fixture QA.'],
+            'route_safety' => ['forbidden_route_patterns_absent_from_internal_links' => true],
+            'v2_optimization' => ['primary_improvement' => 'fixture'],
+            'above_the_fold_module' => ['answer_card_title' => 'Fixture'],
+            'status' => 'draft_for_codex_qa',
+            'serp_ctr_package_v2' => ['seo_title' => 'Fixture title'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $path = sys_get_temp_dir().'/mbti64-contract-'.bin2hex(random_bytes(6)).'.json';
+        File::put($path, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -288,6 +288,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti64_backend_import_contract_dry_run_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityMbti64BackendImportContract;',
+            '+        PersonalityMbti64BackendImportContract::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -3134,6 +3149,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbti64BackendImportContractFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -3903,6 +3922,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsIqNormImportDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4015,6 +4035,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php',
             'backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php',
+        ], true);
+    }
+
+    private function isMbti64BackendImportContractFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php',
+            'backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php',
         ], true);
     }
 
@@ -6037,6 +6065,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bNormsIqImport\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbti64BackendImportContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbti64BackendImportContract\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed

- Added `personality:mbti64-backend-import-contract`, a no-write dry-run command for the MBTI64 pilot V2.1 package.
- Added `Mbti64BackendImportContractPlanner` to validate the locked 8-row V2.1 queue and produce row-level CMS draft mapping.
- Documented exact storage decisions:
  - variant rows map to `PersonalityProfileVariantRevision` draft snapshots under `mbti64_variant_content_package_v2_1`
  - comparison rows map to base `PersonalityProfileRevision` draft overlays under `mbti64_comparison_draft_v2_1`
  - unsupported fields stay as structured metadata, not silently mapped to unrelated columns
- Added focused command tests for dry-run success, comparison overlay mapping, required `--dry-run`, `--write` fail-closed, and row order lock.
- Generated backend contract artifact for the provided 8-row V2.1 package.

## Why

The previous fap-web QA showed the V2.1 content package is content-valid, but backend import semantics were still conditional. This PR makes the backend contract precise before any CMS import PR:

- how all 8 rows become CMS revision drafts
- how comparison pages are stored without inventing a runtime model
- which fields are first-class vs structured metadata
- how dry-run/write flags prevent accidental CMS writes, publish, sitemap/LLMS, or search release

## Validation commands

```bash
php -l backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php
php -l backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php
php -l backend/tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php
php artisan list | rg 'personality:mbti64-backend-import-contract'
php artisan route:list --path=personality
php artisan test tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php --display-warnings
php artisan personality:mbti64-backend-import-contract --package=/Users/rainie/Desktop/mbti64-content-package-pilot-v2.1.json --dry-run --json --output=docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json
jq empty backend/docs/seo/generated/mbti64-backend-import-contract-patch-2026-06-18.json
git diff --check
git diff --cached --check
bash backend/scripts/ci_verify_mbti.sh
```

Results:

- V2.1 contract dry-run: `status=pass`, rows=8, variants=6, comparisons=2, warnings=0, errors=0.
- Focused command test: 5 passed, 39 assertions.
- `backend/scripts/ci_verify_mbti.sh`: passed.

## Intentionally deferred

- No CMS import/write.
- No publish.
- No sitemap or LLMS release.
- No search submission/release.
- No frontend rendering change.
- No comparison runtime/API model change.
- No MBTI result/scoring/payment/account/share/history route changes.

## Repository rule impact

Backend remains the authority layer for personality CMS content. This PR adds a dry-run/import contract only; runtime content authority and publish/search gates remain unchanged.
