### PR TITLE
Add article release closeout command

### DIFF
--- a/backend/app/Console/Commands/ArticleReleaseCloseout.php
+++ b/backend/app/Console/Commands/ArticleReleaseCloseout.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ArticleReleaseCloseoutService;
+use Illuminate\Console\Command;
+
+final class ArticleReleaseCloseout extends Command
+{
+    protected $signature = 'articles:release-closeout
+        {--article-id= : Exact article id to inspect}
+        {--expected-slug= : Expected article slug lock}
+        {--public-smoke-json= : Optional JSON file produced by the public article smoke verifier}
+        {--json : Emit JSON}';
+
+    protected $description = 'Read-only closeout report for one released article across CMS, discoverability, URL Truth, and Search Channel state.';
+
+    public function handle(ArticleReleaseCloseoutService $closeout): int
+    {
+        $articleId = (int) $this->option('article-id');
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+        $publicSmoke = $this->publicSmokePayload((string) $this->option('public-smoke-json'));
+        $payload = $closeout->inspect($articleId, $expectedSlug, $publicSmoke);
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } elseif ((bool) ($payload['ok'] ?? false)) {
+            $this->info((string) ($payload['decision'] ?? 'ok'));
+        } else {
+            $this->error((string) ($payload['decision'] ?? 'blocked'));
+        }
+
+        return (bool) ($payload['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function publicSmokePayload(string $path): ?array
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return null;
+        }
+
+        if (! is_file($path)) {
+            return [
+                'ok' => false,
+                'decision' => 'PUBLIC_SMOKE_EVIDENCE_FILE_MISSING',
+                'path' => $path,
+            ];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            return [
+                'ok' => false,
+                'decision' => 'PUBLIC_SMOKE_EVIDENCE_JSON_INVALID',
+                'path' => $path,
+            ];
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -10,6 +10,7 @@ use App\Console\Commands\ArticleEnsureSeoMetaBaseline;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
+use App\Console\Commands\ArticleReleaseCloseout;
 use App\Console\Commands\ArticleReplaceInlineImageUrl;
 use App\Console\Commands\ArticleSeoGateRollout;
 use App\Console\Commands\ArticleTaxonomyHygiene;
@@ -350,6 +351,7 @@ class Kernel extends ConsoleKernel
         ArticleDiscoverabilityRelease::class,
         ArticlePublishControlled::class,
         ArticleReplaceInlineImageUrl::class,
+        ArticleReleaseCloseout::class,
         ArticleSeoGateRollout::class,
         ArticleTaxonomyHygiene::class,
         ArticleUpdateTranslationGroupId::class,

--- a/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
+++ b/backend/app/Services/Cms/ArticleReleaseCloseoutService.php
@@ -1,0 +1,703 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ArticleReleaseCloseoutService
+{
+    public const COMPLETE_SEARCH_OBSERVATION_PENDING = 'ARTICLE_RELEASE_COMPLETE_SEARCH_OBSERVATION_PENDING';
+
+    public const BLOCKED_DISCOVERABILITY_GAP = 'BLOCKED_DISCOVERABILITY_GAP';
+
+    public const BLOCKED_SEARCH_QUEUE_GAP = 'BLOCKED_SEARCH_QUEUE_GAP';
+
+    public const BLOCKED_PUBLIC_HTML_DRIFT = 'BLOCKED_PUBLIC_HTML_DRIFT';
+
+    public const BLOCKED_OPERATOR_INPUT = 'BLOCKED_OPERATOR_INPUT';
+
+    /**
+     * @param  array<string,mixed>|null  $publicSmoke
+     * @return array<string,mixed>
+     */
+    public function inspect(int $articleId, string $expectedSlug, ?array $publicSmoke = null): array
+    {
+        $errors = [];
+
+        if ($articleId <= 0) {
+            $errors[] = $this->issue('article_id', 'article_id_required', '--article-id is required.');
+        }
+        if ($expectedSlug === '') {
+            $errors[] = $this->issue('expected_slug', 'expected_slug_required', '--expected-slug is required.');
+        }
+
+        $article = $articleId > 0 ? $this->article($articleId) : null;
+        if (! $article instanceof Article) {
+            $errors[] = $this->issue('article', 'article_not_found', 'Article was not found.');
+
+            return $this->summary(
+                articleId: $articleId,
+                expectedSlug: $expectedSlug,
+                canonicalPath: null,
+                canonicalUrl: null,
+                checks: [],
+                errors: $errors,
+                publicSmoke: $publicSmoke,
+            );
+        }
+
+        $canonicalPath = $this->canonicalPathForArticle($article);
+        $canonicalUrl = 'https://fermatmind.com'.$canonicalPath;
+        $checks = [
+            'article' => $this->articleCheck($article, $expectedSlug),
+            'seo_meta' => $this->seoMetaCheck($article, $canonicalPath),
+            'media' => $this->mediaCheck($article),
+            'taxonomy' => $this->taxonomyCheck($article),
+            'discoverability' => $this->discoverabilityCheck($article),
+            'url_truth' => $this->urlTruthCheck($article, $canonicalUrl),
+            'search_channel' => $this->searchChannelCheck($canonicalUrl),
+            'schema_hreflang' => $this->schemaHreflangCheck($article),
+            'public_html_smoke' => $this->publicSmokeCheck($publicSmoke),
+            'gsc_manual' => $this->manualCheck('operator_record_required'),
+            'observation' => $this->manualCheck('d1_d7_d14_queue_record_required'),
+        ];
+
+        return $this->summary(
+            articleId: $articleId,
+            expectedSlug: $expectedSlug,
+            canonicalPath: $canonicalPath,
+            canonicalUrl: $canonicalUrl,
+            checks: $checks,
+            errors: $errors,
+            publicSmoke: $publicSmoke,
+        );
+    }
+
+    private function article(int $articleId): ?Article
+    {
+        /** @var Article|null $article */
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'category' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'tags' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->find($articleId);
+
+        return $article;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function articleCheck(Article $article, string $expectedSlug): array
+    {
+        $issues = [];
+        $revision = $article->publishedRevision;
+
+        if ((string) $article->slug !== $expectedSlug) {
+            $issues[] = $this->issue('article.slug', 'expected_slug_mismatch', 'Article slug does not match expected lock.', [
+                'expected' => $expectedSlug,
+                'actual' => (string) $article->slug,
+            ]);
+        }
+        if ((string) $article->status !== 'published') {
+            $issues[] = $this->issue('article.status', 'article_not_published', 'Article must be published.');
+        }
+        if (! (bool) $article->is_public) {
+            $issues[] = $this->issue('article.is_public', 'article_not_public', 'Article must be public.');
+        }
+        if (! (bool) $article->is_indexable) {
+            $issues[] = $this->issue('article.is_indexable', 'article_not_indexable', 'Article must be indexable.');
+        }
+        if ((string) $article->lifecycle_state !== '' && in_array((string) $article->lifecycle_state, [
+            Article::LIFECYCLE_ARCHIVED,
+            Article::LIFECYCLE_SOFT_DELETED,
+        ], true)) {
+            $issues[] = $this->issue('article.lifecycle_state', 'article_lifecycle_not_releasable', 'Article lifecycle state is not releasable.');
+        }
+        if (! $revision instanceof ArticleTranslationRevision) {
+            $issues[] = $this->issue('article.published_revision_id', 'published_revision_missing', 'Article must have a published revision.');
+        } elseif ((string) $revision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            $issues[] = $this->issue('published_revision.revision_status', 'published_revision_status_invalid', 'Published revision must have published status.');
+        }
+
+        return [
+            'ok' => $issues === [],
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function seoMetaCheck(Article $article, string $canonicalPath): array
+    {
+        $issues = [];
+        $seoMeta = $article->seoMeta;
+
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            return [
+                'ok' => false,
+                'exists' => false,
+                'issues' => [
+                    $this->issue('seo_meta', 'seo_meta_missing', 'Article SEO meta row is required.'),
+                ],
+            ];
+        }
+
+        if ((string) $seoMeta->seo_title === '') {
+            $issues[] = $this->issue('seo_meta.seo_title', 'seo_title_missing', 'SEO title is required.');
+        }
+        if ((string) $seoMeta->seo_description === '') {
+            $issues[] = $this->issue('seo_meta.seo_description', 'seo_description_missing', 'SEO description is required.');
+        }
+        if (! (bool) $seoMeta->is_indexable) {
+            $issues[] = $this->issue('seo_meta.is_indexable', 'seo_meta_not_indexable', 'SEO meta must be indexable.');
+        }
+        if ((string) $seoMeta->robots !== 'index,follow') {
+            $issues[] = $this->issue('seo_meta.robots', 'seo_meta_robots_not_index_follow', 'SEO meta robots must be index,follow.');
+        }
+
+        $actualCanonicalPath = $this->pathFromCanonical((string) $seoMeta->canonical_url);
+        if ($actualCanonicalPath !== $canonicalPath) {
+            $issues[] = $this->issue('seo_meta.canonical_url', 'canonical_path_mismatch', 'SEO canonical must match the article route.', [
+                'expected_canonical_path' => $canonicalPath,
+                'actual_canonical_path' => $actualCanonicalPath,
+            ]);
+        }
+
+        return [
+            'ok' => $issues === [],
+            'exists' => true,
+            'seo_title_present' => (string) $seoMeta->seo_title !== '',
+            'seo_description_present' => (string) $seoMeta->seo_description !== '',
+            'canonical_url' => (string) $seoMeta->canonical_url,
+            'robots' => (string) $seoMeta->robots,
+            'is_indexable' => (bool) $seoMeta->is_indexable,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mediaCheck(Article $article): array
+    {
+        $seoMeta = $article->seoMeta;
+        $bodyUrls = $this->bodyVisualUrls((string) $article->content_md, (string) $article->content_html);
+        $urls = [
+            'cover_image_url' => (string) $article->cover_image_url,
+            'seo_meta.og_image_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->og_image_url : '',
+        ];
+
+        foreach ($bodyUrls as $index => $url) {
+            $urls['body_visual_urls.'.$index] = $url;
+        }
+
+        $issues = [];
+        foreach ($urls as $field => $url) {
+            if ($url === '') {
+                if (in_array($field, ['cover_image_url', 'seo_meta.og_image_url'], true)) {
+                    $issues[] = $this->issue($field, 'media_url_missing', 'Required article media URL is missing.');
+                }
+
+                continue;
+            }
+
+            if (! $this->isPublicMediaUrl($url)) {
+                $issues[] = $this->issue($field, 'media_url_not_public_origin', 'Article media URL must use a public FermatMind origin.', [
+                    'url' => $url,
+                ]);
+            }
+        }
+
+        return [
+            'ok' => $issues === [],
+            'cover_image_url' => (string) $article->cover_image_url,
+            'og_image_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->og_image_url : null,
+            'body_visual_url_count' => count($bodyUrls),
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function taxonomyCheck(Article $article): array
+    {
+        $category = $article->category;
+        $tags = $article->tags;
+        $issues = [];
+        $zh = str_starts_with((string) $article->locale, 'zh');
+
+        if (! $category instanceof ArticleCategory) {
+            $issues[] = $this->issue('article.category_id', 'category_missing', 'Article must have a reader-facing category.');
+        } else {
+            $categoryName = (string) $category->name;
+            if (! (bool) $category->is_active) {
+                $issues[] = $this->issue('category.is_active', 'category_inactive', 'Article category must be active.');
+            }
+            if ($zh && ! $this->isReaderFacingZhLabel($categoryName)) {
+                $issues[] = $this->issue('category.name', 'category_not_reader_facing_zh', 'Chinese articles must use a Chinese-facing category label.', [
+                    'category_name' => $categoryName,
+                ]);
+            }
+        }
+
+        if ($tags->count() === 0) {
+            $issues[] = $this->issue('article.tags', 'tags_missing', 'Article should have reader-facing tags.');
+        }
+
+        $tagPayload = $tags
+            ->map(static fn (ArticleTag $tag): array => [
+                'id' => (int) $tag->id,
+                'name' => (string) $tag->name,
+                'slug' => (string) $tag->slug,
+                'is_active' => (bool) $tag->is_active,
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'ok' => $issues === [],
+            'category' => $category instanceof ArticleCategory ? [
+                'id' => (int) $category->id,
+                'name' => (string) $category->name,
+                'slug' => (string) $category->slug,
+                'is_active' => (bool) $category->is_active,
+            ] : null,
+            'tags' => $tagPayload,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function discoverabilityCheck(Article $article): array
+    {
+        $issues = [];
+
+        if (! (bool) $article->sitemap_eligible) {
+            $issues[] = $this->issue('article.sitemap_eligible', 'sitemap_eligibility_missing', 'Article must be sitemap eligible.');
+        }
+        if (! (bool) $article->llms_eligible) {
+            $issues[] = $this->issue('article.llms_eligible', 'llms_eligibility_missing', 'Article must be llms eligible.');
+        }
+
+        return [
+            'ok' => $issues === [],
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'llms_full_source_eligible' => (bool) $article->llms_eligible && (bool) $article->is_indexable,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function urlTruthCheck(Article $article, string $canonicalUrl): array
+    {
+        $connection = (string) config('seo_intel.connection', 'seo_intel');
+        if (! Schema::connection($connection)->hasTable('seo_urls')) {
+            return [
+                'ok' => false,
+                'table_available' => false,
+                'issues' => [
+                    $this->issue('seo_urls', 'seo_urls_table_missing', 'URL Truth table is missing.'),
+                ],
+            ];
+        }
+
+        $row = DB::connection($connection)
+            ->table('seo_urls')
+            ->where('canonical_url_hash', hash('sha256', $canonicalUrl))
+            ->where('locale', (string) $article->locale)
+            ->first();
+
+        if (! $row) {
+            return [
+                'ok' => false,
+                'table_available' => true,
+                'present' => false,
+                'issues' => [
+                    $this->issue('seo_urls', 'url_truth_missing', 'URL Truth row is missing for the article canonical URL.', [
+                        'canonical_url' => $canonicalUrl,
+                    ]),
+                ],
+            ];
+        }
+
+        $issues = [];
+        if ((string) $row->canonical_url !== $canonicalUrl) {
+            $issues[] = $this->issue('seo_urls.canonical_url', 'url_truth_canonical_mismatch', 'URL Truth canonical URL does not match.');
+        }
+        if ((string) $row->page_entity_type !== 'article') {
+            $issues[] = $this->issue('seo_urls.page_entity_type', 'url_truth_entity_type_invalid', 'URL Truth page entity type must be article.');
+        }
+        if ((string) $row->indexability_state !== 'indexable') {
+            $issues[] = $this->issue('seo_urls.indexability_state', 'url_truth_not_indexable', 'URL Truth indexability must be indexable.');
+        }
+        if ((bool) ($row->is_private_flow ?? false)) {
+            $issues[] = $this->issue('seo_urls.is_private_flow', 'url_truth_private_flow', 'URL Truth row must not be private flow.');
+        }
+
+        return [
+            'ok' => $issues === [],
+            'table_available' => true,
+            'present' => true,
+            'canonical_url' => (string) $row->canonical_url,
+            'page_entity_type' => (string) $row->page_entity_type,
+            'source_authority' => (string) $row->source_authority,
+            'indexability_state' => (string) $row->indexability_state,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function searchChannelCheck(string $canonicalUrl): array
+    {
+        $connection = (string) config('seo_intel.connection', 'seo_intel');
+        if (! Schema::connection($connection)->hasTable('seo_search_channel_queue_items')) {
+            return [
+                'ok' => false,
+                'table_available' => false,
+                'channels' => [],
+                'issues' => [
+                    $this->issue('seo_search_channel_queue_items', 'search_channel_queue_table_missing', 'Search Channel queue table is missing.'),
+                ],
+            ];
+        }
+
+        $rows = DB::connection($connection)
+            ->table('seo_search_channel_queue_items')
+            ->where('canonical_url', $canonicalUrl)
+            ->whereIn('channel', ['indexnow', 'baidu_push'])
+            ->orderByDesc('id')
+            ->get()
+            ->groupBy(static fn (object $row): string => (string) $row->channel);
+
+        $channels = [];
+        $issues = [];
+        foreach (['indexnow', 'baidu_push'] as $channel) {
+            $row = $rows->get($channel)?->first();
+            if (! $row) {
+                $channels[$channel] = [
+                    'present' => false,
+                    'ok' => false,
+                ];
+                $issues[] = $this->issue('search_channel.'.$channel, 'search_channel_queue_missing', 'Search Channel queue item is missing.', [
+                    'channel' => $channel,
+                ]);
+
+                continue;
+            }
+
+            $channelOk = in_array((string) $row->approval_state, ['approved'], true)
+                && in_array((string) $row->execution_state, ['accepted', 'submitted', 'submit_succeeded'], true);
+
+            $channels[$channel] = [
+                'present' => true,
+                'ok' => $channelOk,
+                'queue_item_id' => (int) $row->id,
+                'approval_state' => (string) $row->approval_state,
+                'execution_state' => (string) $row->execution_state,
+                'eligibility_state' => (string) $row->eligibility_state,
+            ];
+
+            if (! $channelOk) {
+                $issues[] = $this->issue('search_channel.'.$channel, 'search_channel_queue_not_accepted', 'Search Channel queue item must be approved and accepted/submitted.', [
+                    'channel' => $channel,
+                    'queue_item_id' => (int) $row->id,
+                    'approval_state' => (string) $row->approval_state,
+                    'execution_state' => (string) $row->execution_state,
+                ]);
+            }
+        }
+
+        return [
+            'ok' => $issues === [],
+            'table_available' => true,
+            'channels' => $channels,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function schemaHreflangCheck(Article $article): array
+    {
+        $seoMeta = $article->seoMeta;
+        $issues = [];
+        $schema = $seoMeta instanceof ArticleSeoMeta && is_array($seoMeta->schema_json) ? $seoMeta->schema_json : [];
+        $package = is_array($schema['editorial_package_v1'] ?? null) ? $schema['editorial_package_v1'] : [];
+        $hreflang = is_array($package['hreflang_gate_v1'] ?? null) ? $package['hreflang_gate_v1'] : null;
+
+        $articleSchemaEnabled = (bool) ($package['article_schema_enabled'] ?? false);
+        $breadcrumbSchemaEnabled = (bool) ($package['breadcrumb_schema_enabled'] ?? false);
+        $faqSchemaEnabled = (bool) ($package['faq_schema_enabled'] ?? false);
+
+        if (! $articleSchemaEnabled) {
+            $issues[] = $this->issue('schema.article_schema_enabled', 'article_schema_not_enabled', 'Article schema gate is not enabled.');
+        }
+        if (! $breadcrumbSchemaEnabled) {
+            $issues[] = $this->issue('schema.breadcrumb_schema_enabled', 'breadcrumb_schema_not_enabled', 'Breadcrumb schema gate is not enabled.');
+        }
+        if ($faqSchemaEnabled) {
+            $issues[] = $this->issue('schema.faq_schema_enabled', 'faq_schema_not_held', 'FAQ schema should remain held unless explicitly reviewed.');
+        }
+        if (! is_array($hreflang) || ($hreflang['enabled'] ?? null) !== false || ($hreflang['policy'] ?? null) !== 'no_hreflang') {
+            $issues[] = $this->issue('hreflang_gate_v1', 'hreflang_policy_missing', 'Hreflang gate must be enabled reciprocally or record no_hreflang policy.');
+        }
+
+        return [
+            'ok' => $issues === [],
+            'article_schema_enabled' => $articleSchemaEnabled,
+            'breadcrumb_schema_enabled' => $breadcrumbSchemaEnabled,
+            'faq_schema_enabled' => $faqSchemaEnabled,
+            'hreflang_gate_v1' => $hreflang,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $publicSmoke
+     * @return array<string,mixed>
+     */
+    private function publicSmokeCheck(?array $publicSmoke): array
+    {
+        if ($publicSmoke === null) {
+            return [
+                'ok' => null,
+                'state' => 'not_provided',
+                'issues' => [],
+            ];
+        }
+
+        $ok = (bool) ($publicSmoke['ok'] ?? false);
+
+        return [
+            'ok' => $ok,
+            'state' => $ok ? 'passed' : 'failed',
+            'issues' => $ok ? [] : [
+                $this->issue('public_html_smoke', 'public_html_smoke_failed', 'Public HTML smoke evidence reported failure.', [
+                    'decision' => $publicSmoke['decision'] ?? null,
+                ]),
+            ],
+            'evidence' => $publicSmoke,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function manualCheck(string $state): array
+    {
+        return [
+            'ok' => null,
+            'state' => $state,
+            'issues' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $publicSmoke
+     * @param  list<array<string,mixed>>  $errors
+     * @param  array<string,mixed>  $checks
+     * @return array<string,mixed>
+     */
+    private function summary(
+        int $articleId,
+        string $expectedSlug,
+        ?string $canonicalPath,
+        ?string $canonicalUrl,
+        array $checks,
+        array $errors,
+        ?array $publicSmoke,
+    ): array {
+        $issues = $errors;
+        foreach ($checks as $check) {
+            foreach ((array) ($check['issues'] ?? []) as $issue) {
+                if (is_array($issue)) {
+                    $issues[] = $issue;
+                }
+            }
+        }
+
+        $decision = $this->decision($checks, $issues, $publicSmoke);
+
+        return [
+            'ok' => $decision === self::COMPLETE_SEARCH_OBSERVATION_PENDING,
+            'decision' => $decision,
+            'read_only' => true,
+            'external_search_submission_attempted' => false,
+            'cms_content_write_attempted' => false,
+            'publish_attempted' => false,
+            'schema_hreflang_write_attempted' => false,
+            'sitemap_llms_mutation_attempted' => false,
+            'article_id' => $articleId,
+            'expected_slug' => $expectedSlug,
+            'canonical_path' => $canonicalPath,
+            'canonical_url' => $canonicalUrl,
+            'checks' => $checks,
+            'issues' => $issues,
+            'remaining_operator_inputs' => [
+                'public_html_smoke' => $publicSmoke === null ? 'not_provided_use_fap_web_smoke_verifier' : 'provided',
+                'gsc_manual_request_indexing' => 'operator_record_required',
+                'd1_d7_d14_observation' => 'schedule_or_record_after_release',
+            ],
+            'allowed_decisions' => [
+                self::COMPLETE_SEARCH_OBSERVATION_PENDING,
+                self::BLOCKED_DISCOVERABILITY_GAP,
+                self::BLOCKED_SEARCH_QUEUE_GAP,
+                self::BLOCKED_PUBLIC_HTML_DRIFT,
+                self::BLOCKED_OPERATOR_INPUT,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $checks
+     * @param  list<array<string,mixed>>  $issues
+     * @param  array<string,mixed>|null  $publicSmoke
+     */
+    private function decision(array $checks, array $issues, ?array $publicSmoke): string
+    {
+        if (($checks['public_html_smoke']['ok'] ?? null) === false) {
+            return self::BLOCKED_PUBLIC_HTML_DRIFT;
+        }
+
+        $codes = array_map(static fn (array $issue): string => (string) ($issue['code'] ?? ''), $issues);
+        foreach ([
+            'article_not_found',
+            'article_id_required',
+            'expected_slug_required',
+            'article_not_published',
+            'article_not_public',
+            'article_not_indexable',
+            'published_revision_missing',
+            'published_revision_status_invalid',
+            'seo_meta_missing',
+            'seo_meta_not_indexable',
+            'seo_meta_robots_not_index_follow',
+            'canonical_path_mismatch',
+            'sitemap_eligibility_missing',
+            'llms_eligibility_missing',
+            'seo_urls_table_missing',
+            'url_truth_missing',
+            'url_truth_canonical_mismatch',
+            'url_truth_entity_type_invalid',
+            'url_truth_not_indexable',
+            'url_truth_private_flow',
+        ] as $discoverabilityCode) {
+            if (in_array($discoverabilityCode, $codes, true)) {
+                return self::BLOCKED_DISCOVERABILITY_GAP;
+            }
+        }
+
+        foreach ([
+            'search_channel_queue_table_missing',
+            'search_channel_queue_missing',
+            'search_channel_queue_not_accepted',
+        ] as $searchCode) {
+            if (in_array($searchCode, $codes, true)) {
+                return self::BLOCKED_SEARCH_QUEUE_GAP;
+            }
+        }
+
+        if ($issues !== []) {
+            return self::BLOCKED_OPERATOR_INPUT;
+        }
+
+        return self::COMPLETE_SEARCH_OBSERVATION_PENDING;
+    }
+
+    private function canonicalPathForArticle(Article $article): string
+    {
+        $locale = (string) $article->locale;
+        $prefix = str_starts_with($locale, 'zh') ? '/zh/articles/' : '/en/articles/';
+
+        return $prefix.(string) $article->slug;
+    }
+
+    private function pathFromCanonical(string $canonical): string
+    {
+        $path = parse_url($canonical, PHP_URL_PATH);
+
+        return is_string($path) ? $path : '';
+    }
+
+    private function isReaderFacingZhLabel(string $label): bool
+    {
+        if ($label === '' || $label === 'SEO Articles' || preg_match('/^[a-z0-9_ -]+$/i', $label) === 1 || str_contains($label, '_')) {
+            return false;
+        }
+
+        return preg_match('/\p{Han}/u', $label) === 1;
+    }
+
+    private function isPublicMediaUrl(string $url): bool
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return in_array($host, [
+            'api.fermatmind.com',
+            'assets.fermatmind.com',
+            'fermatmind.com',
+            'www.fermatmind.com',
+        ], true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function bodyVisualUrls(string $markdown, string $html): array
+    {
+        $urls = [];
+        if (preg_match_all('/!\[[^\]]*]\((https?:\/\/[^)\s]+)\)/', $markdown, $matches)) {
+            foreach ($matches[1] as $url) {
+                $urls[] = (string) $url;
+            }
+        }
+        if (preg_match_all('/<img\b[^>]*\bsrc=["\'](https?:\/\/[^"\']+)["\']/i', $html, $matches)) {
+            foreach ($matches[1] as $url) {
+                $urls[] = (string) $url;
+            }
+        }
+
+        return array_values(array_unique($urls));
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $context = []): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class ArticleReleaseCloseoutCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareSeoIntelSqliteConnection();
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('articles:release-closeout', Artisan::all());
+    }
+
+    public function test_complete_article_outputs_search_observation_pending_decision(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertSame('ARTICLE_RELEASE_COMPLETE_SEARCH_OBSERVATION_PENDING', $payload['decision']);
+        $this->assertSame('/zh/articles/gaokao-score-major-shortlist-riasec-checklist', $payload['canonical_path']);
+        $this->assertSame(58, data_get($payload, 'checks.search_channel.channels.indexnow.queue_item_id'));
+        $this->assertSame(59, data_get($payload, 'checks.search_channel.channels.baidu_push.queue_item_id'));
+        $this->assertSame('not_provided', data_get($payload, 'checks.public_html_smoke.state'));
+        $this->assertFalse($payload['external_search_submission_attempted']);
+        $this->assertFalse($payload['cms_content_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['schema_hreflang_write_attempted']);
+        $this->assertFalse($payload['sitemap_llms_mutation_attempted']);
+    }
+
+    public function test_missing_search_queue_blocks_search_closeout(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('BLOCKED_SEARCH_QUEUE_GAP', $payload['decision']);
+        $this->assertErrorCode($payload, 'search_channel_queue_missing');
+    }
+
+    public function test_internal_taxonomy_and_private_media_block_operator_input(): void
+    {
+        $article = $this->createReleasedArticle([
+            'cover_image_url' => 'https://private.example.test/cover.jpg',
+        ], categoryName: 'SEO Articles');
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('BLOCKED_OPERATOR_INPUT', $payload['decision']);
+        $this->assertErrorCode($payload, 'media_url_not_public_origin');
+        $this->assertErrorCode($payload, 'category_not_reader_facing_zh');
+    }
+
+    public function test_slug_lock_mismatch_blocks_discoverability(): void
+    {
+        $this->createReleasedArticle();
+
+        $exitCode = Artisan::call('articles:release-closeout', [
+            '--article-id' => '53',
+            '--expected-slug' => 'wrong-slug',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('BLOCKED_DISCOVERABILITY_GAP', $payload['decision']);
+        $this->assertErrorCode($payload, 'expected_slug_mismatch');
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createReleasedArticle(array $overrides = [], string $categoryName = '职业决策'): Article
+    {
+        /** @var ArticleCategory $category */
+        $category = Model::unguarded(fn (): ArticleCategory => ArticleCategory::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'career-decision',
+            'name' => $categoryName,
+            'is_active' => true,
+        ]));
+
+        /** @var Article $article */
+        $article = Model::unguarded(fn (): Article => Article::query()->withoutGlobalScopes()->create(array_merge([
+            'id' => 53,
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 12,
+            'slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_gaokao_score_major_shortlist_riasec_2026v1',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '高考出分后专业太多怎么筛？位次+霍兰德排除清单',
+            'excerpt' => '高考出分后，用位次、选科要求、霍兰德职业兴趣测试和排除清单缩小专业范围。',
+            'content_md' => '# 高考出分后专业太多怎么筛？'."\n\n![流程图](https://api.fermatmind.com/storage/media-library/body.png)\n\n正文。",
+            'content_html' => '<h1>高考出分后专业太多怎么筛？</h1><img src="https://api.fermatmind.com/storage/media-library/body.png">',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/cover.jpg',
+            'cover_image_variants' => [
+                'card' => ['url' => 'https://api.fermatmind.com/storage/media-library/card.jpg'],
+            ],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => Carbon::create(2026, 6, 19, 5, 30, 0, 'UTC'),
+        ], $overrides)));
+
+        /** @var ArticleTag $tag */
+        $tag = Model::unguarded(fn (): ArticleTag => ArticleTag::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'riasec',
+            'name' => 'RIASEC',
+            'is_active' => true,
+        ]));
+        DB::table('article_tag_map')->insert([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'tag_id' => (int) $tag->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = Model::unguarded(fn (): ArticleTranslationRevision => ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => $article->published_at,
+        ]));
+
+        $article->forceFill(['published_revision_id' => (int) $revision->id])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist',
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://api.fermatmind.com/storage/media-library/og.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                        'policy' => 'no_hreflang',
+                        'reason' => 'no_direct_english_counterpart_approved',
+                    ],
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['category', 'tags', 'publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    private function prepareSeoIntelSqliteConnection(): void
+    {
+        config([
+            'seo_intel.connection' => 'seo_intel',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function insertUrlTruth(string $canonicalUrl, string $locale, string $slug): void
+    {
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => $locale,
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => $slug,
+            'cluster' => 'article',
+            'source_authority' => 'cms_article',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => now(),
+            'lastmod_source' => 'articles.updated_at',
+            'is_private_flow' => false,
+            'first_seen_at' => now(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode(['source_table' => 'articles'], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertSearchQueue(string $canonicalUrl, string $locale, string $channel, int $id): void
+    {
+        DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insert([
+            'id' => $id,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $locale,
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => '53',
+            'source_authority' => 'cms_article',
+            'source_table' => 'articles',
+            'channel' => $channel,
+            'eligibility_state' => 'eligible',
+            'approval_state' => 'approved',
+            'execution_state' => 'accepted',
+            'indexability_state' => 'indexable',
+            'claim_boundary_state' => 'claim_safe',
+            'private_flow' => false,
+            'reason_codes' => json_encode([], JSON_THROW_ON_ERROR),
+            'lastmod' => now(),
+            'content_hash' => hash('sha256', 'article-53'),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.$locale.'|'.$channel),
+            'approved_by' => 'operator',
+            'approved_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            (array) ($payload['issues'] ?? [])
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1087,8 +1087,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Kernel.php',
             'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
         ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleReleaseCloseout;',
+            '+        ArticleReleaseCloseout::class,',
+        ];
 
-        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
     public function test_runtime_freeze_classifier_ignores_seo_intel_mbti_url_truth_cleanup_runtime_files(): void
@@ -4042,6 +4046,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleImageMetadataUpdaterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleInlineImageUrlReplacerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleTranslationGroupIdCleanupOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsArticleReleaseCloseoutOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsDailyArticleBackendPipelineOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -4442,7 +4447,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleReleaseCloseout.php',
-            'backend/app/Console/Kernel.php',
             'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
         ], true);
     }
@@ -6145,6 +6149,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleUpdateTranslationGroupId\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsArticleReleaseCloseoutOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleReleaseCloseout\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1080,6 +1080,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_release_closeout_read_model_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleReleaseCloseout.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_mbti_url_truth_cleanup_runtime_files(): void
     {
         $changed = [
@@ -3368,6 +3379,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleReleaseCloseoutFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleTranslationGroupIdCleanupFile($file)) {
                 continue;
             }
@@ -4421,6 +4436,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isArticleDiscoverabilityReleaseFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/ArticleDiscoverabilityRelease.php';
+    }
+
+    private function isArticleReleaseCloseoutFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleReleaseCloseout.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
+        ], true);
     }
 
     private function isArticleTranslationGroupIdCleanupFile(string $file): bool


### PR DESCRIPTION
## What changed
- Added `articles:release-closeout`, a read-only article closeout command with article id and expected slug locks.
- Added `ArticleReleaseCloseoutService` to aggregate CMS article state, SEO meta, media/taxonomy, sitemap/llms eligibility, URL Truth, Search Channel queue status, schema/hreflang gates, and operator-only closeout placeholders.
- Added focused feature tests for complete closeout, missing search queue, internal taxonomy/private media, and slug lock mismatch decisions.

## Why
Daily SEO releases need one backend truth command that answers whether a single article can be closed out or which bounded lane remains blocked. This keeps content release, search submission, schema/hreflang, public HTML smoke, and observation follow-up separated.

## Validation commands
- `php artisan test --filter=ArticleReleaseCloseoutCommandTest`
- `php artisan test --filter=ArticleDiscoverabilityReleaseCommandTest`
- `php artisan list --no-ansi | rg "articles:release-closeout|articles:discoverability-release"`
- `./vendor/bin/pint --test app/Console/Commands/ArticleReleaseCloseout.php app/Services/Cms/ArticleReleaseCloseoutService.php tests/Feature/Console/ArticleReleaseCloseoutCommandTest.php app/Console/Kernel.php`
- `git diff --check`

Note: PHPUnit emitted the existing clean-worktree warning that `backend/.env` is absent in this temporary worktree; assertions passed.

## Intentionally deferred
- No deploy.
- No production writes.
- No CMS mutation, publish, promote, production revalidation, search submission, schema/hreflang writes, sitemap/llms mutation, or public HTML fetch.
- Public HTML retry/cache-window smoke belongs to the fap-web verifier PR.
- Ops/CMS panel integration belongs to the later fap-api panel PR.

## Repository rule impact
- Backend remains the source of truth for article release status.
- This PR adds read-only tooling only; it does not change content ownership, publishing SOP, media authority, public API contracts, sitemap/llms generation, or frontend fallback behavior.