### PR TITLE
Add AI Impact v5 approved transition gate

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -16,9 +16,14 @@ final class CareerImportAiImpactAssetsPreview extends Command
         {--slugs= : Optional comma-separated preview slug subset}
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
         {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
+        {--confirm-approved-transition : Explicitly confirm that --force may mark validated rows as approved}
+        {--approval-manifest= : Approval manifest JSON produced by the editorial review package}
+        {--approval-manifest-sha256= : Optional expected SHA-256 for the approval manifest}
+        {--editorial-review-report= : Editorial review JSON report that authorizes the approved transition}
+        {--editorial-review-sha256= : Optional expected SHA-256 for the editorial review report}
         {--dry-run : Validate only; do not write staging or production rows}
-        {--force : Write rows only when --status=staging_preview and validation passes}
-        {--status=staging_preview : Target import status; only staging_preview is supported by this command}
+        {--force : Write rows only when --status=staging_preview or perform explicit approved transition when --status=approved}
+        {--status=staging_preview : Target import status; staging_preview and approved are supported; production_imported is never supported here}
         {--json : Emit machine-readable JSON report}
         {--output= : Optional report output path}';
 
@@ -52,27 +57,46 @@ final class CareerImportAiImpactAssetsPreview extends Command
                 ], false);
             }
 
