### PR TITLE
Add weekly article SEO observation export

### DIFF
--- a/backend/app/Console/Commands/ArticleWeeklySeoObservationExport.php
+++ b/backend/app/Console/Commands/ArticleWeeklySeoObservationExport.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\ArticleWeeklySeoObservationExportService;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+final class ArticleWeeklySeoObservationExport extends Command
+{
+    protected $signature = 'articles:weekly-seo-observation-export
+        {--article-ids= : Optional comma-separated article ids; omitted means recent published public indexable articles}
+        {--expected-slugs= : Optional comma-separated slug locks matching --article-ids order}
+        {--from= : Inclusive start date (Y-m-d); defaults to --days window}
+        {--to= : Inclusive end date (Y-m-d); defaults to today}
+        {--days=14 : Days back when --from is omitted}
+        {--locale= : Optional exact locale filter, for example zh-CN or en-US}
+        {--limit=25 : Max recent articles when --article-ids is omitted}
+        {--json : Emit JSON}';
+
+    protected $description = 'Read-only weekly SEO observation export for article release closeout, GSC, and site conversion metrics.';
+
+    public function handle(ArticleWeeklySeoObservationExportService $exporter): int
+    {
+        $articleIds = $this->parseIdList((string) $this->option('article-ids'));
+        $expectedSlugs = $this->parseStringList((string) $this->option('expected-slugs'));
+
+        if ($expectedSlugs !== [] && $articleIds === []) {
+            $this->error('--expected-slugs requires --article-ids.');
+
+            return self::FAILURE;
+        }
+
+        if ($expectedSlugs !== [] && count($expectedSlugs) !== count($articleIds)) {
+            $this->error('--expected-slugs count must match --article-ids count.');
+
+            return self::FAILURE;
+        }
+
+        $to = $this->parseDate((string) $this->option('to'), now()->toDateString());
+        $from = $this->parseFromDate((string) $this->option('from'), $to, (int) $this->option('days'));
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $slugLocks = [];
+        foreach ($articleIds as $index => $articleId) {
+            if (isset($expectedSlugs[$index])) {
+                $slugLocks[$articleId] = $expectedSlugs[$index];
+            }
+        }
+
+        $payload = $exporter->export(
+            articleIds: $articleIds,
+            expectedSlugsById: $slugLocks,
+            from: $from,
+            to: $to,
+            locale: trim((string) $this->option('locale')),
+            limit: (int) $this->option('limit'),
+        );
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $summary = (array) ($payload['summary'] ?? []);
+            $this->info('weekly SEO observation export complete');
+            $this->line('article_count='.(string) ($summary['article_count'] ?? 0));
+            $this->line('gsc_clicks='.(string) ($summary['gsc_clicks'] ?? 0));
+            $this->line('gsc_impressions='.(string) ($summary['gsc_impressions'] ?? 0));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function parseIdList(string $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $item): int => max(0, (int) trim($item)),
+            explode(',', $value)
+        ), static fn (int $id): bool => $id > 0)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseStringList(string $value): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (string $item): string => trim($item),
+            explode(',', $value)
+        ), static fn (string $item): bool => $item !== ''));
+    }
+
+    private function parseFromDate(string $value, CarbonImmutable $to, int $days): CarbonImmutable
+    {
+        if (trim($value) !== '') {
+            return $this->parseDate($value, $to->toDateString());
+        }
+
+        return $to->subDays(max(1, $days) - 1)->startOfDay();
+    }
+
+    private function parseDate(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -17,6 +17,7 @@ use App\Console\Commands\ArticleTaxonomyHygiene;
 use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\ArticleUpdateTranslationGroupId;
+use App\Console\Commands\ArticleWeeklySeoObservationExport;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
@@ -356,6 +357,7 @@ class Kernel extends ConsoleKernel
         ArticleTaxonomyHygiene::class,
         ArticleUpdateTranslationGroupId::class,
         ArticleUpdateImageMetadata::class,
+        ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,

--- a/backend/app/Services/SeoIntel/ArticleWeeklySeoObservationExportService.php
+++ b/backend/app/Services/SeoIntel/ArticleWeeklySeoObservationExportService.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use App\Models\Article;
+use App\Services\Cms\ArticleReleaseCloseoutService;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ArticleWeeklySeoObservationExportService
+{
+    public const SCHEMA_VERSION = 'article_weekly_seo_observation_export.v1';
+
+    public function __construct(
+        private readonly ArticleReleaseCloseoutService $closeout,
+    ) {}
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  array<int,string>  $expectedSlugsById
+     * @return array<string,mixed>
+     */
+    public function export(
+        array $articleIds,
+        array $expectedSlugsById,
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        string $locale = '',
+        int $limit = 25,
+    ): array {
+        $articles = $this->loadArticles($articleIds, $from, $to, $locale, $limit);
+        $rows = [];
+
+        foreach ($articles as $article) {
+            $expectedSlug = $expectedSlugsById[(int) $article->id] ?? (string) $article->slug;
+            $closeout = $this->closeout->inspect((int) $article->id, $expectedSlug);
+            $canonicalUrl = (string) ($closeout['canonical_url'] ?? $this->canonicalUrl($article));
+            $canonicalPath = (string) ($closeout['canonical_path'] ?? $this->canonicalPath($article));
+
+            $rows[] = [
+                'article_id' => (int) $article->id,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'title' => (string) $article->title,
+                'canonical_path' => $canonicalPath,
+                'canonical_url' => $canonicalUrl,
+                'published_at' => optional($article->published_at)->toIso8601String(),
+                'release_closeout' => [
+                    'decision' => (string) ($closeout['decision'] ?? 'UNKNOWN'),
+                    'ok' => (bool) ($closeout['ok'] ?? false),
+                    'remaining_operator_inputs' => $closeout['remaining_operator_inputs'] ?? [],
+                    'issue_codes' => $this->issueCodes((array) ($closeout['issues'] ?? [])),
+                ],
+                'observation_windows' => $this->observationWindows($article, $to),
+                'gsc' => $this->gscMetrics($canonicalUrl, $from, $to),
+                'site_conversion' => $this->siteConversionMetrics($canonicalPath, $from, $to),
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'schema_version' => self::SCHEMA_VERSION,
+            'generated_at' => now()->toIso8601String(),
+            'read_only' => true,
+            'external_search_submission_attempted' => false,
+            'cms_content_write_attempted' => false,
+            'publish_attempted' => false,
+            'schema_hreflang_write_attempted' => false,
+            'sitemap_llms_mutation_attempted' => false,
+            'date_range' => [
+                'from' => $from->toDateString(),
+                'to' => $to->toDateString(),
+            ],
+            'filters' => [
+                'article_ids' => $articleIds,
+                'locale' => $locale,
+                'limit' => $limit,
+            ],
+            'summary' => $this->summary($rows),
+            'articles' => $rows,
+            'deferred_actions' => [
+                'content_updates' => 'not_performed_by_this_read_only_export',
+                'cms_publish_or_promote' => 'not_performed_by_this_read_only_export',
+                'search_submission' => 'not_performed_by_this_read_only_export',
+                'schema_hreflang_writes' => 'not_performed_by_this_read_only_export',
+                'sitemap_llms_mutation' => 'not_performed_by_this_read_only_export',
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @return Collection<int,Article>
+     */
+    private function loadArticles(array $articleIds, CarbonImmutable $from, CarbonImmutable $to, string $locale, int $limit): Collection
+    {
+        $query = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()])
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->where(static function ($lifecycleQuery): void {
+                $lifecycleQuery
+                    ->whereNull('lifecycle_state')
+                    ->orWhereNotIn('lifecycle_state', [
+                        Article::LIFECYCLE_ARCHIVED,
+                        Article::LIFECYCLE_SOFT_DELETED,
+                    ]);
+            });
+
+        if ($articleIds !== []) {
+            $query->whereIn('id', $articleIds);
+        } else {
+            $query->whereBetween('published_at', [$from->startOfDay(), $to->endOfDay()])
+                ->orderByDesc('published_at')
+                ->orderByDesc('id')
+                ->limit(max(1, min($limit, 100)));
+        }
+
+        if ($locale !== '') {
+            $query->where('locale', $locale);
+        }
+
+        /** @var Collection<int,Article> $articles */
+        $articles = $query->get();
+
+        if ($articleIds !== []) {
+            $positions = array_flip($articleIds);
+
+            /** @var Collection<int,Article> $articles */
+            $articles = $articles
+                ->sortBy(static fn (Article $article): int => (int) ($positions[(int) $article->id] ?? PHP_INT_MAX))
+                ->values();
+        }
+
+        return $articles;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function observationWindows(Article $article, CarbonImmutable $asOf): array
+    {
+        $publishedAt = $article->published_at ? CarbonImmutable::parse($article->published_at) : null;
+        if (! $publishedAt) {
+            return [
+                'd1' => ['date' => null, 'state' => 'published_at_missing'],
+                'd7' => ['date' => null, 'state' => 'published_at_missing'],
+                'd14' => ['date' => null, 'state' => 'published_at_missing'],
+            ];
+        }
+
+        $windows = [];
+        foreach ([1, 7, 14] as $days) {
+            $date = $publishedAt->addDays($days)->toDateString();
+            $windows['d'.$days] = [
+                'date' => $date,
+                'state' => $asOf->toDateString() >= $date ? 'due_or_ready_to_record' : 'scheduled',
+            ];
+        }
+
+        return $windows;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function gscMetrics(string $canonicalUrl, CarbonImmutable $from, CarbonImmutable $to): array
+    {
+        $connection = (string) config('seo_intel.connection', 'seo_intel');
+        if (! Schema::connection($connection)->hasTable('seo_gsc_daily')) {
+            return [
+                'table_available' => false,
+                'warnings' => ['seo_gsc_daily_missing'],
+                'clicks' => 0,
+                'impressions' => 0,
+                'ctr' => null,
+                'average_position' => null,
+                'top_queries' => [],
+            ];
+        }
+
+        $rows = DB::connection($connection)
+            ->table('seo_gsc_daily')
+            ->where('canonical_url_hash', hash('sha256', $canonicalUrl))
+            ->whereBetween('report_date', [$from->toDateString(), $to->toDateString()])
+            ->get();
+
+        $clicks = (int) $rows->sum('clicks');
+        $impressions = (int) $rows->sum('impressions');
+        $positionWeighted = 0;
+        $positionWeight = 0;
+        foreach ($rows as $row) {
+            $rowImpressions = (int) ($row->impressions ?? 0);
+            $positionMilli = $row->average_position_milli ?? null;
+            if ($rowImpressions > 0 && $positionMilli !== null) {
+                $positionWeighted += ((int) $positionMilli) * $rowImpressions;
+                $positionWeight += $rowImpressions;
+            }
+        }
+
+        $topQueries = $rows
+            ->groupBy(static fn (object $row): string => (string) ($row->query_display_masked ?? ''))
+            ->map(static function (Collection $queryRows, string $query): array {
+                return [
+                    'query_display_masked' => $query,
+                    'clicks' => (int) $queryRows->sum('clicks'),
+                    'impressions' => (int) $queryRows->sum('impressions'),
+                ];
+            })
+            ->filter(static fn (array $row): bool => (string) $row['query_display_masked'] !== '')
+            ->sortByDesc('impressions')
+            ->take(5)
+            ->values()
+            ->all();
+
+        return [
+            'table_available' => true,
+            'warnings' => [],
+            'clicks' => $clicks,
+            'impressions' => $impressions,
+            'ctr' => $impressions > 0 ? round($clicks / $impressions, 6) : null,
+            'average_position' => $positionWeight > 0 ? round(($positionWeighted / $positionWeight) / 1000, 2) : null,
+            'top_queries' => $topQueries,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function siteConversionMetrics(string $canonicalPath, CarbonImmutable $from, CarbonImmutable $to): array
+    {
+        if (! Schema::hasTable('analytics_seo_conversion_daily')) {
+            return [
+                'table_available' => false,
+                'warnings' => ['analytics_seo_conversion_daily_missing'],
+                'landing_pv_count' => 0,
+                'article_to_test_click_count' => 0,
+                'start_test_count' => 0,
+                'complete_test_count' => 0,
+                'view_result_count' => 0,
+            ];
+        }
+
+        $row = DB::table('analytics_seo_conversion_daily')
+            ->selectRaw('SUM(landing_pv_count) AS landing_pv_count')
+            ->selectRaw('SUM(article_to_test_click_count) AS article_to_test_click_count')
+            ->selectRaw('SUM(start_test_count) AS start_test_count')
+            ->selectRaw('SUM(complete_test_count) AS complete_test_count')
+            ->selectRaw('SUM(view_result_count) AS view_result_count')
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->where(function ($query) use ($canonicalPath): void {
+                $query->where('url', $canonicalPath)
+                    ->orWhere('source_article', $canonicalPath)
+                    ->orWhere('source_url', $canonicalPath);
+            })
+            ->first();
+
+        return [
+            'table_available' => true,
+            'warnings' => [],
+            'landing_pv_count' => (int) ($row->landing_pv_count ?? 0),
+            'article_to_test_click_count' => (int) ($row->article_to_test_click_count ?? 0),
+            'start_test_count' => (int) ($row->start_test_count ?? 0),
+            'complete_test_count' => (int) ($row->complete_test_count ?? 0),
+            'view_result_count' => (int) ($row->view_result_count ?? 0),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,mixed>
+     */
+    private function summary(array $rows): array
+    {
+        $decisions = [];
+        $clicks = 0;
+        $impressions = 0;
+        foreach ($rows as $row) {
+            $decision = (string) data_get($row, 'release_closeout.decision', 'UNKNOWN');
+            $decisions[$decision] = ($decisions[$decision] ?? 0) + 1;
+            $clicks += (int) data_get($row, 'gsc.clicks', 0);
+            $impressions += (int) data_get($row, 'gsc.impressions', 0);
+        }
+
+        return [
+            'article_count' => count($rows),
+            'release_closeout_decisions' => $decisions,
+            'gsc_clicks' => $clicks,
+            'gsc_impressions' => $impressions,
+            'gsc_ctr' => $impressions > 0 ? round($clicks / $impressions, 6) : null,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $issues
+     * @return list<string>
+     */
+    private function issueCodes(array $issues): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (array $issue): string => (string) ($issue['code'] ?? ''),
+            $issues
+        ))));
+    }
+
+    private function canonicalPath(Article $article): string
+    {
+        $prefix = str_starts_with((string) $article->locale, 'zh') ? '/zh/articles/' : '/en/articles/';
+
+        return $prefix.(string) $article->slug;
+    }
+
+    private function canonicalUrl(Article $article): string
+    {
+        return 'https://fermatmind.com'.$this->canonicalPath($article);
+    }
+}

--- a/backend/tests/Feature/Console/ArticleWeeklySeoObservationExportCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleWeeklySeoObservationExportCommandTest.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTag;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class ArticleWeeklySeoObservationExportCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->prepareSeoIntelSqliteConnection();
+    }
+
+    public function test_command_is_registered(): void
+    {
+        $this->assertArrayHasKey('articles:weekly-seo-observation-export', Artisan::all());
+    }
+
+    public function test_exports_release_closeout_gsc_and_site_conversion_metrics_for_locked_article(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 26, 8, 0, 0, 'UTC'));
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $canonicalPath = '/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+        $this->createGscDailyTable();
+        $this->insertGscDaily($canonicalUrl, '2026-06-20', clicks: 2, impressions: 120, positionMilli: 8400);
+        $this->insertGscDaily($canonicalUrl, '2026-06-21', clicks: 1, impressions: 80, positionMilli: 7600);
+        $this->insertSeoConversionDaily($canonicalPath);
+
+        $exitCode = Artisan::call('articles:weekly-seo-observation-export', [
+            '--article-ids' => '53',
+            '--expected-slugs' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--from' => '2026-06-19',
+            '--to' => '2026-06-25',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertSame('article_weekly_seo_observation_export.v1', $payload['schema_version']);
+        $this->assertSame(1, data_get($payload, 'summary.article_count'));
+        $this->assertSame(3, data_get($payload, 'summary.gsc_clicks'));
+        $this->assertSame(200, data_get($payload, 'summary.gsc_impressions'));
+        $this->assertSame('ARTICLE_RELEASE_COMPLETE_SEARCH_OBSERVATION_PENDING', data_get($payload, 'articles.0.release_closeout.decision'));
+        $this->assertSame('due_or_ready_to_record', data_get($payload, 'articles.0.observation_windows.d1.state'));
+        $this->assertSame('scheduled', data_get($payload, 'articles.0.observation_windows.d7.state'));
+        $this->assertSame(3, data_get($payload, 'articles.0.gsc.clicks'));
+        $this->assertSame(200, data_get($payload, 'articles.0.gsc.impressions'));
+        $this->assertSame(0.015, data_get($payload, 'articles.0.gsc.ctr'));
+        $this->assertSame(8.08, data_get($payload, 'articles.0.gsc.average_position'));
+        $this->assertSame(9, data_get($payload, 'articles.0.site_conversion.landing_pv_count'));
+        $this->assertSame(2, data_get($payload, 'articles.0.site_conversion.article_to_test_click_count'));
+        $this->assertFalse($payload['external_search_submission_attempted']);
+        $this->assertFalse($payload['cms_content_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['schema_hreflang_write_attempted']);
+        $this->assertFalse($payload['sitemap_llms_mutation_attempted']);
+    }
+
+    public function test_missing_gsc_table_warns_without_blocking_export(): void
+    {
+        $article = $this->createReleasedArticle();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist';
+        $this->insertUrlTruth($canonicalUrl, (string) $article->locale, (string) $article->slug);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'indexnow', 58);
+        $this->insertSearchQueue($canonicalUrl, (string) $article->locale, 'baidu_push', 59);
+
+        $exitCode = Artisan::call('articles:weekly-seo-observation-export', [
+            '--article-ids' => '53',
+            '--expected-slugs' => 'gaokao-score-major-shortlist-riasec-checklist',
+            '--from' => '2026-06-19',
+            '--to' => '2026-06-25',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse(data_get($payload, 'articles.0.gsc.table_available'));
+        $this->assertContains('seo_gsc_daily_missing', data_get($payload, 'articles.0.gsc.warnings'));
+    }
+
+    public function test_slug_lock_mismatch_is_reported_in_closeout_row(): void
+    {
+        $this->createReleasedArticle();
+
+        $exitCode = Artisan::call('articles:weekly-seo-observation-export', [
+            '--article-ids' => '53',
+            '--expected-slugs' => 'wrong-slug',
+            '--from' => '2026-06-19',
+            '--to' => '2026-06-25',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('BLOCKED_DISCOVERABILITY_GAP', data_get($payload, 'articles.0.release_closeout.decision'));
+        $this->assertContains('expected_slug_mismatch', data_get($payload, 'articles.0.release_closeout.issue_codes'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createReleasedArticle(array $overrides = []): Article
+    {
+        /** @var ArticleCategory $category */
+        $category = Model::unguarded(fn (): ArticleCategory => ArticleCategory::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'career-decision',
+            'name' => '职业决策',
+            'is_active' => true,
+        ]));
+
+        /** @var Article $article */
+        $article = Model::unguarded(fn (): Article => Article::query()->withoutGlobalScopes()->create(array_merge([
+            'id' => 53,
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'Fermat Institute',
+            'reading_minutes' => 12,
+            'slug' => 'gaokao-score-major-shortlist-riasec-checklist',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'tg_article_gaokao_score_major_shortlist_riasec_2026v1',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => '高考出分后专业太多怎么筛？位次+霍兰德排除清单',
+            'excerpt' => '高考出分后，用位次、选科要求、霍兰德职业兴趣测试和排除清单缩小专业范围。',
+            'content_md' => '# 高考出分后专业太多怎么筛？'."\n\n![流程图](https://api.fermatmind.com/storage/media-library/body.png)\n\n正文。",
+            'content_html' => '<h1>高考出分后专业太多怎么筛？</h1><img src="https://api.fermatmind.com/storage/media-library/body.png">',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/cover.jpg',
+            'cover_image_variants' => [
+                'card' => ['url' => 'https://api.fermatmind.com/storage/media-library/card.jpg'],
+            ],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => Carbon::create(2026, 6, 19, 5, 30, 0, 'UTC'),
+        ], $overrides)));
+
+        /** @var ArticleTag $tag */
+        $tag = Model::unguarded(fn (): ArticleTag => ArticleTag::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'riasec',
+            'name' => 'RIASEC',
+            'is_active' => true,
+        ]));
+        DB::table('article_tag_map')->insert([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'tag_id' => (int) $tag->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        /** @var ArticleTranslationRevision $revision */
+        $revision = Model::unguarded(fn (): ArticleTranslationRevision => ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => $article->published_at,
+        ]));
+
+        $article->forceFill(['published_revision_id' => (int) $revision->id])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => 'https://fermatmind.com/zh/articles/gaokao-score-major-shortlist-riasec-checklist',
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://api.fermatmind.com/storage/media-library/og.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                        'policy' => 'no_hreflang',
+                        'reason' => 'no_direct_english_counterpart_approved',
+                    ],
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['category', 'tags', 'publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    private function prepareSeoIntelSqliteConnection(): void
+    {
+        config([
+            'seo_intel.connection' => 'seo_intel',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function createGscDailyTable(): void
+    {
+        Schema::connection('seo_intel')->create('seo_gsc_daily', function ($table): void {
+            $table->id();
+            $table->date('report_date');
+            $table->char('canonical_url_hash', 64)->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->char('query_hash', 64)->nullable();
+            $table->string('query_display_masked', 255)->nullable();
+            $table->string('locale', 16)->nullable();
+            $table->string('source_engine', 64)->default('google');
+            $table->unsignedInteger('clicks')->default(0);
+            $table->unsignedInteger('impressions')->default(0);
+            $table->unsignedInteger('ctr_ppm')->nullable();
+            $table->unsignedInteger('average_position_milli')->nullable();
+            $table->boolean('is_brand_query')->default(false);
+            $table->string('query_type', 32)->default('unknown');
+            $table->timestamps();
+        });
+    }
+
+    private function insertUrlTruth(string $canonicalUrl, string $locale, string $slug): void
+    {
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => $locale,
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => $slug,
+            'cluster' => 'article',
+            'source_authority' => 'cms_article',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => now(),
+            'lastmod_source' => 'articles.updated_at',
+            'is_private_flow' => false,
+            'first_seen_at' => now(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode(['source_table' => 'articles'], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertSearchQueue(string $canonicalUrl, string $locale, string $channel, int $id): void
+    {
+        DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insert([
+            'id' => $id,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $locale,
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => '53',
+            'source_authority' => 'cms_article',
+            'source_table' => 'articles',
+            'channel' => $channel,
+            'eligibility_state' => 'eligible',
+            'approval_state' => 'approved',
+            'execution_state' => 'accepted',
+            'indexability_state' => 'indexable',
+            'claim_boundary_state' => 'claim_safe',
+            'private_flow' => false,
+            'reason_codes' => json_encode([], JSON_THROW_ON_ERROR),
+            'lastmod' => now(),
+            'content_hash' => hash('sha256', 'article-53'),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.$locale.'|'.$channel),
+            'approved_by' => 'operator',
+            'approved_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertGscDaily(string $canonicalUrl, string $date, int $clicks, int $impressions, int $positionMilli): void
+    {
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'report_date' => $date,
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'query_hash' => hash('sha256', '高考专业筛选'),
+            'query_display_masked' => '高考专业筛选',
+            'locale' => 'zh-CN',
+            'source_engine' => 'google',
+            'clicks' => $clicks,
+            'impressions' => $impressions,
+            'ctr_ppm' => $impressions > 0 ? (int) round(($clicks / $impressions) * 1000000) : null,
+            'average_position_milli' => $positionMilli,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertSeoConversionDaily(string $canonicalPath): void
+    {
+        DB::table('analytics_seo_conversion_daily')->insert([
+            'day' => '2026-06-20',
+            'org_id' => 0,
+            'url' => $canonicalPath,
+            'url_hash' => sha1($canonicalPath),
+            'lang' => 'zh-CN',
+            'page_type' => 'article',
+            'source_url' => $canonicalPath,
+            'source_url_hash' => sha1($canonicalPath),
+            'source_article' => $canonicalPath,
+            'source_article_hash' => sha1($canonicalPath),
+            'target_test' => '/zh/tests/holland-career-interest-test-riasec',
+            'target_test_hash' => sha1('/zh/tests/holland-career-interest-test-riasec'),
+            'scale_id' => 'riasec',
+            'form_id' => 'riasec_60',
+            'session_id_hash' => hash('sha256', 'session'),
+            'referrer_host' => '',
+            'referrer_host_hash' => '',
+            'landing_pv_count' => 9,
+            'article_to_test_click_count' => 2,
+            'start_test_count' => 1,
+            'complete_test_count' => 1,
+            'view_result_count' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1104,6 +1104,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_weekly_seo_observation_export_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleWeeklySeoObservationExport.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoIntel/ArticleWeeklySeoObservationExportService.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleWeeklySeoObservationExport;',
+            '+        ArticleWeeklySeoObservationExport::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_mbti_url_truth_cleanup_runtime_files(): void
     {
         $changed = [
@@ -3420,6 +3435,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleWeeklySeoObservationExportFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleTranslationGroupIdCleanupFile($file)) {
                 continue;
             }
@@ -4091,6 +4110,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleInlineImageUrlReplacerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleTranslationGroupIdCleanupOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleReleaseCloseoutOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsArticleWeeklySeoObservationExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsDailyArticleBackendPipelineOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -4493,6 +4513,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/ArticleReleaseCloseout.php',
             'backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleSeoReleaseStatus.php',
             'backend/app/Services/Cms/ArticleReleaseCloseoutService.php',
+        ], true);
+    }
+
+    private function isArticleWeeklySeoObservationExportFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleWeeklySeoObservationExport.php',
+            'backend/app/Services/SeoIntel/ArticleWeeklySeoObservationExportService.php',
         ], true);
     }
 
@@ -6232,6 +6260,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleReleaseCloseout\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsArticleWeeklySeoObservationExportOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleWeeklySeoObservationExport\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `articles:weekly-seo-observation-export`, a read-only weekly article SEO observation/export command.
- Added `ArticleWeeklySeoObservationExportService` to aggregate article release closeout, GSC daily metrics when available, site conversion daily metrics when available, and D1/D7/D14 observation windows.
- Registered the command in the console kernel and added focused feature coverage.

## Why
Daily article release now has a single-article closeout command. Weekly SEO operations need a batch read-only export that can review released articles without mutating CMS content, publish state, search queues, schema/hreflang, sitemap, or llms.

## Validation commands
- `php artisan test --filter=ArticleWeeklySeoObservationExportCommandTest`
- `php artisan test --filter=ArticleReleaseCloseoutCommandTest`
- `php artisan list --no-ansi | rg "articles:weekly-seo-observation-export|articles:release-closeout"`
- `./vendor/bin/pint --test app/Console/Commands/ArticleWeeklySeoObservationExport.php app/Services/SeoIntel/ArticleWeeklySeoObservationExportService.php tests/Feature/Console/ArticleWeeklySeoObservationExportCommandTest.php app/Console/Kernel.php`
- `git diff --check`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest`

## Intentionally deferred
- No production execution.
- No CMS writes or article content changes.
- No publish/promote/revalidation.
- No search submission or queue mutation.
- No schema/hreflang writes.
- No sitemap/llms mutation.

## Repository rule impact
This adds a read-only operational console command for SEO observation. It does not change content authority, publishing ownership, or runtime public rendering rules.
