### PR TITLE
SEO-OPPORTUNITY-QUEUE-READONLY-01: add read-only opportunity queue

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
@@ -39,6 +39,11 @@ final class SeoIntelDashboardController
         return $this->respond($this->readService->pagePerformance($this->limit($request)));
     }
 
+    public function opportunityQueue(Request $request): JsonResponse
+    {
+        return $this->respond($this->readService->opportunityQueue($this->limit($request)));
+    }
+
     public function conversionFunnel(Request $request): JsonResponse
     {
         return $this->respond($this->readService->conversionFunnel($this->safeFilters($request), $this->limit($request)));

--- a/backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
+++ b/backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
@@ -178,6 +178,14 @@ final class SeoDashboardApiReadService extends AbstractSeoDashboardReadService
     /**
      * @return array<string, mixed>
      */
+    public function opportunityQueue(int $limit = 25): array
+    {
+        return (new SeoOpportunityQueueReadService)->read($limit);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     public function conversionFunnel(array $filters = [], int $limit = 25): array
     {
         return (new SeoConversionFunnelReadService)->read($filters, $limit);

--- a/backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
+++ b/backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\OpsDashboard;
+
+use App\Services\SeoIntel\GscDataQualityGate;
+
+final class SeoOpportunityQueueReadService extends AbstractSeoDashboardReadService
+{
+    public function __construct(
+        ?string $connectionName = null,
+        private readonly GscDataQualityGate $dataQualityGate = new GscDataQualityGate,
+    ) {
+        parent::__construct($connectionName);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function read(int $limit = 25): array
+    {
+        $limit = max(1, min($limit, 100));
+        $rows = $this->gscRows();
+        $qualityGate = $this->dataQualityGate->evaluate($rows);
+
+        return [
+            'schema_version' => 'seo-opportunity-queue-readonly.v1',
+            'mode' => 'read_only',
+            'source_gate' => $qualityGate,
+            'total_count' => $qualityGate['opportunity_queue_eligible'] ? count($this->candidateRows($rows, $limit)) : 0,
+            'recent_rows' => $qualityGate['opportunity_queue_eligible'] ? $this->candidateRows($rows, $limit) : [],
+            'scoring_contract' => [
+                'inputs' => ['seo_gsc_daily', 'seo_urls', 'gsc_data_quality_gate'],
+                'min_impressions' => 50,
+                'max_ctr_ppm' => 10000,
+                'position_milli_window' => [8000, 20000],
+                'brand_query_allowed' => false,
+            ],
+            'boundaries' => [
+                'cms_draft_allowed' => false,
+                'cms_write_allowed' => false,
+                'search_channel_enqueue_allowed' => false,
+                'search_provider_submission_allowed' => false,
+                'execution_allowed' => false,
+                'external_calls_attempted' => false,
+                'writes_attempted' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function gscRows(): array
+    {
+        return $this->table('seo_gsc_daily')
+            ->select([
+                'report_date',
+                'canonical_url_hash',
+                'canonical_url',
+                'query_hash',
+                'query_display_masked',
+                'locale',
+                'source_engine',
+                'clicks',
+                'impressions',
+                'ctr_ppm',
+                'average_position_milli',
+                'is_brand_query',
+                'query_type',
+                'metadata_json',
+            ])
+            ->where('source_engine', 'google')
+            ->orderByDesc('report_date')
+            ->limit(500)
+            ->get()
+            ->map(fn (object $row): array => [
+                'report_date' => (string) $row->report_date,
+                'canonical_url_hash' => (string) $row->canonical_url_hash,
+                'canonical_url' => is_string($row->canonical_url ?? null) ? $row->canonical_url : null,
+                'query_hash' => (string) $row->query_hash,
+                'query_display_masked' => is_string($row->query_display_masked ?? null) ? $row->query_display_masked : null,
+                'locale' => is_string($row->locale ?? null) ? $row->locale : null,
+                'source_engine' => (string) $row->source_engine,
+                'clicks' => (int) ($row->clicks ?? 0),
+                'impressions' => (int) ($row->impressions ?? 0),
+                'ctr_ppm' => $row->ctr_ppm === null ? null : (int) $row->ctr_ppm,
+                'average_position_milli' => $row->average_position_milli === null ? null : (int) $row->average_position_milli,
+                'is_brand_query' => (bool) ($row->is_brand_query ?? false),
+                'query_type' => is_string($row->query_type ?? null) ? $row->query_type : 'unknown',
+                'metadata_json' => $this->decodeJson($row->metadata_json ?? null),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    private function candidateRows(array $rows, int $limit): array
+    {
+        $candidates = array_values(array_filter($rows, static function (array $row): bool {
+            $impressions = (int) ($row['impressions'] ?? 0);
+            $clicks = (int) ($row['clicks'] ?? 0);
+            $ctrPpm = $row['ctr_ppm'] === null ? ($impressions > 0 ? (int) floor(($clicks / $impressions) * 1_000_000) : null) : (int) $row['ctr_ppm'];
+            $positionMilli = $row['average_position_milli'] === null ? null : (int) $row['average_position_milli'];
+
+            return $impressions >= 50
+                && $ctrPpm !== null
+                && $ctrPpm <= 10000
+                && $positionMilli !== null
+                && $positionMilli >= 8000
+                && $positionMilli <= 20000
+                && ! (bool) ($row['is_brand_query'] ?? false)
+                && ($row['query_type'] ?? 'unknown') === 'non_brand';
+        }));
+
+        usort($candidates, static function (array $left, array $right): int {
+            $leftScore = ((int) $left['impressions']) - ((int) ($left['ctr_ppm'] ?? 0) / 1000);
+            $rightScore = ((int) $right['impressions']) - ((int) ($right['ctr_ppm'] ?? 0) / 1000);
+
+            return $rightScore <=> $leftScore;
+        });
+
+        return array_slice(array_map(fn (array $row): array => [
+            'opportunity_id' => hash('sha256', implode('|', [
+                (string) $row['report_date'],
+                (string) $row['canonical_url_hash'],
+                (string) $row['query_hash'],
+            ])),
+            'canonical_path' => $this->safePath(is_string($row['canonical_url'] ?? null) ? $row['canonical_url'] : null),
+            'canonical_url_hash' => (string) $row['canonical_url_hash'],
+            'query_hash' => (string) $row['query_hash'],
+            'query_display_masked' => $row['query_display_masked'],
+            'locale' => $row['locale'],
+            'source_signal' => 'gsc:google',
+            'report_date' => (string) $row['report_date'],
+            'metrics' => [
+                'clicks' => (int) $row['clicks'],
+                'impressions' => (int) $row['impressions'],
+                'ctr_ppm' => $row['ctr_ppm'],
+                'average_position_milli' => $row['average_position_milli'],
+            ],
+            'recommended_next_step' => 'human_review_required_before_cms_or_search_action',
+            'allowed_action' => 'read_only_review',
+        ], $candidates), 0, $limit);
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3964,6 +3964,31 @@
                 "x-laravel-name": "api.v0_5.ops.seo_intel.issues"
             }
         },
+        "/api/v0.5/ops/seo-intel/opportunity-queue": {
+            "get": {
+                "operationId": "api.v0_5.ops.seo_intel.opportunity_queue",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Ops\\SeoIntel\\SeoIntelDashboardController@opportunityQueue",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureSeoIntelReadAuthorized"
+                ],
+                "x-laravel-name": "api.v0_5.ops.seo_intel.opportunity_queue"
+            }
+        },
         "/api/v0.5/ops/seo-intel/overview": {
             "get": {
                 "operationId": "api.v0_5.ops.seo_intel.overview",

--- a/backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json
+++ b/backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json
@@ -9,14 +9,16 @@
     "GET /api/v0.5/ops/seo-intel/url-truth",
     "GET /api/v0.5/ops/seo-intel/issues",
     "GET /api/v0.5/ops/seo-intel/trends",
-    "GET /api/v0.5/ops/seo-intel/page-performance"
+    "GET /api/v0.5/ops/seo-intel/page-performance",
+    "GET /api/v0.5/ops/seo-intel/opportunity-queue"
   ],
   "route_names": [
     "api.v0_5.ops.seo_intel.overview",
     "api.v0_5.ops.seo_intel.url_truth",
     "api.v0_5.ops.seo_intel.issues",
     "api.v0_5.ops.seo_intel.trends",
-    "api.v0_5.ops.seo_intel.page_performance"
+    "api.v0_5.ops.seo_intel.page_performance",
+    "api.v0_5.ops.seo_intel.opportunity_queue"
   ],
   "allowed_permissions": [
     "admin.seo_intel.read",
@@ -67,6 +69,16 @@
     "production_raw_log_read",
     "public_metabase_link"
   ],
+  "opportunity_queue_api_mapping": {
+    "contract_version": "seo-opportunity-queue-readonly.v1",
+    "gsc_data_quality_gate_required": true,
+    "execution_allowed": false,
+    "cms_write_allowed": false,
+    "search_channel_enqueue_allowed": false,
+    "search_provider_submission_allowed": false,
+    "raw_query_exposed": false,
+    "raw_canonical_url_exposed": false
+  },
   "forbidden_response_fields": [
     "email",
     "raw_email",

--- a/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
+++ b/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
@@ -1,0 +1,61 @@
+{
+  "version": "seo-opportunity-queue-readonly.v1",
+  "task": "SEO-OPPORTUNITY-QUEUE-READONLY-01",
+  "repo": "fap-api",
+  "route": "GET /api/v0.5/ops/seo-intel/opportunity-queue",
+  "read_only": true,
+  "private_ops_api_only": true,
+  "gsc_data_quality_gate_required": true,
+  "source_tables": [
+    "seo_gsc_daily",
+    "seo_urls"
+  ],
+  "candidate_fields": [
+    "opportunity_id",
+    "canonical_path",
+    "canonical_url_hash",
+    "query_hash",
+    "query_display_masked",
+    "locale",
+    "source_signal",
+    "report_date",
+    "metrics",
+    "recommended_next_step",
+    "allowed_action"
+  ],
+  "scoring_contract": {
+    "min_impressions": 50,
+    "max_ctr_ppm": 10000,
+    "position_milli_window": [
+      8000,
+      20000
+    ],
+    "brand_query_allowed": false
+  },
+  "forbidden_response_fields": [
+    "canonical_url",
+    "raw_query",
+    "metadata_json",
+    "raw_payload",
+    "order_no",
+    "attempt_id",
+    "payment_id",
+    "provider_event_id"
+  ],
+  "boundaries": {
+    "cms_draft_allowed": false,
+    "cms_write_allowed": false,
+    "search_channel_enqueue_allowed": false,
+    "search_provider_submission_allowed": false,
+    "execution_allowed": false,
+    "external_calls_attempted": false,
+    "writes_attempted": false
+  },
+  "production_operation_performed": false,
+  "migration_added": false,
+  "collector_enabled": false,
+  "cms_mutation_allowed": false,
+  "search_channel_action": false,
+  "deploy_allowed": false,
+  "next_task": "SEO-CMS-DRAFT-PILOT-01 remains HOLD unless GPT 5.5 Pro content approval, exact package hash, and dry-run approval are provided"
+}

--- a/backend/docs/seo/opportunity-queue-readonly.md
+++ b/backend/docs/seo/opportunity-queue-readonly.md
@@ -1,0 +1,34 @@
+# SEO Opportunity Queue Read-only Contract
+
+`SEO-OPPORTUNITY-QUEUE-READONLY-01` adds a private Ops API read model for opportunity candidates derived from the `seo_intel` read model.
+
+The endpoint is read-only:
+
+- no CMS draft creation
+- no CMS write
+- no Search Channel enqueue, approval, retry, or submission
+- no Google/Baidu/IndexNow provider call
+- no scheduler or queue worker activation
+- no raw query or raw private identifier exposure
+
+## Endpoint
+
+- `GET /api/v0.5/ops/seo-intel/opportunity-queue`
+
+The endpoint requires the same private Ops SEO Intel read permission boundary as the other `/api/v0.5/ops/seo-intel/*` routes.
+
+## Source Gate
+
+The read model can return candidate rows only when `GscDataQualityGate` passes on the underlying `seo_gsc_daily` rows. Fixture, mock, static artifact, stale, unknown, incomplete, or non-Google rows block candidate output.
+
+## Candidate Inputs
+
+- `seo_gsc_daily`
+- `seo_urls`
+- `GscDataQualityGate`
+
+Candidate rows expose safe aliases only: canonical path, URL hash, query hash, masked query, locale, report date, metrics, and a human-review next step.
+
+## Boundary
+
+The read-only opportunity queue is not an execution queue. A later PR must separately define and approve CMS draft dry-runs or Search Channel readiness before any write action.

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -574,6 +574,8 @@ Route::prefix('v0.5')->group(function () {
                 ->name('api.v0_5.ops.seo_intel.trends');
             Route::get('/page-performance', [SeoIntelDashboardController::class, 'pagePerformance'])
                 ->name('api.v0_5.ops.seo_intel.page_performance');
+            Route::get('/opportunity-queue', [SeoIntelDashboardController::class, 'opportunityQueue'])
+                ->name('api.v0_5.ops.seo_intel.opportunity_queue');
             Route::get('/conversion-funnel', [SeoIntelDashboardController::class, 'conversionFunnel'])
                 ->name('api.v0_5.ops.seo_intel.conversion_funnel');
         });

--- a/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
@@ -94,6 +94,7 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
                 '/api/v0.5/ops/seo-intel/issues',
                 '/api/v0.5/ops/seo-intel/trends',
                 '/api/v0.5/ops/seo-intel/page-performance',
+                '/api/v0.5/ops/seo-intel/opportunity-queue',
             ] as $path) {
                 $this->actingAs($admin, (string) config('admin.guard', 'admin'))
                     ->getJson($path)
@@ -166,6 +167,48 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
         $this->assertStringNotContainsString('https://fermatmind.com', $json);
         $this->assertStringNotContainsString('query_display_masked', $json);
         $this->assertStringNotContainsString('metadata_json', $json);
+    }
+
+    #[Test]
+    public function opportunity_queue_endpoint_is_gsc_quality_gated_and_read_only(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_SEO_INTEL_READ]);
+
+        $response = $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/opportunity-queue?limit=5')
+            ->assertOk()
+            ->assertJsonPath('data.schema_version', 'seo-opportunity-queue-readonly.v1')
+            ->assertJsonPath('data.mode', 'read_only')
+            ->assertJsonPath('data.source_gate.status', 'pass')
+            ->assertJsonPath('data.source_gate.opportunity_queue_eligible', true)
+            ->assertJsonPath('data.total_count', 1)
+            ->assertJsonPath('data.recent_rows.0.canonical_path', '/en/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonPath('data.recent_rows.0.query_display_masked', 'm**********y')
+            ->assertJsonPath('data.recent_rows.0.allowed_action', 'read_only_review')
+            ->assertJsonPath('data.boundaries.cms_write_allowed', false)
+            ->assertJsonPath('data.boundaries.search_channel_enqueue_allowed', false)
+            ->assertJsonPath('data.boundaries.search_provider_submission_allowed', false)
+            ->assertJsonPath('data.boundaries.execution_allowed', false)
+            ->assertJsonPath('data.boundaries.external_calls_attempted', false)
+            ->assertJsonPath('data.boundaries.writes_attempted', false);
+
+        $json = $response->getContent();
+
+        foreach ([
+            'https://fermatmind.com',
+            'mbti career clarity',
+            'metadata_json',
+            'raw_payload',
+            'order_no',
+            'attempt_id',
+            'payment_id',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $json);
+        }
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/ops/seo-intel/opportunity-queue', [])
+            ->assertMethodNotAllowed();
     }
 
     #[Test]
@@ -297,11 +340,23 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
             $table->id();
             $table->date('report_date');
             $table->char('canonical_url_hash', 64)->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->char('query_hash', 64)->nullable();
             $table->string('query_display_masked', 255)->nullable();
             $table->string('locale', 16)->nullable();
             $table->string('source_engine', 64)->default('google');
+            $table->string('device', 32)->nullable();
+            $table->string('country', 16)->nullable();
+            $table->string('search_type', 32)->nullable();
             $table->unsignedInteger('clicks')->default(0);
             $table->unsignedInteger('impressions')->default(0);
+            $table->unsignedInteger('ctr_ppm')->nullable();
+            $table->unsignedInteger('average_position_milli')->nullable();
+            $table->boolean('is_brand_query')->default(false);
+            $table->string('query_type', 32)->default('unknown');
+            $table->string('data_state', 32)->default('final');
+            $table->timestamp('collected_at')->nullable();
+            $table->json('metadata_json')->nullable();
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('created_at')->nullable();
         });
@@ -467,15 +522,43 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
         ]);
 
         DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
-            'report_date' => '2026-06-02',
+            'report_date' => now()->subDays(4)->toDateString(),
             'canonical_url_hash' => $hash,
+            'canonical_url' => 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            'query_hash' => hash('sha256', 'fermatmind mbti'),
             'query_display_masked' => 'mbti test',
             'locale' => 'en',
             'source_engine' => 'google',
             'clicks' => 7,
             'impressions' => 70,
-            'created_at' => '2026-06-02 00:00:00',
-            'updated_at' => '2026-06-02 00:00:00',
+            'ctr_ppm' => 100000,
+            'average_position_milli' => 4200,
+            'is_brand_query' => true,
+            'query_type' => 'brand',
+            'data_state' => 'final',
+            'metadata_json' => json_encode(['data_origin' => 'live_gsc_api', 'row_source' => 'live_gsc_api'], JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subDays(4)->toDateTimeString(),
+            'updated_at' => now()->subDays(4)->toDateTimeString(),
+        ]);
+
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'report_date' => now()->subDays(4)->toDateString(),
+            'canonical_url_hash' => $hash,
+            'canonical_url' => 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            'query_hash' => hash('sha256', 'mbti career clarity'),
+            'query_display_masked' => 'm**********y',
+            'locale' => 'en',
+            'source_engine' => 'google',
+            'clicks' => 0,
+            'impressions' => 500,
+            'ctr_ppm' => 0,
+            'average_position_milli' => 10700,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'data_state' => 'final',
+            'metadata_json' => json_encode(['data_origin' => 'live_gsc_api', 'row_source' => 'live_gsc_api'], JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subDays(4)->toDateTimeString(),
+            'updated_at' => now()->subDays(4)->toDateTimeString(),
         ]);
 
         DB::connection('seo_intel')->table('seo_baidu_landing_daily')->insert([

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1034,6 +1034,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_opportunity_queue_readonly_files(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php',
+            'backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php',
+            'backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php',
+            'backend/routes/api.php',
+        ];
+
+        $routeChangedLines = [
+            "+            Route::get('/opportunity-queue', [SeoIntelDashboardController::class, 'opportunityQueue'])",
+            "+                ->name('api.v0_5.ops.seo_intel.opportunity_queue');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -4866,6 +4888,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/OpsDashboard/SeoCrawlerLogObservationReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardOverviewReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoIssueQueueReadService.php',
+            'backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoSearchChannelQueueReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoUrlTruthReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/CareerRuntimeReadModelService.php',
@@ -6703,7 +6726,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if (preg_match('/^\+.*(SeoIntelDashboardController|EnsureSeoIntelReadAuthorized|ops\\/seo-intel|api\\.v0_5\\.ops\\.seo_intel|overview|urlTruth|url-truth|issues|trends|pagePerformance|page-performance|cmsAdminMiddleware|Route::prefix|Route::get|middleware|group|name)/u', $line) !== 1) {
+            if (preg_match('/^\+.*(SeoIntelDashboardController|EnsureSeoIntelReadAuthorized|ops\\/seo-intel|api\\.v0_5\\.ops\\.seo_intel|overview|urlTruth|url-truth|issues|trends|pagePerformance|page-performance|opportunityQueue|opportunity-queue|opportunity_queue|cmsAdminMiddleware|Route::prefix|Route::get|middleware|group|name)/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T05:00:00+08:00",
+  "updated_at": "2026-06-20T07:16:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54782,7 +54782,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-gsc-data-quality-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "fermatmind_seo_agent_gsc_quality_gate",
     "title": "test(seo-intel): add GSC data quality gate",
     "depends_on": [
@@ -54840,11 +54840,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "92d73439e55c175ec2d77c0d6115815e2a895562",
+    "commit_sha": "f1b5bd96e2887ba55ca6a4ab56e7a23d9775e007",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2136",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-19T21:04:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-20T04:46:00+08:00",
@@ -54870,6 +54870,11 @@
         "at": "2026-06-20T05:04:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2136 at head 92d73439e55c175ec2d77c0d6115815e2a895562; recording ready_to_merge before merge."
+      },
+      {
+        "at": "2026-06-20T07:08:00+08:00",
+        "status": "merged",
+        "note": "Reconciled while starting SEO-OPPORTUNITY-QUEUE-READONLY-01: GitHub PR #2136 is MERGED, origin/main contains merge commit f1b5bd96e2887ba55ca6a4ab56e7a23d9775e007, and local/remote task branches are absent."
       }
     ]
   },
@@ -54953,6 +54958,87 @@
         "at": "2026-06-14T05:10:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2089 and pre-merge scope validation showed only the 7 declared PR files changed."
+      }
+    ]
+  },
+  "SEO-OPPORTUNITY-QUEUE-READONLY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-opportunity-queue-readonly-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "fermatmind_seo_agent_opportunity_queue_readonly",
+    "title": "feat(seo-intel): add read-only opportunity queue",
+    "depends_on": [
+      "SEO-GSC-DATA-QUALITY-01",
+      "external:fap-web/SEO-OPPORTUNITY-QUEUE-CONTRACT-01#1232",
+      "external:fap-web/SEO-OPS-READMODEL-BRIDGE-01#1227"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided SEO-OPPORTUNITY-QUEUE-READONLY-01 as the eighth PR in the FermatMind SEO Agent sequence and authorized continuous PR-train execution after GSC quality, opportunity queue contract, and ops read-model bridge dependencies."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-GSC-DATA-QUALITY-01 is merged in fap-api PR #2136, fap-web SEO-OPPORTUNITY-QUEUE-CONTRACT-01 is merged in PR #1232, and fap-web SEO-OPS-READMODEL-BRIDGE-01 is merged in PR #1227 before this PR started."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/routes/api.php",
+          "backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php",
+          "backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php",
+          "backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php",
+          "backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "backend/docs/seo/opportunity-queue-readonly.md",
+          "backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json",
+          "backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed files match the SEO-OPPORTUNITY-QUEUE-READONLY-01 allowlist. Existing untracked generated/ directories are unrelated and excluded from staging. No POST route, command, job, migration, scheduler, queue worker, CMS write, Search Channel action, provider call, fap-web, sitemap, llms, robots, schema, hreflang, frontend runtime SEO, or public page changed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/routes/api.php",
+          "php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php",
+          "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php",
+          "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php",
+          "php -l backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi",
+          "cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check",
+          "scope validation"
+        ],
+        "evidence": "Syntax checks passed for route/controller/services/focused test. SeoDashApi01ReadOnlyApiContractTest passed: 7 tests, 145 assertions. route:list showed 7 private Ops SEO Intel GET routes including opportunity-queue and no write route. Pint passed for 5 files. Generated JSON, train state JSON, YAML, git diff --check, and explicit changed-file allowlist validation passed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR not opened yet."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-20T07:08:00+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit user sequence. Scope is backend-only read-only opportunity queue; no CMS/search/provider/write action is allowed."
+      },
+      {
+        "at": "2026-06-20T07:16:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Implemented private read-only opportunity queue endpoint and sanitized read service. Local checks and scope validation passed; existing untracked generated/ directories were excluded from staging."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T07:16:00+08:00",
+  "updated_at": "2026-06-20T07:18:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54965,7 +54965,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-opportunity-queue-readonly-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "committed",
     "train_scope": "fermatmind_seo_agent_opportunity_queue_readonly",
     "title": "feat(seo-intel): add read-only opportunity queue",
     "depends_on": [
@@ -55024,7 +55024,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "c081d1a79fed93160601585641c298718125e193",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55039,6 +55039,11 @@
         "at": "2026-06-20T07:16:00+08:00",
         "status": "local_checks_passed",
         "note": "Implemented private read-only opportunity queue endpoint and sanitized read service. Local checks and scope validation passed; existing untracked generated/ directories were excluded from staging."
+      },
+      {
+        "at": "2026-06-20T07:18:00+08:00",
+        "status": "committed",
+        "note": "Recorded scoped implementation commit c081d1a79fed93160601585641c298718125e193 after local checks and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -55030,7 +55030,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "f2ee09d7bb7d6fd42e8fa6b6dea01eff4c67d71e",
+    "commit_sha": "72b793e421ccc87a85738a9c0fd39850de7a2acf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2139",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55065,6 +55065,11 @@
         "at": "2026-06-20T07:25:00+08:00",
         "status": "local_checks_passed_after_ci_fix",
         "note": "Regenerated OpenAPI snapshot, added the BigFive runtime-freeze classifier exception/test for SeoOpportunityQueueReadService, and reran focused API, OpenAPI, BigFive, Pint, JSON/YAML, diff, and scope checks successfully."
+      },
+      {
+        "at": "2026-06-20T07:26:00+08:00",
+        "status": "ci_fix_committed",
+        "note": "Recorded CI fix commit 72b793e421ccc87a85738a9c0fd39850de7a2acf for PR #2139."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38415,7 +38415,7 @@
     "branch": "codex/analytics-funnel-ops-org0-visibility-repair-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01 show global org0 funnel rows",
-    "status": "local_checks_passed_after_ci_fix",
+    "status": "ready_to_merge",
     "depends_on": [
       "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
     ],
@@ -55025,12 +55025,12 @@
         "evidence": "Syntax checks passed for route/controller/services/focused tests. SeoDashApi01ReadOnlyApiContractTest passed: 7 tests, 145 assertions. BigFive runtime-freeze focused filter passed: 3 tests, 13 assertions. OpenAPI snapshot check passed after exporting the new route. route:list showed 7 private Ops SEO Intel GET routes including opportunity-queue and no write route. Pint passed for 6 files. OpenAPI/generated JSON, train state JSON, YAML, git diff --check, and explicit changed-file allowlist validation passed."
       },
       "github": {
-        "status": "failed_inspected",
-        "evidence": "PR #2139 initial GitHub checks failed on head cf877104d2526fd08274e518064670434114d4bb: verify-mbti-legacy and verify-mbti-v2 reported OpenAPI snapshot drift for /api/v0.5/ops/seo-intel/opportunity-queue; verify-bigfive reported the new SeoOpportunityQueueReadService.php as an unclassified runtime-freeze diff. Both fixes are limited to current PR contract/scope gate files."
+        "status": "pass",
+        "evidence": "PR #2139 GitHub checks passed on head 52447f402a37a23b818b020c0c7c2c23240cd524 after the scoped CI fix: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and semgrep sarif non-blocking upload. mergeStateStatus=CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "72b793e421ccc87a85738a9c0fd39850de7a2acf",
+    "commit_sha": "52447f402a37a23b818b020c0c7c2c23240cd524",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2139",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55070,6 +55070,11 @@
         "at": "2026-06-20T07:26:00+08:00",
         "status": "ci_fix_committed",
         "note": "Recorded CI fix commit 72b793e421ccc87a85738a9c0fd39850de7a2acf for PR #2139."
+      },
+      {
+        "at": "2026-06-20T07:31:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2139 at head 52447f402a37a23b818b020c0c7c2c23240cd524 and mergeStateStatus was CLEAN; pre-merge scope validation remained within the PR8 allowlist."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T07:18:00+08:00",
+  "updated_at": "2026-06-20T07:22:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54965,7 +54965,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-opportunity-queue-readonly-01",
     "base": "main",
-    "status": "committed",
+    "status": "pr_open",
     "train_scope": "fermatmind_seo_agent_opportunity_queue_readonly",
     "title": "feat(seo-intel): add read-only opportunity queue",
     "depends_on": [
@@ -55020,12 +55020,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": "PR not opened yet."
+        "evidence": "PR #2139 opened; GitHub checks pending on head f2ee09d7bb7d6fd42e8fa6b6dea01eff4c67d71e."
       }
     },
     "failure_reason": null,
-    "commit_sha": "c081d1a79fed93160601585641c298718125e193",
-    "pr_url": null,
+    "commit_sha": "f2ee09d7bb7d6fd42e8fa6b6dea01eff4c67d71e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2139",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55044,6 +55044,11 @@
         "at": "2026-06-20T07:18:00+08:00",
         "status": "committed",
         "note": "Recorded scoped implementation commit c081d1a79fed93160601585641c298718125e193 after local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-20T07:22:00+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2139; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38415,7 +38415,7 @@
     "branch": "codex/analytics-funnel-ops-org0-visibility-repair-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01 show global org0 funnel rows",
-    "status": "pr_open",
+    "status": "local_checks_passed_after_ci_fix",
     "depends_on": [
       "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
     ],
@@ -42909,7 +42909,7 @@
         "evidence": "Changed files are limited to seo_intel migration readiness docs/artifact, focused contract test, and PR train metadata. No runtime route, migration file, production DB, collector, external API, CMS, search submission, fap-web, or deploy change was made."
       },
       "local": {
-        "status": "pass",
+        "status": "pass_after_ci_fix",
         "commands": [
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoDashMigration01ReadinessTest --no-ansi",
           "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoDashMigration01ReadinessTest.php",
@@ -54990,6 +54990,8 @@
           "backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php",
           "backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php",
           "backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "backend/docs/contracts/openapi.snapshot.json",
           "backend/docs/seo/opportunity-queue-readonly.md",
           "backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json",
           "backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json",
@@ -55006,9 +55008,13 @@
           "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php",
           "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php",
           "php -l backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_opportunity_queue|seo_dash_api_read_only' --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi",
-          "cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php",
+          "cd backend && APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash scripts/export_openapi.sh --check",
+          "cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null",
           "python3 -m json.tool backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null",
           "python3 -m json.tool backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json >/dev/null",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
@@ -55016,11 +55022,11 @@
           "git diff --check",
           "scope validation"
         ],
-        "evidence": "Syntax checks passed for route/controller/services/focused test. SeoDashApi01ReadOnlyApiContractTest passed: 7 tests, 145 assertions. route:list showed 7 private Ops SEO Intel GET routes including opportunity-queue and no write route. Pint passed for 5 files. Generated JSON, train state JSON, YAML, git diff --check, and explicit changed-file allowlist validation passed."
+        "evidence": "Syntax checks passed for route/controller/services/focused tests. SeoDashApi01ReadOnlyApiContractTest passed: 7 tests, 145 assertions. BigFive runtime-freeze focused filter passed: 3 tests, 13 assertions. OpenAPI snapshot check passed after exporting the new route. route:list showed 7 private Ops SEO Intel GET routes including opportunity-queue and no write route. Pint passed for 6 files. OpenAPI/generated JSON, train state JSON, YAML, git diff --check, and explicit changed-file allowlist validation passed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2139 opened; GitHub checks pending on head f2ee09d7bb7d6fd42e8fa6b6dea01eff4c67d71e."
+        "status": "failed_inspected",
+        "evidence": "PR #2139 initial GitHub checks failed on head cf877104d2526fd08274e518064670434114d4bb: verify-mbti-legacy and verify-mbti-v2 reported OpenAPI snapshot drift for /api/v0.5/ops/seo-intel/opportunity-queue; verify-bigfive reported the new SeoOpportunityQueueReadService.php as an unclassified runtime-freeze diff. Both fixes are limited to current PR contract/scope gate files."
       }
     },
     "failure_reason": null,
@@ -55049,6 +55055,16 @@
         "at": "2026-06-20T07:22:00+08:00",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2139; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-20T07:24:00+08:00",
+        "status": "github_checks_failed_inspected",
+        "note": "Inspected PR #2139 failed checks: OpenAPI snapshot missing the new route and BigFive runtime-freeze classifier missing the new read-only service. Fix remains within the PR8 gate files."
+      },
+      {
+        "at": "2026-06-20T07:25:00+08:00",
+        "status": "local_checks_passed_after_ci_fix",
+        "note": "Regenerated OpenAPI snapshot, added the BigFive runtime-freeze classifier exception/test for SeoOpportunityQueueReadService, and reran focused API, OpenAPI, BigFive, Pint, JSON/YAML, diff, and scope checks successfully."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23899,6 +23899,65 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: SEO-OPPORTUNITY-QUEUE-READONLY-01
+    repo: fap-api
+    branch: codex/seo-opportunity-queue-readonly-01
+    title: "feat(seo-intel): add read-only opportunity queue"
+    train_scope: fermatmind_seo_agent_opportunity_queue_readonly
+    status: in_progress
+    depends_on:
+      - SEO-GSC-DATA-QUALITY-01
+      - external:fap-web/SEO-OPPORTUNITY-QUEUE-CONTRACT-01#1232
+      - external:fap-web/SEO-OPS-READMODEL-BRIDGE-01#1227
+    scope:
+      - Add a private Ops SEO Intel read-only opportunity queue endpoint backed by sanitized seo_intel read models.
+      - Gate candidate rows behind GscDataQualityGate so stale, fixture, mock, static artifact, unknown, incomplete, or non-Google data cannot produce candidates.
+      - Expose only safe aliases such as canonical path, URL hash, query hash, masked query, metrics, and human-review next step.
+      - Add generated contract evidence and focused tests proving no CMS writes, no Search Channel enqueue, no provider calls, and no execution.
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
+      - backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
+      - backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
+      - backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - backend/docs/seo/opportunity-queue-readonly.md
+      - backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
+      - backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add POST/write routes, commands, jobs, migrations, schedulers, queue workers, or production collectors.
+      - Write CMS, create CMS drafts, publish, unpublish, import, upload media, or mutate editorial content.
+      - Enqueue, approve, retry, or submit Search Channel rows.
+      - Call Google Search Console, Baidu, IndexNow, or any external provider.
+      - Expose raw query, raw canonical URL, private identifiers, payment/order data, provider credentials, raw payloads, or metadata_json.
+      - Modify fap-web, sitemap, llms, robots, schema, hreflang, frontend runtime SEO, or public pages.
+    validation:
+      - php -l backend/routes/api.php
+      - php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
+      - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
+      - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
+      - php -l backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi
+      - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - python3 -m json.tool backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - scope validation
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PERSONALITY-AT-DIFFERENCE-SECTIONS-01
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23920,6 +23920,8 @@ prs:
       - backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
       - backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
       - backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/contracts/openapi.snapshot.json
       - backend/docs/seo/opportunity-queue-readonly.md
       - backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
       - backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json
@@ -23938,9 +23940,13 @@ prs:
       - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
       - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
       - php -l backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_opportunity_queue|seo_dash_api_read_only' --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi
-      - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+      - cd backend && APP_ENV=testing PAYMENTS_ALLOW_STUB=true bash scripts/export_openapi.sh --check
+      - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null
       - python3 -m json.tool backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null
       - python3 -m json.tool backend/docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json >/dev/null
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null


### PR DESCRIPTION
## What changed
- Added a private Ops SEO Intel `GET /api/v0.5/ops/seo-intel/opportunity-queue` read-only endpoint.
- Added `SeoOpportunityQueueReadService`, gated by `GscDataQualityGate`, returning only sanitized candidate fields.
- Updated read-only API contract evidence plus a dedicated opportunity queue generated contract and doc.
- Extended the Ops SEO Intel API contract test to cover the opportunity queue route, GSC quality gate, safe fields, and method-not-allowed write boundary.
- Reconciled `SEO-GSC-DATA-QUALITY-01` as merged in the train state and initialized this PR's manifest/state entries.

## Why
This is the first read-only opportunity queue bridge after GSC quality, opportunity queue contract, and ops read-model dependencies. It allows operator review of quality-gated opportunities without creating any execution path.

## Validation
- `php -l backend/routes/api.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php`
- `php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php`
- `php -l backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php`
- `php -l backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi`
- `cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php`
- JSON parse for generated evidence and train state
- YAML parse for train manifest
- `git diff --check`
- explicit changed-file scope validation

## Intentionally deferred
- No CMS writes or CMS draft creation.
- No Search Channel enqueue, approve, retry, or submit action.
- No Google Search Console, Baidu, IndexNow, or provider calls.
- No migration, scheduler, queue worker, command, production collector, deployment, or fap-web change.
- `SEO-CMS-DRAFT-PILOT-01` remains HOLD pending GPT 5.5 Pro content approval, exact package hash, and dry-run approval.

## Repository rule impact
Backend remains the authority for SEO Intel operational read models. This PR adds a private read-only Ops API surface only; it does not create publish, CMS, search, provider, or public runtime authority.
