### PR TITLE
Add bounded Search Channel queue enqueue override

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php
@@ -18,6 +18,7 @@ final class SeoIntelSearchChannelQueueCommand extends Command
         {--channel= : Restrict planning to one supported channel}
         {--canonical-url= : Restrict planning to one persisted canonical URL}
         {--page-type= : Restrict planning to one page entity type}
+        {--confirm-bounded-enqueue-override= : Exact approval phrase for a command-scoped single URL/channel enqueue override}
         {--limit=20 : Maximum URL Truth rows to inspect}';
 
     protected $description = 'Plan or enqueue Search Channel Queue candidates without live search submission.';
@@ -31,6 +32,7 @@ final class SeoIntelSearchChannelQueueCommand extends Command
         $channel = $this->nullableOption('channel');
         $canonicalUrl = $this->nullableOption('canonical-url');
         $pageType = $this->nullableOption('page-type');
+        $boundedEnqueueOverrideConfirmation = $this->nullableOption('confirm-bounded-enqueue-override');
 
         $plan = $planner->plan($channel, $pageType, $limit, $canonicalUrl);
         $plannedItems = $plan['planned_items'];
@@ -47,6 +49,9 @@ final class SeoIntelSearchChannelQueueCommand extends Command
         $status = 'success';
         $issues = [];
         $duplicateDetected = (bool) ($plan['duplicate_detected'] ?? false);
+        $writeAuthorization = 'config_gate';
+        $configWriteGateBypassed = false;
+        $requiredBoundedEnqueueOverrideConfirmation = null;
 
         if ($canonicalUrl !== null && $plan['source_unavailable_reason'] === null && (int) $plan['candidate_count'] === 0) {
             $issues[] = 'canonical_url_not_found';
@@ -87,10 +92,27 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             $enqueueAttempted = true;
             $status = 'blocked';
         } elseif ($writeRequested && ! $writeGateEnabled) {
+            $boundedOverride = $this->boundedEnqueueOverride(
+                enqueue: $enqueue,
+                canonicalUrl: $canonicalUrl,
+                channel: $channel,
+                confirmation: $boundedEnqueueOverrideConfirmation,
+            );
+            $requiredBoundedEnqueueOverrideConfirmation = $boundedOverride['required_confirmation'];
             $writesAttempted = true;
             $enqueueAttempted = true;
-            $status = 'blocked';
-            $issues[] = 'write_gate_disabled';
+
+            if (! $boundedOverride['allowed']) {
+                $status = 'blocked';
+                $issues[] = 'write_gate_disabled';
+                $issues = array_merge($issues, $boundedOverride['issues']);
+            } elseif ($plannedItems !== []) {
+                $writeAuthorization = 'bounded_command_override';
+                $configWriteGateBypassed = true;
+                $writeResult = $writer->write($plannedItems);
+                $writesCommitted = ((int) $writeResult['written_items']) > 0;
+                $enqueueCommitted = $writesCommitted;
+            }
         } elseif ($writeRequested && $plannedItems !== []) {
             $writesAttempted = true;
             $enqueueAttempted = true;
@@ -134,6 +156,9 @@ final class SeoIntelSearchChannelQueueCommand extends Command
             'protected_legacy_tables_not_written' => config('seo_intel.search_channel_queue.protected_legacy_tables', []),
             'write_gate_env' => 'SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED',
             'write_gate_enabled' => $writeGateEnabled,
+            'write_authorization' => $writeAuthorization,
+            'config_write_gate_bypassed' => $configWriteGateBypassed,
+            'required_bounded_enqueue_override_confirmation' => $requiredBoundedEnqueueOverrideConfirmation,
             'batch_ids' => $writeResult['batch_ids'],
             'written_items' => $writeResult['written_items'],
             'issues' => $issues,
@@ -171,6 +196,44 @@ final class SeoIntelSearchChannelQueueCommand extends Command
         $value = trim((string) $value);
 
         return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array{allowed: bool, issues: list<string>, required_confirmation: ?string}
+     */
+    private function boundedEnqueueOverride(bool $enqueue, ?string $canonicalUrl, ?string $channel, ?string $confirmation): array
+    {
+        $issues = [];
+        $requiredConfirmation = null;
+
+        if (! $enqueue) {
+            $issues[] = 'bounded_enqueue_override_requires_enqueue';
+        }
+
+        if ($canonicalUrl === null || $channel === null) {
+            $issues[] = 'bounded_enqueue_override_requires_canonical_url_and_channel';
+        } else {
+            $requiredConfirmation = $this->boundedEnqueueOverrideConfirmation($canonicalUrl, $channel);
+
+            if ($confirmation !== $requiredConfirmation) {
+                $issues[] = 'bounded_enqueue_override_confirmation_required';
+            }
+        }
+
+        return [
+            'allowed' => $issues === [],
+            'issues' => $issues,
+            'required_confirmation' => $requiredConfirmation,
+        ];
+    }
+
+    private function boundedEnqueueOverrideConfirmation(string $canonicalUrl, string $channel): string
+    {
+        return sprintf(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-ENQUEUE write for canonical URL %s channel %s; no live submission, no CMS content changes, no publish, no schema/hreflang writes, no sitemap/llms mutation.',
+            $canonicalUrl,
+            $channel,
+        );
     }
 
     private function stringValue(mixed $value): string

--- a/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php
@@ -39,6 +39,7 @@ final class SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest extends 
         $synopsis = $command->getDefinition()->getSynopsis();
 
         $this->assertStringContainsString('--canonical-url [CANONICAL-URL]', $synopsis);
+        $this->assertStringContainsString('--confirm-bounded-enqueue-override [CONFIRM-BOUNDED-ENQUEUE-OVERRIDE]', $synopsis);
         $this->assertStringContainsString('--enqueue', $synopsis);
     }
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -157,6 +157,71 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
     }
 
     #[Test]
