### PR TITLE
Add AI Impact staging preview write support

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -15,11 +15,13 @@ final class CareerImportAiImpactAssetsPreview extends Command
         {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
         {--slugs= : Optional comma-separated preview slug subset}
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
-        {--dry-run : Validate only; this command never writes staging or production rows}
+        {--dry-run : Validate only; do not write staging or production rows}
+        {--force : Write rows only when --status=staging_preview and validation passes}
+        {--status=staging_preview : Target import status; only staging_preview is supported by this command}
         {--json : Emit machine-readable JSON report}
         {--output= : Optional report output path}';
 
-    protected $description = 'Dry-run validation for PASS v5 career AI impact asset rows and the configured staging preview contract.';
+    protected $description = 'Validate or write PASS v5 career AI impact asset rows for the configured staging preview contract.';
 
     public function __construct(
         private readonly CareerAiImpactAssetImportService $importService,
@@ -38,12 +40,31 @@ final class CareerImportAiImpactAssetsPreview extends Command
                 ], false);
             }
 
-            $report = $this->importService->validateFile(
-                $file,
-                $this->requestedSlugs(),
-                trim((string) $this->option('expected-sha256')) ?: null,
-                (bool) $this->option('all-slugs-from-file'),
-            );
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+            $status = trim((string) $this->option('status')) ?: 'staging_preview';
+
+            if ($force && $dryRun) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--force cannot be combined with --dry-run.'],
+                ], false);
+            }
+
+            $report = $force
+                ? $this->importService->importStagingPreview(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                    $status,
+                )
+                : $this->importService->validateFile(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                );
 
             return $this->finish($report, ($report['decision'] ?? null) === 'pass');
         } catch (Throwable $throwable) {

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -6,8 +6,10 @@ namespace App\Services\Career\AiImpactAssets;
 
 use App\Console\Commands\CareerPublicResolutionTypeMatrix;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobAiImpactAsset;
 use App\Models\Occupation;
 use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Support\Str;
 use Throwable;
 
 final class CareerAiImpactAssetImportService
@@ -171,6 +173,173 @@ final class CareerAiImpactAssetImportService
             'production_import_allowed' => false,
             'staging_write_performed' => false,
             'errors' => $errors,
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function importStagingPreview(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        string $status = CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+    ): array {
+        if ($status !== CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW) {
+            return array_merge($this->baseReport($file, $requestedSlugs, $allSlugsFromFile), [
+                'mode' => 'write',
+                'decision' => 'fail',
+                'status' => $status,
+                'production_import_allowed' => false,
+                'staging_write_performed' => false,
+                'errors' => ['Only staging_preview status is supported by this command.'],
+            ]);
+        }
+
+        $validation = $this->validateFile($file, $requestedSlugs, $expectedSha256, $allSlugsFromFile);
+        if (($validation['decision'] ?? null) !== 'pass') {
+            return array_merge($validation, [
+                'mode' => 'write',
+                'status' => $status,
+                'staging_write_performed' => false,
+                'write_skipped_reason' => 'validation_failed',
+            ]);
+        }
+
+        $targetSlugs = array_values(array_map('strval', (array) ($validation['target_slugs'] ?? [])));
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $targetKeys[$slug.'|'.$locale] = true;
+            }
+        }
+
+        $sourceFileSha256 = is_string($validation['source_file_sha256'] ?? null)
+            ? (string) $validation['source_file_sha256']
+            : null;
+        $importRunId = (string) Str::uuid();
+        $writtenCount = 0;
+        $createdCount = 0;
+        $updatedCount = 0;
+        $writtenRows = [];
+
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return array_merge($validation, [
+                'mode' => 'write',
+                'status' => $status,
+                'decision' => 'fail',
+                'staging_write_performed' => false,
+                'errors' => ['Source JSONL file could not be opened for staging write.'],
+            ]);
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if (! isset($targetKeys[$slug.'|'.$locale])) {
+                continue;
+            }
+
+            $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+            if (! $occupation instanceof Occupation) {
+                continue;
+            }
+
+            $assetVersion = CareerJobAiImpactAsset::ASSET_VERSION_V5;
+            $existing = CareerJobAiImpactAsset::query()
+                ->where('career_job_slug', $slug)
+                ->where('locale', $locale)
+                ->where('asset_version', $assetVersion)
+                ->first();
+
+            $payload = [
+                'occupation_id' => $occupation->id,
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $row,
+                'sources_json' => is_array($row['sources'] ?? null) ? $row['sources'] : null,
+                'evidence_used_json' => is_array($row['evidence_used'] ?? null) ? $row['evidence_used'] : null,
+                'derived_from_synthesis_json' => is_array($row['derived_from_synthesis'] ?? null) ? $row['derived_from_synthesis'] : null,
+                'audit_fields_json' => is_array($row['audit_fields'] ?? null) ? $row['audit_fields'] : null,
+                'asset_row_hash' => (string) (($row['audit_fields']['row_hash'] ?? '') ?: hash('sha256', json_encode($row, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '')),
+                'source_artifact_sha256' => $sourceFileSha256,
+                'evidence_artifact_sha256' => null,
+                'synthesis_artifact_sha256' => null,
+                'import_run_id' => $importRunId,
+            ];
+
+            CareerJobAiImpactAsset::query()->updateOrCreate(
+                [
+                    'career_job_slug' => $slug,
+                    'locale' => $locale,
+                    'asset_version' => $assetVersion,
+                ],
+                $payload,
+            );
+
+            $writtenCount++;
+            if ($existing instanceof CareerJobAiImpactAsset) {
+                $updatedCount++;
+            } else {
+                $createdCount++;
+            }
+
+            $writtenRows[] = [
+                'slug' => $slug,
+                'locale' => $locale,
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'operation' => $existing instanceof CareerJobAiImpactAsset ? 'updated' : 'created',
+            ];
+        }
+
+        fclose($handle);
+
+        $expectedWriteCount = (int) ($validation['expected_preview_rows'] ?? 0);
+        if ($writtenCount !== $expectedWriteCount) {
+            return array_merge($validation, [
+                'mode' => 'write',
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'decision' => 'fail',
+                'staging_write_performed' => true,
+                'production_import_allowed' => false,
+                'import_run_id' => $importRunId,
+                'written_count' => $writtenCount,
+                'created_count' => $createdCount,
+                'updated_count' => $updatedCount,
+                'written_rows' => $writtenRows,
+                'errors' => ["Staging preview write count {$writtenCount} did not match expected row count {$expectedWriteCount}."],
+            ]);
+        }
+
+        return array_merge($validation, [
+            'mode' => 'write',
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'decision' => 'pass',
+            'staging_write_performed' => true,
+            'production_import_allowed' => false,
+            'import_run_id' => $importRunId,
+            'written_count' => $writtenCount,
+            'created_count' => $createdCount,
+            'updated_count' => $updatedCount,
+            'written_rows' => $writtenRows,
+            'errors' => [],
         ]);
     }
 
