### PR TITLE
test: rebaseline enneagram phase8b candidate

### DIFF
--- a/backend/app/Services/Enneagram/Assets/EnneagramInactiveCandidateReleaseImporter.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramInactiveCandidateReleaseImporter.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 final class EnneagramInactiveCandidateReleaseImporter
 {
-    private const DEFAULT_EXPECTED_CANDIDATE_MANIFEST_SHA256 = '87f7eb874eb162ff158b5d3ac5e4393218d045054b2f0e3e0eddc09c6c3ea556';
+    private const DEFAULT_EXPECTED_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
 
     private const DEFAULT_EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
 

--- a/backend/app/Services/Enneagram/Assets/EnneagramProductionEquivalentCandidatePayloadExporter.php
+++ b/backend/app/Services/Enneagram/Assets/EnneagramProductionEquivalentCandidatePayloadExporter.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 final class EnneagramProductionEquivalentCandidatePayloadExporter
 {
-    private const EXPECTED_MANIFEST_SHA256 = '87f7eb874eb162ff158b5d3ac5e4393218d045054b2f0e3e0eddc09c6c3ea556';
+    private const EXPECTED_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
 
     private const EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
 
@@ -284,34 +284,42 @@ final class EnneagramProductionEquivalentCandidatePayloadExporter
             '1R-A' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json',
             ),
             '1R-B' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_v3/FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Legacy_Core_Rewrite_v3_Assets.json',
             ),
             '1R-C' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling/FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Low_Resonance_Objection_Handling_Assets.json',
             ),
             '1R-D' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch/FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Partial_Resonance_Deep_Branch_Assets.json',
             ),
             '1R-E' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence/FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Diffuse_Top3_Convergence_Assets.json',
             ),
             '1R-F' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion/FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Close_Call_36_Pair_Completion_Assets.json',
             ),
             '1R-G' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization/FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Scene_Localization_Assets.json',
             ),
             '1R-H' => $this->resolveExternalAssetPath(
                 '/Users/rainie/Desktop/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
                 '/Users/rainie/Desktop/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
+                '/Users/rainie/Desktop/费马资料文件/九型/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
                 '/mnt/data/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack/FermatMind_Enneagram_Content_Expansion_Batch_1R_H_FC144_Recommendation_Pack_Assets.json',
             ),
         ];

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2337,6 +2337,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_phase8b_candidate_asset_reconciliation_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Enneagram/Assets/EnneagramInactiveCandidateReleaseImporter.php',
+            'backend/app/Services/Enneagram/Assets/EnneagramProductionEquivalentCandidatePayloadExporter.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -3901,6 +3911,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramPhase8bCandidateAssetReconciliationFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -4953,6 +4967,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEnneagramForcedChoiceQuestionPackTranslationFile(string $file): bool
     {
         return preg_match('#^backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/(?:questions\\.compiled|manifest)\\.json$#', $file) === 1;
+    }
+
+    private function isEnneagramPhase8bCandidateAssetReconciliationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Enneagram/Assets/EnneagramInactiveCandidateReleaseImporter.php',
+            'backend/app/Services/Enneagram/Assets/EnneagramProductionEquivalentCandidatePayloadExporter.php',
+        ], true);
     }
 
     private function isIqReportFoundationFile(string $file): bool


### PR DESCRIPTION
## What changed
- Rebased the Enneagram Phase8B exporter/importer expected candidate manifest hash from `87f7eb874eb162ff158b5d3ac5e4393218d045054b2f0e3e0eddc09c6c3ea556` to `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`.
- Added the current local source asset path family under `/Users/rainie/Desktop/费马资料文件/九型/...` to the production-equivalent candidate payload exporter.

## Why
The original `/tmp/fm_enneagram_phase8b_20260427_034305` candidate for `87f7eb...` was not recoverable from the current local machine, retained GitHub artifacts, mounted backup paths, or available Time Machine state. The `a9fd3eb4...` package is being explicitly redefined as the new candidate baseline. This is not a silent replacement for `87f7eb...`.

## Validation
- Regenerated renderable candidate payloads from local source assets into `/tmp/fm_enneagram_a9fd_renderable_20260619` with `PHASE8B_CANDIDATE_DIR=/tmp/fm_enneagram_a9fd_renderable_20260619`.
  - candidate manifest expected/actual: `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`
  - runtime registry manifest: `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`
  - payload count: 630
- `APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fm_phase8d2b_a9fd_pr.sqlite PHASE8B_CANDIDATE_DIR=/tmp/fm_enneagram_a9fd_renderable_20260619 PHASE8D2B_OUTPUT_DIR=/tmp/fm_enneagram_phase8d2b_a9fd_pr_20260619 php artisan enneagram:import-inactive-candidate-release --json`
  - verdict: `PASS_FOR_PHASE_8D_3_ACTIVATION_ROLLBACK_GATE`
  - activation_happened: false
  - production_import_happened: false
  - full_replacement_happened: false
  - out_of_launch_scope: `1R-I`, `1R-J`
  - fc144_boundary_violation_count: 0
- `php -l app/Services/Enneagram/Assets/EnneagramProductionEquivalentCandidatePayloadExporter.php`
- `php -l app/Services/Enneagram/Assets/EnneagramInactiveCandidateReleaseImporter.php`
- `git diff --check`

## Intentionally deferred
- No production activation.
- No production writes.
- No runtime default release switch.
- Web Phase8C expected hash change is handled in the paired fap-web PR.
