### PR TITLE
Add article discoverability release command

### DIFF
--- a/backend/app/Console/Commands/ArticleDiscoverabilityRelease.php
+++ b/backend/app/Console/Commands/ArticleDiscoverabilityRelease.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Audit\AuditLogger;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class ArticleDiscoverabilityRelease extends Command
+{
+    protected $signature = 'articles:discoverability-release
+        {--article-id= : Exact article id to lock}
+        {--expected-slug= : Expected article slug lock}
+        {--confirm= : Exact user confirmation phrase for execute mode}
+        {--dry-run : Validate and plan without writing}
+        {--execute : Release sitemap/llms eligibility}
+        {--json : Emit a JSON summary}
+        {--no-content-change : Required execute-mode hold: do not modify article content}
+        {--no-publish : Required execute-mode hold: do not publish or promote}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-schema-hreflang : Required execute-mode hold: do not modify schema or hreflang gates}
+        {--no-revalidation : Required execute-mode hold: do not revalidate frontend paths}';
+
+    protected $description = 'Safely release sitemap and llms eligibility for one already-published locked article.';
+
+    public function handle(AuditLogger $auditLogger): int
+    {
+        try {
+            $summary = $this->buildSummary($auditLogger);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(AuditLogger $auditLogger): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+        $expectedConfirmation = $this->expectedConfirmation($articleId, $expectedSlug);
+        $confirmation = trim((string) $this->option('confirm'));
+        $errors = [];
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+        if ($execute) {
+            foreach (['no-content-change', 'no-publish', 'no-search', 'no-schema-hreflang', 'no-revalidation'] as $flag) {
+                if ((bool) $this->option($flag) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+            if (! hash_equals($expectedConfirmation, $confirmation)) {
+                $errors[] = $this->issue(
+                    'confirm',
+                    'confirmation_mismatch',
+                    'Exact confirmation phrase is required before discoverability release.',
+                    ['expected_confirmation' => $expectedConfirmation],
+                );
+            }
+        }
+
+        if ($articleId <= 0) {
+            $errors[] = $this->issue('article_id', 'article_id_required', '--article-id is required.');
+        }
+        if ($expectedSlug === '') {
+            $errors[] = $this->issue('expected_slug', 'expected_slug_required', '--expected-slug is required.');
+        }
+
+        $plan = $articleId > 0 ? $this->preflight($articleId, $expectedSlug) : null;
+        if ($plan === null) {
+            $errors[] = $this->issue('article_id', 'article_not_found', 'Article was not found.');
+        } else {
+            foreach ((array) ($plan['errors'] ?? []) as $error) {
+                if (is_array($error)) {
+                    $errors[] = $error;
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $expectedSlug, $expectedConfirmation, $plan, $errors);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_release_article_discoverability', $articleId, $expectedSlug, $expectedConfirmation, $plan, []);
+        }
+
+        $executedPlan = DB::transaction(function () use ($articleId, $expectedSlug): array {
+            $lockedPlan = $this->preflight($articleId, $expectedSlug, lockForUpdate: true);
+            if ($lockedPlan === null) {
+                throw new RuntimeException('planned article disappeared before discoverability release.');
+            }
+
+            $errors = (array) ($lockedPlan['errors'] ?? []);
+            if ($errors !== []) {
+                $codes = collect($errors)
+                    ->map(static fn (mixed $error): string => is_array($error) ? (string) ($error['code'] ?? '') : '')
+                    ->filter()
+                    ->implode(',');
+
+                throw new RuntimeException('discoverability release preflight failed before write: '.$codes);
+            }
+
+            DB::table('articles')
+                ->where('id', $articleId)
+                ->update([
+                    'sitemap_eligible' => true,
+                    'llms_eligible' => true,
+                    'updated_at' => now(),
+                ]);
+
+            return $this->preflight($articleId, $expectedSlug) ?? $lockedPlan;
+        });
+
+        $auditLogger->log(
+            Request::create('/ops/articles/discoverability-release', 'POST'),
+            'articles_discoverability_release',
+            'article',
+            (string) $articleId,
+            [
+                'command' => 'articles:discoverability-release',
+                'article_id' => $articleId,
+                'slug' => $expectedSlug,
+                'confirmation_sha256' => hash('sha256', $confirmation),
+                'updates_scope' => ['articles.sitemap_eligible', 'articles.llms_eligible'],
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_revalidation' => true,
+                'before' => $plan['before'] ?? null,
+                'after' => $executedPlan['after'] ?? null,
+            ],
+            reason: 'controlled_article_discoverability_release',
+            result: 'success',
+        );
+
+        return $this->summary(true, false, 'released_article_discoverability', $articleId, $expectedSlug, $expectedConfirmation, $executedPlan, []);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function preflight(int $articleId, string $expectedSlug, bool $lockForUpdate = false): ?array
+    {
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->when($lockForUpdate, static fn ($query) => $query->lockForUpdate())
+            ->find($articleId);
+
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        $before = $this->snapshot($article);
+        $after = $before;
+        $after['sitemap_eligible'] = true;
+        $after['llms_eligible'] = true;
+        $errors = [];
+
+        if ((string) $article->slug !== $expectedSlug) {
+            $errors[] = $this->issue('article.slug', 'expected_slug_mismatch', 'Article slug does not match expected lock.');
+        }
+        if ((string) $article->status !== 'published') {
+            $errors[] = $this->issue('article.status', 'article_not_published', 'Article must already be published.');
+        }
+        if (! (bool) $article->is_public) {
+            $errors[] = $this->issue('article.is_public', 'article_not_public', 'Article must already be public.');
+        }
+        if (! (bool) $article->is_indexable) {
+            $errors[] = $this->issue('article.is_indexable', 'article_not_indexable', 'Article must already be indexable.');
+        }
+        if ((string) $article->lifecycle_state !== '' && in_array((string) $article->lifecycle_state, [
+            Article::LIFECYCLE_ARCHIVED,
+            Article::LIFECYCLE_SOFT_DELETED,
+        ], true)) {
+            $errors[] = $this->issue('article.lifecycle_state', 'article_lifecycle_not_releasable', 'Archived or soft-deleted articles cannot be released to sitemap/llms.');
+        }
+        if (method_exists($article, 'trashed') && $article->trashed()) {
+            $errors[] = $this->issue('article.deleted_at', 'article_soft_deleted', 'Soft-deleted articles cannot be released to sitemap/llms.');
+        }
+
+        $revision = $article->publishedRevision;
+        if (! $revision instanceof ArticleTranslationRevision) {
+            $errors[] = $this->issue('article.published_revision_id', 'published_revision_missing', 'Article must have a published revision.');
+        } elseif ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            $errors[] = $this->issue('published_revision.revision_status', 'published_revision_status_invalid', 'Published revision must have published status.');
+        }
+
+        $seoMeta = $article->seoMeta;
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            $errors[] = $this->issue('seo_meta', 'seo_meta_missing', 'Article SEO meta must exist before sitemap/llms release.');
+        } else {
+            if (! (bool) $seoMeta->is_indexable) {
+                $errors[] = $this->issue('seo_meta.is_indexable', 'seo_meta_not_indexable', 'SEO meta must already be indexable.');
+            }
+            if ((string) $seoMeta->robots !== 'index,follow') {
+                $errors[] = $this->issue('seo_meta.robots', 'seo_meta_robots_not_index_follow', 'SEO meta robots must be index,follow.');
+            }
+
+            $expectedCanonicalPath = $this->canonicalPathForArticle($article);
+            $actualCanonicalPath = $this->pathFromCanonical((string) $seoMeta->canonical_url);
+            if ($actualCanonicalPath !== $expectedCanonicalPath) {
+                $errors[] = $this->issue(
+                    'seo_meta.canonical_url',
+                    'canonical_path_mismatch',
+                    'SEO meta canonical must match the locked article route.',
+                    [
+                        'expected_canonical_path' => $expectedCanonicalPath,
+                        'actual_canonical_path' => $actualCanonicalPath,
+                    ],
+                );
+            }
+        }
+
+        return [
+            'article_id' => $articleId,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'canonical_path' => $this->canonicalPathForArticle($article),
+            'already_released' => (bool) $article->sitemap_eligible && (bool) $article->llms_eligible,
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $revision = $article->publishedRevision;
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'published_revision_id' => $article->published_revision_id === null ? null : (int) $article->published_revision_id,
+            'published_revision_status' => $revision instanceof ArticleTranslationRevision ? (string) $revision->revision_status : null,
+            'content_md_sha256' => hash('sha256', (string) $article->content_md),
+            'content_html_sha256' => hash('sha256', (string) $article->content_html),
+            'seo_meta_exists' => $seoMeta instanceof ArticleSeoMeta,
+            'seo_robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'canonical_path' => $seoMeta instanceof ArticleSeoMeta ? $this->pathFromCanonical((string) $seoMeta->canonical_url) : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta
+                ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE))
+                : null,
+        ];
+    }
+
+    private function expectedConfirmation(int $articleId, string $expectedSlug): string
+    {
+        return "I explicitly approve articles:discoverability-release execute for article id {$articleId} slug {$expectedSlug} after dry-run passes.";
+    }
+
+    private function canonicalPathForArticle(Article $article): string
+    {
+        $locale = (string) $article->locale;
+        $prefix = str_starts_with($locale, 'zh') ? '/zh' : '/en';
+
+        return $prefix.'/articles/'.(string) $article->slug;
+    }
+
+    private function pathFromCanonical(string $canonical): string
+    {
+        $path = parse_url($canonical, PHP_URL_PATH);
+
+        return is_string($path) && $path !== '' ? $path : $canonical;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, int $articleId, string $expectedSlug, string $expectedConfirmation, ?array $plan, array $errors): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'article_id' => $articleId,
+            'expected_slug' => $expectedSlug,
+            'expected_confirmation' => $expectedConfirmation,
+            'updates_scope' => ['articles.sitemap_eligible', 'articles.llms_eligible'],
+            'protected_holds' => [
+                'no_content_change' => true,
+                'no_publish' => true,
+                'no_search' => true,
+                'no_schema_hreflang' => true,
+                'no_revalidation' => true,
+            ],
+            'external_search_submission_attempted' => false,
+            'schema_hreflang_write_attempted' => false,
+            'content_write_attempted' => false,
+            'publish_attempted' => false,
+            'revalidation_attempted' => false,
+            'plan' => $plan,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+
+        return $this->summary(false, ! (bool) $this->option('execute'), 'will_skip', $articleId, $expectedSlug, $this->expectedConfirmation($articleId, $expectedSlug), null, [[
+            'field' => 'command',
+            'code' => $code,
+            'message' => $message,
+        ]]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? ''));
+        $this->line('article_id='.(string) ($summary['article_id'] ?? ''));
+        $this->line('expected_slug='.(string) ($summary['expected_slug'] ?? ''));
+        $this->line('expected_confirmation='.(string) ($summary['expected_confirmation'] ?? ''));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('error='.$this->issueLine($error));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode('|', array_filter([
+            'field='.(string) ($issue['field'] ?? ''),
+            'code='.(string) ($issue['code'] ?? ''),
+            'message='.(string) ($issue['message'] ?? ''),
+        ]));
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\AdminBootstrapOwner;
 use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\ArticleCoverPropagationSmoke;
