### PR TITLE
test(seo-intel): add GSC data quality gate

### DIFF
--- a/backend/app/Services/SeoIntel/Collectors/GscCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/GscCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\SeoIntel\Collectors;
 
+use App\Services\SeoIntel\GscDataQualityGate;
 use App\Services\SeoIntel\GscSearchAnalyticsRowNormalizer;
 use App\Services\SeoIntel\SeoIntelCollector;
 use App\Services\SeoIntel\SeoIntelCollectorResult;
@@ -12,6 +13,7 @@ final class GscCollector implements SeoIntelCollector
 {
     public function __construct(
         private readonly GscSearchAnalyticsRowNormalizer $normalizer,
+        private readonly GscDataQualityGate $dataQualityGate,
     ) {}
 
     public function name(): string
@@ -29,6 +31,7 @@ final class GscCollector implements SeoIntelCollector
         $windowDays = (int) config('seo_intel.gsc_default_window_days', 28);
         $rows = $this->fixtureRows();
         $normalized = array_map(fn (array $row): array => $this->normalizer->normalize($row), $rows);
+        $qualityGate = $this->dataQualityGate->evaluate($normalized);
         $brandRows = count(array_filter($normalized, static fn (array $row): bool => (bool) ($row['is_brand_query'] ?? false)));
         $nonBrandRows = count(array_filter($normalized, static fn (array $row): bool => ($row['query_type'] ?? 'unknown') === 'non_brand'));
 
@@ -49,6 +52,9 @@ final class GscCollector implements SeoIntelCollector
                 'rows_normalized' => count($normalized),
                 'brand_rows' => $brandRows,
                 'non_brand_rows' => $nonBrandRows,
+                'data_origin' => 'fixture',
+                'data_quality_gate' => $qualityGate,
+                'opportunity_queue_eligible' => false,
                 'date_window' => [
                     'lag_days' => $lagDays,
                     'window_days' => $windowDays,

--- a/backend/app/Services/SeoIntel/GscDataQualityGate.php
+++ b/backend/app/Services/SeoIntel/GscDataQualityGate.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Carbon\CarbonImmutable;
+use Throwable;
+
+final class GscDataQualityGate
+{
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array<string, mixed>
+     */
+    public function evaluate(array $rows, ?CarbonImmutable $now = null): array
+    {
+        $now ??= CarbonImmutable::now();
+        $lagDays = max(0, (int) config('seo_intel.gsc_backfill_lag_days', 3));
+        $maxAgeDays = max($lagDays, (int) config('seo_intel.gsc_data_quality.max_report_age_days', 10));
+        $minRows = max(1, (int) config('seo_intel.gsc_data_quality.min_rows', 1));
+        $forbiddenOrigins = $this->stringList(config('seo_intel.gsc_data_quality.forbidden_data_origins', [
+            'fixture',
+            'mock',
+            'static_artifact',
+            'unknown',
+        ]));
+        $allowedOrigins = $this->stringList(config('seo_intel.gsc_data_quality.allowed_data_origins', [
+            'live_gsc_api',
+        ]));
+
+        $reasons = [];
+        $origins = [];
+        $reportDates = [];
+        $missingRequiredMetricRows = 0;
+        $nonGoogleRows = 0;
+
+        if (count($rows) < $minRows) {
+            $reasons[] = 'insufficient_rows';
+        }
+
+        foreach ($rows as $row) {
+            $metadata = is_array($row['metadata_json'] ?? null) ? $row['metadata_json'] : [];
+            $origin = $this->normalizeOrigin(
+                $metadata['data_origin']
+                    ?? $metadata['row_source']
+                    ?? $row['data_origin']
+                    ?? $row['row_source']
+                    ?? null
+            );
+            $origins[$origin] = true;
+
+            if (in_array($origin, $forbiddenOrigins, true)) {
+                $reasons[] = 'fixture_or_mock_source';
+            }
+
+            if (! in_array($origin, $allowedOrigins, true)) {
+                $reasons[] = 'untrusted_data_origin';
+            }
+
+            if (($row['source_engine'] ?? null) !== 'google') {
+                $nonGoogleRows++;
+            }
+
+            $date = $this->parseReportDate($row['report_date'] ?? null);
+            if ($date === null) {
+                $reasons[] = 'missing_report_date';
+            } else {
+                $reportDates[] = $date;
+            }
+
+            if (
+                empty($row['canonical_url_hash'])
+                || empty($row['query_hash'])
+                || ! array_key_exists('clicks', $row)
+                || ! array_key_exists('impressions', $row)
+            ) {
+                $missingRequiredMetricRows++;
+            }
+        }
+
+        if ($nonGoogleRows > 0) {
+            $reasons[] = 'non_google_source_engine';
+        }
+
+        if ($missingRequiredMetricRows > 0) {
+            $reasons[] = 'missing_required_metric_fields';
+        }
+
+        if ($reportDates !== []) {
+            usort($reportDates, static fn (CarbonImmutable $a, CarbonImmutable $b): int => $a <=> $b);
+
+            $minDate = $reportDates[0];
+            $maxDate = $reportDates[count($reportDates) - 1];
+            $latestFinalDate = $now->subDays($lagDays)->startOfDay();
+            $oldestAllowedDate = $now->subDays($maxAgeDays)->startOfDay();
+
+            if ($maxDate->greaterThan($latestFinalDate)) {
+                $reasons[] = 'gsc_finalization_lag_not_met';
+            }
+
+            if ($maxDate->lessThan($oldestAllowedDate)) {
+                $reasons[] = 'stale_gsc_report_date';
+            }
+        } else {
+            $minDate = null;
+            $maxDate = null;
+        }
+
+        $reasons = array_values(array_unique($reasons));
+        $passed = $reasons === [];
+
+        return [
+            'status' => $passed ? 'pass' : 'blocked',
+            'opportunity_queue_eligible' => $passed,
+            'reasons' => $reasons,
+            'rows_checked' => count($rows),
+            'data_origins' => array_keys($origins),
+            'freshness' => [
+                'lag_days_required' => $lagDays,
+                'max_report_age_days' => $maxAgeDays,
+                'min_report_date' => $minDate?->toDateString(),
+                'max_report_date' => $maxDate?->toDateString(),
+            ],
+            'forbidden_sources' => [
+                'fixture',
+                'mock',
+                'static_artifact',
+            ],
+            'allowed_sources' => $allowedOrigins,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(fn (mixed $item): string => $this->normalizeOrigin($item), $value),
+            static fn (string $item): bool => $item !== ''
+        ));
+    }
+
+    private function normalizeOrigin(mixed $origin): string
+    {
+        $origin = trim(mb_strtolower((string) $origin, 'UTF-8'));
+
+        return $origin === '' ? 'unknown' : $origin;
+    }
+
+    private function parseReportDate(mixed $date): ?CarbonImmutable
+    {
+        if (! is_string($date) || trim($date) === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse(substr($date, 0, 10))->startOfDay();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php
+++ b/backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php
@@ -43,7 +43,8 @@ final class GscSearchAnalyticsRowNormalizer
             'query_type' => $queryType,
             'data_state' => (string) ($row['data_state'] ?? 'final'),
             'metadata_json' => [
-                'row_source' => 'fixture',
+                'data_origin' => (string) ($row['data_origin'] ?? $row['row_source'] ?? 'fixture'),
+                'row_source' => (string) ($row['row_source'] ?? $row['data_origin'] ?? 'fixture'),
                 'purchase_attribution_allowed' => false,
             ],
         ];

--- a/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
+++ b/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
@@ -125,6 +125,7 @@ final class SeoIntelCollectorManager
                 new GscSearchAnalyticsRowNormalizer(
                     new GscQueryClassifier,
                 ),
+                new GscDataQualityGate,
             );
         }
 

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -221,6 +221,19 @@ return [
         'query_purchase_attribution_allowed' => false,
         'purchase_truth_source' => 'backend_orders_payment_benefits',
     ],
+    'gsc_data_quality' => [
+        'min_rows' => 1,
+        'max_report_age_days' => 10,
+        'allowed_data_origins' => [
+            'live_gsc_api',
+        ],
+        'forbidden_data_origins' => [
+            'fixture',
+            'mock',
+            'static_artifact',
+            'unknown',
+        ],
+    ],
     'baidu_enabled' => env('SEO_INTEL_BAIDU_ENABLED', false),
     'baidu_live_api_enabled' => env('SEO_INTEL_BAIDU_LIVE_API_ENABLED', false),
     'indexnow_enabled' => env('SEO_INTEL_INDEXNOW_ENABLED', false),

--- a/backend/docs/seo/generated/gsc-data-quality-gate.v1.json
+++ b/backend/docs/seo/generated/gsc-data-quality-gate.v1.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "id": "SEO-GSC-DATA-QUALITY-01",
+  "repo": "fap-api",
+  "gate": "gsc_data_quality",
+  "collector": "gsc_foundation",
+  "purpose": "Block stale, fixture, mock, static artifact, unknown, or structurally incomplete GSC rows from future opportunity queue use.",
+  "read_only": true,
+  "live_gsc_api_enabled": false,
+  "gsc_credentials_required": false,
+  "production_backfill_executed": false,
+  "scheduler_enabled": false,
+  "queue_worker_enabled": false,
+  "cms_mutation": false,
+  "search_channel_enqueue": false,
+  "search_provider_submission": false,
+  "opportunity_queue_implemented": false,
+  "required_to_pass": {
+    "source_engine": "google",
+    "data_origin": "live_gsc_api",
+    "forbidden_data_origins": [
+      "fixture",
+      "mock",
+      "static_artifact",
+      "unknown"
+    ],
+    "required_metric_fields": [
+      "canonical_url_hash",
+      "query_hash",
+      "clicks",
+      "impressions"
+    ],
+    "lag_days_required": 3,
+    "max_report_age_days": 10
+  },
+  "current_gsc_foundation_status": {
+    "data_origin": "fixture",
+    "data_quality_gate_status": "blocked",
+    "opportunity_queue_eligible": false
+  },
+  "forbidden_actions": [
+    "call_live_gsc_api",
+    "validate_or_store_credentials",
+    "run_production_backfill",
+    "enable_scheduler",
+    "enable_queue_worker",
+    "write_cms",
+    "create_cms_draft",
+    "enqueue_search_channel",
+    "submit_to_search_provider",
+    "score_opportunities"
+  ],
+  "next_allowed_use": "Future opportunity queue may read GSC rows only after this gate reports pass on live_gsc_api data."
+}

