### PR TITLE
Sanitize AI Impact preview projection

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -67,37 +67,28 @@ final class CareerAiImpactAssetPreviewService
      */
     private function readerSafePayload(array $payload): array
     {
+        $safePayload = [];
         foreach ([
-            'audit_fields',
-            'evidence_used',
-            'derived_from_synthesis',
-            'search_projection',
-        ] as $internalKey) {
-            unset($payload[$internalKey]);
+            'slug',
+            'locale',
+            'occupation',
+            'ai_exposure_score',
+            'summary',
+            'items',
+        ] as $readerKey) {
+            if (array_key_exists($readerKey, $payload)) {
+                $safePayload[$readerKey] = $this->sanitizeReaderValue($payload[$readerKey]);
+            }
         }
 
-        $payload['sources'] = $this->readerSafeSources(is_array($payload['sources'] ?? null) ? $payload['sources'] : []);
+        $safePayload['sources'] = $this->readerSafeSources(is_array($payload['sources'] ?? null) ? $payload['sources'] : []);
 
-        return $this->withoutInternalReferences($payload);
-    }
-
-    /**
-     * @param  array<string, mixed>  $payload
-     * @return array<string, mixed>
-     */
-    private function withoutInternalReferences(array $payload): array
-    {
-        if (is_array($payload['score_rationale'] ?? null)) {
-            unset($payload['score_rationale']['source_ids']);
-            unset($payload['score_rationale']['evidence_ids']);
-        }
-
-        return $payload;
+        return $safePayload;
     }
 
     /**
      * @param  list<array<string, mixed>>  $sources
-     * @return list<array<string, string>>
+     * @return list<array{name: string, url: string}>
      */
     private function readerSafeSources(array $sources): array
     {
@@ -110,30 +101,79 @@ final class CareerAiImpactAssetPreviewService
 
             $name = trim((string) ($source['source_name'] ?? $source['name'] ?? ''));
             $url = trim((string) ($source['source_url'] ?? $source['url'] ?? ''));
-            $type = trim((string) ($source['source_type'] ?? ''));
-            $boundary = trim((string) ($source['boundary'] ?? ''));
 
             if ($name === '' || $url === '') {
                 continue;
             }
 
-            $safeSource = [
+            if (str_starts_with($url, 'fermatmind://internal')) {
+                continue;
+            }
+
+            $safeSources[] = [
                 'name' => $name,
                 'url' => $url,
             ];
-
-            if ($type !== '') {
-                $safeSource['source_type'] = $type;
-            }
-
-            if ($boundary !== '') {
-                $safeSource['boundary'] = $boundary;
-            }
-
-            $safeSources[] = $safeSource;
         }
 
         return $safeSources;
+    }
+
+    private function sanitizeReaderValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return $this->sanitizeReaderText($value);
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $sanitized = [];
+        foreach ($value as $key => $nestedValue) {
+            if (is_string($key) && in_array($key, [
+                'source_id',
+                'source_ids',
+                'evidence_id',
+                'evidence_ids',
+                'row_hash',
+                'audit_fields',
+                'search_projection',
+                'derived_from_synthesis',
+                'evidence_used',
+            ], true)) {
+                continue;
+            }
+
+            $sanitized[$key] = $this->sanitizeReaderValue($nestedValue);
+        }
+
+        return $sanitized;
+    }
+
+    private function sanitizeReaderText(string $text): string
+    {
+        return str_replace([
+            'career disappearance',
+            'job-loss risk',
+            'job loss risk',
+            'wage-loss risk',
+            'wage loss risk',
+            '岗位会消失',
+            '职业消失',
+            '失业风险',
+            '降薪风险',
+        ], [
+            'individual career outcome',
+            'individual career outcome forecast',
+            'individual career outcome forecast',
+            'individual wage outcome forecast',
+            'individual wage outcome forecast',
+            '个人职业结果预测',
+            '个人职业结果预测',
+            '个人职业结果预测',
+            '个人收入结果预测',
+        ], $text);
     }
 
     public function normalizeSlug(string $slug): string

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -285,6 +285,16 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $row['search_projection'] = ['candidate_only_not_runtime_seo' => true];
         $row['score_rationale']['source_ids'] = ['source_should_not_leak'];
         $row['score_rationale']['evidence_ids'] = ['evidence_should_not_leak'];
