### PR TITLE
MBTI64-URL-TRUTH-INVENTORY-PATCH-01

### DIFF
--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -7,6 +7,8 @@ namespace App\Services\SeoIntel\Sources;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ContentPage;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
 use App\Models\ResearchReport;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\SeoIntel\UrlTruthInventoryRecord;
@@ -38,6 +40,12 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
 
     private ?string $articlesUnavailableReason = null;
 
+    private bool $personalityProfilesAttempted = false;
+
+    private bool $personalityProfilesAvailable = false;
+
+    private ?string $personalityProfilesUnavailableReason = null;
+
     /**
      * @return list<UrlTruthInventoryRecord>
      */
@@ -48,6 +56,7 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             ...$this->researchReportCandidates(),
             ...$this->contentPageCandidates(),
             ...$this->articleCandidates(),
+            ...$this->personalityProfileCandidates(),
             ...$this->configuredBackendAuthorityCandidates(),
         ]);
     }
@@ -70,6 +79,9 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             'articles_attempted' => $this->articlesAttempted,
             'articles_available' => $this->articlesAvailable,
             'articles_unavailable_reason' => $this->articlesUnavailableReason,
+            'personality_profiles_attempted' => $this->personalityProfilesAttempted,
+            'personality_profiles_available' => $this->personalityProfilesAvailable,
+            'personality_profiles_unavailable_reason' => $this->personalityProfilesUnavailableReason,
             'configured_backend_authority_canary_available' => $this->configuredBackendAuthorityCandidates() !== [],
             'fetches_public_html' => false,
             'external_api_calls' => false,