@@ -385,14 +554,14 @@ final class CareerAiImpactAssetImportService
         return [
             'importer_version' => self::IMPORTER_VERSION,
             'asset_version' => 'career_risk_future_ai_impact_v5',
-            'status_policy' => 'dry_run_only_for_this_contract',
+            'status_policy' => 'dry_run_or_staging_preview_only_for_this_contract',
             'production_import_allowed' => false,
             'production_import_gate' => [
                 'allowed' => false,
                 'required_from_status' => 'approved',
                 'current_command_supports_production_import' => false,
             ],
-            'staging_write_supported' => false,
+            'staging_write_supported' => true,
             'source_file' => $file,
             'requested_slugs' => $requestedSlugs,
             'all_slugs_from_file' => $allSlugsFromFile,
@@ -444,7 +613,7 @@ final class CareerAiImpactAssetImportService
     {
         return [
             'dry_run_writes_database' => false,
-            'staging_preview_write_supported_in_this_pr' => false,
+            'staging_preview_write_supported_in_this_pr' => true,
             'production_import_requires_approved_status' => true,
         ];
     }

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -94,6 +94,85 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertSame(CareerJobAiImpactAsset::STATUS_APPROVED, $decoded['state_machine']['production_import_requires_from_status']);
         $this->assertTrue((bool) $decoded['rollback_policy']['production_import_requires_approved_status']);
         $this->assertFalse((bool) $decoded['rollback_policy']['dry_run_writes_database']);
+        $this->assertTrue((bool) $decoded['rollback_policy']['staging_preview_write_supported_in_this_pr']);
+    }
+
+    public function test_importer_force_writes_staging_preview_rows_after_validation_passes(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors']);
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $sha = hash_file('sha256', $file);
+        $report = storage_path('framework/testing/ai-impact-preview-force-write.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $sha,
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 2);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'source_artifact_sha256' => $sha,
+        ]);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('write', $decoded['mode']);
+        $this->assertSame(2, $decoded['written_count']);
+        $this->assertSame(2, $decoded['created_count']);
+        $this->assertSame(0, $decoded['updated_count']);
+        $this->assertTrue((bool) $decoded['staging_write_performed']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('preview', true)
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('ai_impact_asset_v1.audit_fields')
+            ->assertJsonMissingPath('ai_impact_asset_v1.evidence_used')
+            ->assertJsonMissingPath('ai_impact_asset_v1.derived_from_synthesis')
+            ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
+    }
+
+    public function test_importer_force_rejects_non_staging_preview_status_without_writing(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-force-production-reject.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['staging_write_performed']);
+        $this->assertStringContainsString('Only staging_preview status is supported', implode(' ', $decoded['errors']));
     }
 
     public function test_importer_dry_run_rejects_unexpected_source_sha(): void