-            if ($force && (bool) $this->option('all-slugs-from-file') && ! (bool) $this->option('confirm-full-staging-preview')) {
+            if (
+                $force
+                && $status === 'staging_preview'
+                && (bool) $this->option('all-slugs-from-file')
+                && ! (bool) $this->option('confirm-full-staging-preview')
+            ) {
                 return $this->finish([
                     'decision' => 'fail',
                     'errors' => ['--force --all-slugs-from-file requires --confirm-full-staging-preview.'],
                 ], false);
             }
 
-            $report = $force
-                ? $this->importService->importStagingPreview(
+            if ($force && $status === 'approved') {
+                $report = $this->importService->approveReviewedAssets(
                     $file,
                     $this->requestedSlugs(),
                     trim((string) $this->option('expected-sha256')) ?: null,
                     (bool) $this->option('all-slugs-from-file'),
-                    $status,
-                )
-                : $this->importService->validateFile(
-                    $file,
-                    $this->requestedSlugs(),
-                    trim((string) $this->option('expected-sha256')) ?: null,
-                    (bool) $this->option('all-slugs-from-file'),
+                    trim((string) $this->option('approval-manifest')),
+                    trim((string) $this->option('approval-manifest-sha256')) ?: null,
+                    trim((string) $this->option('editorial-review-report')),
+                    trim((string) $this->option('editorial-review-sha256')) ?: null,
+                    (bool) $this->option('confirm-approved-transition'),
                 );
+            } else {
+                $report = $force
+                    ? $this->importService->importStagingPreview(
+                        $file,
+                        $this->requestedSlugs(),
+                        trim((string) $this->option('expected-sha256')) ?: null,
+                        (bool) $this->option('all-slugs-from-file'),
+                        $status,
+                    )
+                    : $this->importService->validateFile(
+                        $file,
+                        $this->requestedSlugs(),
+                        trim((string) $this->option('expected-sha256')) ?: null,
+                        (bool) $this->option('all-slugs-from-file'),
+                    );
+            }
 
             return $this->finish($report, ($report['decision'] ?? null) === 'pass');
         } catch (Throwable $throwable) {

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -9,6 +9,7 @@ use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\CareerJobAiImpactAsset;
 use App\Models\Occupation;
 use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -344,6 +345,204 @@ final class CareerAiImpactAssetImportService
     }
 
     /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function approveReviewedAssets(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        string $approvalManifestFile = '',
+        ?string $expectedApprovalManifestSha256 = null,
+        string $editorialReviewReportFile = '',
+        ?string $expectedEditorialReviewSha256 = null,
+        bool $confirmed = false,
+    ): array {
+        $baseReport = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile);
+        if (! $confirmed) {
+            return array_merge($baseReport, [
+                'mode' => 'approved_transition',
+                'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'errors' => ['--confirm-approved-transition is required to mark AI impact assets as approved.'],
+            ]);
+        }
+
+        $validation = $this->validateFile($file, $requestedSlugs, $expectedSha256, $allSlugsFromFile);
+        if (($validation['decision'] ?? null) !== 'pass') {
+            return array_merge($validation, [
+                'mode' => 'approved_transition',
+                'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+                'approved_transition_performed' => false,
+                'production_import_performed' => false,
+                'write_skipped_reason' => 'validation_failed',
+            ]);
+        }
+
+        $errors = [];
+        $sourceFileSha256 = is_string($validation['source_file_sha256'] ?? null)
+            ? (string) $validation['source_file_sha256']
+            : null;
+        $targetSlugs = array_values(array_map('strval', (array) ($validation['target_slugs'] ?? [])));
+        $expectedRows = (int) ($validation['expected_preview_rows'] ?? (count($targetSlugs) * 2));
+        $targetSlugCount = count($targetSlugs);
+
+        $approvalArtifact = $this->readJsonArtifact($approvalManifestFile, $expectedApprovalManifestSha256, 'approval manifest', $errors);
+        $editorialArtifact = $this->readJsonArtifact($editorialReviewReportFile, $expectedEditorialReviewSha256, 'editorial review report', $errors);
+        $approvalManifest = is_array($approvalArtifact['payload'] ?? null) ? $approvalArtifact['payload'] : [];
+        $editorialReview = is_array($editorialArtifact['payload'] ?? null) ? $editorialArtifact['payload'] : [];
+
+        $this->validateApprovalManifest($approvalManifest, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+        $this->validateEditorialReviewReport($editorialReview, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+
+        $assetVersion = CareerJobAiImpactAsset::ASSET_VERSION_V5;
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $targetKeys[$slug.'|'.$locale] = ['slug' => $slug, 'locale' => $locale];
+            }
+        }
+
+        $existingRows = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->get();
+
+        $existingByKey = [];
+        foreach ($existingRows as $asset) {
+            $existingByKey[$asset->career_job_slug.'|'.$asset->locale] = $asset;
+        }
+
+        $rollbackRows = [];
+        $previousStatusCounts = [];
+        $approvableStatuses = [
+            CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW,
+            CareerJobAiImpactAsset::STATUS_APPROVED,
+        ];
+
+        foreach ($targetKeys as $key => $target) {
+            $asset = $existingByKey[$key] ?? null;
+            if (! $asset instanceof CareerJobAiImpactAsset) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: approved transition requires an existing staging_preview or editorial_review row.";
+
+                continue;
+            }
+
+            $previousStatus = (string) $asset->status;
+            $previousStatusCounts[$previousStatus] = (int) ($previousStatusCounts[$previousStatus] ?? 0) + 1;
+            if (! in_array($previousStatus, $approvableStatuses, true)) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: cannot approve from status {$previousStatus}.";
+            }
+
+            if ($previousStatus === CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: production_imported rows are immutable in this command.";
+            }
+
+            if (is_string($asset->source_artifact_sha256) && $sourceFileSha256 !== null && $asset->source_artifact_sha256 !== $sourceFileSha256) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: existing source artifact SHA does not match the approved asset artifact SHA.";
+            }
+
+            $rollbackRows[] = [
+                'slug' => $target['slug'],
+                'locale' => $target['locale'],
+                'previous_status' => $previousStatus,
+                'new_status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            ];
+        }
+
+        $productionRowsBefore = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)
+            ->count();
+
+        if ($errors !== []) {
+            return array_merge($validation, [
+                'mode' => 'approved_transition',
+                'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                ],
+                'errors' => $errors,
+            ]);
+        }
+
+        $importRunId = (string) Str::uuid();
+        DB::transaction(function () use ($assetVersion, $targetSlugs, $importRunId): void {
+            CareerJobAiImpactAsset::query()
+                ->where('asset_version', $assetVersion)
+                ->whereIn('career_job_slug', $targetSlugs)
+                ->whereIn('locale', ['zh-CN', 'en'])
+                ->whereIn('status', [
+                    CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                    CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW,
+                    CareerJobAiImpactAsset::STATUS_APPROVED,
+                ])
+                ->update([
+                    'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+                    'preview_allowlisted' => true,
+                    'import_run_id' => $importRunId,
+                    'updated_at' => now(),
+                ]);
+        });
+
+        $approvedCount = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->where('status', CareerJobAiImpactAsset::STATUS_APPROVED)
+            ->count();
+        $productionRowsAfter = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)
+            ->count();
+
+        $productionRowsTouched = $productionRowsAfter - $productionRowsBefore;
+        $decision = $approvedCount === $expectedRows && $productionRowsTouched === 0 ? 'pass' : 'fail';
+
+        return array_merge($validation, [
+            'mode' => 'approved_transition',
+            'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            'decision' => $decision,
+            'approved_transition_performed' => true,
+            'production_import_allowed' => false,
+            'production_import_performed' => false,
+            'staging_write_performed' => false,
+            'import_run_id' => $importRunId,
+            'approval_manifest_file' => $approvalManifestFile,
+            'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+            'editorial_review_report_file' => $editorialReviewReportFile,
+            'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+            'approved_count' => $approvedCount,
+            'expected_approved_count' => $expectedRows,
+            'production_rows_touched' => $productionRowsTouched,
+            'rollback_report' => [
+                'available' => true,
+                'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                'previous_status_counts' => $previousStatusCounts,
+                'rows' => $rollbackRows,
+                'rollback_sql_intent' => 'Restore each row to previous_status by career_job_slug, locale, asset_version, and import_run_id if rollback is required before production import.',
+            ],
+            'errors' => $decision === 'pass' ? [] : ['Approved row count or production row touch invariant failed.'],
+        ]);
+    }
+
+    /**
      * @param  list<string>  $targetSlugs
      * @return array{checked_slug_count: int, ready_slug_count: int, rows: list<array<string, mixed>>}
      */
