### PR TITLE
Enable full AI Impact staging preview contract

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -15,6 +15,7 @@ final class CareerImportAiImpactAssetsPreview extends Command
         {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
         {--slugs= : Optional comma-separated preview slug subset}
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
+        {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
         {--dry-run : Validate only; do not write staging or production rows}
         {--force : Write rows only when --status=staging_preview and validation passes}
         {--status=staging_preview : Target import status; only staging_preview is supported by this command}
@@ -48,6 +49,13 @@ final class CareerImportAiImpactAssetsPreview extends Command
                 return $this->finish([
                     'decision' => 'fail',
                     'errors' => ['--force cannot be combined with --dry-run.'],
+                ], false);
+            }
+
+            if ($force && (bool) $this->option('all-slugs-from-file') && ! (bool) $this->option('confirm-full-staging-preview')) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--force --all-slugs-from-file requires --confirm-full-staging-preview.'],
                 ], false);
             }
 

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -34,7 +34,7 @@ final class CareerAiImpactAssetPreviewService
         $normalizedSlug = $this->normalizeSlug($slug);
         $normalizedLocale = $this->normalizeLocale($locale);
 
-        if (! $this->previewEnabled() || ! in_array($normalizedSlug, $this->previewSlugs(), true)) {
+        if (! $this->previewEnabled()) {
             return null;
         }
 

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -149,6 +149,64 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
     }
 
+    public function test_importer_force_all_slugs_from_file_requires_explicit_confirmation(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-force-full-requires-confirmation.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('--force --all-slugs-from-file requires --confirm-full-staging-preview', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_force_all_slugs_from_file_writes_row_allowlisted_full_preview(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', []);
+        $this->seedCareerJobBundleAuthorities(['accountants-and-auditors', 'actuaries']);
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+            $this->assetRow('actuaries', 'zh-CN'),
+            $this->assetRow('actuaries', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-preview-force-full-confirmed.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--confirm-full-staging-preview' => true,
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 4);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(4, $decoded['written_count']);
+        $this->assertTrue((bool) $decoded['staging_write_performed']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+
+        $this->getJson('/api/v0.5/career/jobs/actuaries/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'actuaries')
+            ->assertJsonMissingPath('ai_impact_asset_v1.evidence_used')
+            ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
+    }
+
     public function test_importer_force_rejects_non_staging_preview_status_without_writing(): void
     {
         $this->seedCareerJobBundleAuthority('accountants-and-auditors');
@@ -374,6 +432,10 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
 
         Config::set('career_ai_impact_assets.staging_preview_enabled', true);
         Config::set('career_ai_impact_assets.preview_slugs', ['actuaries']);
+        CareerJobAiImpactAsset::query()
+            ->where('career_job_slug', 'accountants-and-auditors')
+            ->where('locale', 'zh-CN')
+            ->update(['preview_allowlisted' => false]);
         $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=zh-CN')
             ->assertNotFound();
     }


### PR DESCRIPTION
## Summary
- Allows AI Impact staging preview API reads to use row-level `preview_allowlisted` rows, matching the full-preview model needed for 1046 rows.
- Adds an explicit `--confirm-full-staging-preview` safety gate for `--force --all-slugs-from-file`.
- Covers full-preview confirmation, row-level preview behavior, and fail-closed behavior in feature tests.

## Validation
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
  - 13 warnings, 104 assertions, exit 0
- `./vendor/bin/pint --test app/Console/Commands/CareerImportAiImpactAssetsPreview.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`

## Intentionally deferred
- No staging_preview write in this PR.
- No production import.
- No AI Impact asset content changes.
- No frontend/runtime page changes.

## Next step after merge/deploy
Deploy fap-api staging to this merged commit, then run `--force --all-slugs-from-file --confirm-full-staging-preview` and the 2092-row API smoke.
