### PR TITLE
MBTI64-BACKEND-PROMOTION-CONTRACT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\Mbti64CmsRevisionPromotionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbti64CmsRevisionPromote extends Command
+{
+    private const OPERATOR_APPROVAL = 'MBTI64-BACKEND-PROMOTION-CONTRACT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'promote-live-content',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:mbti64-cms-revision-promote
+        {--package= : Path to the MBTI64 pilot V2.1 JSON package}
+        {--dry-run : Plan promotion without database writes}
+        {--write : Promote latest matching revision snapshots to live CMS content fields}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--promote-live-content : Required for --write; confirms live CMS content promotion intent}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release or queue action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Promote MBTI64 pilot V2.1 CMS draft revisions into live CMS content with no index/search side effects.';
+
+    public function handle(Mbti64CmsRevisionPromotionService $service): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($service);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(Mbti64CmsRevisionPromotionService $service): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = $this->resolvePath($packagePath);
+        $raw = (string) File::get($resolved);
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        $summary = $write
+            ? $service->promote($decoded, hash('sha256', $raw), $this->optionsPayload())
+            : $service->plan($decoded, hash('sha256', $raw), $this->optionsPayload());
+
+        return array_merge($summary, [
+            'package_path' => $resolved,
+            'command' => 'personality:mbti64-cms-revision-promote',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path): string
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'promote_live_content' => (bool) $this->option('promote-live-content'),
+            'no_index' => (bool) $this->option('no-index'),
+            'no_sitemap' => (bool) $this->option('no-sitemap'),
+            'no_llms' => (bool) $this->option('no-llms'),
+            'no_search_release' => (bool) $this->option('no-search-release'),
+            'operator_approved' => (string) $this->option('operator-approved'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('promoted_count='.(string) ($summary['promoted_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'MBTI64-BACKEND-PROMOTION-CONTRACT-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_committed' => false,
+            'content_promotion_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'queue_enqueue_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -157,6 +157,7 @@ use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
+use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
@@ -192,6 +193,7 @@ class Kernel extends ConsoleKernel
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64CmsRevisionDraft::class,
+        PersonalityMbti64CmsRevisionPromote::class,
         PersonalityMbti64BackendImportContract::class,
         MetricsWeeklyValidity::class,
         MbtiPrewarm::class,

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -1,0 +1,713 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+final class Mbti64CmsRevisionPromotionService
+{
+    private const VARIANT_SNAPSHOT_KEY = 'mbti64_variant_content_package_v2_1';
+
+    private const COMPARISON_SNAPSHOT_KEY = 'mbti64_comparison_draft_v2_1';
+
+    public function __construct(private readonly Mbti64BackendImportContractPlanner $planner)
+    {
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, string $sourceSha256, array $options = []): array
+    {
+        return $this->buildSummary($package, $sourceSha256, false, $options);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function promote(array $package, string $sourceSha256, array $options = []): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $sourceSha256, true, $options));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, string $sourceSha256, bool $write, array $options): array
+    {
+        $contract = $this->planner->plan($package);
+        if (($contract['ok'] ?? false) !== true) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'contract' => $contract,
+                'errors' => $contract['errors'] ?? [],
+                'warnings' => $contract['warnings'] ?? [],
+            ]);
+        }
+
+        $preparedRows = [];
+        $errors = [];
+        foreach ((array) ($contract['rows'] ?? []) as $plannedRow) {
+            if (! is_array($plannedRow)) {
+                continue;
+            }
+
+            $row = $this->packageRow($package, (int) ($plannedRow['position'] ?? 0));
+            $preparedRows[] = $this->prepareRow($plannedRow, $row, $sourceSha256, $write, $errors);
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'contract' => $contract,
+                'rows' => $preparedRows,
+                'errors' => $errors,
+                'warnings' => $contract['warnings'] ?? [],
+            ]);
+        }
+
+        $promoted = 0;
+        $skippedExisting = 0;
+        foreach ($preparedRows as &$preparedRow) {
+            if (($preparedRow['live_matches_revision'] ?? false) === true) {
+                $preparedRow['action'] = $write ? 'skipped_existing' : 'would_skip_existing';
+                $skippedExisting++;
+
+                continue;
+            }
+
+            if ($write) {
+                $this->applyPromotion($preparedRow);
+                $preparedRow['action'] = 'promoted';
+                $promoted++;
+
+                continue;
+            }
+
+            $preparedRow['action'] = 'would_promote';
+        }
+        unset($preparedRow);
+
+        return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'contract' => $contract,
+            'row_count' => count($preparedRows),
+            'variant_row_count' => count(array_filter(
+                $preparedRows,
+                static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant'
+            )),
+            'comparison_row_count' => count(array_filter(
+                $preparedRows,
+                static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison'
+            )),
+            'promoted_count' => $promoted,
+            'skipped_existing_count' => $skippedExisting,
+            'would_promote_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
+            'writes_committed' => $write && $promoted > 0,
+            'rows' => $preparedRows,
+            'errors' => [],
+            'warnings' => $contract['warnings'] ?? [],
+            'options' => $options,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'MBTI64-BACKEND-PROMOTION-CONTRACT-01',
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'content_promotion_attempted' => $write,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'queue_enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'writes_committed' => false,
+            'side_effect_boundary' => [
+                'live_cms_content_fields_may_change' => $write,
+                'profile_publish_state_changes_allowed' => false,
+                'variant_publish_state_changes_allowed' => false,
+                'sitemap_llms_changes_allowed' => false,
+                'search_queue_changes_allowed' => false,
+                'search_submit_allowed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function packageRow(array $package, int $position): array
+    {
+        $rows = is_array($package['rows'] ?? null) ? array_values((array) $package['rows']) : [];
+        $row = $rows[$position - 1] ?? [];
+
+        return is_array($row) ? $row : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plannedRow
+     * @param  array<string,mixed>  $row
+     * @param  list<array<string,string>>  $errors
+     * @return array<string,mixed>
+     */
+    private function prepareRow(
+        array $plannedRow,
+        array $row,
+        string $sourceSha256,
+        bool $write,
+        array &$errors,
+    ): array {
+        $pageType = (string) ($plannedRow['page_type'] ?? '');
+        $snapshotKey = $pageType === 'comparison' ? self::COMPARISON_SNAPSHOT_KEY : self::VARIANT_SNAPSHOT_KEY;
+        $target = $this->targetRecord($plannedRow);
+        $targetId = $target['id'] ?? null;
+        $targetField = $pageType === 'comparison' ? 'profile_id' : 'personality_profile_variant_id';
+        $revision = null;
+        $snapshot = [];
+        $promotionPayload = [];
+        $latestRevisionNo = null;
+
+        if (! is_int($targetId)) {
+            $errors[] = [
+                'field' => 'rows.'.((string) ((int) ($plannedRow['position'] ?? 0) - 1)).'.url',
+                'code' => 'target_not_found',
+                'message' => 'CMS target record was not found for '.$pageType.' row '.((string) ($plannedRow['url'] ?? '')),
+            ];
+        } else {
+            $revision = $this->matchingRevision($pageType, $targetField, $targetId, $snapshotKey, $sourceSha256);
+            $latestRevisionNo = $this->latestRevisionNo($pageType, $targetField, $targetId);
+
+            if (! $revision instanceof Model) {
+                $errors[] = [
+                    'field' => 'rows.'.((string) ((int) ($plannedRow['position'] ?? 0) - 1)).'.revision',
+                    'code' => 'revision_not_found_for_source_sha256',
+                    'message' => 'No matching draft revision was found for source hash '.$sourceSha256.'.',
+                ];
+            } else {
+                $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+                if ((int) $revision->revision_no !== (int) $latestRevisionNo) {
+                    $errors[] = [
+                        'field' => 'rows.'.((string) ((int) ($plannedRow['position'] ?? 0) - 1)).'.revision',
+                        'code' => 'revision_not_latest_for_target',
+                        'message' => 'Matching revision is not the latest revision for its target.',
+                    ];
+                }
+
+                if (! $this->safetyHoldsArePromotable($snapshot, $snapshotKey, $sourceSha256)) {
+                    $errors[] = [
+                        'field' => 'rows.'.((string) ((int) ($plannedRow['position'] ?? 0) - 1)).'.revision',
+                        'code' => 'revision_safety_holds_not_promotable',
+                        'message' => 'Draft revision safety holds are not eligible for controlled promotion.',
+                    ];
+                }
+
+                $promotionPayload = $this->promotionPayload($pageType, $snapshotKey, $snapshot, $row, $plannedRow);
+            }
+        }
+
+        return [
+            'position' => (int) ($plannedRow['position'] ?? 0),
+            'url' => (string) ($plannedRow['url'] ?? ''),
+            'locale' => (string) ($plannedRow['locale'] ?? ''),
+            'page_type' => $pageType,
+            'identity' => $plannedRow['identity'] ?? [],
+            'target_table' => (string) (($plannedRow['target']['target_table'] ?? '')),
+            'target_id' => $targetId,
+            'snapshot_key' => $snapshotKey,
+            'source_sha256' => $sourceSha256,
+            'revision_id' => $revision instanceof Model ? (int) $revision->getKey() : null,
+            'revision_no' => $revision instanceof Model ? (int) $revision->getAttribute('revision_no') : null,
+            'latest_revision_no' => $latestRevisionNo,
+            'write_mode' => $write ? 'write_live_cms_content' : 'dry_run',
+            'live_matches_revision' => is_int($targetId) && $promotionPayload !== []
+                ? $this->liveMatchesPromotion($pageType, $targetId, $promotionPayload)
+                : false,
+            'action' => 'pending',
+            'promotion_preview' => $promotionPayload,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plannedRow
+     * @return array{id?:int}
+     */
+    private function targetRecord(array $plannedRow): array
+    {
+        $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+        $locale = (string) ($plannedRow['locale'] ?? '');
+
+        $profile = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('locale', $locale)
+            ->where('canonical_type_code', (string) ($identity['canonical_type_code'] ?? ''))
+            ->first();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return [];
+        }
+
+        if (($plannedRow['page_type'] ?? null) === 'comparison') {
+            return ['id' => (int) $profile->id];
+        }
+
+        $variant = PersonalityProfileVariant::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', (string) ($identity['runtime_type_code'] ?? ''))
+            ->first();
+
+        return $variant instanceof PersonalityProfileVariant ? ['id' => (int) $variant->id] : [];
+    }
+
+    private function matchingRevision(
+        string $pageType,
+        string $targetField,
+        int $targetId,
+        string $snapshotKey,
+        string $sourceSha256,
+    ): PersonalityProfileRevision|PersonalityProfileVariantRevision|null {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        foreach ($query->orderByDesc('revision_no')->get() as $revision) {
+            $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+            $storedSha = (string) ($snapshot[$snapshotKey]['source']['source_sha256'] ?? '');
+            if ($storedSha === $sourceSha256) {
+                return $revision;
+            }
+        }
+
+        return null;
+    }
+
+    private function latestRevisionNo(string $pageType, string $targetField, int $targetId): int
+    {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        return (int) $query->max('revision_no');
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function safetyHoldsArePromotable(array $snapshot, string $snapshotKey, string $sourceSha256): bool
+    {
+        $node = is_array($snapshot[$snapshotKey] ?? null) ? $snapshot[$snapshotKey] : [];
+        $holds = is_array($node['safety_holds'] ?? null) ? $node['safety_holds'] : [];
+
+        return (string) ($node['source']['source_sha256'] ?? '') === $sourceSha256
+            && ($holds['draft_only'] ?? null) === true
+            && ($holds['publish_attempted'] ?? null) === false
+            && ($holds['index_attempted'] ?? null) === false
+            && ($holds['sitemap_llms_release_attempted'] ?? null) === false
+            && ($holds['search_release_attempted'] ?? null) === false
+            && ($holds['runtime_content_updated'] ?? null) === false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $plannedRow
+     * @return array<string,mixed>
+     */
+    private function promotionPayload(string $pageType, string $snapshotKey, array $snapshot, array $row, array $plannedRow): array
+    {
+        $node = is_array($snapshot[$snapshotKey] ?? null) ? $snapshot[$snapshotKey] : [];
+        $fields = is_array($node['first_class_draft_fields'] ?? null) ? $node['first_class_draft_fields'] : [];
+        $metadata = is_array($node['structured_metadata'] ?? null) ? $node['structured_metadata'] : [];
+        $seo = is_array($fields['seo'] ?? null) ? $fields['seo'] : (is_array($row['seo'] ?? null) ? $row['seo'] : []);
+        $content = is_array($fields['content'] ?? null) ? $fields['content'] : (is_array($row['content'] ?? null) ? $row['content'] : []);
+        $faq = is_array($fields['faq'] ?? null) ? array_values((array) $fields['faq']) : (is_array($row['faq'] ?? null) ? array_values((array) $row['faq']) : []);
+        $links = is_array($fields['internal_links'] ?? null)
+            ? array_values((array) $fields['internal_links'])
+            : (is_array($row['internal_links'] ?? null) ? array_values((array) $row['internal_links']) : []);
+        $canonical = (string) ($fields['canonical_target'] ?? ($row['canonical_target'] ?? ($plannedRow['url'] ?? '')));
+
+        return [
+            'page_type' => $pageType,
+            'seo' => [
+                'seo_title' => $this->nullableString($seo['seo_title'] ?? null),
+                'seo_description' => $this->nullableString($seo['seo_description'] ?? null),
+                'canonical_url' => $canonical,
+                'og_title' => $this->nullableString($seo['og_title'] ?? ($seo['seo_title'] ?? null)),
+                'og_description' => $this->nullableString($seo['og_description'] ?? ($seo['seo_description'] ?? null)),
+                'twitter_title' => $this->nullableString($seo['twitter_title'] ?? ($seo['seo_title'] ?? null)),
+                'twitter_description' => $this->nullableString($seo['twitter_description'] ?? ($seo['seo_description'] ?? null)),
+                'robots' => 'index,follow',
+                'jsonld_overrides_json' => [
+                    'name' => $this->nullableString($seo['h1'] ?? ($seo['seo_title'] ?? null)),
+                    'description' => $this->nullableString($seo['seo_description'] ?? null),
+                    'url' => $canonical,
+                ],
+            ],
+            'sections' => $this->sectionPayloads($content, $faq, $links, $seo, $metadata, $row, $plannedRow, $snapshotKey),
+            'comparison_section' => $this->comparisonSectionPayload($content, $faq, $links, $seo, $metadata, $row, $plannedRow, $snapshotKey),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @param  list<mixed>  $faq
+     * @param  list<mixed>  $links
+     * @param  array<string,mixed>  $seo
+     * @param  array<string,mixed>  $metadata
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $plannedRow
+     * @return list<array<string,mixed>>
+     */
+    private function sectionPayloads(
+        array $content,
+        array $faq,
+        array $links,
+        array $seo,
+        array $metadata,
+        array $row,
+        array $plannedRow,
+        string $snapshotKey,
+    ): array {
+        $sections = [];
+        $sort = 100;
+        foreach ($content as $key => $value) {
+            $sectionKey = $this->safeSectionKey((string) $key);
+            $payload = is_array($value) ? $value : ['body' => $value];
+            $body = $this->bodyFromContent($value);
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'render_variant' => 'rich_text',
+                'body_md' => $body,
+                'body_html' => null,
+                'payload_json' => [
+                    'title' => $this->nullableString($payload['h2'] ?? ($payload['title'] ?? null)),
+                    'body' => $body,
+                    'source' => 'mbti64_v2_1_revision_promotion',
+                    'raw' => $payload,
+                ],
+                'sort_order' => $sort,
+                'is_enabled' => true,
+            ];
+            $sort += 10;
+        }
+
+        if ($faq !== []) {
+            $sections[] = [
+                'section_key' => 'faq',
+                'render_variant' => 'faq',
+                'body_md' => null,
+                'body_html' => null,
+                'payload_json' => [
+                    'items' => $faq,
+                    'source' => 'mbti64_v2_1_revision_promotion',
+                ],
+                'sort_order' => 900,
+                'is_enabled' => true,
+            ];
+        }
+
+        if ($links !== []) {
+            $sections[] = [
+                'section_key' => 'related_content',
+                'render_variant' => 'links',
+                'body_md' => null,
+                'body_html' => null,
+                'payload_json' => [
+                    'links' => $links,
+                    'source' => 'mbti64_v2_1_revision_promotion',
+                ],
+                'sort_order' => 910,
+                'is_enabled' => true,
+            ];
+        }
+
+        $sections[] = [
+            'section_key' => 'mbti64_promotion_metadata',
+            'render_variant' => 'callout',
+            'body_md' => $this->nullableString($seo['quick_answer_summary'] ?? null),
+            'body_html' => null,
+            'payload_json' => [
+                'snapshot_key' => $snapshotKey,
+                'url' => (string) ($plannedRow['url'] ?? ''),
+                'identity' => $plannedRow['identity'] ?? [],
+                'structured_metadata' => $metadata,
+                'raw_row' => $row,
+            ],
+            'sort_order' => 990,
+            'is_enabled' => true,
+        ];
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string,mixed>  $content
+     * @param  list<mixed>  $faq
+     * @param  list<mixed>  $links
+     * @param  array<string,mixed>  $seo
+     * @param  array<string,mixed>  $metadata
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $plannedRow
+     * @return array<string,mixed>
+     */
+    private function comparisonSectionPayload(
+        array $content,
+        array $faq,
+        array $links,
+        array $seo,
+        array $metadata,
+        array $row,
+        array $plannedRow,
+        string $snapshotKey,
+    ): array {
+        return [
+            'section_key' => 'mbti64_comparison_a_vs_t',
+            'title' => $this->nullableString($seo['h1'] ?? ($seo['seo_title'] ?? 'A/T comparison')),
+            'render_variant' => 'rich_text',
+            'body_md' => $this->nullableString($seo['quick_answer_summary'] ?? $this->bodyFromContent($content['quick_answer'] ?? null)),
+            'body_html' => null,
+            'payload_json' => [
+                'snapshot_key' => $snapshotKey,
+                'url' => (string) ($plannedRow['url'] ?? ''),
+                'seo' => $seo,
+                'content' => $content,
+                'faq' => $faq,
+                'internal_links' => $links,
+                'structured_metadata' => $metadata,
+                'identity' => $plannedRow['identity'] ?? [],
+                'raw_row' => $row,
+                'source' => 'mbti64_v2_1_comparison_revision_promotion',
+            ],
+            'sort_order' => 920,
+            'is_enabled' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $preparedRow
+     */
+    private function applyPromotion(array $preparedRow): void
+    {
+        $pageType = (string) ($preparedRow['page_type'] ?? '');
+        $targetId = (int) ($preparedRow['target_id'] ?? 0);
+        $payload = is_array($preparedRow['promotion_preview'] ?? null) ? $preparedRow['promotion_preview'] : [];
+
+        if ($pageType === 'comparison') {
+            $this->upsertComparisonSection($targetId, $payload);
+
+            return;
+        }
+
+        $this->upsertVariantSeo($targetId, $payload);
+        $this->upsertVariantSections($targetId, $payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function liveMatchesPromotion(string $pageType, int $targetId, array $payload): bool
+    {
+        if ($pageType === 'comparison') {
+            $section = PersonalityProfileSection::query()
+                ->withoutGlobalScopes()
+                ->where('profile_id', $targetId)
+                ->where('section_key', 'mbti64_comparison_a_vs_t')
+                ->first();
+
+            return $section instanceof PersonalityProfileSection
+                && $this->modelSubsetMatches($section, $payload['comparison_section'] ?? []);
+        }
+
+        return $this->variantSeoMatches($targetId, $payload)
+            && $this->variantSectionsMatch($targetId, $payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function upsertVariantSeo(int $variantId, array $payload): void
+    {
+        $seo = is_array($payload['seo'] ?? null) ? $payload['seo'] : [];
+        PersonalityProfileVariantSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->updateOrCreate(
+                ['personality_profile_variant_id' => $variantId],
+                array_merge($seo, ['personality_profile_variant_id' => $variantId])
+            );
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function upsertVariantSections(int $variantId, array $payload): void
+    {
+        foreach ((array) ($payload['sections'] ?? []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            PersonalityProfileVariantSection::query()
+                ->withoutGlobalScopes()
+                ->updateOrCreate(
+                    [
+                        'personality_profile_variant_id' => $variantId,
+                        'section_key' => (string) ($section['section_key'] ?? ''),
+                    ],
+                    array_merge($section, ['personality_profile_variant_id' => $variantId])
+                );
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function upsertComparisonSection(int $profileId, array $payload): void
+    {
+        $section = is_array($payload['comparison_section'] ?? null) ? $payload['comparison_section'] : [];
+        PersonalityProfileSection::query()
+            ->withoutGlobalScopes()
+            ->updateOrCreate(
+                [
+                    'profile_id' => $profileId,
+                    'section_key' => (string) ($section['section_key'] ?? 'mbti64_comparison_a_vs_t'),
+                ],
+                array_merge($section, ['profile_id' => $profileId])
+            );
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function variantSeoMatches(int $variantId, array $payload): bool
+    {
+        $seo = PersonalityProfileVariantSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', $variantId)
+            ->first();
+        if (! $seo instanceof PersonalityProfileVariantSeoMeta) {
+            return false;
+        }
+
+        return $this->modelSubsetMatches($seo, $payload['seo'] ?? []);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function variantSectionsMatch(int $variantId, array $payload): bool
+    {
+        foreach ((array) ($payload['sections'] ?? []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+
+            $live = PersonalityProfileVariantSection::query()
+                ->withoutGlobalScopes()
+                ->where('personality_profile_variant_id', $variantId)
+                ->where('section_key', (string) ($section['section_key'] ?? ''))
+                ->first();
+
+            if (! $live instanceof PersonalityProfileVariantSection || ! $this->modelSubsetMatches($live, $section)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string,mixed>  $expected
+     */
+    private function modelSubsetMatches(Model $model, array $expected): bool
+    {
+        foreach ($expected as $key => $value) {
+            if (in_array($key, ['org_id', 'created_at', 'updated_at'], true)) {
+                continue;
+            }
+
+            $actual = $model->getAttribute($key);
+            if (is_array($value)) {
+                if ($actual !== $value) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if ($actual !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function safeSectionKey(string $key): string
+    {
+        $normalized = strtolower(trim(preg_replace('/[^a-zA-Z0-9_]+/', '_', $key) ?? '', '_'));
+
+        return substr($normalized !== '' ? $normalized : 'content', 0, 90);
+    }
+
+    private function bodyFromContent(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return trim($value) !== '' ? trim($value) : null;
+        }
+
+        if (! is_array($value)) {
+            return null;
+        }
+
+        foreach (['body', 'summary', 'text', 'answer'] as $key) {
+            if (isset($value[$key]) && is_string($value[$key]) && trim($value[$key]) !== '') {
+                return trim($value[$key]);
+            }
+        }
+
+        return null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -1,0 +1,479 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_lists_eight_latest_revisions_without_live_writes(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame(8, $payload['row_count']);
+        $this->assertSame(6, $payload['variant_row_count']);
+        $this->assertSame(2, $payload['comparison_row_count']);
+        $this->assertSame(8, $payload['would_promote_count']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_write_promotes_eight_revisions_to_live_cms_fields_without_index_search_side_effects(): void
+    {
+        $targets = $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+        $profileBefore = $this->profilePublishState($targets['en|INTJ']);
+        $variantBefore = $this->variantPublishState($targets['en|INTJ-A']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['queue_enqueue_attempted']);
+        $this->assertSame(8, $payload['promoted_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame($profileBefore, $this->profilePublishState($targets['en|INTJ']));
+        $this->assertSame($variantBefore, $this->variantPublishState($targets['en|INTJ-A']));
+
+        $seo = PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|INTJ-A']->id)
+            ->firstOrFail();
+        $this->assertSame('SEO title for /en/personality/intj-a', $seo->seo_title);
+        $this->assertSame('/en/personality/intj-a', $seo->canonical_url);
+        $this->assertSame('index,follow', $seo->robots);
+
+        $section = PersonalityProfileVariantSection::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|INTJ-A']->id)
+            ->where('section_key', 'quick_answer')
+            ->firstOrFail();
+        $this->assertSame('Quick answer for /en/personality/intj-a.', $section->body_md);
+
+        $comparison = PersonalityProfileSection::query()
+            ->where('profile_id', (int) $targets['en|INTJ']->id)
+            ->where('section_key', 'mbti64_comparison_a_vs_t')
+            ->firstOrFail();
+        $this->assertSame('H1 for /en/personality/intj-a-vs-intj-t', $comparison->title);
+        $this->assertSame('/en/personality/intj-a-vs-intj-t', $comparison->payload_json['url'] ?? null);
+    }
+
+    public function test_second_write_is_idempotent(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+
+        $this->assertSame(0, Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath)));
+        $secondExit = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(8, $payload['skipped_existing_count']);
+    }
+
+    public function test_write_fails_closed_when_required_safety_flag_is_missing(): void
+    {
+        $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+        $options = $this->promoteWriteOptions($packagePath);
+        unset($options['--no-search-release']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('--no-search-release is required', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_wrong_source_hash_fails_closed(): void
+    {
+        $this->seedTargets();
+        $package = $this->validPackage();
+        $packagePath = $this->writePackage($package);
+        $this->createDraftRevisions($packagePath);
+        $package['rows'][4]['seo']['seo_title'] = 'Different package hash';
+        $changedPackagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($changedPackagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('revision_not_found_for_source_sha256', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_missing_target_rolls_back_entire_batch(): void
+    {
+        $targets = $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+        $targets['zh-CN|INTJ-T']->delete();
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('target_not_found', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_non_latest_revision_fails_closed(): void
+    {
+        $targets = $this->seedTargets();
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->createDraftRevisions($packagePath);
+
+        PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => (int) $targets['en|INTJ-A']->id,
+            'revision_no' => 2,
+            'snapshot_json' => ['manual_revision' => true],
+            'note' => 'newer manual draft',
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('revision_not_latest_for_target', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_forbidden_private_route_pattern_is_rejected_before_writes(): void
+    {
+        $this->seedTargets();
+        $package = $this->validPackage();
+        $package['rows'][0]['internal_links'][] = [
+            'href' => '/results/lookup',
+            'anchor_text' => 'Forbidden',
+            'role' => 'forbidden',
+            'safe_public_route' => false,
+        ];
+        $packagePath = $this->writePackage($package);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('forbidden_public_route_pattern_present', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    /**
+     * @return array<string,PersonalityProfile|PersonalityProfileVariant>
+     */
+    private function seedTargets(): array
+    {
+        $targets = [];
+        $profiles = [
+            ['en', 'INTJ', 'Architect'],
+            ['en', 'INTP', 'Logician'],
+            ['zh-CN', 'ISTJ', '物流师'],
+            ['zh-CN', 'INFP', '调停者'],
+            ['zh-CN', 'INTJ', '建筑师'],
+        ];
+
+        foreach ($profiles as [$locale, $typeCode, $typeName]) {
+            $profile = $this->createProfile($locale, $typeCode, $typeName);
+            $targets[$locale.'|'.$typeCode] = $profile;
+        }
+
+        foreach ([
+            ['zh-CN', 'ISTJ-A'],
+            ['zh-CN', 'INFP-T'],
+            ['en', 'INTJ-A'],
+            ['en', 'INTJ-T'],
+            ['zh-CN', 'INTJ-A'],
+            ['zh-CN', 'INTJ-T'],
+        ] as [$locale, $runtimeTypeCode]) {
+            [$typeCode] = explode('-', $runtimeTypeCode);
+            $targets[$locale.'|'.$runtimeTypeCode] = $this->createVariant($targets[$locale.'|'.$typeCode], $runtimeTypeCode);
+        }
+
+        return $targets;
+    }
+
+    private function createProfile(string $locale, string $typeCode, string $typeName): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' - '.$typeName,
+            'type_name' => $typeName,
+            'nickname' => $typeName,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => $locale === 'zh-CN' ? $typeName.' 类型摘要' : $typeName.' type summary',
+            'hero_kicker' => $typeName,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function profilePublishState(PersonalityProfile $profile): array
+    {
+        $fresh = $profile->fresh();
+        $this->assertInstanceOf(PersonalityProfile::class, $fresh);
+
+        return [
+            'status' => (string) $fresh->status,
+            'is_public' => (bool) $fresh->is_public,
+            'is_indexable' => (bool) $fresh->is_indexable,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function variantPublishState(PersonalityProfileVariant $variant): array
+    {
+        $fresh = $variant->fresh();
+        $this->assertInstanceOf(PersonalityProfileVariant::class, $fresh);
+
+        return [
+            'is_published' => (bool) $fresh->is_published,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $rows = [
+            ['/en/personality/intj-a-vs-intj-t', 'en', 'comparison'],
+            ['/zh/personality/istj-a', 'zh-CN', 'variant'],
+            ['/en/personality/intp-a-vs-intp-t', 'en', 'comparison'],
+            ['/zh/personality/infp-t', 'zh-CN', 'variant'],
+            ['/en/personality/intj-a', 'en', 'variant'],
+            ['/en/personality/intj-t', 'en', 'variant'],
+            ['/zh/personality/intj-a', 'zh-CN', 'variant'],
+            ['/zh/personality/intj-t', 'zh-CN', 'variant'],
+        ];
+
+        return [
+            'artifact' => 'mbti64-content-package-pilot-v2.1',
+            'version' => 'pilot-v2.1',
+            'status' => 'draft_for_codex_qa',
+            'rows' => array_map(fn (array $row): array => $this->row($row[0], $row[1], $row[2]), $rows),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function row(string $url, string $locale, string $pageType): array
+    {
+        return [
+            'url' => $url,
+            'locale' => $locale,
+            'page_type' => $pageType,
+            'primary_query' => 'fixture query',
+            'secondary_queries' => ['fixture secondary'],
+            'excluded_queries' => ['fixture excluded'],
+            'target_intent' => 'fixture intent',
+            'target_test_route' => str_starts_with($url, '/zh/')
+                ? '/zh/tests/mbti-personality-test-16-personality-types'
+                : '/en/tests/mbti-personality-test-16-personality-types',
+            'canonical_target' => $url,
+            'seo' => [
+                'seo_title' => 'SEO title for '.$url,
+                'seo_description' => 'SEO description for '.$url.'.',
+                'breadcrumb_title' => 'Breadcrumb '.$url,
+                'h1' => 'H1 for '.$url,
+                'quick_answer_summary' => 'Quick answer summary for '.$url.'.',
+            ],
+            'content' => [
+                'quick_answer' => 'Quick answer for '.$url.'.',
+                'method_boundary' => ['h2' => 'Method boundary', 'body' => 'Boundary copy for '.$url.'.'],
+            ],
+            'faq' => [
+                ['question' => 'Question for '.$url.'?', 'answer' => 'Answer for '.$url.'.'],
+            ],
+            'internal_links' => [
+                [
+                    'href' => str_starts_with($url, '/zh/') ? '/zh/personality' : '/en/personality',
+                    'anchor_text' => 'Personality hub',
+                    'role' => 'hub',
+                    'safe_public_route' => true,
+                ],
+            ],
+            'method_boundary' => 'Fixture method boundary.',
+            'trademark_boundary' => 'Fixture trademark boundary.',
+            'information_gain' => ['unique_user_value' => 'fixture'],
+            'claim_risk_notes' => ['No deterministic claims.'],
+            'qa_flags_for_codex' => ['Fixture QA.'],
+            'route_safety' => ['forbidden_route_patterns_absent_from_internal_links' => true],
+            'v2_optimization' => ['primary_improvement' => 'fixture'],
+            'above_the_fold_module' => ['answer_card_title' => 'Fixture'],
+            'status' => 'draft_for_codex_qa',
+            'serp_ctr_package_v2' => ['seo_title' => 'SEO title for '.$url],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $path = sys_get_temp_dir().'/mbti64-cms-promote-'.bin2hex(random_bytes(6)).'.json';
+        File::put($path, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    private function createDraftRevisions(string $packagePath): void
+    {
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-draft', [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'MBTI64-CMS-REVISION-DRAFT-01',
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function promoteWriteOptions(string $packagePath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+            '--promote-live-content' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'MBTI64-BACKEND-PROMOTION-CONTRACT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3172,6 +3172,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbti64CmsRevisionPromoteFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -3943,6 +3947,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsIqNormImportDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4071,6 +4076,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbti64CmsRevisionDraft.php',
             'backend/app/Services/Cms/Mbti64CmsRevisionDraftWriter.php',
+        ], true);
+    }
+
+    private function isMbti64CmsRevisionPromoteFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php',
+            'backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php',
         ], true);
     }
 
@@ -6132,6 +6145,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityMbti64CmsRevisionDraft\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbti64CmsRevisionPromoteOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbti64CmsRevisionPromote\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed

Adds a controlled MBTI64 V2.1 CMS revision promotion contract for the 8-page pilot package.

- Added `personality:mbti64-cms-revision-promote`.
- Added `Mbti64CmsRevisionPromotionService`.
- Registered the command in the console Kernel.
- Added feature coverage for dry-run, guarded write, idempotency, wrong source hash, missing target rollback, non-latest revision blocking, and forbidden private route scanning.
- Updated the Big Five runtime freeze classifier allowlist so this backend-only MBTI64 contract does not look like a result-page runtime change.

## Why

The previous draft command can create MBTI64 V2.1 draft revisions, but production readiness found there was no safe command to promote those exact latest draft revisions into the live CMS/profile/variant content layer. This PR adds that promotion contract without combining sitemap, llms, search queue, search submission, frontend, or result-page changes.

## Safety boundaries

Write mode requires all of these flags:

```bash
--write \
  --promote-live-content \
  --no-index \
  --no-sitemap \
  --no-llms \
  --no-search-release \
  --operator-approved=MBTI64-BACKEND-PROMOTION-CONTRACT-01
```

The service fails closed unless each target has a matching latest draft revision with the expected source SHA and draft-only safety holds. The promotion only updates live CMS content fields:

- variant rows: `personality_profile_variant_seo_meta` and `personality_profile_variant_sections`
- comparison rows: a base `personality_profile_sections` overlay section

It does not update profile/variant publish state, sitemap, llms, search queue, search submit, result pages, payment routes, or frontend rendering.

## Validation

```bash
php -l backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
php -l backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
php -l backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
php artisan test tests/Feature/Console/PersonalityMbti64BackendImportContractCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings
bash backend/scripts/ci_verify_mbti.sh
git diff --check
```

Focused tests passed with Dotenv warnings because the isolated temp worktree intentionally had no `.env`; no `.env` was read or committed. `ci_verify_mbti.sh` passed after restoring local compiled Big Five artifacts generated as check side effects.

## Intentionally deferred

- No production promotion.
- No CMS write outside local tests.
- No sitemap or llms generation change.
- No search queue planning/enqueue/submit.
- No frontend or runtime renderer change.
- No `/results/lookup` classification fix.