@@ -450,8 +529,8 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
                 'reader_boundary' => [
                     'label' => $isZh ? 'AI 评分边界' : 'AI score boundary',
                     'body' => $isZh
-                        ? '该分数是任务暴露信号，不是岗位消失、收入变化或个人结果预测。'
-                        : 'This score is a task-exposure signal, not a prediction of job loss, wage change, or an individual outcome.',
+                        ? '该分数是任务暴露信号，不是个人职业结果预测。'
+                        : 'This score is a task-exposure signal, not an individual career outcome forecast.',
                 ],
             ],
             'score_rationale' => [


### PR DESCRIPTION
## Summary
- Adds `--force --status=staging_preview` support to the AI Impact preview importer command.
- Writes validated AI Impact v5 preview rows into the independent `career_job_ai_impact_assets` channel with `staging_preview` status only.
- Keeps production import explicitly blocked and verifies reader-safe API projection in feature tests.

## Why
The 50-slug AI Impact dry-run contract already validates parsing, authority, and reader-safe projection. The next staging step needs a controlled staging_preview write path before API smoke can verify the 100 preview endpoints.

## Validation
- `cd backend && php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `cd backend && ./vendor/bin/pint app/Console/Commands/CareerImportAiImpactAssetsPreview.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php --test`
- `cd backend && php artisan route:list --path=api/v0.5/career/jobs --except-vendor | head -80`
- `git diff --check`

## Intentionally deferred
- No production import support.
- No staging force run in this PR; that should happen only after this is merged and deployed to staging.
- No AI Impact asset content changes.
- No frontend/runtime rendering changes.
- No sitemap, llms, canonical, noindex, or JSON-LD changes.

## Repository rule impact
This keeps AI Impact content backend-authoritative in a dedicated asset channel. It does not introduce frontend fallback content or change publishing/SEO enumeration behavior.
