### PR TITLE
Add article taxonomy-only revalidation mode

### DIFF
--- a/backend/app/Console/Commands/ContentReleaseRevalidate.php
+++ b/backend/app/Console/Commands/ContentReleaseRevalidate.php
@@ -15,6 +15,9 @@ final class ContentReleaseRevalidate extends Command
     protected $signature = 'content-release:revalidate
         {--type=article : Content type to revalidate}
         {--article-id= : Article id when --type=article}
+        {--article-ids= : Comma-separated article ids when --type=article-taxonomy}
+        {--expected-slugs= : Comma-separated expected slugs in article-id order for identity locks}
+        {--include-index= : Article index path to include for taxonomy-only revalidation}
         {--source=manual_revalidate : Safe audit/source label}
         {--dry-run : Plan paths without posting to configured revalidation endpoints}
         {--execute : Dispatch configured frontend revalidation endpoints}
@@ -38,23 +41,39 @@ final class ContentReleaseRevalidate extends Command
         $execute = (bool) $this->option('execute');
         $dryRun = ! $execute;
         $type = trim((string) $this->option('type'));
-        $articleId = (int) $this->option('article-id');
         $issues = [];
 
         if ((bool) $this->option('dry-run') && $execute) {
             $issues[] = 'execute_dry_run_conflict';
         }
 
-        if ($type !== 'article') {
-            $issues[] = 'unsupported_type';
+        if ($type === 'article') {
+            return $this->articleSummary($pathPlanner, $execute, $dryRun, $issues);
         }
+
+        if ($type === 'article-taxonomy') {
+            return $this->articleTaxonomySummary($execute, $dryRun, $issues);
+        }
+
+        $issues[] = 'unsupported_type';
+
+        return $this->blockedSummary($type, $dryRun, $issues);
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return array<string,mixed>
+     */
+    private function articleSummary(ContentReleasePathPlanner $pathPlanner, bool $execute, bool $dryRun, array $issues): array
+    {
+        $articleId = (int) $this->option('article-id');
 
         if ($articleId <= 0) {
             $issues[] = 'article_id_required';
         }
 
         $article = null;
-        if ($type === 'article' && $articleId > 0) {
+        if ($articleId > 0) {
             $article = Article::query()
                 ->withoutGlobalScopes()
                 ->with(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()])
@@ -66,17 +85,7 @@ final class ContentReleaseRevalidate extends Command
         }
 
         $paths = $article instanceof Article ? $pathPlanner->paths('article', $article) : [];
-        $endpoints = $this->cacheInvalidationUrls();
-        $tokenPresent = $this->cacheInvalidationSecretPresent();
-
-        if ($execute && $endpoints === []) {
-            $issues[] = 'cache_invalidation_urls_missing';
-        }
-
-        if ($execute && ! $tokenPresent) {
-            $issues[] = 'cache_invalidation_secret_missing';
-        }
-
+        $issues = $this->validateExecuteRuntime($execute, $issues);
         $ok = $issues === [];
         $action = $execute ? 'revalidation_dispatched' : 'would_revalidate_content_release_paths';
 
@@ -91,6 +100,132 @@ final class ContentReleaseRevalidate extends Command
             );
         }
 