@@ -158,6 +170,118 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
         $this->articlesAvailable = $records !== [];
         if (! $this->articlesAvailable) {
             $this->articlesUnavailableReason = 'articles_empty_or_ineligible';
+        }
+
+        return $records;
+    }
+
+    /**
+     * @return list<UrlTruthInventoryRecord>
+     */
+    private function personalityProfileCandidates(): array
+    {
+        $this->personalityProfilesAttempted = true;
+
+        try {
+            $profiles = PersonalityProfile::query()
+                ->withoutGlobalScopes()
+                ->with(['variants' => static function ($query): void {
+                    $query
+                        ->withoutGlobalScopes()
+                        ->where('is_published', true)
+                        ->where(static function ($builder): void {
+                            $builder->whereNull('published_at')
+                                ->orWhere('published_at', '<=', now());
+                        })
+                        ->orderBy('variant_code');
+                }])
+                ->where('org_id', 0)
+                ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+                ->whereIn('type_code', PersonalityProfile::BASE_TYPE_CODES)
+                ->whereIn('locale', PersonalityProfile::SUPPORTED_LOCALES)
+                ->where('status', 'published')
+                ->where('is_public', true)
+                ->where('is_indexable', true)
+                ->where(static function ($builder): void {
+                    $builder->whereNull('published_at')
+                        ->orWhere('published_at', '<=', now());
+                })
+                ->orderBy('locale')
+                ->orderBy('type_code')
+                ->get();
+        } catch (\Throwable) {
+            $this->personalityProfilesUnavailableReason = 'personality_profiles_unavailable';
+
+            return [];
+        }
+
+        $records = [];
+        foreach ($profiles as $profile) {
+            if (! $profile instanceof PersonalityProfile || ! $this->hasRequiredPersonalityProfileFields($profile)) {
+                continue;
+            }
+
+            $variants = $profile->variants
+                ->filter(static fn (PersonalityProfileVariant $variant): bool => trim((string) $variant->runtime_type_code) !== '')
+                ->values();
+
+            foreach ($variants as $variant) {
+                $path = $this->personalityVariantCanonicalPath($profile, $variant);
+                if ($path === null) {
+                    continue;
+                }
+
+                $records[] = $this->personalityRecord(
+                    canonicalPath: $path,
+                    locale: (string) $profile->locale,
+                    pageEntityType: 'personality_profile_variant',
+                    entityIdOrSlug: (string) $variant->id,
+                    entitySource: 'personality_profile_variants',
+                    lastmodSource: 'personality_profile_variants.updated_at',
+                    sourceUpdatedAt: $variant->updated_at instanceof Carbon ? $variant->updated_at : null,
+                    lastmodAt: $variant->updated_at instanceof Carbon ? $variant->updated_at : null,
+                    extraMetadata: [
+                        'profile_id_hash' => hash('sha256', (string) $profile->id),
+                        'variant_id_hash' => hash('sha256', (string) $variant->id),
+                        'runtime_type_code_hash' => hash('sha256', (string) $variant->runtime_type_code),
+                        'canonical_type_code_hash' => hash('sha256', (string) $variant->canonical_type_code),
+                    ],
+                    extraAttributes: [
+                        'profile_id_hash' => hash('sha256', (string) $profile->id),
+                        'variant_id_hash' => hash('sha256', (string) $variant->id),
+                        'runtime_type_code_hash' => hash('sha256', (string) $variant->runtime_type_code),
+                    ],
+                );
+            }
+
+            $comparisonPath = $this->personalityComparisonCanonicalPath($profile, $variants);
+            if ($comparisonPath !== null) {
+                $updatedAt = $profile->updated_at instanceof Carbon ? $profile->updated_at : null;
+                $records[] = $this->personalityRecord(
+                    canonicalPath: $comparisonPath,
+                    locale: (string) $profile->locale,
+                    pageEntityType: 'personality_profile_comparison',
+                    entityIdOrSlug: (string) $profile->id,
+                    entitySource: 'personality_profiles',
+                    lastmodSource: 'personality_profiles.updated_at',
+                    sourceUpdatedAt: $updatedAt,
+                    lastmodAt: $updatedAt,
+                    extraMetadata: [
+                        'profile_id_hash' => hash('sha256', (string) $profile->id),
+                        'canonical_type_code_hash' => hash('sha256', (string) $profile->canonical_type_code),
+                        'comparison_kind' => 'a_vs_t',
+                    ],
+                    extraAttributes: [
+                        'profile_id_hash' => hash('sha256', (string) $profile->id),
+                        'canonical_type_code_hash' => hash('sha256', (string) $profile->canonical_type_code),
+                    ],
+                );
+            }
+        }
+
+        $this->personalityProfilesAvailable = $records !== [];
+        if (! $this->personalityProfilesAvailable) {
+            $this->personalityProfilesUnavailableReason = 'personality_profiles_empty_or_ineligible';
         }
 
         return $records;
@@ -566,6 +690,115 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
 
         return trim((string) $page->content_md) !== ''
             || trim((string) $page->content_html) !== '';
+    }
+
+    private function hasRequiredPersonalityProfileFields(PersonalityProfile $profile): bool
+    {
+        return trim((string) $profile->type_code) !== ''
+            && trim((string) $profile->canonical_type_code) !== ''
+            && in_array((string) $profile->canonical_type_code, PersonalityProfile::BASE_TYPE_CODES, true)
+            && trim((string) $profile->title) !== ''
+            && (string) $profile->status === 'published'
+            && (bool) $profile->is_public
+            && (bool) $profile->is_indexable;
+    }
+
+    private function personalityVariantCanonicalPath(
+        PersonalityProfile $profile,
+        PersonalityProfileVariant $variant
+    ): ?string {
+        $localeSegment = match ((string) $profile->locale) {
+            'zh-CN', 'zh' => 'zh',
+            'en' => 'en',
+            default => null,
+        };
+
+        $runtimeTypeCode = strtolower(trim((string) $variant->runtime_type_code));
+
+        if ($localeSegment === null || preg_match('/^[a-z]{4}-[at]$/', $runtimeTypeCode) !== 1) {
+            return null;
+        }
+
+        return '/'.$localeSegment.'/personality/'.$runtimeTypeCode;
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<int, PersonalityProfileVariant>  $variants
+     */
+    private function personalityComparisonCanonicalPath(PersonalityProfile $profile, $variants): ?string
+    {
+        $localeSegment = match ((string) $profile->locale) {
+            'zh-CN', 'zh' => 'zh',
+            'en' => 'en',
+            default => null,
+        };
+
+        $typeCode = strtolower(trim((string) $profile->canonical_type_code));
+        if ($localeSegment === null || preg_match('/^[a-z]{4}$/', $typeCode) !== 1) {
+            return null;
+        }
+
+        $variantCodes = $variants
+            ->map(static fn (PersonalityProfileVariant $variant): string => strtoupper(trim((string) $variant->variant_code)))
+            ->unique()
+            ->values()
+            ->all();
+
+        if (! in_array('A', $variantCodes, true) || ! in_array('T', $variantCodes, true)) {
+            return null;
+        }
+
+        return '/'.$localeSegment.'/personality/'.$typeCode.'-a-vs-'.$typeCode.'-t';
+    }
+
+    /**
+     * @param  array<string, mixed>  $extraMetadata
+     * @param  array<string, mixed>  $extraAttributes
+     */
+    private function personalityRecord(
+        string $canonicalPath,
+        string $locale,
+        string $pageEntityType,
+        string $entityIdOrSlug,
+        string $entitySource,
+        string $lastmodSource,
+        ?Carbon $sourceUpdatedAt,
+        ?Carbon $lastmodAt,
+        array $extraMetadata = [],
+        array $extraAttributes = [],
+    ): UrlTruthInventoryRecord {
+        return new UrlTruthInventoryRecord(
+            canonicalUrl: $this->canonicalUrl($canonicalPath),
+            locale: $locale,
+            pageEntityType: $pageEntityType,
+            entityIdOrSlug: $entityIdOrSlug,
+            sourceAuthority: 'backend_cms',
+            indexabilityState: 'indexable',
+            lastmodAt: $lastmodAt,
+            lastmodSource: $lastmodSource,
+            cluster: 'personality',
+            entitySource: $entitySource,
+            authorityStatus: 'published_approved',
+            sourceUpdatedAt: $sourceUpdatedAt,
+            metadata: [
+                'source_table_hash' => hash('sha256', $entitySource),
+                'canonical_path_hash' => hash('sha256', $canonicalPath),
+                'claim_boundary_state' => 'claim_safe',
+                'claim_safe' => true,
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'publication_state' => 'published',
+                'robots' => 'index',
+                'frontend_fallback' => false,
+                'static_sitemap_fallback' => false,
+                'static_llms_fallback' => false,
+                'private_flow' => false,
+            ] + $extraMetadata,
+            attributes: [
+                'source_authority' => 'backend_cms',
+                'claim_safe' => true,
+            ] + $extraAttributes,
+        );
     }
 
     /**

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -40,6 +40,8 @@ return [
             'article',
             'topic',
             'personality',
+            'personality_profile_variant',
+            'personality_profile_comparison',
             'career_job',
             'career_recommendation',
             'methodology',
@@ -270,6 +272,8 @@ return [
             'home',
             'test_hub',
             'test_detail',
+            'personality_profile_variant',
+            'personality_profile_comparison',
         ],
         'forbidden_page_entity_types' => [
             'take',

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
@@ -76,6 +76,47 @@ final class SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest extends 
     }
 
     #[Test]
+    public function dry_run_with_persisted_personality_variant_url_is_queue_eligible(): void
+    {
+        $url = 'https://fermatmind.com/en/personality/intj-a';
+        $this->seedSeoUrl([
+            'canonical_url' => $url,
+            'page_entity_type' => 'personality_profile_variant',
+            'entity_id_or_slug' => 'variant-intj-a',
+            'source_authority' => 'backend_cms',
+            'cluster' => 'personality',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'claim_safe',
+                'publication_state' => 'published',
+                'robots' => 'index',
+                'sitemap_eligible' => true,
+                'llms_eligible' => true,
+                'source_table' => 'personality_profile_variants',
+            ],
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--channel' => 'indexnow',
+            '--canonical-url' => $url,
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertSame(1, $output['candidate_count'] ?? null);
+        $this->assertSame(1, $output['eligible_count'] ?? null);
+        $this->assertSame(1, $output['planned_queue_count'] ?? null);
+        $this->assertSame('personality_profile_variant', data_get($output, 'selected_candidate.page_entity_type'));
+        $this->assertFalse((bool) ($output['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+    }
+
+    #[Test]
     public function dry_run_with_absent_url_returns_zero_candidates_and_safe_issue(): void
     {
         $exitCode = Artisan::call('seo-intel:search-channel-queue', [

--- a/backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Services\SeoIntel\Sources\BackendAuthorityUrlTruthSource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelMbti64PersonalityUrlTruthInventoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function backend_authority_source_emits_mbti64_variant_and_comparison_url_truth_candidates(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $this->seedPublishedMbti64Profiles();
+
+        $source = new BackendAuthorityUrlTruthSource;
+        $records = collect($source->candidates());
+        $personalityRecords = $records
+            ->filter(static fn ($record): bool => in_array($record->pageEntityType, [
+                'personality_profile_variant',
+                'personality_profile_comparison',
+            ], true))
+            ->values();
+
+        $this->assertCount(96, $personalityRecords);
+        $this->assertCount(64, $personalityRecords->where('pageEntityType', 'personality_profile_variant'));
+        $this->assertCount(32, $personalityRecords->where('pageEntityType', 'personality_profile_comparison'));
+
+        $canonicalUrls = $personalityRecords->pluck('canonicalUrl')->all();
+        foreach ($this->pilotCanonicalUrls() as $url) {
+            $this->assertContains($url, $canonicalUrls);
+        }
+
+        $this->assertFalse($personalityRecords->contains(
+            static fn ($record): bool => str_contains($record->canonicalUrl, 'https://www.fermatmind.com')
+                || str_contains($record->canonicalUrl, '/zh-CN/')
+                || str_contains($record->canonicalUrl, '/results')
+                || str_contains($record->canonicalUrl, '/orders')
+                || str_contains($record->canonicalUrl, '/pay')
+                || str_contains($record->canonicalUrl, '/account')
+        ));
+
+        $sampleVariant = $personalityRecords->firstWhere(
+            'canonicalUrl',
+            'https://fermatmind.com/en/personality/intj-a'
+        );
+        $sampleComparison = $personalityRecords->firstWhere(
+            'canonicalUrl',
+            'https://fermatmind.com/en/personality/intj-a-vs-intj-t'
+        );
+
+        $this->assertNotNull($sampleVariant);
+        $this->assertSame('personality_profile_variant', $sampleVariant->pageEntityType);
+        $this->assertSame('backend_cms', $sampleVariant->sourceAuthority);
+        $this->assertSame('indexable', $sampleVariant->indexabilityState);
+        $this->assertFalse($sampleVariant->isPrivateFlow);
+        $this->assertSame('published', $sampleVariant->metadata['publication_state'] ?? null);
+        $this->assertTrue((bool) ($sampleVariant->metadata['claim_safe'] ?? false));
+        $this->assertFalse((bool) ($sampleVariant->metadata['frontend_fallback'] ?? true));
+        $this->assertFalse((bool) ($sampleVariant->metadata['static_sitemap_fallback'] ?? true));
+        $this->assertFalse((bool) ($sampleVariant->metadata['static_llms_fallback'] ?? true));
+
+        $this->assertNotNull($sampleComparison);
+        $this->assertSame('personality_profile_comparison', $sampleComparison->pageEntityType);
+        $this->assertSame('backend_cms', $sampleComparison->sourceAuthority);
+        $this->assertSame('indexable', $sampleComparison->indexabilityState);
+        $this->assertSame('a_vs_t', $sampleComparison->metadata['comparison_kind'] ?? null);
+
+        $metadata = $source->metadata();
+        $this->assertTrue((bool) ($metadata['personality_profiles_attempted'] ?? false));
+        $this->assertTrue((bool) ($metadata['personality_profiles_available'] ?? false));
+        $this->assertContains('personality_profile_variant', config('seo_intel.url_truth_inventory.allowed_page_entity_types', []));
+        $this->assertContains('personality_profile_comparison', config('seo_intel.url_truth_inventory.allowed_page_entity_types', []));
+        $this->assertContains('personality_profile_variant', config('seo_intel.search_channel_queue.allowed_page_entity_types', []));
+        $this->assertContains('personality_profile_comparison', config('seo_intel.search_channel_queue.allowed_page_entity_types', []));
+    }
+
+    #[Test]
+    public function backend_authority_source_excludes_unpublished_private_or_incomplete_personality_pages(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+
+        $draft = $this->createProfile('INTJ', 'en', [
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+        ]);
+        $this->createVariant($draft, 'A', ['is_published' => true]);
+        $this->createVariant($draft, 'T', ['is_published' => true]);
+
+        $noindex = $this->createProfile('INTP', 'en', [
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+        ]);
+        $this->createVariant($noindex, 'A', ['is_published' => true]);
+        $this->createVariant($noindex, 'T', ['is_published' => true]);
+
+        $missingT = $this->createProfile('ENTJ', 'en', [
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+        ]);
+        $this->createVariant($missingT, 'A', ['is_published' => true]);
+        $this->createVariant($missingT, 'T', ['is_published' => false]);
+
+        $records = collect((new BackendAuthorityUrlTruthSource)->candidates());
+        $canonicalUrls = $records->pluck('canonicalUrl')->all();
+
+        $this->assertNotContains('https://fermatmind.com/en/personality/intj-a', $canonicalUrls);
+        $this->assertNotContains('https://fermatmind.com/en/personality/intp-a', $canonicalUrls);
+        $this->assertContains('https://fermatmind.com/en/personality/entj-a', $canonicalUrls);
+        $this->assertNotContains('https://fermatmind.com/en/personality/entj-t', $canonicalUrls);
+        $this->assertNotContains('https://fermatmind.com/en/personality/entj-a-vs-entj-t', $canonicalUrls);
+    }
+
+    private function seedPublishedMbti64Profiles(): void
+    {
+        foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $profile = $this->createProfile($typeCode, $locale, [
+                    'status' => 'published',
+                    'is_public' => true,
+                    'is_indexable' => true,
+                ]);
+                $this->createVariant($profile, 'A', ['is_published' => true]);
+                $this->createVariant($profile, 'T', ['is_published' => true]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createProfile(string $typeCode, string $locale, array $overrides = []): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create($overrides + [
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' profile',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createVariant(PersonalityProfile $profile, string $variantCode, array $overrides = []): PersonalityProfileVariant
+    {
+        return PersonalityProfileVariant::query()->create($overrides + [
+            'org_id' => 0,
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => (string) $profile->canonical_type_code,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => ((string) $profile->canonical_type_code).'-'.$variantCode,
+            'type_name' => ((string) $profile->canonical_type_code).'-'.$variantCode,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pilotCanonicalUrls(): array
+    {
+        return [
+            'https://fermatmind.com/en/personality/intj-a-vs-intj-t',
+            'https://fermatmind.com/zh/personality/istj-a',
+            'https://fermatmind.com/en/personality/intp-a-vs-intp-t',
+            'https://fermatmind.com/zh/personality/infp-t',
+            'https://fermatmind.com/en/personality/intj-a',
+            'https://fermatmind.com/en/personality/intj-t',
+            'https://fermatmind.com/zh/personality/intj-a',
+            'https://fermatmind.com/zh/personality/intj-t',
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- Added backend-authoritative MBTI64 personality URL Truth candidates from `personality_profiles` and `personality_profile_variants`.
- Emits 64 A/T variant candidates and 32 A-vs-T comparison candidates when CMS records are published/public/indexable.
- Adds Search Channel Queue allowlist support for:
  - `personality_profile_variant`
  - `personality_profile_comparison`
- Adds focused tests covering 96-candidate inventory, the 8 pilot URLs, exclusion of draft/private/noindex/incomplete rows, and dry-run queue eligibility for a persisted personality URL.

## Why
`MBTI64-SEARCH-CHANNEL-URL-TRUTH-RECHECK-01` showed the 8 pilot canonical URLs still returned `canonical_url_not_found`. This patch makes those public personality pages discoverable by the backend URL Truth authority so a later URL Truth handoff/import gate can write validated records under separate approval.

## Validation
- `APP_ENV=testing php artisan test tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix02UrlTruthAlignmentTest.php tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `./vendor/bin/pint app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php config/seo_intel.php tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php tests/Feature/SeoIntel/SeoIntelMbti64PersonalityUrlTruthInventoryTest.php`
- `git diff --check`
- Scope validation: only URL Truth source/config/focused SeoIntel tests changed.

## Intentionally deferred
- No production URL Truth write/import.
- No Search Queue enqueue, approval, or search submit.
- No frontend, CMS live content, sitemap, llms.txt, or llms-full changes.
- Next task: production URL Truth handoff dry-run/import gate, then rerun `MBTI64-SEARCH-CHANNEL-URL-TRUTH-RECHECK-01`.
