### PR TITLE
Add article taxonomy hygiene command

### DIFF
--- a/backend/app/Console/Commands/ArticleTaxonomyHygiene.php
+++ b/backend/app/Console/Commands/ArticleTaxonomyHygiene.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\AuditLog;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+final class ArticleTaxonomyHygiene extends Command
+{
+    private const EXECUTE_SAFETY_FLAGS = [
+        'no_content_change',
+        'no_publish',
+        'no_search',
+        'no_schema_hreflang',
+        'no_sitemap_llms_change',
+        'no_revalidation',
+    ];
+
+    private const ARTICLE_CATEGORY_TARGETS = [
+        40 => '职业探索',
+        48 => '职业探索',
+        50 => '能力与认知',
+        51 => '人格心理学',
+        52 => '职业决策',
+    ];
+
+    protected $signature = 'articles:taxonomy-hygiene
+        {--article-ids= : Comma-separated article ids to lock}
+        {--expected-slugs= : Comma-separated expected slugs in article-id order}
+        {--dry-run : Validate and plan without writing}
+        {--execute : Execute the bounded taxonomy write}
+        {--json : Emit JSON}
+        {--no-content-change : Required for execute; confirms no body/editorial content mutation}
+        {--no-publish : Required for execute; confirms no publish/promote action}
+        {--no-search : Required for execute; confirms no search submission}
+        {--no-schema-hreflang : Required for execute; confirms no schema/hreflang writes}
+        {--no-sitemap-llms-change : Required for execute; confirms no sitemap/llms mutation}
+        {--no-revalidation : Required for execute; confirms no cache revalidation}';
+
+    protected $description = 'Controlled article taxonomy hygiene with article identity locks, dry-run, side-effect guards, and audit logging.';
+
+    public function handle(): int
+    {
+        $payload = $this->buildPayload();
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } elseif ((bool) ($payload['ok'] ?? false)) {
+            $this->info((string) ($payload['action'] ?? 'ok'));
+        } else {
+            $this->error((string) ($payload['action'] ?? 'failed'));
+        }
+
+        return (bool) ($payload['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildPayload(): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $errors = [];
+        $warnings = [];
+        $articleIds = $this->articleIds((string) $this->option('article-ids'), $errors);
+        $expectedSlugs = $this->expectedSlugs((string) $this->option('expected-slugs'), $errors);
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+        if ($articleIds !== [] && $expectedSlugs !== [] && count($expectedSlugs) !== count($articleIds)) {
+            $errors[] = $this->issue('expected_slugs', 'expected_slug_count_mismatch', 'expected-slugs must match article-ids count.');
+        }
+        if ($articleIds === []) {
+            $errors[] = $this->issue('article_ids', 'article_ids_required', '--article-ids is required.');
+        }
+        if ($expectedSlugs === []) {
+            $errors[] = $this->issue('expected_slugs', 'expected_slugs_required', '--expected-slugs is required.');
+        }
+        foreach ($articleIds as $id) {
+            if (! array_key_exists($id, self::ARTICLE_CATEGORY_TARGETS)) {
+                $errors[] = $this->issue('article_ids', 'article_not_in_taxonomy_hygiene_scope', 'Article id is not in the approved taxonomy hygiene scope.', ['article_id' => $id]);
+            }
+        }
+        if ($execute) {
+            foreach (self::EXECUTE_SAFETY_FLAGS as $flag) {
+                if ((bool) $this->option(str_replace('_', '-', $flag)) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        $articles = $this->resolveArticles($articleIds);
+        $this->validateLocks($articles, $articleIds, $expectedSlugs, $errors);
+        $categoryPlan = $this->categoryPlan($articleIds, $errors, $warnings);
+        $before = array_map(fn (Article $article): array => $this->articleSnapshot($article), $articles);
+        $after = array_map(fn (Article $article): array => $this->plannedArticleSnapshot($article, $categoryPlan), $articles);
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleIds, $before, $after, $categoryPlan, $errors, $warnings);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_apply_article_taxonomy_hygiene', $articleIds, $before, $after, $categoryPlan, [], $warnings);
+        }
+
+        DB::transaction(function () use ($articleIds, $expectedSlugs, &$after, &$categoryPlan): void {
+            $errors = [];
+            $warnings = [];
+            $locked = $this->resolveArticles($articleIds, true);
+            $this->validateLocks($locked, $articleIds, $expectedSlugs, $errors);
+            $categoryPlan = $this->categoryPlan($articleIds, $errors, $warnings, true);
+            if ($errors !== []) {
+                throw new \RuntimeException('Article taxonomy hygiene lock changed during execute.');
+            }
+
+            $targetCategories = $categoryPlan['target_categories'];
+            foreach ($locked as $article) {
+                $targetName = self::ARTICLE_CATEGORY_TARGETS[(int) $article->id];
+                $target = $targetCategories[$targetName] ?? null;
+                if (! is_array($target) || ! is_int($target['id'])) {
+                    throw new \RuntimeException('Target category could not be resolved during execute.');
+                }
+                $article->forceFill(['category_id' => $target['id']])->save();
+            }
+
+            $careerExploration = ArticleCategory::query()->withoutGlobalScopes()->find(11);
+            if ($careerExploration instanceof ArticleCategory) {
+                $careerExploration->forceFill(['name' => '职业探索'])->save();
+            }
+
+            $seoArticles = $this->seoArticlesCategory();
+            if ($seoArticles instanceof ArticleCategory && $this->remainingSeoArticlesReferences($articleIds) === 0) {
+                $seoArticles->forceFill(['is_active' => false])->save();
+            }
+
+            $fresh = $this->resolveArticles($articleIds);
+            $after = array_map(fn (Article $article): array => $this->articleSnapshot($article), $fresh);
+            $this->writeAudit($fresh, $categoryPlan);
+        });
+
+        return $this->summary(true, false, 'applied_article_taxonomy_hygiene', $articleIds, $before, $after, $categoryPlan, [], $warnings);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<int>
+     */
+    private function articleIds(string $value, array &$errors): array
+    {
+        $ids = array_values(array_filter(array_map(
+            static fn (string $item): string => trim($item),
+            explode(',', $value)
+        ), static fn (string $item): bool => $item !== ''));
+
+        $parsed = [];
+        foreach ($ids as $id) {
+            if (! ctype_digit($id) || (int) $id <= 0) {
+                $errors[] = $this->issue('article_ids', 'invalid_article_id', 'Article ids must be positive integers.', ['value' => $id]);
+
+                continue;
+            }
+            $parsed[] = (int) $id;
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<string>
+     */
+    private function expectedSlugs(string $value, array &$errors): array
+    {
+        $slugs = array_values(array_filter(array_map(
+            static fn (string $item): string => trim($item),
+            explode(',', $value)
+        ), static fn (string $item): bool => $item !== ''));
+
+        foreach ($slugs as $slug) {
+            if ($slug !== Str::slug($slug)) {
+                $errors[] = $this->issue('expected_slugs', 'invalid_expected_slug', 'Expected slugs must already be canonical slugs.', ['value' => $slug]);
+            }
+        }
+
+        return $slugs;
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<Article>
+     */
+    private function resolveArticles(array $ids, bool $lock = false): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $query = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'category' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'tags' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->whereIn('id', $ids);
+
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        /** @var list<Article> $articles */
+        $articles = $query->get()
+            ->sortBy(static fn (Article $article): int => array_search((int) $article->id, $ids, true))
+            ->values()
+            ->all();
+
+        return $articles;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  list<int>  $articleIds
+     * @param  list<string>  $expectedSlugs
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateLocks(array $articles, array $articleIds, array $expectedSlugs, array &$errors): void
+    {
+        $foundIds = array_map(static fn (Article $article): int => (int) $article->id, $articles);
+        foreach ($articleIds as $id) {
+            if (! in_array($id, $foundIds, true)) {
+                $errors[] = $this->issue('article_ids', 'article_not_found', 'Requested article id was not found.', ['article_id' => $id]);
+            }
+        }
+
+        foreach ($articles as $index => $article) {
+            $expectedSlug = $expectedSlugs[$index] ?? null;
+            if ($expectedSlug !== null && (string) $article->slug !== $expectedSlug) {
+                $errors[] = $this->issue('article.'.$article->id.'.slug', 'expected_slug_mismatch', 'Article slug does not match expected identity lock.', [
+                    'article_id' => (int) $article->id,
+                    'actual' => (string) $article->slug,
+                    'expected' => $expectedSlug,
+                ]);
+            }
+            if ((int) $article->org_id !== 0 || (string) $article->locale !== 'zh-CN') {
+                $errors[] = $this->issue('article.'.$article->id.'.locale', 'article_scope_mismatch', 'Taxonomy hygiene is limited to org 0 zh-CN articles.', [
+                    'article_id' => (int) $article->id,
+                    'org_id' => (int) $article->org_id,
+                    'locale' => (string) $article->locale,
+                ]);
+            }
+            if ((string) $article->status !== 'published' || ! (bool) $article->is_public || (int) $article->published_revision_id <= 0) {
+                $errors[] = $this->issue('article.'.$article->id.'.status', 'article_not_published_public', 'Taxonomy hygiene is limited to published public articles with a published revision.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function categoryPlan(array $articleIds, array &$errors, array &$warnings, bool $execute = false): array
+    {
+        $careerExploration = ArticleCategory::query()->withoutGlobalScopes()->find(11);
+        if (! $careerExploration instanceof ArticleCategory) {
+            $errors[] = $this->issue('category.11', 'category_not_found', 'Category id 11 is required for 职业探索.');
+        } elseif ((string) $careerExploration->slug !== 'career-exploration') {
+            $errors[] = $this->issue('category.11.slug', 'category_slug_mismatch', 'Category id 11 must keep slug career-exploration.', [
+                'actual' => (string) $careerExploration->slug,
+            ]);
+        }
+
+        $targets = [];
+        foreach (array_unique(array_values(self::ARTICLE_CATEGORY_TARGETS)) as $name) {
+            $category = $name === '职业探索'
+                ? $careerExploration
+                : ArticleCategory::query()->withoutGlobalScopes()->where('org_id', 0)->where('name', $name)->first();
+
+            if (! $category instanceof ArticleCategory && $name === '能力与认知' && $execute) {
+                $category = ArticleCategory::query()->withoutGlobalScopes()->create([
+                    'org_id' => 0,
+                    'slug' => 'ability-cognition',
+                    'name' => '能力与认知',
+                    'is_active' => true,
+                    'sort_order' => 0,
+                ]);
+            }
+
+            if (! $category instanceof ArticleCategory && $name !== '能力与认知') {
+                $errors[] = $this->issue('category.'.$name, 'target_category_not_found', 'Required target category was not found.', [
+                    'category_name' => $name,
+                ]);
+            }
+
+            $targets[$name] = [
+                'id' => $category instanceof ArticleCategory ? (int) $category->id : null,
+                'name' => $name,
+                'slug' => $category instanceof ArticleCategory ? (string) $category->slug : ($name === '能力与认知' ? 'ability-cognition' : null),
+                'exists' => $category instanceof ArticleCategory,
+                'would_create' => ! $category instanceof ArticleCategory && $name === '能力与认知',
+            ];
+        }
+
+        $seoArticles = $this->seoArticlesCategory();
+        $remainingSeoArticlesReferences = $this->remainingSeoArticlesReferences($articleIds);
+        if ($seoArticles instanceof ArticleCategory && $remainingSeoArticlesReferences > 0) {
+            $warnings[] = $this->issue('category.seo-articles', 'seo_articles_references_remaining', 'SEO Articles category still has public article references outside this hygiene scope.', [
+                'remaining_public_references' => $remainingSeoArticlesReferences,
+            ]);
+        }
+
+        return [
+            'category_11' => [
+                'before' => $careerExploration instanceof ArticleCategory ? $this->categorySnapshot($careerExploration) : null,
+                'after' => $careerExploration instanceof ArticleCategory ? array_merge($this->categorySnapshot($careerExploration), ['name' => '职业探索']) : null,
+            ],
+            'target_categories' => $targets,
+            'seo_articles_category' => [
+                'before' => $seoArticles instanceof ArticleCategory ? $this->categorySnapshot($seoArticles) : null,
+                'after' => $seoArticles instanceof ArticleCategory
+                    ? array_merge($this->categorySnapshot($seoArticles), ['is_active' => $remainingSeoArticlesReferences === 0 ? false : (bool) $seoArticles->is_active])
+                    : null,
+                'remaining_public_references_after_plan' => $remainingSeoArticlesReferences,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $categoryPlan
+     * @return array<string,mixed>
+     */
+    private function plannedArticleSnapshot(Article $article, array $categoryPlan): array
+    {
+        $snapshot = $this->articleSnapshot($article);
+        $targetName = self::ARTICLE_CATEGORY_TARGETS[(int) $article->id] ?? null;
+        $target = is_string($targetName) ? ($categoryPlan['target_categories'][$targetName] ?? null) : null;
+        if (is_array($target)) {
+            $snapshot['category'] = [
+                'id' => $target['id'],
+                'slug' => $target['slug'],
+                'name' => $target['name'],
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function articleSnapshot(Article $article): array
+    {
+        return [
+            'id' => (int) $article->id,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'published_revision_id' => $article->published_revision_id !== null ? (int) $article->published_revision_id : null,
+            'content_hash' => hash('sha256', (string) $article->content_md),
+            'category' => $article->category instanceof ArticleCategory ? $this->categorySnapshot($article->category) : null,
+            'first_visible_tags' => $article->tags->take(3)->map(static fn ($tag): array => [
+                'id' => (int) $tag->id,
+                'slug' => (string) $tag->slug,
+                'name' => (string) $tag->name,
+            ])->values()->all(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function categorySnapshot(ArticleCategory $category): array
+    {
+        return [
+            'id' => (int) $category->id,
+            'slug' => (string) $category->slug,
+            'name' => (string) $category->name,
+            'is_active' => (bool) $category->is_active,
+        ];
+    }
+
+    private function seoArticlesCategory(): ?ArticleCategory
+    {
+        return ArticleCategory::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where(static function ($query): void {
+                $query->where('slug', 'seo-articles')->orWhere('name', 'SEO Articles');
+            })
+            ->first();
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     */
+    private function remainingSeoArticlesReferences(array $articleIds): int
+    {
+        $category = $this->seoArticlesCategory();
+        if (! $category instanceof ArticleCategory) {
+            return 0;
+        }
+
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('category_id', (int) $category->id)
+            ->where('locale', 'zh-CN')
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->whereNotIn('id', $articleIds)
+            ->count();
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  array<string,mixed>  $categoryPlan
+     */
+    private function writeAudit(array $articles, array $categoryPlan): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        AuditLog::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'articles_taxonomy_hygiene',
+            'target_type' => 'articles',
+            'target_id' => implode(',', array_map(static fn (Article $article): string => (string) $article->id, $articles)),
+            'meta_json' => [
+                'command' => 'articles:taxonomy-hygiene',
+                'article_ids' => array_map(static fn (Article $article): int => (int) $article->id, $articles),
+                'category_plan' => $categoryPlan,
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_sitemap_llms_change' => true,
+                'no_revalidation' => true,
+            ],
+            'ip' => null,
+            'user_agent' => 'artisan',
+            'request_id' => null,
+            'reason' => 'seo_article_taxonomy_hygiene',
+            'result' => 'success',
+            'created_at' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @param  array<string,mixed>  $categoryPlan
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(
+        bool $ok,
+        bool $dryRun,
+        string $action,
+        array $articleIds,
+        array $before,
+        array $after,
+        array $categoryPlan,
+        array $errors,
+        array $warnings
+    ): array {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok,
+            'article_ids' => $articleIds,
+            'safety_flags' => [
+                'content_change' => false,
+                'publish_or_promote' => false,
+                'search_submission' => false,
+                'schema_hreflang_write' => false,
+                'sitemap_llms_mutation' => false,
+                'revalidation' => false,
+            ],
+            'before' => $before,
+            'after' => $after,
+            'category_plan' => $categoryPlan,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $context);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -11,6 +11,7 @@ use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 use App\Console\Commands\ArticleReplaceInlineImageUrl;
 use App\Console\Commands\ArticleSeoGateRollout;
+use App\Console\Commands\ArticleTaxonomyHygiene;
 use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\Big5AttemptPurge;
@@ -341,6 +342,7 @@ class Kernel extends ConsoleKernel
         ArticlePublishControlled::class,
         ArticleReplaceInlineImageUrl::class,
         ArticleSeoGateRollout::class,
+        ArticleTaxonomyHygiene::class,
         ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoIntelUrlTruthHandoffCommand::class,

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -169,7 +169,11 @@ final class SeoContentPackageDraftImporter
             throw new RuntimeException('Existing published/public article cannot be mutated by SEO content package draft import.');
         }
 
-        $category = $this->resolveCategory();
+        $category = $this->resolveCategory(
+            (string) $item['category_name'],
+            (string) $item['category_slug'],
+            (string) $item['locale'],
+        );
         $metadata = $this->normalizedJsonForWrite('article.cover_image_variants', $this->metadata($item));
         $body = (string) $item['body_markdown'];
 
@@ -855,6 +859,8 @@ final class SeoContentPackageDraftImporter
             'locale' => $locale,
             'translation_group_id' => $translationGroupId,
             'slug' => $slug,
+            'category_name' => $this->firstString($import['category_name'] ?? null, $import['category'] ?? null, $fields['category_name'] ?? null, $fields['category'] ?? null, $frontmatter['category_name'] ?? null, $frontmatter['category'] ?? null, $manifestPage['category_name'] ?? null, $manifestPage['category'] ?? null, $manifest['category_name'] ?? null, $manifest['category'] ?? null),
+            'category_slug' => $this->firstString($import['category_slug'] ?? null, $fields['category_slug'] ?? null, $frontmatter['category_slug'] ?? null, $manifestPage['category_slug'] ?? null),
             'title' => $title,
             'meta_title' => $metaTitle,
             'meta_description' => $metaDescription,
@@ -937,6 +943,7 @@ final class SeoContentPackageDraftImporter
         if (! str_starts_with((string) $item['canonical_url'], $locale === 'zh-CN' ? '/zh/articles/' : '/en/articles/')) {
             $errors[] = $this->issue($locale.'.canonical_url', 'invalid_canonical_route', 'canonical_url must be a locale article route.');
         }
+        $this->validateReaderFacingCategory($item, $errors);
         if ((string) $item['cover_media_asset_key'] === '' || (string) $item['cover_image_url'] === '' || (string) $item['og_image_url'] === '') {
             $errors[] = $this->issue($locale.'.social_image_metadata', 'missing_social_image_metadata', 'social image asset, cover URL, and OG URL are required.');
         }
@@ -985,12 +992,102 @@ final class SeoContentPackageDraftImporter
             || $article->published_at !== null;
     }
 
-    private function resolveCategory(): ArticleCategory
+    private function resolveCategory(string $categoryName, string $categorySlug, string $locale): ArticleCategory
     {
+        $name = trim($categoryName);
+        if ($name !== '') {
+            $existing = ArticleCategory::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('name', $name)
+                ->first();
+
+            if ($existing instanceof ArticleCategory) {
+                if (! (bool) $existing->is_active) {
+                    $existing->forceFill(['is_active' => true])->save();
+                }
+
+                return $existing;
+            }
+
+            $slug = $this->uniqueCategorySlug($categorySlug !== '' ? $categorySlug : $name);
+
+            return ArticleCategory::query()->withoutGlobalScopes()->create([
+                'org_id' => 0,
+                'slug' => $slug,
+                'name' => $name,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]);
+        }
+
+        if ($locale === 'zh-CN') {
+            throw new RuntimeException('Reader-facing zh category is required before importing SEO content package draft.');
+        }
+
         return ArticleCategory::query()->withoutGlobalScopes()->firstOrCreate(
             ['org_id' => 0, 'slug' => 'seo-articles'],
             ['name' => 'SEO Articles', 'is_active' => true, 'sort_order' => 0]
         );
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateReaderFacingCategory(array $item, array &$errors): void
+    {
+        $locale = (string) $item['locale'];
+        if ($locale !== 'zh-CN') {
+            return;
+        }
+
+        $category = trim((string) ($item['category_name'] ?? ''));
+        if ($category === '') {
+            $errors[] = $this->issue($locale.'.category', 'category_required', 'zh-CN SEO articles require a reader-facing category name.');
+
+            return;
+        }
+
+        if (! $this->containsHan($category)) {
+            $errors[] = $this->issue($locale.'.category', 'category_reader_facing_label_required', 'zh-CN SEO article category must be a Chinese-facing display label.');
+        }
+
+        if ($this->isInternalVisibleCategoryName($category)) {
+            $errors[] = $this->issue($locale.'.category', 'internal_visible_category_forbidden', 'Visible zh article category cannot be SEO Articles, snake_case, or an internal taxonomy label.');
+        }
+    }
+
+    private function containsHan(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
+    }
+
+    private function isInternalVisibleCategoryName(string $value): bool
+    {
+        $normalized = strtolower(trim($value));
+        if (in_array($normalized, ['seo articles', 'seo-articles', 'career_exploration', 'career-exploration'], true)) {
+            return true;
+        }
+
+        return preg_match('/^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/', $normalized) === 1;
+    }
+
+    private function uniqueCategorySlug(string $seed): string
+    {
+        $base = Str::slug($seed);
+        if ($base === '') {
+            $base = 'article-category-'.substr(hash('sha256', $seed), 0, 10);
+        }
+
+        $slug = $base;
+        $suffix = 2;
+        while (ArticleCategory::query()->withoutGlobalScopes()->where('org_id', 0)->where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -83,6 +83,44 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 
+    public function test_dry_run_rejects_internal_visible_zh_category_name(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json']['category_name'] = 'SEO Articles';
+            $files['cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json']['category_name'] = 'SEO Articles';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'category_reader_facing_label_required');
+        $this->assertErrorCode($payload, 'internal_visible_category_forbidden');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_snake_case_zh_category_name(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json']['category_name'] = 'career_exploration';
+            $files['cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json']['category_name'] = 'career_exploration';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'category_reader_facing_label_required');
+        $this->assertErrorCode($payload, 'internal_visible_category_forbidden');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
     public function test_dry_run_accepts_old_big_five_alias_key_with_canonical_value(): void
     {
         $package = $this->writeModeCPackage(static function (array &$files): void {
@@ -654,6 +692,8 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
             'sitemap_eligible' => false,
             'llms_eligible' => false,
             'claim_gate_status' => 'not_reviewed',
+            'category_name' => '职业决策',
+            'category_slug' => 'career-decision-making',
             'primary_keyword' => 'career interest test vs personality test',
             'secondary_keywords' => ['Holland Code vs MBTI', 'career assessment vs personality assessment'],
             'primary_hub_url' => '/tests/holland-career-interest-test-riasec',
@@ -711,6 +751,8 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
             ]),
             'cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
                 'locale' => 'en',
+                'category_name' => 'Career Decision-Making',
+                'category_slug' => 'career-decision-making',
                 'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
                 'slug' => 'career-interest-test-vs-personality-test',
                 'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',
@@ -728,6 +770,8 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
             ]),
             'cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
                 'locale' => 'en',
+                'category_name' => 'Career Decision-Making',
+                'category_slug' => 'career-decision-making',
                 'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
                 'slug' => 'career-interest-test-vs-personality-test',
                 'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',

--- a/backend/tests/Feature/Console/ArticleTaxonomyHygieneCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleTaxonomyHygieneCommandTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleTaxonomyHygieneCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered_for_production_artisan_path(): void
+    {
+        $this->assertArrayHasKey('articles:taxonomy-hygiene', Artisan::all());
+    }
+
+    public function test_dry_run_plans_taxonomy_hygiene_without_database_writes(): void
+    {
+        $this->seedTaxonomy();
+        $article = $this->createPublishedArticle(52, 'college-major-choice-holland-mbti-career-test', 14);
+        $this->attachTag($article, 'RIASEC');
+
+        $exitCode = Artisan::call('articles:taxonomy-hygiene', [
+            '--article-ids' => '52',
+            '--expected-slugs' => 'college-major-choice-holland-mbti-career-test',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_apply_article_taxonomy_hygiene', $payload['action']);
+        $this->assertSame('SEO Articles', data_get($payload, 'before.0.category.name'));
+        $this->assertSame('职业决策', data_get($payload, 'after.0.category.name'));
+        $this->assertSame('career_exploration', data_get($payload, 'category_plan.category_11.before.name'));
+        $this->assertSame('职业探索', data_get($payload, 'category_plan.category_11.after.name'));
+        $this->assertSame('RIASEC', data_get($payload, 'after.0.first_visible_tags.0.name'));
+
+        $this->assertSame(14, (int) $article->fresh()->category_id);
+        $this->assertSame('career_exploration', (string) ArticleCategory::query()->withoutGlobalScopes()->findOrFail(11)->name);
+        $this->assertTrue((bool) ArticleCategory::query()->withoutGlobalScopes()->findOrFail(14)->is_active);
+        $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_taxonomy_hygiene')->count());
+    }
+
+    public function test_execute_applies_bounded_taxonomy_hygiene_without_content_or_publish_changes(): void
+    {
+        $this->seedTaxonomy();
+        $articles = [
+            $this->createPublishedArticle(40, 'riasec-holland-career-interest-test-explained', 11),
+            $this->createPublishedArticle(48, 'big-five-tool-guide', 14),
+            $this->createPublishedArticle(50, 'iq-test-score-and-limits-explained', 14),
+            $this->createPublishedArticle(51, 'enneagram-personality-test-explained', 14),
+            $this->createPublishedArticle(52, 'college-major-choice-holland-mbti-career-test', 14),
+        ];
+        $contentHashes = collect($articles)->mapWithKeys(
+            static fn (Article $article): array => [(int) $article->id => hash('sha256', (string) $article->content_md)]
+        )->all();
+        $publishedRevisionIds = collect($articles)->mapWithKeys(
+            static fn (Article $article): array => [(int) $article->id => (int) $article->published_revision_id]
+        )->all();
+
+        $exitCode = Artisan::call('articles:taxonomy-hygiene', [
+            '--article-ids' => '40,48,50,51,52',
+            '--expected-slugs' => 'riasec-holland-career-interest-test-explained,big-five-tool-guide,iq-test-score-and-limits-explained,enneagram-personality-test-explained,college-major-choice-holland-mbti-career-test',
+            '--execute' => true,
+            '--json' => true,
+            '--no-content-change' => true,
+            '--no-publish' => true,
+            '--no-search' => true,
+            '--no-schema-hreflang' => true,
+            '--no-sitemap-llms-change' => true,
+            '--no-revalidation' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('applied_article_taxonomy_hygiene', $payload['action']);
+
+        $this->assertSame('职业探索', (string) ArticleCategory::query()->withoutGlobalScopes()->findOrFail(11)->name);
+        $this->assertSame('career-exploration', (string) ArticleCategory::query()->withoutGlobalScopes()->findOrFail(11)->slug);
+        $this->assertFalse((bool) ArticleCategory::query()->withoutGlobalScopes()->findOrFail(14)->is_active);
+        $ability = ArticleCategory::query()->withoutGlobalScopes()->where('name', '能力与认知')->firstOrFail();
+        $this->assertSame('ability-cognition', (string) $ability->slug);
+
+        $expectedCategoryNames = [
+            40 => '职业探索',
+            48 => '职业探索',
+            50 => '能力与认知',
+            51 => '人格心理学',
+            52 => '职业决策',
+        ];
+        foreach ($expectedCategoryNames as $articleId => $categoryName) {
+            $fresh = Article::query()->withoutGlobalScopes()->with('category')->findOrFail($articleId);
+            $this->assertSame($categoryName, (string) $fresh->category?->name);
+            $this->assertSame($contentHashes[$articleId], hash('sha256', (string) $fresh->content_md));
+            $this->assertSame($publishedRevisionIds[$articleId], (int) $fresh->published_revision_id);
+            $this->assertSame('published', (string) $fresh->status);
+            $this->assertTrue((bool) $fresh->is_public);
+        }
+
+        $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_taxonomy_hygiene')->first();
+        $this->assertInstanceOf(AuditLog::class, $audit);
+        $this->assertSame('40,48,50,51,52', (string) $audit->target_id);
+        $this->assertSame('articles:taxonomy-hygiene', data_get($audit->meta_json, 'command'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_content_change'));
+    }
+
+    public function test_execute_requires_safety_flags_and_slug_locks(): void
+    {
+        $this->seedTaxonomy();
+        $this->createPublishedArticle(52, 'college-major-choice-holland-mbti-career-test', 14);
+
+        $exitCode = Artisan::call('articles:taxonomy-hygiene', [
+            '--article-ids' => '52',
+            '--expected-slugs' => 'wrong-slug',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'expected_slug_mismatch');
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+    }
+
+    private function seedTaxonomy(): void
+    {
+        DB::table('article_categories')->insert([
+            ['id' => 1, 'org_id' => 0, 'slug' => 'personality-psychology', 'name' => '人格心理学', 'description' => null, 'sort_order' => 1, 'is_active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['id' => 8, 'org_id' => 0, 'slug' => 'career-decision-making', 'name' => '职业决策', 'description' => null, 'sort_order' => 8, 'is_active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['id' => 11, 'org_id' => 0, 'slug' => 'career-exploration', 'name' => 'career_exploration', 'description' => null, 'sort_order' => 11, 'is_active' => true, 'created_at' => now(), 'updated_at' => now()],
+            ['id' => 14, 'org_id' => 0, 'slug' => 'seo-articles', 'name' => 'SEO Articles', 'description' => null, 'sort_order' => 14, 'is_active' => true, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    private function createPublishedArticle(int $id, string $slug, int $categoryId): Article
+    {
+        /** @var Article $article */
+        $article = Model::unguarded(fn (): Article => Article::query()->withoutGlobalScopes()->create([
+            'id' => $id,
+            'org_id' => 0,
+            'category_id' => $categoryId,
+            'author_admin_user_id' => null,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 8,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_'.$slug,
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => 'Article '.$id,
+            'excerpt' => 'Excerpt '.$id,
+            'content_md' => '# Article '.$id."\n\nBody.",
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => Carbon::create(2026, 6, 18, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+        ]));
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = Model::unguarded(fn (): ArticleTranslationRevision => ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
+        ]));
+
+        $article->forceFill(['published_revision_id' => (int) $revision->id])->save();
+
+        return $article->fresh(['category', 'tags']) ?? $article;
+    }
+
+    private function attachTag(Article $article, string $name): void
+    {
+        /** @var ArticleTag $tag */
+        $tag = Model::unguarded(fn (): ArticleTag => ArticleTag::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => Str::slug($name),
+            'name' => $name,
+            'is_active' => true,
+        ]));
+
+        DB::table('article_tag_map')->insert([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'tag_id' => (int) $tag->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['errors'] ?? [])
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4245,6 +4245,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php',
+            'backend/app/Console/Commands/ArticleTaxonomyHygiene.php',
             'backend/app/Console/Commands/ArticleUpdateExistingSeoContentPackage.php',
         ], true)
             || str_starts_with($file, 'backend/app/Services/Cms/SeoContentPackage/');
@@ -5953,7 +5954,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Add a controlled `articles:taxonomy-hygiene` Artisan command for bounded article category cleanup with dry-run/execute modes, article id + slug locks, no-side-effect execute guards, JSON output, and audit logging.
- Normalize future Mode C SEO draft imports to use package-provided reader-facing categories instead of hardcoded `SEO Articles` for zh articles.
- Add regression coverage for the hygiene command and zh category guardrails.

## Validation
- `php artisan test --filter=ArticleTaxonomyHygieneCommandTest` (passes with existing Vite manifest warnings)
- `php artisan test --filter=ArticleImportSeoContentPackageDraftCommandTest` (passes with existing Vite manifest warnings)
- `php artisan list --no-ansi | rg "articles:taxonomy-hygiene|articles:import-seo-content-package-draft"`
- `./vendor/bin/pint --test app/Console/Commands/ArticleTaxonomyHygiene.php app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php tests/Feature/Console/ArticleTaxonomyHygieneCommandTest.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
- `git diff --check`

## Intentionally deferred
- No production taxonomy write in this PR.
- No content body changes, publish/promote, search submission, schema/hreflang writes, sitemap/llms mutation, or revalidation.
- Production dry-run/execute and affected path revalidation require separate deployment and exact operator authorization.