--- a/backend/docs/seo/gsc-data-quality-gate.md
+++ b/backend/docs/seo/gsc-data-quality-gate.md
@@ -1,0 +1,40 @@
+# GSC Data Quality Gate
+
+## Purpose
+
+`SEO-GSC-DATA-QUALITY-01` adds a backend-only quality gate for Google Search Console rows before any future opportunity queue may use them.
+
+The gate is read-only. It does not call Google Search Console, does not request indexing, does not enqueue Search Channel items, does not write CMS drafts, does not run migrations, and does not enable scheduler or queue workers.
+
+## Gate Contract
+
+GSC rows are eligible for future opportunity scoring only when all of these are true:
+
+- source engine is `google`
+- data origin is `live_gsc_api`
+- row source is not `fixture`, `mock`, `static_artifact`, or `unknown`
+- report date satisfies the configured GSC finalization lag
+- report date is not older than the configured freshness window
+- required metric fields are present: canonical URL hash, query hash, clicks, and impressions
+
+Current `gsc_foundation` dry-run data remains fixture-only, so its gate status is intentionally `blocked` and `opportunity_queue_eligible=false`.
+
+## Current Defaults
+
+- `gsc_backfill_lag_days=3`
+- `gsc_data_quality.max_report_age_days=10`
+- `gsc_data_quality.allowed_data_origins=["live_gsc_api"]`
+- `gsc_data_quality.forbidden_data_origins=["fixture","mock","static_artifact","unknown"]`
+
+## Boundary
+
+This gate is a prerequisite for future opportunity queue work. It is not the opportunity queue, does not score opportunities, and does not authorize CMS/search execution.
+
+Deferred:
+
+- live GSC connector activation
+- GSC credential validation
+- production GSC backfill
+- opportunity queue implementation
+- CMS draft/package generation
+- Search Channel enqueue/approval/submission

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php
@@ -34,6 +34,8 @@ final class SeoIntelGscCollectorTest extends TestCase
         $this->assertSame(2, $result->metadata['rows_normalized'] ?? null);
         $this->assertSame(3, $result->metadata['data_lag_days'] ?? null);
         $this->assertSame('google', $result->metadata['source_engine'] ?? null);
