### PR TITLE
Add AI Impact asset preview contract

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\AiImpactAssets\CareerAiImpactAssetImportService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class CareerImportAiImpactAssetsPreview extends Command
+{
+    protected $signature = 'career:ai-impact-assets-import-preview
+        {--file= : Absolute path to PASS career_risk_future_ai_impact v5 assets JSONL}
+        {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
+        {--slugs= : Optional comma-separated preview slug subset}
+        {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
+        {--dry-run : Validate only; this command never writes staging or production rows}
+        {--json : Emit machine-readable JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Dry-run validation for PASS v5 career AI impact asset rows and the configured staging preview contract.';
+
+    public function __construct(
+        private readonly CareerAiImpactAssetImportService $importService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $file = trim((string) $this->option('file'));
+            if ($file === '') {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--file is required.'],
+                ], false);
+            }
+
+            $report = $this->importService->validateFile(
+                $file,
+                $this->requestedSlugs(),
+                trim((string) $this->option('expected-sha256')) ?: null,
+                (bool) $this->option('all-slugs-from-file'),
+            );
+
+            return $this->finish($report, ($report['decision'] ?? null) === 'pass');
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'decision' => 'fail',
+                'errors' => [$throwable->getMessage()],
+            ], false);
+        }
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function requestedSlugs(): ?array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            return null;
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (string $slug): string => strtolower(trim($slug)), explode(',', $raw)),
+            static fn (string $slug): bool => $slug !== ''
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $outputPath = trim((string) $this->option('output'));
+        if ($outputPath !== '') {
+            $directory = dirname($outputPath);
+            if (! is_dir($directory)) {
+                mkdir($directory, 0775, true);
+            }
+
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif ($success) {
+            $this->info('career AI impact asset preview import validation passed.');
+        } else {
+            $this->error('career AI impact asset preview import validation failed.');
+            foreach ((array) ($report['errors'] ?? []) as $error) {
+                $this->line('- '.(string) $error);
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerAiImpactAssetPreviewController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerAiImpactAssetPreviewController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\CareerJobAiImpactAsset;
+use App\Services\Career\AiImpactAssets\CareerAiImpactAssetPreviewService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerAiImpactAssetPreviewController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerAiImpactAssetPreviewService $previewService,
+    ) {}
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $locale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $asset = $this->previewService->previewAsset($slug, $locale);
+
+        if (! $asset instanceof CareerJobAiImpactAsset) {
+            return $this->notFoundResponse('career AI impact asset preview unavailable.');
+        }
+
+        return response()->json($this->previewService->publicPayload($asset));
+    }
+}