+use App\Console\Commands\ArticleDiscoverabilityRelease;
 use App\Console\Commands\ArticleEnsureSeoMetaBaseline;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
@@ -345,6 +346,7 @@ class Kernel extends ConsoleKernel
         ArticleEnsureSeoMetaBaseline::class,
         ArticleUpdateExistingSeoContentPackage::class,
         ArticleCoverPropagationSmoke::class,
+        ArticleDiscoverabilityRelease::class,
         ArticlePublishControlled::class,
         ArticleReplaceInlineImageUrl::class,
         ArticleSeoGateRollout::class,

--- a/backend/tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ArticleDiscoverabilityReleaseCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_is_registered_for_production_artisan_path(): void
+    {
+        $this->assertArrayHasKey('articles:discoverability-release', Artisan::all());
+    }
+
+    public function test_dry_run_plans_sitemap_and_llms_release_without_writes(): void
+    {
+        $article = $this->createPublishedIndexableArticle();
+
+        $exitCode = Artisan::call('articles:discoverability-release', [
+            '--article-id' => (string) $article->id,
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertSame('would_release_article_discoverability', $payload['action']);
+        $this->assertFalse(data_get($payload, 'plan.before.sitemap_eligible'));
+        $this->assertFalse(data_get($payload, 'plan.before.llms_eligible'));
+        $this->assertTrue(data_get($payload, 'plan.after.sitemap_eligible'));
+        $this->assertTrue(data_get($payload, 'plan.after.llms_eligible'));
+        $this->assertFalse($payload['external_search_submission_attempted']);
+        $this->assertFalse($payload['schema_hreflang_write_attempted']);
+        $this->assertStringContainsString('article id 53 slug gaokao-score-major-shortlist-riasec-checklist', $payload['expected_confirmation']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail(53);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+        $this->assertSame(0, AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_discoverability_release')->count());
+    }
+
+    public function test_execute_releases_only_sitemap_and_llms_eligibility(): void
+    {
+        $article = $this->createPublishedIndexableArticle();
+        $contentHash = hash('sha256', (string) $article->content_md);
+        $publishedRevisionId = (int) $article->published_revision_id;
+        $schemaHash = hash('sha256', (string) json_encode($article->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+        $exitCode = Artisan::call('articles:discoverability-release', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--confirm' => 'I explicitly approve articles:discoverability-release execute for article id 53 slug gaokao-score-major-shortlist-riasec-checklist after dry-run passes.',
+            '--execute' => true,
+            '--json' => true,
+            '--no-content-change' => true,
+            '--no-publish' => true,
+            '--no-search' => true,
+            '--no-schema-hreflang' => true,
+            '--no-revalidation' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('released_article_discoverability', $payload['action']);
+        $this->assertTrue(data_get($payload, 'plan.after.sitemap_eligible'));
+        $this->assertTrue(data_get($payload, 'plan.after.llms_eligible'));
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail(53);
+        $this->assertSame('published', (string) $fresh->status);
+        $this->assertTrue((bool) $fresh->is_public);
+        $this->assertTrue((bool) $fresh->is_indexable);
+        $this->assertTrue((bool) $fresh->sitemap_eligible);
+        $this->assertTrue((bool) $fresh->llms_eligible);
+        $this->assertSame($contentHash, hash('sha256', (string) $fresh->content_md));
+        $this->assertSame($publishedRevisionId, (int) $fresh->published_revision_id);
+        $this->assertSame($schemaHash, hash('sha256', (string) json_encode($fresh->seoMeta?->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)));
+
+        $audit = AuditLog::query()->withoutGlobalScopes()->where('action', 'articles_discoverability_release')->first();
+        $this->assertInstanceOf(AuditLog::class, $audit);
+        $this->assertSame('article', (string) $audit->target_type);
+        $this->assertSame('53', (string) $audit->target_id);
+        $this->assertSame('articles:discoverability-release', data_get($audit->meta_json, 'command'));
+        $this->assertTrue((bool) data_get($audit->meta_json, 'no_search'));
+        $this->assertSame(['articles.sitemap_eligible', 'articles.llms_eligible'], data_get($audit->meta_json, 'updates_scope'));
+    }
+
+    public function test_execute_requires_confirmation_and_safety_flags(): void
+    {
+        $this->createPublishedIndexableArticle();
+
+        $exitCode = Artisan::call('articles:discoverability-release', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--execute' => true,
+            '--json' => true,
+            '--no-content-change' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        $this->assertErrorCode($payload, 'confirmation_mismatch');
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail(53);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+    }
+
+    public function test_slug_lock_and_indexability_preflight_block_without_write(): void
+    {
+        $article = $this->createPublishedIndexableArticle([
+            'is_indexable' => false,
+        ]);
+        ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->update([
+            'is_indexable' => false,
+            'robots' => 'noindex,nofollow',
+        ]);
+
+        $exitCode = Artisan::call('articles:discoverability-release', [
+            '--article-id' => '53',
+            '--expected-slug' => 'wrong-slug',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'expected_slug_mismatch');
+        $this->assertErrorCode($payload, 'article_not_indexable');
+        $this->assertErrorCode($payload, 'seo_meta_not_indexable');
+        $this->assertErrorCode($payload, 'seo_meta_robots_not_index_follow');
+
+        $fresh = Article::query()->withoutGlobalScopes()->findOrFail(53);
+        $this->assertFalse((bool) $fresh->sitemap_eligible);
+        $this->assertFalse((bool) $fresh->llms_eligible);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createPublishedIndexableArticle(array $overrides = []): Article
+    {
+        /** @var Article $article */
+        $article = Model::unguarded(fn (): Article => Article::query()->withoutGlobalScopes()->create(array_merge([
+            'id' => 53,
+            'org_id' => 0,
+            'category_id' => null,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 12,
+            'slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_gaokao_score_major_shortlist_riasec_2026v1',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '高考出分后专业太多怎么筛？位次+霍兰德排除清单',
+            'excerpt' => '高考出分后，用位次、选科要求、霍兰德职业兴趣测试和排除清单缩小专业范围。',
+            'content_md' => '# 高考出分后专业太多怎么筛？'."\n\n正文。",
+            'content_html' => '<h1>高考出分后专业太多怎么筛？</h1>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => Carbon::create(2026, 6, 19, 5, 30, 0, 'UTC'),
+        ], $overrides)));
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = Model::unguarded(fn (): ArticleTranslationRevision => ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => $article->published_at,
+        ]));
+
+        $article->forceFill(['published_revision_id' => (int) $revision->id])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist',
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/article/og.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'schema_gates_v1' => [
+                    'article' => true,
+                    'breadcrumb' => true,
+                    'faq' => false,
+                ],
+                'hreflang_gate_v1' => [
+                    'enabled' => false,
+                    'policy' => 'no_direct_english_counterpart_approved',
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['errors'] ?? [])
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1794,6 +1794,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_discoverability_release_tooling_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleDiscoverabilityRelease.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleDiscoverabilityRelease;',
+            '+        ArticleDiscoverabilityRelease::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -3326,6 +3340,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleDiscoverabilityReleaseFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -4365,6 +4383,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/ArticleSeoGateRollout.php',
             'backend/app/Services/Cms/ArticleSeoGateRollout.php',
         ], true);
+    }
+
+    private function isArticleDiscoverabilityReleaseFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/ArticleDiscoverabilityRelease.php';
     }
 
     private function isArticleBodyH1GuardFile(string $file): bool
@@ -6051,7 +6074,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+            if (preg_match('/\b(ArticleDiscoverabilityRelease|ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Add `articles:discoverability-release` for controlled sitemap/llms eligibility release on one already-published article.
- Require article id + slug locks, dry-run by default, execute safety flags, exact confirmation phrase, and audit logging.
- Register the command in the Console Kernel and cover dry-run, execute, guard failure, and registration behavior with focused tests.

## Why
Newly published SEO article 53 is public and indexable, but remains absent from sitemap/llms/URL Truth because backend authority still has `sitemap_eligible=false` and `llms_eligible=false`. This PR adds the missing narrow production tooling instead of using direct DB edits.

## Validation
- `php artisan test --filter=ArticleDiscoverabilityReleaseCommandTest`
- `php artisan test --filter=ArticleEnsureSeoMetaBaselineCommandTest`
- `./vendor/bin/pint --test app/Console/Commands/ArticleDiscoverabilityRelease.php app/Console/Kernel.php tests/Feature/Console/ArticleDiscoverabilityReleaseCommandTest.php`
- `php artisan list --no-ansi | rg "articles:discoverability-release|articles:publish-controlled|seo-intel:url-truth-handoff"`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No production execute of `articles:discoverability-release`.
- No content changes, publish/promote, schema/hreflang writes, revalidation, sitemap static refresh, URL Truth import, Search Channel enqueue, IndexNow/Baidu/GSC submission.

## Repository rule impact
Backend CMS remains the authority for article discoverability gates. This adds a controlled backend command for a previously manual backend metadata transition; it does not move content or discoverability authority to frontend fallback logic.