+        $this->assertSame('blocked', data_get($result->metadata, 'data_quality_gate.status'));
+        $this->assertFalse((bool) ($result->metadata['opportunity_queue_eligible'] ?? true));
         $this->assertFalse((bool) ($result->metadata['gsc_live_api_enabled'] ?? true));
         $this->assertFalse((bool) ($result->metadata['query_purchase_attribution_allowed'] ?? true));
         $this->assertSame('backend_orders_payment_benefits', $result->metadata['purchase_truth_source'] ?? null);
@@ -120,6 +122,8 @@ final class SeoIntelGscCollectorTest extends TestCase
         $this->assertFalse((bool) ($decoded['metadata']['external_calls_attempted'] ?? true));
         $this->assertFalse((bool) ($decoded['metadata']['credentials_required'] ?? true));
         $this->assertSame(3, $decoded['metadata']['data_lag_days'] ?? null);
+        $this->assertSame('blocked', data_get($decoded, 'metadata.data_quality_gate.status'));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.data_quality_gate.opportunity_queue_eligible', true));
 
         foreach (['email', 'order_no', 'attempt_id', 'payment_id', 'provider_event_id', 'cookie', 'token', 'secret'] as $forbidden) {
             $this->assertStringNotContainsString($forbidden, $output);

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\GscDataQualityGate;
+use App\Services\SeoIntel\SeoIntelCollectorManager;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscDataQualityGateTest extends TestCase
+{
+    #[Test]
+    public function gsc_foundation_fixture_data_is_blocked_from_opportunity_queue(): void
+    {
+        $result = (new SeoIntelCollectorManager)->collect('gsc_foundation', ['dry_run' => true]);
+        $gate = $result->metadata['data_quality_gate'] ?? null;
+
+        $this->assertIsArray($gate);
+        $this->assertSame('blocked', $gate['status'] ?? null);
+        $this->assertFalse((bool) ($gate['opportunity_queue_eligible'] ?? true));
+        $this->assertContains('fixture_or_mock_source', $gate['reasons'] ?? []);
+        $this->assertContains('untrusted_data_origin', $gate['reasons'] ?? []);
+        $this->assertSame('fixture', $result->metadata['data_origin'] ?? null);
+        $this->assertFalse((bool) ($result->metadata['opportunity_queue_eligible'] ?? true));
+        $this->assertFalse($result->externalCallsAttempted);
+        $this->assertFalse($result->writesAttempted);
+    }
+
+    #[Test]
+    public function gate_rejects_stale_or_too_fresh_live_gsc_rows(): void
+    {
+        $gate = new GscDataQualityGate;
+        $now = CarbonImmutable::parse('2026-06-20 12:00:00');
+
+        $stale = $gate->evaluate([
+            $this->liveRow('2026-06-01'),
+        ], $now);
+        $tooFresh = $gate->evaluate([
+            $this->liveRow('2026-06-19'),
+        ], $now);
+
+        $this->assertSame('blocked', $stale['status']);
+        $this->assertContains('stale_gsc_report_date', $stale['reasons']);
+        $this->assertFalse((bool) $stale['opportunity_queue_eligible']);
+
+        $this->assertSame('blocked', $tooFresh['status']);
+        $this->assertContains('gsc_finalization_lag_not_met', $tooFresh['reasons']);
+        $this->assertFalse((bool) $tooFresh['opportunity_queue_eligible']);
+    }
+
+    #[Test]
+    public function gate_passes_fresh_final_live_gsc_rows_with_required_metrics(): void
+    {
+        $gate = new GscDataQualityGate;
+        $result = $gate->evaluate([
+            $this->liveRow('2026-06-17'),
+        ], CarbonImmutable::parse('2026-06-20 12:00:00'));
+
+        $this->assertSame('pass', $result['status']);
+        $this->assertSame([], $result['reasons']);
+        $this->assertTrue((bool) $result['opportunity_queue_eligible']);
+        $this->assertSame(['live_gsc_api'], $result['data_origins']);
+        $this->assertSame('2026-06-17', $result['freshness']['max_report_date'] ?? null);
+    }
+
+    #[Test]
+    public function dry_run_command_exposes_quality_gate_without_live_calls_or_writes(): void
+    {
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'gsc_foundation',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertIsArray($decoded);
+        $this->assertSame('blocked', data_get($decoded, 'metadata.data_quality_gate.status'));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.data_quality_gate.opportunity_queue_eligible', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.opportunity_queue_eligible', true));
+        $this->assertFalse((bool) ($decoded['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($decoded['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($decoded['writes_committed'] ?? true));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function liveRow(string $reportDate): array
+    {
+        return [
+            'report_date' => $reportDate,
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types'),
+            'query_hash' => hash('sha256', '人格测试'),
+            'source_engine' => 'google',
+            'clicks' => 2,
+            'impressions' => 80,
+            'metadata_json' => [
+                'data_origin' => 'live_gsc_api',
+                'row_source' => 'live_gsc_api',
+                'purchase_attribution_allowed' => false,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -881,6 +881,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
             'backend/database/migrations/2026_05_17_000900_create_seo_gsc_daily_table.php',
@@ -4651,6 +4652,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
             'backend/database/migrations/2026_05_17_000900_create_seo_gsc_daily_table.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -54782,7 +54782,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-gsc-data-quality-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "ready_to_merge",
     "train_scope": "fermatmind_seo_agent_gsc_quality_gate",
     "title": "test(seo-intel): add GSC data quality gate",
     "depends_on": [
@@ -54835,13 +54835,13 @@
         "evidence": "Focused GSC data quality gate and existing GSC collector tests passed with 11 warnings / 131 assertions; runtime-freeze focused filter passed with 1 warning / 1 assertion; dry-run collector JSON showed data_quality_gate.status=blocked, opportunity_queue_eligible=false, external_calls_attempted=false, writes_attempted=false; Pint, JSON/YAML, diff check, and scope validation passed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2136 opened; GitHub checks pending."
+        "status": "pass",
+        "evidence": "PR #2136 GitHub checks passed for head 92d73439e55c175ec2d77c0d6115815e2a895562: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload."
       }
     },
     "failure_reason": null,
-    "commit_sha": "6c310c263dedec47173f9ef857326744ca238de1",
-    "pr_url": null,
+    "commit_sha": "92d73439e55c175ec2d77c0d6115815e2a895562",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2136",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -54865,6 +54865,11 @@
         "at": "2026-06-20T05:00:00+08:00",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2136."
+      },
+      {
+        "at": "2026-06-20T05:04:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2136 at head 92d73439e55c175ec2d77c0d6115815e2a895562; recording ready_to_merge before merge."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-14T00:20:00+08:00",
+  "updated_at": "2026-06-20T04:54:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54775,6 +54775,85 @@
         "at": "2026-06-14T04:42:00+08:00",
         "status": "merged",
         "note": "Reconciled GitHub PR #2087 as merged; origin/main contains merge commit 1b9074549211fe15b257a9595a88782cef118616 and the remote branch is deleted."
+      }
+    ]
+  },
+  "SEO-GSC-DATA-QUALITY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-gsc-data-quality-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "fermatmind_seo_agent_gsc_quality_gate",
+    "title": "test(seo-intel): add GSC data quality gate",
+    "depends_on": [
+      "external:fap-web/SEO-RUNTIME-QA-AGENT-01#1229"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided SEO-GSC-DATA-QUALITY-01 as the third PR in the FermatMind SEO Agent sequence and authorized continuous PR-train execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "fap-web SEO-RUNTIME-QA-AGENT-01 is merged in PR #1229 with merge commit 39b6357d841378baabf69d71a0f044d3e2b341f5 before this fap-api PR started."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/config/seo_intel.php",
+          "backend/app/Services/SeoIntel/Collectors/GscCollector.php",
+          "backend/app/Services/SeoIntel/GscDataQualityGate.php",
+          "backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php",
+          "backend/app/Services/SeoIntel/SeoIntelCollectorManager.php",
+          "backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php",
+          "backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "backend/docs/seo/gsc-data-quality-gate.md",
+          "backend/docs/seo/generated/gsc-data-quality-gate.v1.json",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed files are confined to the declared backend GSC data quality gate scope. No route, migration, CMS, Search Channel, scheduler, env, deploy, fap-web, sitemap, llms, robots, schema, hreflang, payment, order, report, recommendation, or scoring files changed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "composer install --no-interaction --prefer-dist",
+          "php -l backend/app/Services/SeoIntel/GscDataQualityGate.php",
+          "php -l backend/app/Services/SeoIntel/Collectors/GscCollector.php",
+          "php -l backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_intel_gsc_foundation --no-ansi",
+          "cd backend && php artisan seo-intel:collect --collector=gsc_foundation --dry-run --json",
+          "cd backend && ./vendor/bin/pint --test app/Services/SeoIntel/Collectors/GscCollector.php app/Services/SeoIntel/GscDataQualityGate.php app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php app/Services/SeoIntel/SeoIntelCollectorManager.php config/seo_intel.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/gsc-data-quality-gate.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'metadata ok'\"",
+          "git diff --check",
+          "scope validation"
+        ],
+        "evidence": "Focused GSC data quality gate and existing GSC collector tests passed with 11 warnings / 131 assertions; runtime-freeze focused filter passed with 1 warning / 1 assertion; dry-run collector JSON showed data_quality_gate.status=blocked, opportunity_queue_eligible=false, external_calls_attempted=false, writes_attempted=false; Pint, JSON/YAML, diff check, and scope validation passed."
+      },
+      "github": {
+        "status": "pending"
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-20T04:46:00+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit user sequence. Scope is backend-only GSC data quality gate; no CMS/search/live GSC/provider/write action is allowed."
+      },
+      {
+        "at": "2026-06-20T04:54:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Implemented GSC data quality gate, collector metadata, docs/generated contract, manifest/state entry, and focused tests. Local checks and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T04:54:00+08:00",
+  "updated_at": "2026-06-20T04:55:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54839,7 +54839,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "6c310c263dedec47173f9ef857326744ca238de1",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -54854,6 +54854,11 @@
         "at": "2026-06-20T04:54:00+08:00",
         "status": "local_checks_passed",
         "note": "Implemented GSC data quality gate, collector metadata, docs/generated contract, manifest/state entry, and focused tests. Local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-20T04:55:00+08:00",
+        "status": "committed",
+        "note": "Recorded implementation commit 6c310c263dedec47173f9ef857326744ca238de1 after rebasing onto latest origin/main and rerunning local checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T04:55:00+08:00",
+  "updated_at": "2026-06-20T05:00:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -41537,7 +41537,7 @@
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
     "commit_sha": "11e82c0c7000bc90f2ec550b83d80a9b941465dc",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2136",
     "checks": {},
     "failure_reason": null,
     "merged_at": null,
@@ -54835,7 +54835,8 @@
         "evidence": "Focused GSC data quality gate and existing GSC collector tests passed with 11 warnings / 131 assertions; runtime-freeze focused filter passed with 1 warning / 1 assertion; dry-run collector JSON showed data_quality_gate.status=blocked, opportunity_queue_eligible=false, external_calls_attempted=false, writes_attempted=false; Pint, JSON/YAML, diff check, and scope validation passed."
       },
       "github": {
-        "status": "pending"
+        "status": "pending",
+        "evidence": "PR #2136 opened; GitHub checks pending."
       }
     },
     "failure_reason": null,