@@ -554,7 +753,7 @@ final class CareerAiImpactAssetImportService
         return [
             'importer_version' => self::IMPORTER_VERSION,
             'asset_version' => 'career_risk_future_ai_impact_v5',
-            'status_policy' => 'dry_run_or_staging_preview_only_for_this_contract',
+            'status_policy' => 'dry_run_staging_preview_or_approved_transition_only_for_this_contract',
             'production_import_allowed' => false,
             'production_import_gate' => [
                 'allowed' => false,
@@ -566,6 +765,145 @@ final class CareerAiImpactAssetImportService
             'requested_slugs' => $requestedSlugs,
             'all_slugs_from_file' => $allSlugsFromFile,
         ];
+    }
+
+    /**
+     * @param  list<string>  $errors
+     * @return array{payload: array<string, mixed>|null, sha256: string|null}
+     */
+    private function readJsonArtifact(string $file, ?string $expectedSha256, string $label, array &$errors): array
+    {
+        $file = trim($file);
+        if ($file === '') {
+            $errors[] = ucfirst($label).' file is required.';
+
+            return ['payload' => null, 'sha256' => null];
+        }
+
+        if (! is_file($file) || ! is_readable($file)) {
+            $errors[] = ucfirst($label).' file is missing or unreadable.';
+
+            return ['payload' => null, 'sha256' => null];
+        }
+
+        $sha256 = hash_file('sha256', $file) ?: null;
+        $expectedSha256 = $this->normalizeSha256($expectedSha256);
+        if ($expectedSha256 !== null && $sha256 !== $expectedSha256) {
+            $errors[] = ucfirst($label).' SHA-256 does not match expected artifact SHA.';
+        }
+
+        try {
+            $payload = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            $errors[] = ucfirst($label).' file must be valid JSON.';
+
+            return ['payload' => null, 'sha256' => $sha256];
+        }
+
+        if (! is_array($payload)) {
+            $errors[] = ucfirst($label).' JSON must be an object.';
+
+            return ['payload' => null, 'sha256' => $sha256];
+        }
+
+        return ['payload' => $payload, 'sha256' => $sha256];
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @param  list<string>  $errors
+     */
+    private function validateApprovalManifest(array $manifest, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
+    {
+        if ($manifest === []) {
+            return;
+        }
+
+        if (($manifest['final_conclusion'] ?? null) !== 'AI_IMPACT_V5_EDITORIAL_REVIEW_PASS') {
+            $errors[] = 'Approval manifest final_conclusion must be AI_IMPACT_V5_EDITORIAL_REVIEW_PASS.';
+        }
+
+        if (($manifest['next_allowed_transition'] ?? null) !== CareerJobAiImpactAsset::STATUS_APPROVED) {
+            $errors[] = 'Approval manifest next_allowed_transition must be approved.';
+        }
+
+        if ((bool) ($manifest['production_import_allowed'] ?? true)) {
+            $errors[] = 'Approval manifest must not allow production import.';
+        }
+
+        if ((int) ($manifest['approved_rows'] ?? -1) !== $expectedRows) {
+            $errors[] = "Approval manifest approved_rows must be {$expectedRows}.";
+        }
+
+        if ((int) ($manifest['rejected_rows'] ?? -1) !== 0) {
+            $errors[] = 'Approval manifest rejected_rows must be 0.';
+        }
+
+        if ((int) ($manifest['unique_slugs'] ?? -1) !== $expectedSlugs) {
+            $errors[] = "Approval manifest unique_slugs must be {$expectedSlugs}.";
+        }
+
+        $manifestAssetSha = $this->normalizeSha256((string) ($manifest['final_repaired_asset_sha256'] ?? ''))
+            ?? $this->normalizeSha256((string) (($manifest['required_for_approved_transition']['asset_sha256'] ?? '') ?: ''));
+        if ($assetSha256 !== null && $manifestAssetSha !== $assetSha256) {
+            $errors[] = 'Approval manifest asset SHA does not match the source JSONL SHA.';
+        }
+
+        $required = is_array($manifest['required_for_approved_transition'] ?? null)
+            ? $manifest['required_for_approved_transition']
+            : [];
+        if ($required !== []) {
+            if ((int) ($required['row_count'] ?? -1) !== $expectedRows) {
+                $errors[] = "Approval manifest required row_count must be {$expectedRows}.";
+            }
+
+            if ((int) ($required['slug_count'] ?? -1) !== $expectedSlugs) {
+                $errors[] = "Approval manifest required slug_count must be {$expectedSlugs}.";
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @param  list<string>  $errors
+     */
+    private function validateEditorialReviewReport(array $report, ?string $assetSha256, int $expectedRows, int $expectedSlugs, array &$errors): void
+    {
+        if ($report === []) {
+            return;
+        }
+
+        if (($report['final_conclusion'] ?? null) !== 'AI_IMPACT_V5_EDITORIAL_REVIEW_PASS') {
+            $errors[] = 'Editorial review final_conclusion must be AI_IMPACT_V5_EDITORIAL_REVIEW_PASS.';
+        }
+
+        $metrics = is_array($report['metrics'] ?? null) ? $report['metrics'] : [];
+        if ((int) ($metrics['asset_rows'] ?? -1) !== $expectedRows) {
+            $errors[] = "Editorial review asset_rows must be {$expectedRows}.";
+        }
+
+        if ((int) ($metrics['unique_slugs'] ?? -1) !== $expectedSlugs) {
+            $errors[] = "Editorial review unique_slugs must be {$expectedSlugs}.";
+        }
+
+        if ((int) ($metrics['findings'] ?? -1) !== 0) {
+            $errors[] = 'Editorial review findings must be 0.';
+        }
+
+        if ((int) ($metrics['rejected_rows'] ?? -1) !== 0) {
+            $errors[] = 'Editorial review rejected_rows must be 0.';
+        }
+
+        $inputs = is_array($report['inputs'] ?? null) ? $report['inputs'] : [];
+        $reportAssetSha = $this->normalizeSha256((string) (($inputs['final_repaired_asset_sha256'] ?? '') ?: ''));
+        if ($assetSha256 !== null && $reportAssetSha !== $assetSha256) {
+            $errors[] = 'Editorial review asset SHA does not match the source JSONL SHA.';
+        }
+
+        $guarantees = is_array($report['guarantees'] ?? null) ? $report['guarantees'] : [];
+        if ((bool) ($guarantees['no_production_import'] ?? false) !== true) {
+            $errors[] = 'Editorial review must guarantee no production import.';
+        }
     }
 
     /**

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -42,7 +42,11 @@ final class CareerAiImpactAssetPreviewService
             ->where('career_job_slug', $normalizedSlug)
             ->where('locale', $normalizedLocale)
             ->where('asset_version', CareerJobAiImpactAsset::ASSET_VERSION_V5)
-            ->where('status', CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW)
+            ->whereIn('status', [
+                CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW,
+                CareerJobAiImpactAsset::STATUS_APPROVED,
+            ])
             ->where('preview_allowlisted', true)
             ->first();
     }

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -233,6 +233,154 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertStringContainsString('Only staging_preview status is supported', implode(' ', $decoded['errors']));
     }
 
+    public function test_importer_force_approved_requires_explicit_manifest_and_confirmation(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-approved-requires-manifest.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['approved_transition_performed']);
+        $this->assertStringContainsString('--confirm-approved-transition is required', implode(' ', $decoded['errors']));
+
+        $missingArtifactReport = storage_path('framework/testing/ai-impact-approved-requires-artifacts.json');
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            '--confirm-approved-transition' => true,
+            '--output' => $missingArtifactReport,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($missingArtifactReport), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['approved_transition_performed']);
+        $this->assertStringContainsString('Approval manifest file is required', implode(' ', $decoded['errors']));
+        $this->assertStringContainsString('Editorial review report file is required', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_force_approved_marks_existing_reviewed_rows_without_touching_production(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors', 'actuaries']);
+        $this->seedCareerJobBundleAuthorities(['accountants-and-auditors', 'actuaries']);
+
+        $zhRow = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $enRow = $this->assetRow('accountants-and-auditors', 'en');
+        $file = $this->writeJsonl([$zhRow, $enRow]);
+        $assetSha = hash_file('sha256', $file);
+        $approvalManifest = $this->writeJsonArtifact($this->approvalManifest($assetSha, 2, 1));
+        $editorialReview = $this->writeJsonArtifact($this->editorialReviewReport($assetSha, 2, 1));
+        $approvalSha = hash_file('sha256', $approvalManifest);
+        $editorialSha = hash_file('sha256', $editorialReview);
+
+        $occupation = Occupation::query()->where('canonical_slug', 'accountants-and-auditors')->firstOrFail();
+        foreach ([$zhRow, $enRow] as $row) {
+            CareerJobAiImpactAsset::query()->create([
+                'occupation_id' => $occupation->id,
+                'career_job_slug' => 'accountants-and-auditors',
+                'locale' => $row['locale'],
+                'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                'status' => CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $row,
+                'sources_json' => $row['sources'],
+                'evidence_used_json' => $row['evidence_used'],
+                'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+                'audit_fields_json' => $row['audit_fields'],
+                'asset_row_hash' => $row['audit_fields']['row_hash'],
+                'source_artifact_sha256' => $assetSha,
+            ]);
+        }
+
+        $productionOccupation = Occupation::query()->where('canonical_slug', 'actuaries')->firstOrFail();
+        $productionRow = $this->assetRow('actuaries', 'en');
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $productionOccupation->id,
+            'career_job_slug' => 'actuaries',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            'preview_allowlisted' => false,
+            'asset_payload_json' => $productionRow,
+            'sources_json' => $productionRow['sources'],
+            'evidence_used_json' => $productionRow['evidence_used'],
+            'derived_from_synthesis_json' => $productionRow['derived_from_synthesis'],
+            'audit_fields_json' => $productionRow['audit_fields'],
+            'asset_row_hash' => $productionRow['audit_fields']['row_hash'],
+        ]);
+
+        $report = storage_path('framework/testing/ai-impact-approved-transition.json');
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            '--confirm-approved-transition' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalSha,
+            '--editorial-review-report' => $editorialReview,
+            '--editorial-review-sha256' => $editorialSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 3);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+        ]);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+        ]);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'actuaries',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+        ]);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('approved_transition', $decoded['mode']);
+        $this->assertSame(2, $decoded['approved_count']);
+        $this->assertSame(0, $decoded['production_rows_touched']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertTrue((bool) $decoded['rollback_report']['available']);
+        $this->assertSame([CareerJobAiImpactAsset::STATUS_EDITORIAL_REVIEW => 2], $decoded['rollback_report']['previous_status_counts']);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('ai_impact_asset_v1.evidence_used')
+            ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
+    }
+
     public function test_importer_dry_run_rejects_unexpected_source_sha(): void
     {
         $this->seedCareerJobBundleAuthority('accountants-and-auditors');
@@ -594,6 +742,67 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         )));
 
         return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJsonArtifact(array $payload): string
+    {
+        $path = storage_path('framework/testing/ai-impact-artifact-'.bin2hex(random_bytes(4)).'.json');
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        file_put_contents($path, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT).PHP_EOL);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function approvalManifest(string $assetSha, int $rows, int $slugs): array
+    {
+        return [
+            'schema_version' => 'career_ai_impact_v5_approval_manifest_v1',
+            'final_conclusion' => 'AI_IMPACT_V5_EDITORIAL_REVIEW_PASS',
+            'production_import_allowed' => false,
+            'next_allowed_transition' => CareerJobAiImpactAsset::STATUS_APPROVED,
+            'approved_rows' => $rows,
+            'rejected_rows' => 0,
+            'unique_slugs' => $slugs,
+            'final_repaired_asset_sha256' => $assetSha,
+            'required_for_approved_transition' => [
+                'asset_sha256' => $assetSha,
+                'row_count' => $rows,
+                'slug_count' => $slugs,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function editorialReviewReport(string $assetSha, int $rows, int $slugs): array
+    {
+        return [
+            'schema_version' => 'career_ai_impact_v5_editorial_review_package_v1',
+            'final_conclusion' => 'AI_IMPACT_V5_EDITORIAL_REVIEW_PASS',
+            'inputs' => [
+                'final_repaired_asset_sha256' => $assetSha,
+            ],
+            'metrics' => [
+                'asset_rows' => $rows,
+                'unique_slugs' => $slugs,
+                'findings' => 0,
+                'rejected_rows' => 0,
+            ],
+            'guarantees' => [
+                'no_production_import' => true,
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
## What changed
- Extend the AI Impact v5 importer with an explicit approved transition path.
- Require an approval manifest, editorial review report, artifact SHA checks, row/slug counts, and explicit confirmation before rows can be marked approved.
- Keep production import unsupported and report production rows touched as an invariant.
- Allow reader-safe preview API projection for staging_preview, editorial_review, and approved rows while still fail-closing production_imported rows.
- Add feature tests for missing approval artifacts, approved transition, rollback reporting, and production-row immutability.

## Why
This is the next AI Impact v5 staging-to-production gate: move already editorial-reviewed staging rows to approved without importing production.

## Validation
- php -l app/Console/Commands/CareerImportAiImpactAssetsPreview.php
- php -l app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
- php -l app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
- php -l tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
- ./vendor/bin/pint --no-interaction app/Console/Commands/CareerImportAiImpactAssetsPreview.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
- php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
- git diff --check

## Deferred
- No production import.
- No staging write performed by this PR.
- No frontend/runtime page changes.
- No AI Impact asset content changes.