### PR TITLE
MBTI64-CMS-REVISION-DRAFT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\Mbti64CmsRevisionDraftWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbti64CmsRevisionDraft extends Command
+{
+    private const OPERATOR_APPROVAL = 'MBTI64-CMS-REVISION-DRAFT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'draft-only',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:mbti64-cms-revision-draft
+        {--package= : Path to the MBTI64 pilot V2.1 JSON package}
+        {--dry-run : Validate and plan without database writes}
+        {--write : Create CMS draft revision rows}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--draft-only : Required for --write; confirms revision draft only}
+        {--no-publish : Required for --write; confirms no publish action}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Create MBTI64 pilot V2.1 CMS revision drafts with explicit no-publish/no-index guards.';
+
+    public function handle(Mbti64CmsRevisionDraftWriter $writer): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(Mbti64CmsRevisionDraftWriter $writer): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = $this->resolvePath($packagePath);
+        $raw = (string) File::get($resolved);
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        $summary = $write
+            ? $writer->write($decoded, hash('sha256', $raw), $this->optionsPayload())
+            : $writer->plan($decoded, hash('sha256', $raw), $this->optionsPayload());
+
+        return array_merge($summary, [
+            'package_path' => $resolved,
+            'command' => 'personality:mbti64-cms-revision-draft',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path): string
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'draft_only' => (bool) $this->option('draft-only'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_index' => (bool) $this->option('no-index'),
+            'no_sitemap' => (bool) $this->option('no-sitemap'),
+            'no_llms' => (bool) $this->option('no-llms'),
+            'no_search_release' => (bool) $this->option('no-search-release'),
+            'operator_approved' => (string) $this->option('operator-approved'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('created_revision_count='.(string) ($summary['created_revision_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'MBTI64-CMS-REVISION-DRAFT-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_committed' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -156,6 +156,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
+use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
@@ -190,6 +191,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
+        PersonalityMbti64CmsRevisionDraft::class,
         PersonalityMbti64BackendImportContract::class,
         MetricsWeeklyValidity::class,
         MbtiPrewarm::class,

--- a/backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use Illuminate\Support\Facades\DB;
+
+final class Mbti64CmsRevisionDraftWriter
+{
+    private const VARIANT_SNAPSHOT_KEY = 'mbti64_variant_content_package_v2_1';
+
+    private const COMPARISON_SNAPSHOT_KEY = 'mbti64_comparison_draft_v2_1';
+
+    private const STRUCTURED_METADATA_FIELDS = [
+        'primary_query',
+        'secondary_queries',
+        'excluded_queries',
+        'target_intent',
+        'target_test_route',
+        'method_boundary',
+        'trademark_boundary',
+        'information_gain',
+        'claim_risk_notes',
+        'qa_flags_for_codex',
+        'route_safety',
+        'v2_optimization',
+        'above_the_fold_module',
+        'serp_ctr_package_v2',
+        'status',
+    ];
+
+    public function __construct(private readonly Mbti64BackendImportContractPlanner $planner)
+    {
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, string $sourceSha256, array $options = []): array
+    {
+        return $this->buildSummary($package, $sourceSha256, false, $options);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function write(array $package, string $sourceSha256, array $options = []): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $sourceSha256, true, $options));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, string $sourceSha256, bool $write, array $options): array
+    {
+        $contract = $this->planner->plan($package);
+        if (($contract['ok'] ?? false) !== true) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'contract' => $contract,
+                'errors' => $contract['errors'] ?? [],
+                'warnings' => $contract['warnings'] ?? [],
+            ]);
+        }
+
+        $preparedRows = [];
+        $errors = [];
+        foreach ((array) ($contract['rows'] ?? []) as $plannedRow) {
+            if (! is_array($plannedRow)) {
+                continue;
+            }
+
+            $row = $this->packageRow($package, (int) ($plannedRow['position'] ?? 0));
+            $preparedRows[] = $this->prepareRow($plannedRow, $row, $package, $sourceSha256, $write, $errors);
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'contract' => $contract,
+                'rows' => $preparedRows,
+                'errors' => $errors,
+                'warnings' => $contract['warnings'] ?? [],
+            ]);
+        }
+
+        $created = 0;
+        $skippedExisting = 0;
+        if ($write) {
+            foreach ($preparedRows as &$preparedRow) {
+                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                    $preparedRow['action'] = 'skipped_existing';
+                    $skippedExisting++;
+
+                    continue;
+                }
+
+                $revision = $this->createRevision($preparedRow);
+                $preparedRow['action'] = 'created';
+                $preparedRow['created_revision_id'] = (int) $revision->id;
+                $preparedRow['created_revision_no'] = (int) $revision->revision_no;
+                $created++;
+            }
+            unset($preparedRow);
+        } else {
+            foreach ($preparedRows as &$preparedRow) {
+                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                    $preparedRow['action'] = 'would_skip_existing';
+                    $skippedExisting++;
+
+                    continue;
+                }
+
+                $preparedRow['action'] = 'would_create';
+            }
+            unset($preparedRow);
+        }
+
+        return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'contract' => $contract,
+            'row_count' => count($preparedRows),
+            'variant_row_count' => count(array_filter(
+                $preparedRows,
+                static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant'
+            )),
+            'comparison_row_count' => count(array_filter(
+                $preparedRows,
+                static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison'
+            )),
+            'created_revision_count' => $created,
+            'skipped_existing_count' => $skippedExisting,
+            'would_create_revision_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
+            'writes_committed' => $write && $created > 0,
+            'rows' => $preparedRows,
+            'errors' => [],
+            'warnings' => $contract['warnings'] ?? [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'MBTI64-CMS-REVISION-DRAFT-01',
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'draft_only' => true,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function packageRow(array $package, int $position): array
+    {
+        $rows = is_array($package['rows'] ?? null) ? array_values((array) $package['rows']) : [];
+        $row = $rows[$position - 1] ?? [];
+
+        return is_array($row) ? $row : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plannedRow
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $package
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function prepareRow(
+        array $plannedRow,
+        array $row,
+        array $package,
+        string $sourceSha256,
+        bool $write,
+        array &$errors,
+    ): array {
+        $pageType = (string) ($plannedRow['page_type'] ?? '');
+        $snapshotKey = $pageType === 'comparison' ? self::COMPARISON_SNAPSHOT_KEY : self::VARIANT_SNAPSHOT_KEY;
+        $target = $this->targetRecord($plannedRow);
+        $targetId = $target['id'] ?? null;
+        $targetField = $pageType === 'comparison' ? 'profile_id' : 'personality_profile_variant_id';
+
+        if (! is_int($targetId)) {
+            $errors[] = [
+                'field' => 'rows.'.((string) ((int) ($plannedRow['position'] ?? 0) - 1)).'.url',
+                'code' => 'target_not_found',
+                'message' => 'CMS target record was not found for '.$pageType.' row '.((string) ($plannedRow['url'] ?? '')),
+            ];
+        }
+
+        $existingRevision = is_int($targetId)
+            ? $this->existingRevision($pageType, $targetField, $targetId, $snapshotKey, $sourceSha256)
+            : null;
+        $nextRevisionNo = is_int($targetId)
+            ? $this->nextRevisionNo($pageType, $targetField, $targetId)
+            : null;
+
+        return [
+            'position' => (int) ($plannedRow['position'] ?? 0),
+            'url' => (string) ($plannedRow['url'] ?? ''),
+            'locale' => (string) ($plannedRow['locale'] ?? ''),
+            'page_type' => $pageType,
+            'identity' => $plannedRow['identity'] ?? [],
+            'target_table' => (string) (($plannedRow['target']['target_table'] ?? '')),
+            'target_id' => $targetId,
+            'snapshot_key' => $snapshotKey,
+            'source_sha256' => $sourceSha256,
+            'existing_revision_id' => $existingRevision?->id !== null ? (int) $existingRevision->id : null,
+            'existing_revision_no' => $existingRevision?->revision_no !== null ? (int) $existingRevision->revision_no : null,
+            'next_revision_no' => $nextRevisionNo,
+            'write_mode' => $write ? 'write_draft_revision' : 'dry_run',
+            'action' => 'pending',
+            'snapshot_preview' => $this->snapshotPayload($snapshotKey, $row, $package, $plannedRow, $sourceSha256),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plannedRow
+     * @return array{id?:int}
+     */
+    private function targetRecord(array $plannedRow): array
+    {
+        $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+        $locale = (string) ($plannedRow['locale'] ?? '');
+
+        $profile = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('locale', $locale)
+            ->where('canonical_type_code', (string) ($identity['canonical_type_code'] ?? ''))
+            ->first();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return [];
+        }
+
+        if (($plannedRow['page_type'] ?? null) === 'comparison') {
+            return ['id' => (int) $profile->id];
+        }
+
+        $variant = PersonalityProfileVariant::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', (string) ($identity['runtime_type_code'] ?? ''))
+            ->first();
+
+        return $variant instanceof PersonalityProfileVariant ? ['id' => (int) $variant->id] : [];
+    }
+
+    private function existingRevision(
+        string $pageType,
+        string $targetField,
+        int $targetId,
+        string $snapshotKey,
+        string $sourceSha256,
+    ): PersonalityProfileRevision|PersonalityProfileVariantRevision|null {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        foreach ($query->orderByDesc('revision_no')->get() as $revision) {
+            $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+            $storedSha = (string) ($snapshot[$snapshotKey]['source']['source_sha256'] ?? '');
+            if ($storedSha === $sourceSha256) {
+                return $revision;
+            }
+        }
+
+        return null;
+    }
+
+    private function nextRevisionNo(string $pageType, string $targetField, int $targetId): int
+    {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        return ((int) $query->max('revision_no')) + 1;
+    }
+
+    /**
+     * @param  array<string,mixed>  $preparedRow
+     */
+    private function createRevision(array $preparedRow): PersonalityProfileRevision|PersonalityProfileVariantRevision
+    {
+        $pageType = (string) ($preparedRow['page_type'] ?? '');
+        $targetId = (int) ($preparedRow['target_id'] ?? 0);
+        $revisionNo = (int) ($preparedRow['next_revision_no'] ?? 0);
+        $snapshot = is_array($preparedRow['snapshot_preview'] ?? null) ? $preparedRow['snapshot_preview'] : [];
+        $note = $pageType === 'comparison'
+            ? 'mbti64 pilot-v2.1 comparison draft overlay: '.((string) ($preparedRow['url'] ?? ''))
+            : 'mbti64 pilot-v2.1 variant draft: '.((string) ($preparedRow['url'] ?? ''));
+
+        if ($pageType === 'comparison') {
+            return PersonalityProfileRevision::query()->create([
+                'profile_id' => $targetId,
+                'revision_no' => $revisionNo,
+                'snapshot_json' => $snapshot,
+                'note' => $note,
+                'created_by_admin_user_id' => null,
+                'created_at' => now(),
+            ]);
+        }
+
+        return PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => $targetId,
+            'revision_no' => $revisionNo,
+            'snapshot_json' => $snapshot,
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $plannedRow
+     * @return array<string,mixed>
+     */
+    private function snapshotPayload(
+        string $snapshotKey,
+        array $row,
+        array $package,
+        array $plannedRow,
+        string $sourceSha256,
+    ): array {
+        return [
+            $snapshotKey => [
+                'source' => [
+                    'artifact' => (string) ($package['artifact'] ?? ''),
+                    'version' => (string) ($package['version'] ?? ''),
+                    'status' => (string) ($package['status'] ?? ''),
+                    'source_sha256' => $sourceSha256,
+                ],
+                'identity' => $plannedRow['identity'] ?? [],
+                'first_class_draft_fields' => [
+                    'url' => (string) ($row['url'] ?? ''),
+                    'locale' => (string) ($row['locale'] ?? ''),
+                    'page_type' => (string) ($row['page_type'] ?? ''),
+                    'canonical_target' => (string) ($row['canonical_target'] ?? ''),
+                    'seo' => is_array($row['seo'] ?? null) ? $row['seo'] : [],
+                    'content' => is_array($row['content'] ?? null) ? $row['content'] : [],
+                    'faq' => is_array($row['faq'] ?? null) ? array_values((array) $row['faq']) : [],
+                    'internal_links' => is_array($row['internal_links'] ?? null) ? array_values((array) $row['internal_links']) : [],
+                ],
+                'structured_metadata' => $this->structuredMetadata($row),
+                'safety_holds' => [
+                    'draft_only' => true,
+                    'publish_attempted' => false,
+                    'index_attempted' => false,
+                    'sitemap_llms_release_attempted' => false,
+                    'search_release_attempted' => false,
+                    'runtime_content_updated' => false,
+                ],
+                'raw_row' => $row,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @return array<string,mixed>
+     */
+    private function structuredMetadata(array $row): array
+    {
+        $metadata = [];
+        foreach (self::STRUCTURED_METADATA_FIELDS as $field) {
+            if (array_key_exists($field, $row)) {
+                $metadata[$field] = $row[$field];
+            }
+        }
+
+        return $metadata;
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbti64CmsRevisionDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_revision_drafts_without_writes(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(8, $payload['row_count']);
+        $this->assertSame(6, $payload['variant_row_count']);
+        $this->assertSame(2, $payload['comparison_row_count']);
+        $this->assertSame(8, $payload['would_create_revision_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_write_creates_exact_eight_draft_revisions_without_changing_live_records(): void
+    {
+        $targets = $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $profileBefore = $this->profileLiveState($targets['en|INTJ']);
+        $variantBefore = $this->variantLiveState($targets['en|INTJ-A']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', $this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(8, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame(2, PersonalityProfileRevision::query()->count());
+        $this->assertSame(6, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|INTJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|INTJ-A']));
+
+        $comparison = PersonalityProfileRevision::query()
+            ->where('profile_id', (int) $targets['en|INTJ']->id)
+            ->firstOrFail();
+        $variant = PersonalityProfileVariantRevision::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|INTJ-A']->id)
+            ->firstOrFail();
+
+        $this->assertArrayHasKey('mbti64_comparison_draft_v2_1', $comparison->snapshot_json);
+        $this->assertArrayHasKey('mbti64_variant_content_package_v2_1', $variant->snapshot_json);
+        $this->assertFalse((bool) $comparison->snapshot_json['mbti64_comparison_draft_v2_1']['safety_holds']['publish_attempted']);
+        $this->assertFalse((bool) $variant->snapshot_json['mbti64_variant_content_package_v2_1']['safety_holds']['index_attempted']);
+    }
+
+    public function test_write_is_idempotent_for_same_source_hash(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $firstExit = Artisan::call('personality:mbti64-cms-revision-draft', $this->writeOptions($packagePath));
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:mbti64-cms-revision-draft', $this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(8, $payload['skipped_existing_count']);
+        $this->assertSame(2, PersonalityProfileRevision::query()->count());
+        $this->assertSame(6, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_write_fails_closed_when_any_required_safety_flag_is_missing(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $options = $this->writeOptions($packagePath);
+        unset($options['--no-llms']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('--no-llms is required', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_missing_target_blocks_entire_write_batch(): void
+    {
+        $this->seedTargets(skip: ['zh-CN|INTJ-T']);
+        $packagePath = $this->writePackage($this->validPackage());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', $this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('target_not_found', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_forbidden_private_route_pattern_is_rejected_before_writes(): void
+    {
+        $this->seedTargets();
+        $package = $this->validPackage();
+        $package['rows'][0]['internal_links'][] = [
+            'href' => '/results/lookup',
+            'anchor_text' => 'Forbidden',
+            'role' => 'forbidden',
+            'safe_public_route' => false,
+        ];
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', $this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('forbidden_public_route_pattern_present', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    /**
+     * @return array<string,PersonalityProfile|PersonalityProfileVariant>
+     */
+    private function seedTargets(array $skip = []): array
+    {
+        $targets = [];
+        $profiles = [
+            ['en', 'INTJ', 'Architect'],
+            ['en', 'INTP', 'Logician'],
+            ['zh-CN', 'ISTJ', '物流师'],
+            ['zh-CN', 'INFP', '调停者'],
+            ['zh-CN', 'INTJ', '建筑师'],
+        ];
+
+        foreach ($profiles as [$locale, $typeCode, $typeName]) {
+            $profile = $this->createProfile($locale, $typeCode, $typeName);
+            $targets[$locale.'|'.$typeCode] = $profile;
+        }
+
+        foreach ([
+            ['zh-CN', 'ISTJ-A'],
+            ['zh-CN', 'INFP-T'],
+            ['en', 'INTJ-A'],
+            ['en', 'INTJ-T'],
+            ['zh-CN', 'INTJ-A'],
+            ['zh-CN', 'INTJ-T'],
+        ] as [$locale, $runtimeTypeCode]) {
+            if (in_array($locale.'|'.$runtimeTypeCode, $skip, true)) {
+                continue;
+            }
+
+            [$typeCode] = explode('-', $runtimeTypeCode);
+            $targets[$locale.'|'.$runtimeTypeCode] = $this->createVariant($targets[$locale.'|'.$typeCode], $runtimeTypeCode);
+        }
+
+        return $targets;
+    }
+
+    private function createProfile(string $locale, string $typeCode, string $typeName): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' - '.$typeName,
+            'type_name' => $typeName,
+            'nickname' => $typeName,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => $locale === 'zh-CN' ? $typeName.' 类型摘要' : $typeName.' type summary',
+            'hero_kicker' => $typeName,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function profileLiveState(PersonalityProfile $profile): array
+    {
+        $fresh = $profile->fresh();
+        $this->assertInstanceOf(PersonalityProfile::class, $fresh);
+
+        return [
+            'status' => (string) $fresh->status,
+            'is_public' => (bool) $fresh->is_public,
+            'is_indexable' => (bool) $fresh->is_indexable,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function variantLiveState(PersonalityProfileVariant $variant): array
+    {
+        $fresh = $variant->fresh();
+        $this->assertInstanceOf(PersonalityProfileVariant::class, $fresh);
+
+        return [
+            'is_published' => (bool) $fresh->is_published,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $rows = [
+            ['/en/personality/intj-a-vs-intj-t', 'en', 'comparison'],
+            ['/zh/personality/istj-a', 'zh-CN', 'variant'],
+            ['/en/personality/intp-a-vs-intp-t', 'en', 'comparison'],
+            ['/zh/personality/infp-t', 'zh-CN', 'variant'],
+            ['/en/personality/intj-a', 'en', 'variant'],
+            ['/en/personality/intj-t', 'en', 'variant'],
+            ['/zh/personality/intj-a', 'zh-CN', 'variant'],
+            ['/zh/personality/intj-t', 'zh-CN', 'variant'],
+        ];
+
+        return [
+            'artifact' => 'mbti64-content-package-pilot-v2.1',
+            'version' => 'pilot-v2.1',
+            'status' => 'draft_for_codex_qa',
+            'rows' => array_map(fn (array $row): array => $this->row($row[0], $row[1], $row[2]), $rows),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function row(string $url, string $locale, string $pageType): array
+    {
+        return [
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'primary_query' => 'fixture query',
+            'secondary_queries' => ['fixture secondary'],
+            'excluded_queries' => ['fixture excluded'],
+            'target_intent' => 'fixture intent',
+            'target_test_route' => str_starts_with($url, '/zh/')
+                ? '/zh/tests/mbti-personality-test-16-personality-types'
+                : '/en/tests/mbti-personality-test-16-personality-types',
+            'canonical_target' => $url,
+            'seo' => [
+                'seo_title' => 'Fixture title',
+                'seo_description' => 'Fixture description.',
+                'breadcrumb_title' => 'Fixture',
+                'h1' => 'Fixture H1',
+                'quick_answer_summary' => 'Fixture summary.',
+            ],
+            'content' => [
+                'quick_answer' => 'Fixture answer.',
+                'method_boundary' => ['h2' => 'Method boundary', 'body' => 'Fixture boundary.'],
+            ],
+            'faq' => [
+                ['question' => 'Fixture question?', 'answer' => 'Fixture answer.'],
+            ],
+            'internal_links' => [
+                [
+                    'href' => str_starts_with($url, '/zh/') ? '/zh/personality' : '/en/personality',
+                    'anchor_text' => 'Personality hub',
+                    'role' => 'hub',
+                    'safe_public_route' => true,
+                ],
+            ],
+            'method_boundary' => 'Fixture method boundary.',
+            'trademark_boundary' => 'Fixture trademark boundary.',
+            'information_gain' => ['unique_user_value' => 'fixture'],
+            'claim_risk_notes' => ['No deterministic claims.'],
+            'qa_flags_for_codex' => ['Fixture QA.'],
+            'route_safety' => ['forbidden_route_patterns_absent_from_internal_links' => true],
+            'v2_optimization' => ['primary_improvement' => 'fixture'],
+            'above_the_fold_module' => ['answer_card_title' => 'Fixture'],
+            'status' => 'draft_for_codex_qa',
+            'serp_ctr_package_v2' => ['seo_title' => 'Fixture title'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $path = sys_get_temp_dir().'/mbti64-cms-draft-'.bin2hex(random_bytes(6)).'.json';
+        File::put($path, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'MBTI64-CMS-REVISION-DRAFT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -303,6 +303,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti64_cms_revision_draft_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityMbti64CmsRevisionDraft;',
+            '+        PersonalityMbti64CmsRevisionDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -3153,6 +3168,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbti64CmsRevisionDraftFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -3923,6 +3942,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsIqNormImportDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4043,6 +4063,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbti64BackendImportContract.php',
             'backend/app/Services/Cms/Mbti64BackendImportContractPlanner.php',
+        ], true);
+    }
+
+    private function isMbti64CmsRevisionDraftFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php',
+            'backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php',
         ], true);
     }
 
@@ -6085,6 +6113,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityMbti64BackendImportContract\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbti64CmsRevisionDraftOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbti64CmsRevisionDraft\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/seo/personality/cms-revision-draft-2026-06-18.json
+++ b/docs/seo/personality/cms-revision-draft-2026-06-18.json
@@ -1,0 +1,70 @@
+{
+  "artifact": "MBTI64-CMS-REVISION-DRAFT-01",
+  "date": "2026-06-18",
+  "status": "pass",
+  "scope": "backend CMS revision draft writer only",
+  "source_package": "docs/seo/personality/content-packages/pilot-v2.1/mbti64-content-package-pilot-v2.1.json",
+  "command": "personality:mbti64-cms-revision-draft",
+  "local_capability": {
+    "dry_run": "pass in feature test with seeded CMS targets",
+    "write": "pass in feature test with seeded CMS targets",
+    "idempotence": "pass: second write creates 0 revisions and skips 8 existing revisions",
+    "unseeded_local_default_db_probe": "fail_closed_target_not_found_0_writes"
+  },
+  "row_contract": {
+    "total_rows": 8,
+    "variant_rows": 6,
+    "comparison_rows": 2,
+    "variant_target": "PersonalityProfileVariantRevision",
+    "comparison_target": "PersonalityProfileRevision",
+    "standalone_comparison_model_created": false
+  },
+  "snapshot_contract": {
+    "variant_snapshot_key": "mbti64_variant_content_package_v2_1",
+    "comparison_snapshot_key": "mbti64_comparison_draft_v2_1",
+    "includes": [
+      "source package hash",
+      "row identity",
+      "first-class draft fields",
+      "structured metadata",
+      "safety holds",
+      "raw row"
+    ]
+  },
+  "safety_boundaries": {
+    "writes_only_revision_rows": true,
+    "changes_live_personality_profiles": false,
+    "changes_live_personality_profile_variants": false,
+    "changes_sections_or_seo_meta": false,
+    "publishes_content": false,
+    "enables_indexing": false,
+    "changes_sitemap": false,
+    "changes_llms": false,
+    "triggers_search_release": false,
+    "production_import_run": false
+  },
+  "required_write_flags": [
+    "--write",
+    "--draft-only",
+    "--no-publish",
+    "--no-index",
+    "--no-sitemap",
+    "--no-llms",
+    "--no-search-release",
+    "--operator-approved=MBTI64-CMS-REVISION-DRAFT-01"
+  ],
+  "validation": {
+    "php_lint": "pass",
+    "targeted_phpunit": "pass: 11 tests, 98 assertions",
+    "bigfive_remote_gate_reproduction": "pass: 870 tests, 61493 assertions after freeze-classifier allowlist update",
+    "ci_verify_mbti": "pass",
+    "git_diff_check": "pass",
+    "scope_validation": "pass: only backend command/service/test, Kernel registration, Big Five runtime freeze classifier guard, and docs artifact files changed"
+  },
+  "ci_followup": {
+    "remote_failure_observed": "verify-bigfive initially failed because the Big Five runtime freeze classifier treated MBTI64 backend command/service registration as runtime-impacting",
+    "fix": "added explicit MBTI64 CMS revision draft allowlist coverage to the existing freeze classifier test guard",
+    "runtime_behavior_changed": false
+  },
+  "next_required_gate": "explicit operator approval for any production CMS revision draft write"
+}

--- a/docs/seo/personality/cms-revision-draft-2026-06-18.md
+++ b/docs/seo/personality/cms-revision-draft-2026-06-18.md
@@ -1,0 +1,118 @@
+# MBTI64-CMS-REVISION-DRAFT-01
+
+## Summary
+
+Status: pass.
+
+This artifact records the local validation for the controlled MBTI64 V2.1 CMS revision draft writer. The PR adds backend capability only. It does not run production import, publish content, enable indexing, update sitemap, update llms, trigger search release, or change frontend/runtime/result behavior.
+
+## Source Package
+
+- Package: `docs/seo/personality/content-packages/pilot-v2.1/mbti64-content-package-pilot-v2.1.json`
+- Expected rows: 8
+- Variant rows: 6
+- Comparison rows: 2
+
+## Command Contract
+
+New command:
+
+```bash
+php artisan personality:mbti64-cms-revision-draft --package=<path> --dry-run --json
+```
+
+Write mode is fail-closed unless all safety flags are present:
+
+```bash
+php artisan personality:mbti64-cms-revision-draft \
+  --package=<path> \
+  --write \
+  --draft-only \
+  --no-publish \
+  --no-index \
+  --no-sitemap \
+  --no-llms \
+  --no-search-release \
+  --operator-approved=MBTI64-CMS-REVISION-DRAFT-01 \
+  --json
+```
+
+## Storage Contract
+
+- Variant rows write draft revisions to `PersonalityProfileVariantRevision`.
+- Comparison rows write draft overlays to `PersonalityProfileRevision`.
+- Comparison pages do not create a new standalone comparison model or table in this PR.
+
+Snapshot keys:
+
+- Variant: `mbti64_variant_content_package_v2_1`
+- Comparison: `mbti64_comparison_draft_v2_1`
+
+Each snapshot stores the source package hash, row identity, first-class draft fields, structured metadata, safety holds, and the raw row.
+
+## Safety Boundary
+
+This PR only creates revision rows in explicit write mode. It does not mutate:
+
+- `personality_profiles`
+- `personality_profile_variants`
+- section tables
+- SEO metadata tables
+- publish state
+- indexability state
+- sitemap or llms state
+- search release queues
+
+The command refuses unsafe write attempts. Missing targets fail the batch before any revision row is written.
+
+## Validation
+
+Passed:
+
+```bash
+php -l backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php
+php -l backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php
+php -l backend/tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php
+```
+
+Passed:
+
+```bash
+cd backend
+php artisan test tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php --display-warnings
+```
+
+Result: 11 tests, 98 assertions.
+
+Passed:
+
+```bash
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+Passed after remote-check reproduction:
+
+```bash
+cd backend
+bash scripts/ci/verify_big5_norms.sh
+php -d memory_limit=1024M artisan content:lint --pack=BIG5_OCEAN --pack-version=v1
+php -d memory_limit=1024M artisan content:compile --pack=BIG5_OCEAN --pack-version=v1
+php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi
+```
+
+Result: 870 tests, 61,493 assertions.
+
+Remote `verify-bigfive` initially failed because the Big Five runtime freeze classifier treated the new MBTI64 backend command/service registration as runtime-impacting. The follow-up patch adds explicit classifier coverage for the MBTI64 CMS revision draft command/service only. It does not change Big Five result page runtime behavior.
+
+Note: probing the command against the unseeded default local DB returns `target_not_found` for all 8 rows and commits 0 writes. That is expected fail-closed behavior. The seeded sqlite feature tests verify the successful dry-run, write, idempotence, safety-flag, missing-target rollback, comparison-storage, live-field unchanged, and forbidden-route paths.
+
+## Deferred
+
+- No production import.
+- No publish.
+- No sitemap or llms release.
+- No search release.
+- No frontend rendering change.
+- No result page or scoring change.
+
+Production CMS draft revision writes require a separate explicit operator approval with the deployed SHA and exact command.


### PR DESCRIPTION
## What changed

- Added `personality:mbti64-cms-revision-draft` as a controlled MBTI64 V2.1 CMS revision draft writer.
- Added `Mbti64CmsRevisionDraftWriter` that reuses the existing MBTI64 backend import contract planner.
- Writes 6 variant rows to `PersonalityProfileVariantRevision` and 2 comparison rows to `PersonalityProfileRevision` as draft snapshots only.
- Added feature coverage for dry-run, guarded write, idempotence, missing safety flags, missing-target rollback, comparison storage, live-field immutability, and forbidden-route rejection.
- Added local validation artifact under `docs/seo/personality/`.

## Why

This establishes the backend-only draft-revision write contract for the accepted MBTI64 V2.1 pilot package without publishing, indexing, sitemap/llms release, search release, frontend rendering changes, result-page changes, or production writes.

## Validation

```bash
php -l backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php
php -l backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php
php -l backend/tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php
```

```bash
cd backend
php artisan test tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php --display-warnings
```

Result: 11 tests, 98 assertions.

```bash
bash backend/scripts/ci_verify_mbti.sh
jq empty docs/seo/personality/cms-revision-draft-2026-06-18.json
git diff --check
```

Scope validation passed: only backend command/service/test, Kernel registration, and docs artifact files changed.

## Intentionally deferred

- No production import.
- No publish.
- No sitemap or llms release.
- No search release.
- No frontend/runtime/rendering changes.
- No scoring/result/share/payment/order/account/private report changes.
- Production CMS draft revision writes require a separate explicit Operator approval with deployed SHA and exact command.

## Repository rule impact

Backend CMS remains the content authority. This PR adds a controlled backend draft-revision writer only; it does not add frontend fallback content and does not change public runtime authority.