@@ -54859,6 +54860,11 @@
         "at": "2026-06-20T04:55:00+08:00",
         "status": "committed",
         "note": "Recorded implementation commit 6c310c263dedec47173f9ef857326744ca238de1 after rebasing onto latest origin/main and rerunning local checks."
+      },
+      {
+        "at": "2026-06-20T05:00:00+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2136."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23848,6 +23848,57 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: SEO-GSC-DATA-QUALITY-01
+    repo: fap-api
+    branch: codex/seo-gsc-data-quality-01
+    title: "test(seo-intel): add GSC data quality gate"
+    train_scope: fermatmind_seo_agent_gsc_quality_gate
+    status: in_progress
+    depends_on:
+      - external:fap-web/SEO-RUNTIME-QA-AGENT-01#1229
+    scope:
+      - Add a backend SeoIntel data-quality gate that blocks stale, fixture, mock, static artifact, unknown, or incomplete GSC rows from future opportunity queue use.
+      - Keep the existing gsc_foundation collector disabled/dry-run and explicitly mark fixture output as opportunity_queue_eligible=false.
+      - Add docs/generated contract evidence and focused tests proving no live GSC call, no writes, and no CMS/search action.
+    allowed_paths:
+      - backend/config/seo_intel.php
+      - backend/app/Services/SeoIntel/Collectors/GscCollector.php
+      - backend/app/Services/SeoIntel/GscDataQualityGate.php
+      - backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php
+      - backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
+      - backend/tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php
+      - backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/seo/gsc-data-quality-gate.md
+      - backend/docs/seo/generated/gsc-data-quality-gate.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Call live GSC APIs, validate/store credentials, or enable GSC live connector.
+      - Create CMS drafts, publish, unpublish, mutate CMS, enqueue Search Channel, approve or submit URLs.
+      - Run production backfills, production migrations, scheduler jobs, queue workers, deploy, SSH, edit env, or touch Node2/Node3.
+      - Modify fap-web, sitemap, llms, robots, schema, hreflang, payment, order, report, recommendation, scoring, or public runtime behavior.
+      - Implement opportunity queue scoring or execution.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_intel_gsc_foundation --no-ansi
+      - cd backend && php artisan seo-intel:collect --collector=gsc_foundation --dry-run --json
+      - cd backend && ./vendor/bin/pint --test app/Services/SeoIntel/Collectors/GscCollector.php app/Services/SeoIntel/GscDataQualityGate.php app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php app/Services/SeoIntel/SeoIntelCollectorManager.php config/seo_intel.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/seo/generated/gsc-data-quality-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PERSONALITY-AT-DIFFERENCE-SECTIONS-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added `GscDataQualityGate` to block fixture, mock, static artifact, unknown, stale, too-fresh, non-Google, or incomplete GSC rows from future opportunity queue use.
- Wired the existing disabled `gsc_foundation` collector to expose `metadata.data_quality_gate` and `opportunity_queue_eligible=false` for fixture dry-run data.
- Added focused SeoIntel tests, docs, generated contract artifact, and runtime-freeze classifier coverage.
- Registered `SEO-GSC-DATA-QUALITY-01` in the fap-api PR-train manifest/state from the user-provided sequence.

## Why
The FermatMind SEO Agent must not build an opportunity queue from stale, fixture, or mock GSC data. This PR creates the backend guardrail before any future opportunity scoring or execution work.

## Validation
- `composer install --no-interaction --prefer-dist`
- `php -l backend/app/Services/SeoIntel/GscDataQualityGate.php`
- `php -l backend/app/Services/SeoIntel/Collectors/GscCollector.php`
- `php -l backend/tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_intel_gsc_foundation --no-ansi`
- `cd backend && php artisan seo-intel:collect --collector=gsc_foundation --dry-run --json`
- `cd backend && ./vendor/bin/pint --test app/Services/SeoIntel/Collectors/GscCollector.php app/Services/SeoIntel/GscDataQualityGate.php app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php app/Services/SeoIntel/SeoIntelCollectorManager.php config/seo_intel.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/gsc-data-quality-gate.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'metadata ok'"`
- `git diff --check`
- scope validation against the PR3 allowlist

## Intentionally deferred
- No live GSC API calls, credential validation, or credential storage.
- No CMS draft/write/publish/unpublish action.
- No Search Channel enqueue/approve/submit or search provider submission.
- No production backfill, migration execution, scheduler, queue worker, deploy, SSH, env edit, Node2/Node3 touch, fap-web change, sitemap/llms/robots/schema/hreflang change, or opportunity queue implementation.