+    public function bounded_enqueue_override_writes_one_article_url_channel_when_write_gate_is_disabled(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => '53',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_source' => 'articles.updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+        $approvalPhrase = sprintf(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-ENQUEUE write for canonical URL %s channel indexnow; no live submission, no CMS content changes, no publish, no schema/hreflang writes, no sitemap/llms mutation.',
+            $canonicalUrl,
+        );
+
+        $blockedOutput = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--limit' => 20,
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $blockedOutput['status'] ?? null);
+        $this->assertContains('write_gate_disabled', $blockedOutput['issues'] ?? []);
+        $this->assertContains('bounded_enqueue_override_confirmation_required', $blockedOutput['issues'] ?? []);
+        $this->assertSame($approvalPhrase, $blockedOutput['required_bounded_enqueue_override_confirmation'] ?? null);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+
+        $output = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--confirm-bounded-enqueue-override' => $approvalPhrase,
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertSame('bounded_command_override', $output['write_authorization'] ?? null);
+        $this->assertTrue((bool) ($output['config_write_gate_bypassed'] ?? false));
+        $this->assertTrue((bool) ($output['writes_attempted'] ?? false));
+        $this->assertTrue((bool) ($output['writes_committed'] ?? false));
+        $this->assertTrue((bool) ($output['enqueue_committed'] ?? false));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertSame(['indexnow' => 1], $output['channel_breakdown'] ?? null);
+        $this->assertSame(['article' => 1], $output['page_type_breakdown'] ?? null);
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_baidu_push_logs')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_indexnow_submissions')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_domestic_submission_logs')->count());
+    }
+
+    #[Test]
     public function unsafe_article_urls_remain_blocked(): void
     {
         $unsafeCases = [
@@ -523,12 +588,12 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
      * @param  array<string, mixed>  $arguments
      * @return array<string, mixed>
      */
-    private function runQueueCommand(array $arguments): array
+    private function runQueueCommand(array $arguments, bool $expectSuccess = true): array
     {
         $exitCode = Artisan::call('seo-intel:search-channel-queue', $arguments);
         $output = json_decode(trim(Artisan::output()), true);
 
-        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame($expectSuccess ? 0 : 1, $exitCode, Artisan::output());
         $this->assertIsArray($output);
 
         return $output;


### PR DESCRIPTION
## Summary
- Add a command-scoped `--confirm-bounded-enqueue-override` option to `seo-intel:search-channel-queue`.
- Allow a bounded queue enqueue override only when the production write gate is disabled, `--enqueue` is present, and both canonical URL and channel match the exact approval phrase.
- Keep the existing Search Channel Queue writer, target tables, duplicate protection, and no-live-submission boundaries unchanged.

## Why
Article 53 needs IndexNow/Baidu queue items after URL Truth import, but production config cache keeps the global queue write gate disabled. This adds a narrow, auditable command-level override instead of changing global config.

## Validation
- `composer install --no-interaction --prefer-dist`
- `php artisan test --filter=SeoIntelSearchChannelQueueRuntimeTest`
- `php artisan test --filter=SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest`
- `./vendor/bin/pint --test app/Console/Commands/SeoIntelSearchChannelQueueCommand.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php tests/Feature/SeoIntel/SeoIntelGrowthMbtiAction01bFix01SingleUrlEnqueueCommandTest.php`
- `php artisan list --no-ansi | rg "seo-intel:search-channel-queue"`
- `git diff --check`

## Intentionally deferred
- No backend deploy in this PR.
- No production queue enqueue execution in this PR.
- No IndexNow/Baidu/GSC live submission.
- No CMS content changes, publish/promote, schema/hreflang writes, sitemap, or llms mutation.

Repository rule impact: backend command-level search queue tooling only; no content authority or runtime public content ownership changes.