### PR TITLE
Show article SEO release closeout status in Ops

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ArticleResource\Pages;
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleSeoReleaseStatus;
 use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
 use App\Filament\Ops\Support\ContentAccess;
 use App\Filament\Ops\Support\ContentReleaseAudit;
@@ -386,6 +387,16 @@ class ArticleResource extends Resource
                                     ->label(__('ops.resources.articles.fields.og_image_url'))
                                     ->maxLength(255)
                                     ->helperText(__('ops.resources.articles.helpers.og_image_url')),
+                            ]),
+                        Forms\Components\Section::make('SEO Release Status')
+                            ->description('Read-only closeout snapshot for article discoverability and search-release readiness.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-edit-workspace-section ops-edit-workspace-section--rail ops-article-workspace-section--rail'])
+                            ->visible(fn (?Article $record): bool => filled($record))
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_release_closeout_status')
+                                    ->label('Single article closeout')
+                                    ->content(fn (?Article $record) => ArticleSeoReleaseStatus::render($record))
+                                    ->columnSpanFull(),
                             ]),
                         Forms\Components\Section::make(__('ops.edit.sections.audit'))
                             ->description(__('ops.edit.descriptions.audit'))

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleResource\Support;
+
+use App\Models\Article;
+use App\Services\Cms\ArticleReleaseCloseoutService;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
+use Throwable;
+
+final class ArticleSeoReleaseStatus
+{
+    public static function render(?Article $record): Htmlable
+    {
+        if (! $record instanceof Article || ! $record->getKey()) {
+            return new HtmlString('');
+        }
+
+        $payload = self::closeoutPayload($record);
+
+        return new HtmlString((string) view('filament.ops.articles.partials.seo-release-status', [
+            'decision' => (string) ($payload['decision'] ?? ArticleReleaseCloseoutService::BLOCKED_OPERATOR_INPUT),
+            'ok' => (bool) ($payload['ok'] ?? false),
+            'canonicalUrl' => $payload['canonical_url'] ?? null,
+            'command' => self::commandFor($record),
+            'checks' => self::checks($payload),
+            'issues' => (array) ($payload['issues'] ?? []),
+        ])->render());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function closeoutPayload(Article $record): array
+    {
+        try {
+            return app(ArticleReleaseCloseoutService::class)->inspect(
+                articleId: (int) $record->getKey(),
+                expectedSlug: (string) $record->slug,
+            );
+        } catch (Throwable $exception) {
+            return [
+                'ok' => false,
+                'decision' => ArticleReleaseCloseoutService::BLOCKED_OPERATOR_INPUT,
+                'canonical_url' => null,
+                'checks' => [],
+                'issues' => [[
+                    'field' => 'article_release_closeout',
+                    'code' => 'release_closeout_unavailable',
+                    'message' => 'Article release closeout service could not read all required status sources.',
+                    'context' => [
+                        'exception' => $exception::class,
+                    ],
+                ]],
+            ];
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<array{key:string,label:string,state:string,summary:string,issues:int}>
+     */
+    private static function checks(array $payload): array
+    {
+        $checks = (array) ($payload['checks'] ?? []);
+
+        return [
+            self::check('article', 'Content', $checks),
+            self::check('seo_meta', 'Title, meta, canonical, robots', $checks),
+            self::check('media', 'Cover, OG image, body visuals', $checks),
+            self::check('taxonomy', 'Category and tags', $checks),
+            self::check('discoverability', 'Sitemap, llms, llms-full eligibility', $checks),
+            self::check('url_truth', 'URL Truth', $checks),
+            self::check('search_channel', 'IndexNow and Baidu queue', $checks),
+            self::check('schema_hreflang', 'Schema and hreflang gates', $checks),
+            self::check('public_html_smoke', 'Public HTML smoke', $checks, nullableOkState: 'manual'),
+            self::check('gsc_manual', 'GSC manual request', $checks, nullableOkState: 'manual'),
+            self::check('observation', 'D1 / D7 / D14 observation', $checks, nullableOkState: 'manual'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $checks
+     * @return array{key:string,label:string,state:string,summary:string,issues:int}
+     */
+    private static function check(string $key, string $label, array $checks, string $nullableOkState = 'hold'): array
+    {
+        $check = (array) ($checks[$key] ?? []);
+        $ok = $check['ok'] ?? false;
+        $issues = (array) ($check['issues'] ?? []);
+        $state = match ($ok) {
+            true => 'success',
+            null => $nullableOkState,
+            default => 'danger',
+        };
+
+        return [
+            'key' => $key,
+            'label' => $label,
+            'state' => $state,
+            'summary' => self::summary($key, $check),
+            'issues' => count($issues),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $check
+     */
+    private static function summary(string $key, array $check): string
+    {
+        return match ($key) {
+            'article' => sprintf(
+                '%s / public=%s / indexable=%s',
+                (string) ($check['status'] ?? 'unknown'),
+                self::yesNo($check['is_public'] ?? null),
+                self::yesNo($check['is_indexable'] ?? null),
+            ),
+            'seo_meta' => sprintf(
+                'canonical=%s / robots=%s',
+                (string) ($check['canonical_path'] ?? 'unknown'),
+                (string) ($check['robots'] ?? 'unknown'),
+            ),
+            'media' => sprintf('body visuals=%d', count((array) ($check['body_visual_urls'] ?? []))),
+            'taxonomy' => (string) data_get($check, 'category.name', 'category missing'),
+            'discoverability' => sprintf(
+                'sitemap=%s / llms=%s / full=%s',
+                self::yesNo($check['sitemap_eligible'] ?? null),
+                self::yesNo($check['llms_eligible'] ?? null),
+                self::yesNo($check['llms_full_source_eligible'] ?? null),
+            ),
+            'url_truth' => self::yesNo($check['present'] ?? null),
+            'search_channel' => self::searchChannelSummary((array) ($check['channels'] ?? [])),
+            'schema_hreflang' => sprintf(
+                'Article=%s / Breadcrumb=%s / FAQ=%s',
+                self::yesNo($check['article_schema_enabled'] ?? null),
+                self::yesNo($check['breadcrumb_schema_enabled'] ?? null),
+                self::yesNo($check['faq_schema_enabled'] ?? null),
+            ),
+            'public_html_smoke', 'gsc_manual', 'observation' => (string) ($check['state'] ?? 'not recorded'),
+            default => 'not checked',
+        };
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $channels
+     */
+    private static function searchChannelSummary(array $channels): string
+    {
+        $parts = [];
+        foreach (['indexnow', 'baidu_push'] as $channel) {
+            $row = (array) ($channels[$channel] ?? []);
+            $parts[] = $channel.'#'.(string) ($row['queue_item_id'] ?? 'missing').':'.(string) ($row['execution_state'] ?? 'missing');
+        }
+
+        return implode(' / ', $parts);
+    }
+
+    private static function yesNo(mixed $value): string
+    {
+        return match ($value) {
+            true => 'yes',
+            false => 'no',
+            default => 'unknown',
+        };
+    }
+
+    private static function commandFor(Article $record): string
+    {
+        return sprintf(
+            'php artisan articles:release-closeout --article-id=%d --expected-slug=%s --json --no-ansi',
+            (int) $record->getKey(),
+            escapeshellarg((string) $record->slug),
+        );
+    }
+}

--- a/backend/resources/views/filament/ops/articles/partials/seo-release-status.blade.php
+++ b/backend/resources/views/filament/ops/articles/partials/seo-release-status.blade.php
@@ -1,0 +1,58 @@
+<div class="ops-article-workspace-seo-release">
+    <div class="ops-article-workspace-seo-release__header">
+        <x-filament.ops.shared.status-pill
+            :label="$decision"
+            :state="$ok ? 'complete' : 'danger'"
+        />
+
+        @if (filled($canonicalUrl))
+            <a
+                class="ops-article-workspace-seo-release__link"
+                href="{{ $canonicalUrl }}"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Open public URL
+            </a>
+        @endif
+    </div>
+
+    <div class="ops-article-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-article-workspace-seo__item">
+                <div class="ops-article-workspace-seo__copy">
+                    <span class="ops-article-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-article-workspace-seo__description">{{ $check['summary'] }}</span>
+
+                    @if ($check['issues'] > 0)
+                        <span class="ops-article-workspace-seo__description">
+                            {{ $check['issues'] }} issue{{ $check['issues'] === 1 ? '' : 's' }}
+                        </span>
+                    @endif
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['state']"
+                    :state="$check['state']"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if ($issues !== [])
+        <details class="ops-article-workspace-seo-release__details">
+            <summary>Closeout issues</summary>
+
+            <ul>
+                @foreach ($issues as $issue)
+                    <li>
+                        <code>{{ $issue['code'] ?? 'unknown_issue' }}</code>
+                        {{ $issue['message'] ?? '' }}
+                    </li>
+                @endforeach
+            </ul>
+        </details>
+    @endif
+
+    <code class="ops-article-workspace-seo-release__command">{{ $command }}</code>
+</div>

--- a/backend/tests/Feature/Ops/ArticleSeoReleaseStatusPanelTest.php
+++ b/backend/tests/Feature/Ops/ArticleSeoReleaseStatusPanelTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleSeoReleaseStatus;
+use App\Models\Article;
+use App\Services\Cms\ArticleReleaseCloseoutService;
+use RuntimeException;
+use Tests\TestCase;
+
+final class ArticleSeoReleaseStatusPanelTest extends TestCase
+{
+    public function test_panel_renders_read_only_closeout_projection(): void
+    {
+        $this->app->instance(ArticleReleaseCloseoutService::class, new class
+        {
+            /**
+             * @return array<string,mixed>
+             */
+            public function inspect(int $articleId, string $expectedSlug, ?array $publicSmoke = null): array
+            {
+                return [
+                    'ok' => true,
+                    'decision' => ArticleReleaseCloseoutService::COMPLETE_SEARCH_OBSERVATION_PENDING,
+                    'canonical_url' => 'https://fermatmind.com/zh/articles/'.$expectedSlug,
+                    'checks' => [
+                        'article' => ['ok' => true, 'status' => 'published', 'is_public' => true, 'is_indexable' => true, 'issues' => []],
+                        'seo_meta' => ['ok' => true, 'canonical_path' => '/zh/articles/'.$expectedSlug, 'robots' => 'index,follow', 'issues' => []],
+                        'media' => ['ok' => true, 'body_visual_urls' => ['https://api.fermatmind.com/body.png'], 'issues' => []],
+                        'taxonomy' => ['ok' => true, 'category' => ['name' => '职业决策'], 'issues' => []],
+                        'discoverability' => ['ok' => true, 'sitemap_eligible' => true, 'llms_eligible' => true, 'llms_full_source_eligible' => true, 'issues' => []],
+                        'url_truth' => ['ok' => true, 'present' => true, 'issues' => []],
+                        'search_channel' => [
+                            'ok' => true,
+                            'channels' => [
+                                'indexnow' => ['queue_item_id' => 58, 'execution_state' => 'accepted'],
+                                'baidu_push' => ['queue_item_id' => 59, 'execution_state' => 'accepted'],
+                            ],
+                            'issues' => [],
+                        ],
+                        'schema_hreflang' => [
+                            'ok' => true,
+                            'article_schema_enabled' => true,
+                            'breadcrumb_schema_enabled' => true,
+                            'faq_schema_enabled' => false,
+                            'issues' => [],
+                        ],
+                        'public_html_smoke' => ['ok' => null, 'state' => 'not_provided', 'issues' => []],
+                        'gsc_manual' => ['ok' => null, 'state' => 'operator_record_required', 'issues' => []],
+                        'observation' => ['ok' => null, 'state' => 'd1_d7_d14_queue_record_required', 'issues' => []],
+                    ],
+                    'issues' => [],
+                ];
+            }
+        });
+
+        $html = (string) ArticleSeoReleaseStatus::render($this->article());
+
+        $this->assertStringContainsString(ArticleReleaseCloseoutService::COMPLETE_SEARCH_OBSERVATION_PENDING, $html);
+        $this->assertStringContainsString('Title, meta, canonical, robots', $html);
+        $this->assertStringContainsString('IndexNow and Baidu queue', $html);
+        $this->assertStringContainsString('indexnow#58:accepted / baidu_push#59:accepted', $html);
+        $this->assertStringContainsString('php artisan articles:release-closeout --article-id=53 --expected-slug=', $html);
+        $this->assertStringNotContainsString('production_write_attempted', $html);
+    }
+
+    public function test_panel_falls_back_to_blocked_status_when_status_source_is_unavailable(): void
+    {
+        $this->app->instance(ArticleReleaseCloseoutService::class, new class
+        {
+            public function inspect(int $articleId, string $expectedSlug, ?array $publicSmoke = null): array
+            {
+                throw new RuntimeException('seo intel unavailable');
+            }
+        });
+
+        $html = (string) ArticleSeoReleaseStatus::render($this->article());
+
+        $this->assertStringContainsString(ArticleReleaseCloseoutService::BLOCKED_OPERATOR_INPUT, $html);
+        $this->assertStringContainsString('release_closeout_unavailable', $html);
+        $this->assertStringContainsString('Article release closeout service could not read all required status sources.', $html);
+    }
+
+    public function test_article_resource_mounts_seo_release_status_panel(): void
+    {
+        $source = (string) file_get_contents(app_path('Filament/Ops/Resources/ArticleResource.php'));
+
+        $this->assertStringContainsString('SEO Release Status', $source);
+        $this->assertStringContainsString('ArticleSeoReleaseStatus::render($record)', $source);
+    }
+
+    private function article(): Article
+    {
+        $article = new Article;
+        $article->forceFill([
+            'id' => 53,
+            'slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+        ]);
+        $article->exists = true;
+
+        return $article;
+    }
+}

--- a/backend/tests/Feature/Ops/OpsCmsEditPolishTest.php
+++ b/backend/tests/Feature/Ops/OpsCmsEditPolishTest.php
@@ -99,6 +99,10 @@ final class OpsCmsEditPolishTest extends TestCase
 
         if ($expectsSeo) {
             $test->assertSee(__('ops.edit.sections.seo'));
+
+            if ($component === EditArticle::class) {
+                $test->assertSee('SEO Release Status');
+            }
         }
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1095,6 +1095,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_release_closeout_ops_panel_files(): void
+    {
+        $changed = [
+            'backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_mbti_url_truth_cleanup_runtime_files(): void
     {
         $changed = [
@@ -4482,6 +4491,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ArticleReleaseCloseout.php',
+            'backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php',
             'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
         ], true);
     }


### PR DESCRIPTION
## What changed
- Added an Ops/CMS Article `SEO Release Status` rail panel for existing article records.
- Reused the read-only `ArticleReleaseCloseoutService` to project content, SEO metadata, media, taxonomy, discoverability, URL Truth, Search Channel, schema/hreflang, public smoke, GSC, and observation states.
- Added a defensive blocked-state fallback when a status source is unavailable so the Article editor remains usable.
- Added focused panel rendering tests and an Ops edit-page mounting assertion.

## Why
Daily article releases need a single operator-facing status snapshot in CMS so closeout gaps are visible without reconstructing state from separate tools or chat history.

## Validation commands
- `php artisan test --filter=ArticleSeoReleaseStatusPanelTest`
- `php artisan test --filter=OpsCmsEditPolishTest`
- `php artisan test --filter=ArticleReleaseCloseoutCommandTest`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest`
- `./vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php tests/Feature/Ops/ArticleSeoReleaseStatusPanelTest.php tests/Feature/Ops/OpsCmsEditPolishTest.php`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No production writes.
- No CMS content mutation.
- No publish/promote action.
- No revalidation, sitemap, llms, URL Truth, Search Channel, GSC, IndexNow, or Baidu action.
- No schema/hreflang mutation.

## Repository rule impact
This keeps Article release status backend/Ops-authoritative and does not introduce frontend fallback content or editorial data. It adds a read-only Ops projection over the existing backend closeout service.