+        $row['items']['reader_boundary']['body'] = 'This score is not a career disappearance or job-loss risk prediction.';
+        $row['sources'][] = [
+            'source_id' => 'internal_rubric_v5',
+            'source_name' => 'FermatMind AI Task-Exposure Rubric v5',
+            'source_type' => 'internal_rubric',
+            'source_url' => 'fermatmind://internal/rubric/career-ai-task-exposure-v5',
+            'used_for' => 'Internal scoring lens.',
+            'captured_fact' => 'Internal rubric.',
+            'boundary' => 'Never used alone.',
+        ];
 
         CareerJobAiImpactAsset::query()->create([
             'occupation_id' => $occupation->id,
@@ -309,15 +319,32 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertJsonPath('ai_impact_asset_v1.locale', 'en');
 
         $asset = $response->json('ai_impact_asset_v1');
-        foreach (['audit_fields', 'evidence_used', 'derived_from_synthesis', 'search_projection'] as $internalKey) {
+        foreach ([
+            'asset_version',
+            'ledger_type',
+            'block_type',
+            'batch_role',
+            'seed_ordinal',
+            'audit_fields',
+            'evidence_used',
+            'derived_from_synthesis',
+            'search_projection',
+            'score_rationale',
+            'micro_family',
+        ] as $internalKey) {
             $this->assertArrayNotHasKey($internalKey, $asset);
         }
 
         $this->assertArrayNotHasKey('source_id', $asset['sources'][0]);
         $this->assertArrayNotHasKey('used_for', $asset['sources'][0]);
-        $this->assertArrayNotHasKey('source_ids', $asset['score_rationale']);
-        $this->assertArrayNotHasKey('evidence_ids', $asset['score_rationale']);
+        $this->assertArrayNotHasKey('source_type', $asset['sources'][0]);
+        $this->assertArrayNotHasKey('boundary', $asset['sources'][0]);
         $this->assertSame('O*NET OnLine summary for Accountants and Auditors', $asset['sources'][0]['name']);
+        $this->assertCount(1, $asset['sources']);
+        $this->assertStringNotContainsString('fermatmind://internal', json_encode($asset, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('career disappearance', $asset['items']['reader_boundary']['body']);
+        $this->assertStringNotContainsString('job-loss risk', $asset['items']['reader_boundary']['body']);
+        $this->assertStringContainsString('individual career outcome', $asset['items']['reader_boundary']['body']);
     }
 
     public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void


### PR DESCRIPTION
## Summary
- tighten AI Impact staging preview reader-safe projection to return only reader-facing fields
- remove internal asset metadata, score rationale internals, enum-like source fields, and internal `fermatmind://` rubric source URLs from the preview API payload
- neutralize job-loss / career-disappearance boundary wording in preview projection without changing stored assets

## Why
The 50-slug AI Impact staging preview editorial QA found the API smoke passed technically, but the preview payload still exposed internal metadata/source details and outcome-risk wording that should not reach frontend reader surfaces.

## Validation
- `cd backend && php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `cd backend && ./vendor/bin/pint --dirty --test`
- `git diff --check`
- `cd backend && php artisan route:list --path=ai-impact-asset`

Attempted but blocked by local DB credentials, with no migrations changed in this PR:
- `cd backend && php artisan migrate --pretend`
  - blocked by local MySQL `Access denied for user 'root'@'localhost'`

## Intentionally deferred
- no salary or AI Impact asset content edits
- no staging writes
- no production import
- no frontend/runtime page changes
- rerun the same 50-slug staging editorial QA after this PR is deployed to staging

## Repository rule impact
This preserves backend authority for the AI Impact content channel and narrows public API projection. It does not introduce a new content source or frontend fallback.
