### PR TITLE
chore(pr-train): mark opportunity queue merged

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -54965,7 +54965,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-opportunity-queue-readonly-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "fermatmind_seo_agent_opportunity_queue_readonly",
     "title": "feat(seo-intel): add read-only opportunity queue",
     "depends_on": [


### PR DESCRIPTION
## What changed
- Corrects SEO-OPPORTUNITY-QUEUE-READONLY-01 top-level ledger status from pr_open to merged.

## Why
- PR #2139 and closeout PR #2140 are merged; the entry already had merge facts, but the top-level status field still needed correction.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check
- diff limited to docs/codex/pr-train-state.json status field

## Deferred
- No runtime/API/CMS/search changes.