+        return $this->baseSummary($ok, $dryRun, $action, 'article', $paths, $issues) + [
+            'article_id' => $articleId > 0 ? $articleId : null,
+            'article_ids' => $articleId > 0 ? [$articleId] : [],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return array<string,mixed>
+     */
+    private function articleTaxonomySummary(bool $execute, bool $dryRun, array $issues): array
+    {
+        $articleIds = $this->integerList((string) $this->option('article-ids'), 'article_ids', $issues);
+        $expectedSlugs = $this->stringList((string) $this->option('expected-slugs'));
+        $includeIndex = trim((string) $this->option('include-index'));
+
+        if ($articleIds === []) {
+            $issues[] = 'article_ids_required';
+        }
+        if ($expectedSlugs !== [] && count($expectedSlugs) !== count($articleIds)) {
+            $issues[] = 'expected_slug_count_mismatch';
+        }
+        if ($includeIndex === '') {
+            $issues[] = 'include_index_required';
+        } elseif (! in_array($includeIndex, ['/zh/articles', '/en/articles'], true)) {
+            $issues[] = 'include_index_not_allowed';
+        }
+
+        $articles = $this->articles($articleIds);
+        $foundIds = array_map(static fn (Article $article): int => (int) $article->id, $articles);
+        foreach ($articleIds as $articleId) {
+            if (! in_array($articleId, $foundIds, true)) {
+                $issues[] = 'article_not_found';
+            }
+        }
+
+        $paths = $includeIndex !== '' && in_array($includeIndex, ['/zh/articles', '/en/articles'], true)
+            ? [$includeIndex]
+            : [];
+        $indexLocale = str_starts_with($includeIndex, '/zh/') ? 'zh' : (str_starts_with($includeIndex, '/en/') ? 'en' : null);
+        $articleSummaries = [];
+
+        foreach ($articles as $index => $article) {
+            $slug = trim((string) $article->slug);
+            $locale = $this->localeSegment((string) $article->locale);
+            $expectedSlug = $expectedSlugs[$index] ?? null;
+
+            if ($expectedSlug !== null && $slug !== $expectedSlug) {
+                $issues[] = 'expected_slug_mismatch';
+            }
+            if ($slug === '' || ! $this->isCanonicalSlug($slug)) {
+                $issues[] = 'article_slug_not_canonical';
+            }
+            if ($indexLocale !== null && $locale !== $indexLocale) {
+                $issues[] = 'include_index_locale_mismatch';
+            }
+
+            if ($slug !== '' && $this->isCanonicalSlug($slug)) {
+                $paths[] = "/{$locale}/articles/{$slug}";
+            }
+
+            $articleSummaries[] = [
+                'id' => (int) $article->id,
+                'slug' => $slug,
+                'locale' => (string) $article->locale,
+                'canonical_path' => $slug !== '' && $this->isCanonicalSlug($slug) ? "/{$locale}/articles/{$slug}" : null,
+            ];
+        }
+
+        $paths = array_values(array_unique($paths));
+        $issues = $this->validateExecuteRuntime($execute, $issues);
+        $ok = $issues === [];
+        $action = $execute ? 'taxonomy_only_revalidation_dispatched' : 'would_revalidate_article_taxonomy_paths';
+
+        if (! $ok) {
+            $action = 'will_skip';
+        } elseif ($execute) {
+            ContentReleaseFollowUp::dispatchExplicitPaths(
+                'article-taxonomy',
+                $this->taxonomyBatchRecord($articleIds, $indexLocale ?? 'zh'),
+                $paths,
+                $this->safeSource(),
+                Request::create('/ops/content-release/revalidate-command', 'POST'),
+                [
+                    'article_ids' => $articleIds,
+                    'path_scope' => 'taxonomy_only',
+                ]
+            );
+        }
+
+        return $this->baseSummary($ok, $dryRun, $action, 'article-taxonomy', $paths, $issues) + [
+            'article_id' => null,
+            'article_ids' => $articleIds,
+            'articles' => $articleSummaries,
+            'include_index' => $includeIndex !== '' ? $includeIndex : null,
+            'allowed_path_scope' => 'taxonomy_only',
+            'excluded_path_classes' => ['home', 'llms', 'topics', 'tests', 'search', 'schema_hreflang', 'sitemap'],
+            'sitemap_llms_mutation_attempted' => false,
+            'schema_hreflang_write_attempted' => false,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return list<string>
+     */
+    private function validateExecuteRuntime(bool $execute, array $issues): array
+    {
+        if ($execute && $this->cacheInvalidationUrls() === []) {
+            $issues[] = 'cache_invalidation_urls_missing';
+        }
+
+        if ($execute && ! $this->cacheInvalidationSecretPresent()) {
+            $issues[] = 'cache_invalidation_secret_missing';
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @param  list<string>  $issues
+     * @return array<string,mixed>
+     */
+    private function baseSummary(bool $ok, bool $dryRun, string $action, string $type, array $paths, array $issues): array
+    {
         return [
             'runtime' => 'content_release_revalidate',
             'status' => $ok ? 'success' : 'blocked',
@@ -98,16 +233,108 @@ final class ContentReleaseRevalidate extends Command
             'dry_run' => $dryRun,
             'action' => $action,
             'type' => $type,
-            'article_id' => $articleId > 0 ? $articleId : null,
             'paths' => $paths,
-            'endpoint_count' => count($endpoints),
-            'token_present' => $tokenPresent,
+            'endpoint_count' => count($this->cacheInvalidationUrls()),
+            'token_present' => $this->cacheInvalidationSecretPresent(),
             'token_output' => false,
             'external_search_submission_attempted' => false,
             'search_submission_attempted' => false,
             'live_submission_attempted' => false,
             'secrets_read_from_environment_by_operator' => false,
             'issues' => array_values(array_unique($issues)),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return array<string,mixed>
+     */
+    private function blockedSummary(string $type, bool $dryRun, array $issues): array
+    {
+        return $this->baseSummary(false, $dryRun, 'will_skip', $type, [], $issues) + [
+            'article_id' => null,
+            'article_ids' => [],
+        ];
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<Article>
+     */
+    private function articles(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        /** @var list<Article> $articles */
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->whereIn('id', $ids)
+            ->get()
+            ->sortBy(static fn (Article $article): int => array_search((int) $article->id, $ids, true))
+            ->values()
+            ->all();
+
+        return $articles;
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return list<int>
+     */
+    private function integerList(string $value, string $field, array &$issues): array
+    {
+        $items = $this->stringList($value);
+        $ids = [];
+
+        foreach ($items as $item) {
+            if (! ctype_digit($item) || (int) $item <= 0) {
+                $issues[] = $field.'_invalid';
+
+                continue;
+            }
+            $ids[] = (int) $item;
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(string $value): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (string $item): string => trim($item),
+            explode(',', $value)
+        ), static fn (string $item): bool => $item !== ''));
+    }
+
+    private function localeSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    private function isCanonicalSlug(string $slug): bool
+    {
+        return preg_match('/^[a-z0-9][a-z0-9-]*$/', $slug) === 1;
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     */
+    private function taxonomyBatchRecord(array $articleIds, string $locale): object
+    {
+        return (object) [
+            'id' => 0,
+            'org_id' => 0,
+            'title' => 'Article taxonomy revalidation '.implode(',', $articleIds),
+            'slug' => 'article-taxonomy',
+            'locale' => $locale === 'zh' ? 'zh-CN' : 'en',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now(),
         ];
     }
 

--- a/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
+++ b/backend/app/Filament/Ops/Support/ContentReleaseFollowUp.php
@@ -17,6 +17,38 @@ final class ContentReleaseFollowUp
     public static function dispatch(string $type, object $record, string $source, Request $request): void
     {
         $payload = self::payload($type, $record, $source);
+        self::dispatchPayload($request, $payload);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @param  array<string, mixed>  $contentExtras
+     */
+    public static function dispatchExplicitPaths(
+        string $type,
+        object $record,
+        array $paths,
+        string $source,
+        Request $request,
+        array $contentExtras = [],
+    ): void {
+        $payload = self::payload(
+            type: $type,
+            record: $record,
+            source: $source,
+            paths: self::normalizePaths($paths),
+            contentExtras: $contentExtras,
+            event: 'content_release_revalidate',
+        );
+
+        self::dispatchPayload($request, $payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function dispatchPayload(Request $request, array $payload): void
+    {
         $cacheInvalidationUrls = self::cacheInvalidationUrls();
         $cacheInvalidationSecret = self::cacheInvalidationSecret();
 
@@ -68,20 +100,30 @@ final class ContentReleaseFollowUp
     }
 
     /**
+     * @param  list<string>|null  $paths
+     * @param  array<string, mixed>  $contentExtras
      * @return array<string, mixed>
      */
-    private static function payload(string $type, object $record, string $source): array
-    {
+    private static function payload(
+        string $type,
+        object $record,
+        string $source,
+        ?array $paths = null,
+        array $contentExtras = [],
+        string $event = 'content_release_publish',
+    ): array {
         $title = trim((string) data_get($record, 'title', 'Untitled'));
         $locale = trim((string) data_get($record, 'locale', ''));
         $publishedAt = optional(data_get($record, 'published_at'))?->toISOString();
-        $paths = self::invalidateUrls($type, $record);
+        $paths = $paths ?? self::invalidateUrls($type, $record);
+        $verb = $event === 'content_release_publish' ? 'published' : 'revalidated';
 
         return [
-            'event' => 'content_release_publish',
+            'event' => $event,
             'text' => sprintf(
-                '[CMS release] %s published via %s (%s)',
+                '[CMS release] %s %s via %s (%s)',
                 $title !== '' ? $title : 'Untitled',
+                $verb,
                 $source,
                 $type
             ),
@@ -96,7 +138,7 @@ final class ContentReleaseFollowUp
                 'status' => trim((string) data_get($record, 'status', 'published')),
                 'visibility' => data_get($record, 'is_public') ? 'public' : 'private',
                 'published_at' => $publishedAt,
-            ],
+            ] + $contentExtras,
             'cache_signal' => [
                 'kind' => 'invalidate',
                 'paths' => $paths,
@@ -111,6 +153,25 @@ final class ContentReleaseFollowUp
     private static function invalidateUrls(string $type, object $record): array
     {
         return app(ContentReleasePathPlanner::class)->paths($type, $record);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private static function normalizePaths(array $paths): array
+    {
+        $normalized = [];
+        foreach ($paths as $path) {
+            $path = trim($path);
+            if ($path === '' || ! str_starts_with($path, '/')) {
+                continue;
+            }
+
+            $normalized[] = $path;
+        }
+
+        return array_values(array_unique($normalized));
     }
 
     /**

--- a/backend/tests/Feature/Console/ContentReleaseRevalidateCommandTest.php
+++ b/backend/tests/Feature/Console/ContentReleaseRevalidateCommandTest.php
@@ -103,6 +103,143 @@ final class ContentReleaseRevalidateCommandTest extends TestCase
         });
     }
 
+    public function test_dry_run_plans_article_taxonomy_paths_without_broad_article_planner_paths(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake();
+
+        $first = $this->articleWithSeoMeta('zh-CN', [
+            'target_topics' => ['mbti'],
+            'target_tests' => ['mbti-personality-test-16-personality-types'],
+        ], 'taxonomy-first');
+        $second = $this->articleWithSeoMeta('zh-CN', [
+            'target_topics' => ['riasec'],
+            'target_tests' => ['holland-career-interest-test-riasec'],
+        ], 'taxonomy-second');
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article-taxonomy',
+            '--article-ids' => $first->id.','.$second->id,
+            '--expected-slugs' => 'taxonomy-first,taxonomy-second',
+            '--include-index' => '/zh/articles',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $rawOutput = Artisan::output();
+        $payload = $this->jsonOutput($rawOutput);
+
+        $this->assertSame(0, $exitCode, $rawOutput);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertSame('article-taxonomy', $payload['type'] ?? null);
+        $this->assertSame('taxonomy_only', $payload['allowed_path_scope'] ?? null);
+        $this->assertSame([
+            '/zh/articles',
+            '/zh/articles/taxonomy-first',
+            '/zh/articles/taxonomy-second',
+        ], $payload['paths'] ?? []);
+        $this->assertContains('llms', $payload['excluded_path_classes'] ?? []);
+        $this->assertContains('topics', $payload['excluded_path_classes'] ?? []);
+        $this->assertContains('tests', $payload['excluded_path_classes'] ?? []);
+        $this->assertNotContains('/zh', $payload['paths'] ?? []);
+        $this->assertNotContains('/llms.txt', $payload['paths'] ?? []);
+        $this->assertNotContains('/llms-full.txt', $payload['paths'] ?? []);
+        $this->assertNotContains('/zh/topics/mbti', $payload['paths'] ?? []);
+        $this->assertNotContains('/zh/tests/mbti-personality-test-16-personality-types', $payload['paths'] ?? []);
+        $this->assertFalse((bool) ($payload['external_search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['schema_hreflang_write_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['sitemap_llms_mutation_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['token_output'] ?? true));
+        $this->assertStringNotContainsString('release-secret', $rawOutput);
+        $this->assertStringNotContainsString('cache.example.test', $rawOutput);
+
+        Http::assertNothingSent();
+    }
+
+    public function test_execute_dispatches_article_taxonomy_paths_without_broad_article_planner_paths(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake([
+            'https://cache.example.test/*' => Http::response(['ok' => true], 200),
+        ]);
+
+        $article = $this->articleWithSeoMeta('zh-CN', [
+            'target_topics' => ['mbti'],
+        ], 'taxonomy-execute');
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article-taxonomy',
+            '--article-ids' => (string) $article->id,
+            '--expected-slugs' => 'taxonomy-execute',
+            '--include-index' => '/zh/articles',
+            '--source' => 'article_taxonomy_hygiene_20260618',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $rawOutput = Artisan::output();
+        $payload = $this->jsonOutput($rawOutput);
+
+        $this->assertSame(0, $exitCode, $rawOutput);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['dry_run'] ?? true));
+        $this->assertSame('taxonomy_only_revalidation_dispatched', $payload['action'] ?? null);
+        $this->assertSame([
+            '/zh/articles',
+            '/zh/articles/taxonomy-execute',
+        ], $payload['paths'] ?? []);
+        $this->assertStringNotContainsString('release-secret', $rawOutput);
+        $this->assertStringNotContainsString('cache.example.test', $rawOutput);
+
+        Http::assertSent(function ($request) use ($article): bool {
+            $paths = (array) data_get($request->data(), 'cache_signal.paths', []);
+
+            return $request->url() === 'https://cache.example.test/api/content-release/revalidate'
+                && $request->hasHeader('X-FM-Content-Release-Token', 'release-secret')
+                && data_get($request->data(), 'event') === 'content_release_revalidate'
+                && data_get($request->data(), 'content.type') === 'article-taxonomy'
+                && data_get($request->data(), 'content.article_ids') === [(int) $article->id]
+                && data_get($request->data(), 'content.path_scope') === 'taxonomy_only'
+                && $paths === ['/zh/articles', '/zh/articles/taxonomy-execute'];
+        });
+    }
+
+    public function test_article_taxonomy_blocks_slug_lock_mismatch_without_posting(): void
+    {
+        config()->set('ops.content_release_observability.cache_invalidation_urls', [
+            'https://cache.example.test/api/content-release/revalidate',
+        ]);
+        config()->set('ops.content_release_observability.cache_invalidation_secret', 'release-secret');
+        Http::fake();
+
+        $article = $this->articleWithSeoMeta('zh-CN', [], 'taxonomy-lock');
+
+        $exitCode = Artisan::call('content-release:revalidate', [
+            '--type' => 'article-taxonomy',
+            '--article-ids' => (string) $article->id,
+            '--expected-slugs' => 'wrong-slug',
+            '--include-index' => '/zh/articles',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput(Artisan::output());
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertSame('will_skip', $payload['action'] ?? null);
+        $this->assertContains('expected_slug_mismatch', $payload['issues'] ?? []);
+
+        Http::assertNothingSent();
+    }
+
     public function test_execute_blocks_when_revalidation_token_or_endpoint_config_is_missing(): void
     {
         config()->set('ops.content_release_observability.cache_invalidation_urls', []);
@@ -131,11 +268,11 @@ final class ContentReleaseRevalidateCommandTest extends TestCase
     /**
      * @param  array<string,mixed>  $editorialMetadata
      */
-    private function articleWithSeoMeta(string $locale, array $editorialMetadata = []): Article
+    private function articleWithSeoMeta(string $locale, array $editorialMetadata = [], string $slug = 'content-release-article'): Article
     {
         $article = Article::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
-            'slug' => 'content-release-article',
+            'slug' => $slug,
             'locale' => $locale,
             'title' => 'Content Release Article',
             'excerpt' => 'Release excerpt',
@@ -154,7 +291,7 @@ final class ContentReleaseRevalidateCommandTest extends TestCase
             'locale' => $locale,
             'seo_title' => 'Release SEO title',
             'seo_description' => 'Release SEO description',
-            'canonical_url' => 'https://fermatmind.com/'.(str_starts_with($locale, 'zh') ? 'zh' : 'en').'/articles/content-release-article',
+            'canonical_url' => 'https://fermatmind.com/'.(str_starts_with($locale, 'zh') ? 'zh' : 'en').'/articles/'.$slug,
             'robots' => 'index,follow',
             'schema_json' => [
                 'editorial_package_v1' => $editorialMetadata,


### PR DESCRIPTION
## Summary
- add a controlled content-release:revalidate --type=article-taxonomy mode for taxonomy-only cache refreshes
- allow explicit path dispatch through ContentReleaseFollowUp so taxonomy revalidation does not reuse the broad article planner
- cover dry-run, execute, and slug-lock blocking behavior while keeping the existing article planner behavior intact

## Validation
- php artisan test --filter=ContentReleaseRevalidateCommandTest
- php artisan test --filter=ArticleTaxonomyHygieneCommandTest
- php artisan list --no-ansi | rg "content-release:revalidate|articles:taxonomy-hygiene"
- ./vendor/bin/pint --test app/Console/Commands/ContentReleaseRevalidate.php app/Filament/Ops/Support/ContentReleaseFollowUp.php tests/Feature/Console/ContentReleaseRevalidateCommandTest.php
- git diff --check

## Intentionally deferred
- no production revalidation executed
- no CMS content changes, publish/promote, search submission, schema/hreflang, sitemap, or llms mutation
- no frontend fallback or hardcoded taxonomy label mapping