--- a/backend/app/Models/CareerJobAiImpactAsset.php
+++ b/backend/app/Models/CareerJobAiImpactAsset.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerJobAiImpactAsset extends CareerFoundationModel
+{
+    public const ASSET_VERSION_V5 = 'career_risk_future_ai_impact_v5';
+
+    public const STATUS_STAGING_PREVIEW = 'staging_preview';
+
+    public const STATUS_EDITORIAL_REVIEW = 'editorial_review';
+
+    public const STATUS_APPROVED = 'approved';
+
+    public const STATUS_PRODUCTION_IMPORTED = 'production_imported';
+
+    protected $table = 'career_job_ai_impact_assets';
+
+    protected $casts = [
+        'preview_allowlisted' => 'boolean',
+        'asset_payload_json' => 'array',
+        'sources_json' => 'array',
+        'evidence_used_json' => 'array',
+        'derived_from_synthesis_json' => 'array',
+        'audit_fields_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -1,0 +1,478 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\AiImpactAssets;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\Occupation;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Throwable;
+
+final class CareerAiImpactAssetImportService
+{
+    public const IMPORTER_VERSION = 'career_ai_impact_asset_v5_staging_preview_importer_v0.1';
+
+    public function __construct(
+        private readonly CareerAiImpactAssetPreviewService $previewService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
+        private readonly PublicCareerAuthorityResponseCache $authorityResponseCache,
+        private readonly CareerAiImpactAssetImportStateMachine $stateMachine,
+    ) {}
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function validateFile(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+    ): array {
+        $report = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile);
+        $errors = [];
+
+        if (! is_file($file) || ! is_readable($file)) {
+            return array_merge($report, [
+                'decision' => 'fail',
+                'errors' => ['Source JSONL file is missing or unreadable.'],
+            ]);
+        }
+
+        $rowsByKey = [];
+        $duplicateKeys = [];
+        $parseErrors = [];
+        $slugsFromFile = [];
+        $totalLines = 0;
+        $lineNumber = 0;
+
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return array_merge($report, [
+                'decision' => 'fail',
+                'errors' => ['Source JSONL file could not be opened.'],
+            ]);
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $lineNumber++;
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $totalLines++;
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                $parseErrors[] = "Line {$lineNumber}: invalid JSON.";
+
+                continue;
+            }
+
+            if (! is_array($row)) {
+                $parseErrors[] = "Line {$lineNumber}: row must be an object.";
+
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
+
+            $slugsFromFile[$slug] = true;
+            $key = $slug.'|'.$locale;
+            if (isset($rowsByKey[$key])) {
+                $errors[] = "{$slug}/{$locale}: duplicate asset row.";
+                $duplicateKeys[] = $key;
+
+                continue;
+            }
+
+            $rowsByKey[$key] = [
+                'line' => $lineNumber,
+                'row' => $row,
+            ];
+        }
+
+        fclose($handle);
+
+        foreach ($parseErrors as $parseError) {
+            $errors[] = $parseError;
+        }
+
+        $targetSlugs = $allSlugsFromFile
+            ? array_values(array_keys($slugsFromFile))
+            : $this->targetSlugs($requestedSlugs, $errors);
+
+        $sourceFileSha256 = hash_file('sha256', $file) ?: null;
+        $expectedSha256 = $this->normalizeSha256($expectedSha256);
+        if ($expectedSha256 !== null && $sourceFileSha256 !== $expectedSha256) {
+            $errors[] = 'Source JSONL SHA-256 does not match expected artifact SHA.';
+        }
+
+        $validatedRows = [];
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $key = $slug.'|'.$locale;
+                if (! isset($rowsByKey[$key])) {
+                    $errors[] = "{$slug}/{$locale}: required preview row missing.";
+
+                    continue;
+                }
+
+                $row = $rowsByKey[$key]['row'];
+                foreach ($this->rowErrors($row, $slug, $locale) as $rowError) {
+                    $errors[] = "{$slug}/{$locale}: {$rowError}";
+                }
+
+                $validatedRows[] = $row;
+            }
+        }
+
+        $authorityReport = $this->careerJobBundleAuthorityReport($targetSlugs);
+        foreach ($authorityReport['rows'] as $authorityRow) {
+            $authorityErrors = is_array($authorityRow['errors'] ?? null) ? $authorityRow['errors'] : [];
+            foreach ($authorityErrors as $authorityError) {
+                $errors[] = ((string) ($authorityRow['slug'] ?? 'unknown')).': missing_career_job_bundle_authority: '.(string) $authorityError;
+            }
+        }
+
+        $projectionSafetyReport = $this->projectionSafetyReport($validatedRows);
+        foreach ($projectionSafetyReport['rows'] as $projectionRow) {
+            $projectionErrors = is_array($projectionRow['errors'] ?? null) ? $projectionRow['errors'] : [];
+            foreach ($projectionErrors as $projectionError) {
+                $errors[] = ((string) ($projectionRow['slug'] ?? 'unknown')).'/'.((string) ($projectionRow['locale'] ?? 'unknown')).': ai_impact_projection_gate: '.(string) $projectionError;
+            }
+        }
+
+        return array_merge($report, [
+            'mode' => 'dry_run',
+            'decision' => $errors === [] ? 'pass' : 'fail',
+            'total_jsonl_lines' => $totalLines,
+            'target_slug_count' => count($targetSlugs),
+            'validated_preview_rows' => count($validatedRows),
+            'expected_preview_rows' => count($targetSlugs) * 2,
+            'source_file_sha256' => $sourceFileSha256,
+            'expected_source_file_sha256' => $expectedSha256,
+            'source_file_sha256_match' => $expectedSha256 === null || $sourceFileSha256 === $expectedSha256,
+            'duplicate_key_count' => count(array_unique($duplicateKeys)),
+            'duplicate_keys' => array_values(array_unique($duplicateKeys)),
+            'idempotency' => $this->idempotencyReport($sourceFileSha256, $targetSlugs),
+            'rollback_policy' => $this->rollbackPolicy(),
+            'state_machine' => $this->stateMachine->report(),
+            'target_slugs' => $targetSlugs,
+            'all_slugs_from_file' => $allSlugsFromFile,
+            'career_job_bundle_authority' => $authorityReport,
+            'projection_safety_gate' => $projectionSafetyReport,
+            'production_import_allowed' => false,
+            'staging_write_performed' => false,
+            'errors' => $errors,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array{checked_slug_count: int, ready_slug_count: int, rows: list<array<string, mixed>>}
+     */
+    private function careerJobBundleAuthorityReport(array $targetSlugs): array
+    {
+        $rows = [];
+        $readyCount = 0;
+
+        foreach ($targetSlugs as $slug) {
+            $occupationExists = Occupation::query()->where('canonical_slug', $slug)->exists();
+            $enItem = $this->runtimeProjection->itemForSlug($slug, 'en');
+            $zhItem = $this->runtimeProjection->itemForSlug($slug, 'zh-CN');
+            $projectionItem = is_array($enItem) ? $enItem : (is_array($zhItem) ? $zhItem : null);
+            $projectionExists = is_array($projectionItem);
+            $publicResolutionType = $projectionExists ? (string) ($projectionItem['public_resolution_type'] ?? '') : null;
+            $detailRouteEnabled = $projectionExists ? (($projectionItem['detail_route_enabled'] ?? false) === true) : false;
+            $releaseGatePass = $projectionExists ? (($projectionItem['release_gate_pass'] ?? false) === true) : false;
+            $detailApiZh = $this->authorityResponseCache->jobDetailPayload($slug, 'zh-CN') !== null;
+            $detailApiEn = $this->authorityResponseCache->jobDetailPayload($slug, 'en') !== null;
+            $errors = [];
+
+            if (! $occupationExists) {
+                $errors[] = 'occupation row is missing.';
+            }
+
+            if (! $projectionExists) {
+                $errors[] = 'runtime publish projection item is missing.';
+            }
+
+            if ($projectionExists && $publicResolutionType !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $errors[] = 'public_resolution_type must be public_canonical_job.';
+            }
+
+            if ($projectionExists && ! $detailRouteEnabled) {
+                $errors[] = 'detail_route_enabled must be true.';
+            }
+
+            if ($projectionExists && ! $releaseGatePass) {
+                $errors[] = 'release_gate_pass must be true.';
+            }
+
+            if (! $detailApiZh) {
+                $errors[] = 'zh-CN career job detail API is not ready.';
+            }
+
+            if (! $detailApiEn) {
+                $errors[] = 'en career job detail API is not ready.';
+            }
+
+            if ($errors === []) {
+                $readyCount++;
+            }
+
+            $rows[] = [
+                'slug' => $slug,
+                'occupation_row_exists' => $occupationExists,
+                'runtime_publish_projection_item_exists' => $projectionExists,
+                'public_resolution_type' => $publicResolutionType,
+                'public_resolution_type_pass' => $publicResolutionType === CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+                'detail_route_enabled' => $detailRouteEnabled,
+                'release_gate_pass' => $releaseGatePass,
+                'detail_api_zh_CN_200' => $detailApiZh,
+                'detail_api_en_200' => $detailApiEn,
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_slug_count' => count($targetSlugs),
+            'ready_slug_count' => $readyCount,
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array{checked_row_count: int, ready_row_count: int, rows: list<array<string, mixed>>}
+     */
+    private function projectionSafetyReport(array $rows): array
+    {
+        $reportRows = [];
+        $readyCount = 0;
+
+        foreach ($rows as $row) {
+            $errors = [];
+            $readerText = $this->readerText($row);
+
+            foreach (['evidence_id', 'source_id', 'row_hash', 'audit_fields', 'search_projection', 'candidate_only', 'not_runtime_seo'] as $fragment) {
+                if (str_contains($readerText, $fragment)) {
+                    $errors[] = "reader-facing text must not leak {$fragment}.";
+                }
+            }
+
+            foreach ([
+                'predicts job loss',
+                'job-loss risk',
+                'wage-loss risk',
+                'career disappearance',
+                'AI-proof',
+                'will replace',
+                '岗位会消失',
+                '收入会下降',
+                '不会被 AI 影响',
+            ] as $fragment) {
+                if (str_contains($readerText, $fragment)) {
+                    $errors[] = "reader-facing text contains blocked AI outcome framing: {$fragment}.";
+                }
+            }
+
+            if ($errors === []) {
+                $readyCount++;
+            }
+
+            $reportRows[] = [
+                'slug' => $this->previewService->normalizeSlug((string) ($row['slug'] ?? '')),
+                'locale' => $this->previewService->normalizeLocale((string) ($row['locale'] ?? '')),
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_row_count' => count($rows),
+            'ready_row_count' => $readyCount,
+            'rows' => $reportRows,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function rowErrors(array $row, string $slug, string $locale): array
+    {
+        $errors = [];
+
+        if (($row['ledger_type'] ?? null) !== 'career-risk-future_asset') {
+            $errors[] = 'ledger_type must be career-risk-future_asset.';
+        }
+
+        if (($row['block_type'] ?? null) !== 'career-risk-future-ai-impact') {
+            $errors[] = 'block_type must be career-risk-future-ai-impact.';
+        }
+
+        $assetVersion = (string) ($row['asset_version'] ?? '');
+        if (! str_starts_with($assetVersion, 'career_risk_future_ai_impact_v5')) {
+            $errors[] = 'asset_version must be an AI Impact v5 asset version.';
+        }
+
+        if ($this->previewService->normalizeSlug((string) ($row['slug'] ?? '')) !== $slug) {
+            $errors[] = 'slug mismatch.';
+        }
+
+        if ($this->previewService->normalizeLocale((string) ($row['locale'] ?? '')) !== $locale) {
+            $errors[] = 'locale mismatch.';
+        }
+
+        foreach (['occupation', 'ai_exposure_score', 'items', 'score_rationale', 'sources', 'evidence_used', 'derived_from_synthesis', 'audit_fields'] as $requiredKey) {
+            if (! array_key_exists($requiredKey, $row)) {
+                $errors[] = "{$requiredKey} is required.";
+            }
+        }
+
+        if (array_key_exists('search_projection', $row)) {
+            $errors[] = 'search_projection must remain in a separate candidate file and not be embedded in the reader asset.';
+        }
+
+        $score = is_array($row['ai_exposure_score'] ?? null) ? $row['ai_exposure_score'] : [];
+        $scoreValue = $score['score_1_to_10'] ?? null;
+        if (! is_int($scoreValue) || $scoreValue < 1 || $scoreValue > 10) {
+            $errors[] = 'ai_exposure_score.score_1_to_10 must be an integer from 1 to 10.';
+        }
+
+        if (! in_array((string) ($score['exposure_type'] ?? ''), ['augmentation', 'automation', 'mixed', 'unknown'], true)) {
+            $errors[] = 'ai_exposure_score.exposure_type is invalid.';
+        }
+
+        if (! in_array((string) ($score['confidence'] ?? ''), ['low', 'medium', 'high'], true)) {
+            $errors[] = 'ai_exposure_score.confidence is invalid.';
+        }
+
+        $items = is_array($row['items'] ?? null) ? $row['items'] : [];
+        foreach (['most_ai_exposed_workflows', 'human_accountability_anchors', 'how_to_prepare'] as $listKey) {
+            if (! is_array($items[$listKey] ?? null) || count($items[$listKey]) < 1) {
+                $errors[] = "items.{$listKey} must contain at least one reader-facing item.";
+            }
+        }
+
+        if (! is_array($items['reader_boundary'] ?? null)) {
+            $errors[] = 'items.reader_boundary must be present.';
+        }
+
+        $auditFields = is_array($row['audit_fields'] ?? null) ? $row['audit_fields'] : [];
+        if (! is_string($auditFields['row_hash'] ?? null) || ! preg_match('/^[a-f0-9]{64}$/', (string) $auditFields['row_hash'])) {
+            $errors[] = 'audit_fields.row_hash must be a SHA-256 string.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    private function baseReport(string $file, ?array $requestedSlugs, bool $allSlugsFromFile): array
+    {
+        return [
+            'importer_version' => self::IMPORTER_VERSION,
+            'asset_version' => 'career_risk_future_ai_impact_v5',
+            'status_policy' => 'dry_run_only_for_this_contract',
+            'production_import_allowed' => false,
+            'production_import_gate' => [
+                'allowed' => false,
+                'required_from_status' => 'approved',
+                'current_command_supports_production_import' => false,
+            ],
+            'staging_write_supported' => false,
+            'source_file' => $file,
+            'requested_slugs' => $requestedSlugs,
+            'all_slugs_from_file' => $allSlugsFromFile,
+        ];
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @param  list<string>  $errors
+     * @return list<string>
+     */
+    private function targetSlugs(?array $requestedSlugs, array &$errors): array
+    {
+        $allowlist = $this->previewService->previewSlugs();
+        $target = $requestedSlugs === null || $requestedSlugs === []
+            ? $allowlist
+            : array_values(array_unique(array_map(
+                fn (string $slug): string => $this->previewService->normalizeSlug($slug),
+                $requestedSlugs
+            )));
+
+        foreach ($target as $slug) {
+            if (! in_array($slug, $allowlist, true)) {
+                $errors[] = "{$slug}: slug is not in the AI Impact staging preview allowlist.";
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array<string, mixed>
+     */
+    private function idempotencyReport(?string $sourceFileSha256, array $targetSlugs): array
+    {
+        return [
+            'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+            'source_file_sha256' => $sourceFileSha256,
+            'target_slug_count' => count($targetSlugs),
+            'expected_row_count' => count($targetSlugs) * 2,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rollbackPolicy(): array
+    {
+        return [
+            'dry_run_writes_database' => false,
+            'staging_preview_write_supported_in_this_pr' => false,
+            'production_import_requires_approved_status' => true,
+        ];
+    }
+
+    private function normalizeSha256(?string $value): ?string
+    {
+        $normalized = strtolower(trim((string) $value));
+
+        return preg_match('/^[a-f0-9]{64}$/', $normalized) === 1 ? $normalized : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function readerText(array $row): string
+    {
+        $scoreRationale = is_array($row['score_rationale'] ?? null) ? $row['score_rationale'] : null;
+        if (is_array($scoreRationale)) {
+            unset($scoreRationale['source_ids']);
+            unset($scoreRationale['evidence_ids']);
+        }
+
+        $readerKeys = [
+            'summary' => $row['summary'] ?? null,
+            'items' => $row['items'] ?? null,
+            'score_rationale' => $scoreRationale,
+        ];
+
+        return json_encode($readerKeys, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+    }
+}

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportStateMachine.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportStateMachine.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\AiImpactAssets;
+
+use App\Models\CareerJobAiImpactAsset;
+
+final class CareerAiImpactAssetImportStateMachine
+{
+    public const STATE_DRY_RUN = 'dry_run';
+
+    public const STATE_STAGING_PREVIEW = CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW;
+
+    public const STATE_EDITORIAL_REVIEW = CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW;
+
+    public const STATE_APPROVED = CareerJobAiImpactAsset::STATUS_APPROVED;
+
+    public const STATE_PRODUCTION_IMPORTED = CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED;
+
+    /**
+     * @return list<string>
+     */
+    public function states(): array
+    {
+        return [
+            self::STATE_DRY_RUN,
+            self::STATE_STAGING_PREVIEW,
+            self::STATE_EDITORIAL_REVIEW,
+            self::STATE_APPROVED,
+            self::STATE_PRODUCTION_IMPORTED,
+        ];
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function transitions(): array
+    {
+        return [
+            self::STATE_DRY_RUN => [self::STATE_STAGING_PREVIEW],
+            self::STATE_STAGING_PREVIEW => [self::STATE_EDITORIAL_REVIEW],
+            self::STATE_EDITORIAL_REVIEW => [self::STATE_APPROVED, self::STATE_STAGING_PREVIEW],
+            self::STATE_APPROVED => [self::STATE_PRODUCTION_IMPORTED, self::STATE_EDITORIAL_REVIEW],
+            self::STATE_PRODUCTION_IMPORTED => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function report(): array
+    {
+        return [
+            'states' => $this->states(),
+            'transitions' => $this->transitions(),
+            'production_import_requires_from_status' => self::STATE_APPROVED,
+            'production_import_without_approved_allowed' => false,
+        ];
+    }
+}

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\AiImpactAssets;
+
+use App\Models\CareerJobAiImpactAsset;
+
+final class CareerAiImpactAssetPreviewService
+{
+    public function previewEnabled(): bool
+    {
+        return (bool) config('career_ai_impact_assets.staging_preview_enabled', false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function previewSlugs(): array
+    {
+        $slugs = config('career_ai_impact_assets.preview_slugs', []);
+        if (! is_array($slugs)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            array_map(fn (mixed $slug): string => $this->normalizeSlug((string) $slug), $slugs),
+            static fn (string $slug): bool => $slug !== ''
+        )));
+    }
+
+    public function previewAsset(string $slug, string $locale): ?CareerJobAiImpactAsset
+    {
+        $normalizedSlug = $this->normalizeSlug($slug);
+        $normalizedLocale = $this->normalizeLocale($locale);
+
+        if (! $this->previewEnabled() || ! in_array($normalizedSlug, $this->previewSlugs(), true)) {
+            return null;
+        }
+
+        return CareerJobAiImpactAsset::query()
+            ->where('career_job_slug', $normalizedSlug)
+            ->where('locale', $normalizedLocale)
+            ->where('asset_version', CareerJobAiImpactAsset::ASSET_VERSION_V5)
+            ->where('status', CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW)
+            ->where('preview_allowlisted', true)
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function publicPayload(CareerJobAiImpactAsset $asset): array
+    {
+        $payload = is_array($asset->asset_payload_json) ? $asset->asset_payload_json : [];
+
+        return [
+            'ok' => true,
+            'preview' => true,
+            'ai_impact_asset_v1' => $this->readerSafePayload($payload),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function readerSafePayload(array $payload): array
+    {
+        foreach ([
+            'audit_fields',
+            'evidence_used',
+            'derived_from_synthesis',
+            'search_projection',
+        ] as $internalKey) {
+            unset($payload[$internalKey]);
+        }
+
+        $payload['sources'] = $this->readerSafeSources(is_array($payload['sources'] ?? null) ? $payload['sources'] : []);
+
+        return $this->withoutInternalReferences($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function withoutInternalReferences(array $payload): array
+    {
+        if (is_array($payload['score_rationale'] ?? null)) {
+            unset($payload['score_rationale']['source_ids']);
+            unset($payload['score_rationale']['evidence_ids']);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sources
+     * @return list<array<string, string>>
+     */
+    private function readerSafeSources(array $sources): array
+    {
+        $safeSources = [];
+
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $name = trim((string) ($source['source_name'] ?? $source['name'] ?? ''));
+            $url = trim((string) ($source['source_url'] ?? $source['url'] ?? ''));
+            $type = trim((string) ($source['source_type'] ?? ''));
+            $boundary = trim((string) ($source['boundary'] ?? ''));
+
+            if ($name === '' || $url === '') {
+                continue;
+            }
+
+            $safeSource = [
+                'name' => $name,
+                'url' => $url,
+            ];
+
+            if ($type !== '') {
+                $safeSource['source_type'] = $type;
+            }
+
+            if ($boundary !== '') {
+                $safeSource['boundary'] = $boundary;
+            }
+
+            $safeSources[] = $safeSource;
+        }
+
+        return $safeSources;
+    }
+
+    public function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    public function normalizeLocale(string $locale): string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            default => 'zh-CN',
+        };
+    }
+}

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -1700,22 +1700,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.0",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1728,7 +1728,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1808,7 +1808,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -1824,7 +1824,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T22:11:48+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1912,16 +1912,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -2011,7 +2011,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -2027,7 +2027,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T21:50:11+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/backend/config/career_ai_impact_assets.php
+++ b/backend/config/career_ai_impact_assets.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+$resolvePreviewSlugs = static function (): array {
+    $raw = trim((string) env('CAREER_AI_IMPACT_ASSETS_PREVIEW_SLUGS', ''));
+    if ($raw !== '') {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            return array_values(array_unique(array_map(
+                static fn (mixed $slug): string => strtolower(trim((string) $slug)),
+                $decoded
+            )));
+        }
+
+        return array_values(array_unique(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            preg_split('/\s*,\s*/', $raw, -1, PREG_SPLIT_NO_EMPTY) ?: []
+        )));
+    }
+
+    return [
+        'accountants-and-auditors',
+        'actuaries',
+        'computer-programmers',
+        'agents-and-business-managers-of-artists-performers-and-athletes',
+        'writers-and-authors',
+        'zoologists-and-wildlife-biologists',
+        'wind-turbine-technicians',
+        'woodworking-machine-setters-operators-and-tenders-except-sawing',
+        'air-traffic-controllers',
+        'athletes-and-sports-competitors',
+        'acute-care-nurses',
+        'emergency-medicine-physicians',
+        'nurse-anesthetists',
+        'pharmacists',
+        'diagnostic-medical-sonographers',
+        'medical-and-clinical-laboratory-technologists',
+        'genetic-counselors',
+        'physicians-and-surgeons',
+        'airline-pilots-copilots-and-flight-engineers',
+        'aviation-inspectors',
+        'aircraft-and-avionics-equipment-mechanics-and-technicians',
+        'commercial-pilots',
+        'administrative-law-judges-adjudicators-and-hearing-officers',
+        'judges-magistrate-judges-and-magistrates',
+        'lawyers',
+        'judicial-law-clerks',
+        'military-careers',
+        'first-line-supervisors-of-air-crew-members',
+        'first-line-supervisors-of-weapons-specialists-crew-members',
+        'command-and-control-center-officers',
+        'elementary-school-teachers-except-special-education',
+        'school-and-career-counselors',
+        'adult-literacy-and-ged-teachers',
+        'special-education-teachers-elementary-school',
+        'actors',
+        'poets-lyricists-and-creative-writers',
+        'multimedia-artists-and-animators',
+        'dancers-and-choreographers',
+        'electricians',
+        'plumbers-pipefitters-and-steamfitters',
+        'firefighters',
+        'police-and-sheriff-s-patrol-officers',
+        'heavy-and-tractor-trailer-truck-drivers',
+        'construction-and-building-inspectors',
+        'web-developers',
+        'data-scientists',
+        'information-security-analysts',
+        'civil-engineers',
+        'biomedical-engineers',
+        'computer-systems-engineers-architects',
+    ];
+};
+
+return [
+    'staging_preview_enabled' => env('CAREER_AI_IMPACT_ASSETS_STAGING_PREVIEW_ENABLED', false),
+    'preview_slugs' => $resolvePreviewSlugs(),
+];

--- a/backend/database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php
+++ b/backend/database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('career_job_ai_impact_assets')) {
+            return;
+        }
+
+        Schema::create('career_job_ai_impact_assets', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('career_job_slug', 160);
+            $table->string('locale', 16);
+            $table->string('asset_version', 96);
+            $table->string('status', 64);
+            $table->boolean('preview_allowlisted')->default(false);
+            $table->json('asset_payload_json');
+            $table->json('sources_json')->nullable();
+            $table->json('evidence_used_json')->nullable();
+            $table->json('derived_from_synthesis_json')->nullable();
+            $table->json('audit_fields_json')->nullable();
+            $table->string('asset_row_hash', 64);
+            $table->string('source_artifact_sha256', 64)->nullable();
+            $table->string('evidence_artifact_sha256', 64)->nullable();
+            $table->string('synthesis_artifact_sha256', 64)->nullable();
+            $table->uuid('import_run_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['career_job_slug', 'locale', 'asset_version'], 'career_ai_impact_assets_slug_locale_version_unique');
+            $table->index(['status', 'preview_allowlisted'], 'career_ai_impact_assets_status_preview_idx');
+            $table->index('asset_version', 'career_ai_impact_assets_version_idx');
+            $table->index('import_run_id', 'career_ai_impact_assets_import_run_idx');
+            $table->index('occupation_id', 'career_ai_impact_assets_occupation_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2855,6 +2855,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/jobs/{slug}/ai-impact-asset": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_ai_impact_asset",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAiImpactAssetPreviewController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/jobs/{slug}/explainability": {
             "get": {
                 "operationId": "get_api_v0_5_career_jobs_slug_explainability",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
+use App\Http\Controllers\API\V0_5\Career\CareerAiImpactAssetPreviewController;
 use App\Http\Controllers\API\V0_5\Career\CareerAliasResolutionController;
 use App\Http\Controllers\API\V0_5\Career\CareerAttributionEventController;
 use App\Http\Controllers\API\V0_5\Career\CareerCnProxyPublicOwnerController;
@@ -506,6 +507,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/directory', [CareerDirectoryController::class, 'index']);
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/cn-proxy/{slug}', [CareerCnProxyPublicOwnerController::class, 'show']);
+    Route::get('/career/jobs/{slug}/ai-impact-asset', [CareerAiImpactAssetPreviewController::class, 'show']);
     Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/jobs/{slug}/explainability', [CareerJobExplainabilityController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobAiImpactAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Services\Career\AiImpactAssets\CareerAiImpactAssetImportService;
+use App\Services\Career\AiImpactAssets\CareerAiImpactAssetPreviewService;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class CareerAiImpactAssetPreviewImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        $this->seedRuntimeProjectionAuthority([]);
+    }
+
+    public function test_ai_impact_asset_sidecar_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('career_job_ai_impact_assets'));
+        $this->assertTrue(Schema::hasColumn('career_job_ai_impact_assets', 'asset_payload_json'));
+        $this->assertTrue(Schema::hasColumn('career_job_ai_impact_assets', 'asset_row_hash'));
+        $this->assertTrue(Schema::hasColumn('career_job_ai_impact_assets', 'preview_allowlisted'));
+    }
+
+    public function test_importer_dry_run_validates_preview_rows_without_writing(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-dry-run.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(2, $decoded['validated_preview_rows']);
+        $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
+        $this->assertFalse((bool) ($decoded['staging_write_performed'] ?? true));
+    }
+
+    public function test_importer_dry_run_reports_state_machine_sha_idempotency_and_rollback_policy(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $sha = hash_file('sha256', $file);
+        $report = storage_path('framework/testing/ai-impact-preview-state-machine-dry-run.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $sha,
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame($sha, $decoded['source_file_sha256']);
+        $this->assertTrue((bool) $decoded['source_file_sha256_match']);
+        $this->assertSame(0, $decoded['duplicate_key_count']);
+        $this->assertSame(['career_job_slug', 'locale', 'asset_version'], $decoded['idempotency']['target_key']);
+        $this->assertFalse((bool) $decoded['state_machine']['production_import_without_approved_allowed']);
+        $this->assertSame(CareerJobAiImpactAsset::STATUS_APPROVED, $decoded['state_machine']['production_import_requires_from_status']);
+        $this->assertTrue((bool) $decoded['rollback_policy']['production_import_requires_approved_status']);
+        $this->assertFalse((bool) $decoded['rollback_policy']['dry_run_writes_database']);
+    }
+
+    public function test_importer_dry_run_rejects_unexpected_source_sha(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-sha-mismatch.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => str_repeat('0', 64),
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertFalse((bool) $decoded['source_file_sha256_match']);
+        $this->assertStringContainsString('Source JSONL SHA-256 does not match expected artifact SHA', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_dry_run_validates_full_1046_contract_without_writing(): void
+    {
+        $slugs = array_map(static fn (int $index): string => 'ai-impact-contract-career-'.$index, range(1, 1046));
+        $this->seedCareerJobBundleAuthorities($slugs);
+
+        $rows = [];
+        foreach ($slugs as $slug) {
+            $rows[] = $this->assetRow($slug, 'zh-CN');
+            $rows[] = $this->assetRow($slug, 'en');
+        }
+        $file = $this->writeJsonl($rows);
+        $report = storage_path('framework/testing/ai-impact-preview-full-1046-dry-run.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(1046, $decoded['target_slug_count']);
+        $this->assertSame(2092, $decoded['validated_preview_rows']);
+        $this->assertSame(2092, $decoded['expected_preview_rows']);
+        $this->assertSame(1046, $decoded['career_job_bundle_authority']['ready_slug_count']);
+    }
+
+    public function test_importer_dry_run_rejects_embedded_search_projection_and_outcome_claims(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $zh = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $zh['search_projection'] = ['candidate_only_not_runtime_seo' => true];
+        $en = $this->assetRow('accountants-and-auditors', 'en');
+        $en['summary'] = 'This score predicts job loss for Accountants and Auditors.';
+        $file = $this->writeJsonl([$zh, $en]);
+        $report = storage_path('framework/testing/ai-impact-preview-projection-gate-fail.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $errors = implode(' ', $decoded['errors']);
+        $this->assertStringContainsString('search_projection must remain in a separate candidate file', $errors);
+        $this->assertStringContainsString('blocked AI outcome framing: predicts job loss', $errors);
+    }
+
+    public function test_importer_blocks_when_career_job_bundle_authority_is_missing(): void
+    {
+        $this->seedOccupation('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-authority-fail.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertStringContainsString('missing_career_job_bundle_authority', implode(' ', $decoded['errors']));
+        $this->assertSame(0, $decoded['career_job_bundle_authority']['ready_slug_count']);
+    }
+
+    public function test_preview_api_projects_reader_safe_payload_when_enabled(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors']);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'en');
+        $row['search_projection'] = ['candidate_only_not_runtime_seo' => true];
+        $row['score_rationale']['source_ids'] = ['source_should_not_leak'];
+        $row['score_rationale']['evidence_ids'] = ['evidence_should_not_leak'];
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('preview', true)
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'accountants-and-auditors')
+            ->assertJsonPath('ai_impact_asset_v1.locale', 'en');
+
+        $asset = $response->json('ai_impact_asset_v1');
+        foreach (['audit_fields', 'evidence_used', 'derived_from_synthesis', 'search_projection'] as $internalKey) {
+            $this->assertArrayNotHasKey($internalKey, $asset);
+        }
+
+        $this->assertArrayNotHasKey('source_id', $asset['sources'][0]);
+        $this->assertArrayNotHasKey('used_for', $asset['sources'][0]);
+        $this->assertArrayNotHasKey('source_ids', $asset['score_rationale']);
+        $this->assertArrayNotHasKey('evidence_ids', $asset['score_rationale']);
+        $this->assertSame('O*NET OnLine summary for Accountants and Auditors', $asset['sources'][0]['name']);
+    }
+
+    public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', false);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors']);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=zh-CN')
+            ->assertNotFound();
+
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['actuaries']);
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=zh-CN')
+            ->assertNotFound();
+    }
+
+    private function seedCareerJobBundleAuthority(string $slug): void
+    {
+        $this->seedCareerJobBundleAuthorities([$slug]);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedCareerJobBundleAuthorities(array $slugs): void
+    {
+        $this->seedRuntimeProjectionAuthority($slugs);
+
+        foreach ($slugs as $slug) {
+            if (! Occupation::query()->where('canonical_slug', $slug)->exists()) {
+                $this->seedOccupation($slug);
+            }
+
+            app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'zh-CN');
+            app(PublicCareerAuthorityResponseCache::class)->forgetJobDetailPayload($slug, 'en');
+            app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'zh-CN', true);
+            app(PublicCareerAuthorityResponseCache::class)->warmJobDetailPayload($slug, 'en', true);
+        }
+
+        $this->app->forgetInstance(CareerAiImpactAssetImportService::class);
+        $this->app->forgetInstance(CareerAiImpactAssetPreviewService::class);
+        $this->app->forgetInstance('App\\Console\\Commands\\CareerImportAiImpactAssetsPreview');
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedRuntimeProjectionAuthority(array $slugs): void
+    {
+        $detailRouteEnabled = [];
+        $robotsIndexable = [];
+        $releaseGatePass = [];
+        $items = [];
+
+        foreach ($slugs as $slug) {
+            $normalizedSlug = strtolower(trim($slug));
+            if ($normalizedSlug === '') {
+                continue;
+            }
+
+            $detailRouteEnabled[$normalizedSlug] = true;
+            $robotsIndexable[$normalizedSlug] = true;
+            $releaseGatePass[$normalizedSlug] = true;
+            foreach (['en', 'zh', 'zh-CN'] as $locale) {
+                $items[$normalizedSlug.'|'.$locale] = [
+                    'slug' => $normalizedSlug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'runtime_publish_state' => 'published',
+                ];
+            }
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                detailRouteEnabled: $detailRouteEnabled,
+                robotsIndexable: $robotsIndexable,
+                releaseGatePass: $releaseGatePass,
+                items: $items,
+            ),
+        );
+    }
+
+    private function seedOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'ai-impact-preview-'.$slug,
+            'title_en' => 'AI Impact Preview',
+            'title_zh' => 'AI 影响预览',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Accountants and Auditors',
+            'canonical_title_zh' => '会计师和审计师',
+            'search_h1_zh' => '会计师和审计师',
+            'structural_stability' => 0.9,
+            'task_prototype_signature' => ['analysis' => 0.8],
+            'market_semantics_gap' => 0.1,
+            'regulatory_divergence' => 0.1,
+            'toolchain_divergence' => 0.1,
+            'skill_gap_threshold' => 0.4,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeJsonl(array $rows): string
+    {
+        $path = storage_path('framework/testing/ai-impact-preview-'.bin2hex(random_bytes(4)).'.jsonl');
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        file_put_contents($path, implode('', array_map(
+            static fn (array $row): string => json_encode($row, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL,
+            $rows
+        )));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assetRow(string $slug, string $locale): array
+    {
+        $hash = hash('sha256', 'ai-impact|'.$slug.'|'.$locale);
+        $isZh = $locale === 'zh-CN';
+
+        return [
+            'ledger_type' => 'career-risk-future_asset',
+            'asset_version' => 'career_risk_future_ai_impact_v5_batch_001',
+            'block_type' => 'career-risk-future-ai-impact',
+            'slug' => $slug,
+            'locale' => $locale,
+            'seed_ordinal' => 1,
+            'batch_role' => 'new_50',
+            'occupation' => [
+                'title_en' => 'Accountants and Auditors',
+                'title_zh' => '会计师和审计师',
+                'soc_code' => '13-2011',
+                'onet_code' => '13-2011.00',
+            ],
+            'micro_family' => 'audit and assurance workflow',
+            'ai_exposure_score' => [
+                'score_1_to_10' => 8,
+                'exposure_type' => 'mixed',
+                'confidence' => 'high',
+            ],
+            'summary' => $isZh
+                ? 'FermatMind 将会计师和审计师评为 8/10 AI 任务暴露度：凭证核对、审计底稿初筛和差异汇总容易被加速，但签字责任、重大错报判断和客户沟通仍由人承担。'
+                : 'FermatMind rates Accountants and Auditors at 8/10 AI task exposure: reconciliation, workpaper triage, and variance summaries can be accelerated, while sign-off accountability and materiality judgment remain human-owned.',
+            'items' => [
+                'most_ai_exposed_workflows' => [[
+                    'label' => $isZh ? '审计底稿初筛' : 'Workpaper triage',
+                    'body' => $isZh
+                        ? 'AI 可把凭证、银行流水和底稿注释整理成可复核的异常清单，帮助审计人员先定位收入确认、费用截止和关联交易线索。'
+                        : 'AI can organize invoices, bank activity, and workpaper notes into reviewable exception lists for revenue recognition, cutoff, and related-party follow-up.',
+                ]],
+                'human_accountability_anchors' => [[
+                    'label' => $isZh ? '重大性和签字责任' : 'Materiality and sign-off',
+                    'body' => $isZh
+                        ? '是否构成重大错报、是否扩大抽样、如何向客户和合伙人解释风险，仍需要会计与审计人员承担专业判断。'
+                        : 'Material misstatement calls, sample expansion, and explanations to clients or partners remain professional-accountability decisions.',
+                ]],
+                'how_to_prepare' => [[
+                    'label' => $isZh ? '准备可展示的底稿复盘' : 'Build a workpaper review sample',
+                    'body' => $isZh
+                        ? '准备一份脱敏的审计底稿复盘，展示输入资料、AI 初筛、人工删改、最终判断和复核理由。'
+                        : 'Create a sanitized workpaper review sample showing inputs, AI triage, human edits, final judgment, and review rationale.',
+                ]],
+                'reader_boundary' => [
+                    'label' => $isZh ? 'AI 评分边界' : 'AI score boundary',
+                    'body' => $isZh
+                        ? '该分数是任务暴露信号，不是岗位消失、收入变化或个人结果预测。'
+                        : 'This score is a task-exposure signal, not a prediction of job loss, wage change, or an individual outcome.',
+                ],
+            ],
+            'score_rationale' => [
+                'why_not_higher' => $isZh
+                    ? '不是 9/10 或 10/10，因为审计意见、重大性判断、客户沟通和责任归属不能由模型端到端完成。'
+                    : 'The score is not 9/10 or 10/10 because audit opinions, materiality calls, client communication, and accountability cannot be delegated end-to-end.',
+                'why_not_lower' => $isZh
+                    ? '不是低分，因为大量凭证核对、底稿摘要、差异说明和报告初稿都属于可被 AI 加速的信息处理任务。'
+                    : 'The score is not lower because reconciliation, workpaper summaries, variance explanations, and report drafting are recurring information-processing tasks.',
+                'confidence_reason' => $isZh
+                    ? 'O*NET 任务、审计工作流和外部 AI 暴露研究共同支持高暴露但强责任边界的判断。'
+                    : 'O*NET task evidence, audit workflows, and external AI-exposure research support high exposure with a strong accountability boundary.',
+                'drivers' => ['reconciliation workflow', 'workpaper summarization', 'variance explanation'],
+                'anchors' => ['materiality judgment', 'audit sign-off', 'client communication'],
+                'source_ids' => ['onet_13_2011_00_summary'],
+                'evidence_ids' => ['ai_impact_evidence_001'],
+            ],
+            'sources' => [[
+                'source_id' => 'onet_13_2011_00_summary',
+                'source_name' => 'O*NET OnLine summary for Accountants and Auditors',
+                'source_type' => 'task_taxonomy',
+                'source_url' => 'https://www.onetonline.org/link/summary/13-2011.00',
+                'used_for' => 'Occupation-specific task and workflow evidence.',
+                'captured_fact' => 'Accountants and auditors prepare, examine, and analyze accounting records and financial statements.',
+                'boundary' => 'Task taxonomy only; not a personal outcome prediction.',
+            ]],
+            'evidence_used' => [
+                'evidence_row_hash' => str_repeat('a', 64),
+                'source_ids' => ['onet_13_2011_00_summary'],
+                'workflow_evidence_ids' => ['ai_impact_evidence_001'],
+            ],
+            'derived_from_synthesis' => [
+                'synthesis_row_hash' => str_repeat('b', 64),
+            ],
+            'audit_fields' => [
+                'generated_at' => '2026-06-19T00:00:00Z',
+                'row_hash' => $hash,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2523,6 +2523,30 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_ai_impact_asset_preview_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerAiImpactAssetPreviewController.php',
+            'backend/app/Models/CareerJobAiImpactAsset.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportStateMachine.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php',
+            'backend/database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAiImpactAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/ai-impact-asset', [CareerAiImpactAssetPreviewController::class, 'show']);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_asset_backed_bundle_changes(): void
     {
         $changed = [
@@ -3655,6 +3679,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerAiImpactAssetPreviewContractFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Services/Content/ContentPacksIndex.php'
                 && $this->contentPacksIndexDiffIsStreamingScanOnly(
@@ -3710,6 +3738,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerSalaryAssetStagingPreviewOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsCareerAiImpactAssetPreviewContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -5335,6 +5370,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isCareerAiImpactAssetPreviewContractFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerAiImpactAssetPreviewController.php',
+            'backend/app/Models/CareerJobAiImpactAsset.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportStateMachine.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php',
+            'backend/database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php',
+        ], true);
+    }
+
     private function isCareerPublicDistributionFile(string $file): bool
     {
         return in_array($file, [
@@ -6408,6 +6455,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowedLines = [
             '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerSalaryAssetPreviewController;',
             "+    Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);",
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsCareerAiImpactAssetPreviewContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAiImpactAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/ai-impact-asset', [CareerAiImpactAssetPreviewController::class, 'show']);",
         ];
 
         foreach ($changedLines as $line) {


### PR DESCRIPTION
## What changed
- Added an independent `career_job_ai_impact_assets` sidecar channel for AI Impact v5 assets.
- Added a dry-run-only AI Impact importer command with SHA/idempotency/reporting contract and career job bundle authority gate.
- Added a reader-safe preview API projection at `GET /api/v0.5/career/jobs/{slug}/ai-impact-asset?locale={locale}`.
- Added feature coverage for dry-run validation, full 1046 JSONL contract, authority failures, reader-safe projection, allowlist/fail-closed behavior, and unsafe claim/search-projection rejection.
- Updated the OpenAPI snapshot for the new route.

## Why
This prepares the backend contract for AI Impact v5 staging preview without writing staging data or production data. The AI Impact channel remains backend-authoritative and separate from salary assets.

## Validation
- `cd backend && php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `cd backend && bash scripts/export_openapi.sh --check`
- `cd backend && php artisan route:list --path=api/v0.5/career/jobs/{slug}/ai-impact-asset`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --path=database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php`
- `cd backend && ./vendor/bin/pint --test routes/api.php docs/contracts/openapi.snapshot.json app/Console/Commands/CareerImportAiImpactAssetsPreview.php app/Http/Controllers/API/V0_5/Career/CareerAiImpactAssetPreviewController.php app/Models/CareerJobAiImpactAsset.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportStateMachine.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php config/career_ai_impact_assets.php database/migrations/2026_06_19_000100_create_career_job_ai_impact_assets_table.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `cd backend && git diff --check`
- `cd backend && bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No `staging_preview` write command.
- No editorial_review / approved transition implementation.
- No production import.
- No fap-web consumer/runtime changes.
- No runtime SEO, JSON-LD, sitemap, canonical, noindex, or search projection use.

## Repository rule impact
This adds a new backend-authoritative AI Impact asset channel. Frontend remains a consumer only and must fail closed without adding local editorial fallback content.