### PR TITLE
Fix AI impact preview locale fail-closed

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -32,9 +32,9 @@ final class CareerAiImpactAssetPreviewService
     public function previewAsset(string $slug, string $locale): ?CareerJobAiImpactAsset
     {
         $normalizedSlug = $this->normalizeSlug($slug);
-        $normalizedLocale = $this->normalizeLocale($locale);
+        $normalizedLocale = $this->normalizePreviewLocale($locale);
 
-        if (! $this->previewEnabled()) {
+        if ($normalizedLocale === null || ! $this->previewEnabled()) {
             return null;
         }
 
@@ -186,6 +186,15 @@ final class CareerAiImpactAssetPreviewService
         return match (strtolower(trim($locale))) {
             'en', 'en-us', 'en_us' => 'en',
             default => 'zh-CN',
+        };
+    }
+
+    private function normalizePreviewLocale(string $locale): ?string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            'zh', 'zh-cn', 'zh_cn' => 'zh-CN',
+            default => null,
         };
     }
 }

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -440,6 +440,37 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertNotFound();
     }
 
+    public function test_preview_api_fails_closed_for_unsupported_locale_without_fallback(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors']);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $zhRow = $this->assetRow('accountants-and-auditors', 'zh-CN');
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $zhRow,
+            'sources_json' => $zhRow['sources'],
+            'evidence_used_json' => $zhRow['evidence_used'],
+            'derived_from_synthesis_json' => $zhRow['derived_from_synthesis'],
+            'audit_fields_json' => $zhRow['audit_fields'],
+            'asset_row_hash' => $zhRow['audit_fields']['row_hash'],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=fr')
+            ->assertNotFound()
+            ->assertJsonPath('ok', false);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('ai_impact_asset_v1.locale', 'zh-CN');
+    }
+
     private function seedCareerJobBundleAuthority(string $slug): void
     {
         $this->seedCareerJobBundleAuthorities([$slug]);


### PR DESCRIPTION
## What changed
- Makes the AI Impact preview endpoint reject unsupported locale values instead of falling back to zh-CN.
- Adds a feature test proving `locale=fr` returns not found while supported zh-CN still renders.

## Why
- The 1046 staging preview API smoke found unsupported locale requests could return a readable zh-CN asset. Preview APIs should fail closed for unsupported locales.

## Validation
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `./vendor/bin/pint --test app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`

## Deferred
- No salary or AI Impact content asset edits.
- No staging write in this PR.
- No production import.
- No frontend/page runtime changes.

## Repository rule impact
- Backend/API remains the authority for AI Impact preview projection and fail-closed behavior; no frontend content fallback is introduced.