### PR TITLE
Enable AI Impact v5 production import ops gate

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -17,13 +17,14 @@ final class CareerImportAiImpactAssetsPreview extends Command
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
         {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
         {--confirm-approved-transition : Explicitly confirm that --force may mark validated rows as approved}
+        {--confirm-production-import : Explicitly confirm that --force may import validated, approved AI Impact rows into production_imported}
         {--approval-manifest= : Approval manifest JSON produced by the editorial review package}
         {--approval-manifest-sha256= : Optional expected SHA-256 for the approval manifest}
         {--editorial-review-report= : Editorial review JSON report that authorizes the approved transition}
         {--editorial-review-sha256= : Optional expected SHA-256 for the editorial review report}
         {--dry-run : Validate only; do not write staging or production rows}
-        {--force : Write rows only when --status=staging_preview or perform explicit approved transition when --status=approved}
-        {--status=staging_preview : Target import status; staging_preview and approved are supported; production_imported is never supported here}
+        {--force : Write rows only when --status=staging_preview, perform explicit approved transition, or perform explicit production import}
+        {--status=staging_preview : Target import status; staging_preview, approved, and production_imported are supported through their explicit gates}
         {--json : Emit machine-readable JSON report}
         {--output= : Optional report output path}';
 
@@ -80,6 +81,18 @@ final class CareerImportAiImpactAssetsPreview extends Command
                     trim((string) $this->option('editorial-review-report')),
                     trim((string) $this->option('editorial-review-sha256')) ?: null,
                     (bool) $this->option('confirm-approved-transition'),
+                );
+            } elseif ($force && $status === 'production_imported') {
+                $report = $this->importService->importApprovedAssetsToProduction(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                    trim((string) $this->option('approval-manifest')),
+                    trim((string) $this->option('approval-manifest-sha256')) ?: null,
+                    trim((string) $this->option('editorial-review-report')),
+                    trim((string) $this->option('editorial-review-sha256')) ?: null,
+                    (bool) $this->option('confirm-production-import'),
                 );
             } else {
                 $report = $force

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -33,8 +33,9 @@ final class CareerAiImpactAssetImportService
         ?array $requestedSlugs = null,
         ?string $expectedSha256 = null,
         bool $allSlugsFromFile = false,
+        bool $enforcePreviewAllowlist = true,
     ): array {
-        $report = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile);
+        $report = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile, $enforcePreviewAllowlist);
         $errors = [];
 
         if (! is_file($file) || ! is_readable($file)) {
@@ -109,7 +110,7 @@ final class CareerAiImpactAssetImportService
 
         $targetSlugs = $allSlugsFromFile
             ? array_values(array_keys($slugsFromFile))
-            : $this->targetSlugs($requestedSlugs, $errors);
+            : $this->targetSlugs($requestedSlugs, $errors, $enforcePreviewAllowlist);
 
         $sourceFileSha256 = hash_file('sha256', $file) ?: null;
         $expectedSha256 = $this->normalizeSha256($expectedSha256);
@@ -169,6 +170,7 @@ final class CareerAiImpactAssetImportService
             'state_machine' => $this->stateMachine->report(),
             'target_slugs' => $targetSlugs,
             'all_slugs_from_file' => $allSlugsFromFile,
+            'preview_allowlist_enforced' => $enforcePreviewAllowlist,
             'career_job_bundle_authority' => $authorityReport,
             'projection_safety_gate' => $projectionSafetyReport,
             'production_import_allowed' => false,
@@ -543,6 +545,251 @@ final class CareerAiImpactAssetImportService
     }
 
     /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function importApprovedAssetsToProduction(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        string $approvalManifestFile = '',
+        ?string $expectedApprovalManifestSha256 = null,
+        string $editorialReviewReportFile = '',
+        ?string $expectedEditorialReviewSha256 = null,
+        bool $confirmed = false,
+    ): array {
+        $baseReport = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile);
+        if (! $confirmed) {
+            return array_merge($baseReport, [
+                'mode' => 'production_import',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'errors' => ['--confirm-production-import is required to import AI impact assets into production.'],
+            ]);
+        }
+
+        if ($this->normalizeSha256($expectedSha256) === null) {
+            return array_merge($baseReport, [
+                'mode' => 'production_import',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'errors' => ['--expected-sha256 with the approved asset artifact SHA is required for production import.'],
+            ]);
+        }
+
+        $validation = $this->validateFile($file, $requestedSlugs, $expectedSha256, $allSlugsFromFile, false);
+        if (($validation['decision'] ?? null) !== 'pass') {
+            return array_merge($validation, [
+                'mode' => 'production_import',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'write_skipped_reason' => 'validation_failed',
+            ]);
+        }
+
+        $errors = [];
+        $sourceFileSha256 = is_string($validation['source_file_sha256'] ?? null)
+            ? (string) $validation['source_file_sha256']
+            : null;
+        $targetSlugs = array_values(array_map('strval', (array) ($validation['target_slugs'] ?? [])));
+        $expectedRows = (int) ($validation['expected_preview_rows'] ?? (count($targetSlugs) * 2));
+        $targetSlugCount = count($targetSlugs);
+
+        $approvalArtifact = $this->readJsonArtifact($approvalManifestFile, $expectedApprovalManifestSha256, 'approval manifest', $errors);
+        $editorialArtifact = $this->readJsonArtifact($editorialReviewReportFile, $expectedEditorialReviewSha256, 'editorial review report', $errors);
+        $approvalManifest = is_array($approvalArtifact['payload'] ?? null) ? $approvalArtifact['payload'] : [];
+        $editorialReview = is_array($editorialArtifact['payload'] ?? null) ? $editorialArtifact['payload'] : [];
+
+        $this->validateApprovalManifest($approvalManifest, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+        $this->validateEditorialReviewReport($editorialReview, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+
+        $assetVersion = CareerJobAiImpactAsset::ASSET_VERSION_V5;
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $targetKeys[$slug.'|'.$locale] = ['slug' => $slug, 'locale' => $locale];
+            }
+        }
+
+        $existingRows = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->get();
+
+        $existingByKey = [];
+        foreach ($existingRows as $asset) {
+            $existingByKey[$asset->career_job_slug.'|'.$asset->locale] = $asset;
+        }
+
+        $rollbackRows = [];
+        $previousStatusCounts = [];
+        foreach ($targetKeys as $key => $target) {
+            $asset = $existingByKey[$key] ?? null;
+            $previousStatus = $asset instanceof CareerJobAiImpactAsset ? (string) $asset->status : 'missing';
+            $previousStatusCounts[$previousStatus] = (int) ($previousStatusCounts[$previousStatus] ?? 0) + 1;
+
+            if ($asset instanceof CareerJobAiImpactAsset) {
+                if (! in_array($previousStatus, [
+                    CareerJobAiImpactAsset::STATUS_APPROVED,
+                    CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                ], true)) {
+                    $errors[] = "{$target['slug']}/{$target['locale']}: production import requires approved source rows or an empty production target, found {$previousStatus}.";
+                }
+
+                if (is_string($asset->source_artifact_sha256) && $sourceFileSha256 !== null && $asset->source_artifact_sha256 !== $sourceFileSha256) {
+                    $errors[] = "{$target['slug']}/{$target['locale']}: existing source artifact SHA does not match the approved production artifact SHA.";
+                }
+            }
+
+            $rollbackRows[] = [
+                'slug' => $target['slug'],
+                'locale' => $target['locale'],
+                'previous_status' => $previousStatus,
+                'new_status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($validation, [
+                'mode' => 'production_import',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                ],
+                'errors' => $errors,
+            ]);
+        }
+
+        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys));
+        $importRunId = (string) Str::uuid();
+        $writtenCount = 0;
+        $createdCount = 0;
+        $updatedCount = 0;
+        $writtenRows = [];
+
+        DB::transaction(function () use (
+            $targetRows,
+            $assetVersion,
+            $sourceFileSha256,
+            $importRunId,
+            &$writtenCount,
+            &$createdCount,
+            &$updatedCount,
+            &$writtenRows
+        ): void {
+            foreach ($targetRows as $key => $row) {
+                $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+                $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+                $occupation = Occupation::query()->where('canonical_slug', $slug)->first();
+                if (! $occupation instanceof Occupation) {
+                    continue;
+                }
+
+                $existing = CareerJobAiImpactAsset::query()
+                    ->where('career_job_slug', $slug)
+                    ->where('locale', $locale)
+                    ->where('asset_version', $assetVersion)
+                    ->first();
+
+                CareerJobAiImpactAsset::query()->updateOrCreate(
+                    [
+                        'career_job_slug' => $slug,
+                        'locale' => $locale,
+                        'asset_version' => $assetVersion,
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                        'preview_allowlisted' => false,
+                        'asset_payload_json' => $row,
+                        'sources_json' => is_array($row['sources'] ?? null) ? $row['sources'] : null,
+                        'evidence_used_json' => is_array($row['evidence_used'] ?? null) ? $row['evidence_used'] : null,
+                        'derived_from_synthesis_json' => is_array($row['derived_from_synthesis'] ?? null) ? $row['derived_from_synthesis'] : null,
+                        'audit_fields_json' => is_array($row['audit_fields'] ?? null) ? $row['audit_fields'] : null,
+                        'asset_row_hash' => (string) (($row['audit_fields']['row_hash'] ?? '') ?: hash('sha256', json_encode($row, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '')),
+                        'source_artifact_sha256' => $sourceFileSha256,
+                        'evidence_artifact_sha256' => null,
+                        'synthesis_artifact_sha256' => null,
+                        'import_run_id' => $importRunId,
+                    ],
+                );
+
+                $writtenCount++;
+                if ($existing instanceof CareerJobAiImpactAsset) {
+                    $updatedCount++;
+                } else {
+                    $createdCount++;
+                }
+
+                $writtenRows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                    'operation' => $existing instanceof CareerJobAiImpactAsset ? 'updated' : 'created',
+                    'key' => $key,
+                ];
+            }
+        });
+
+        $productionImportedCount = CareerJobAiImpactAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)
+            ->count();
+        $decision = $writtenCount === $expectedRows && $productionImportedCount === $expectedRows ? 'pass' : 'fail';
+
+        return array_merge($validation, [
+            'mode' => 'production_import',
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            'decision' => $decision,
+            'approved_transition_performed' => false,
+            'production_import_allowed' => true,
+            'production_import_performed' => true,
+            'staging_write_performed' => false,
+            'import_run_id' => $importRunId,
+            'approval_manifest_file' => $approvalManifestFile,
+            'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+            'editorial_review_report_file' => $editorialReviewReportFile,
+            'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+            'written_count' => $writtenCount,
+            'created_count' => $createdCount,
+            'updated_count' => $updatedCount,
+            'expected_written_count' => $expectedRows,
+            'production_imported_count' => $productionImportedCount,
+            'production_rows_touched' => $writtenCount,
+            'written_rows' => $writtenRows,
+            'rollback_report' => [
+                'available' => true,
+                'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                'previous_status_counts' => $previousStatusCounts,
+                'rows' => $rollbackRows,
+                'rollback_sql_intent' => 'Restore each row to previous_status, or delete rows whose previous_status was missing, by career_job_slug, locale, asset_version, and import_run_id if rollback is required.',
+            ],
+            'errors' => $decision === 'pass' ? [] : ['Production import row count invariant failed.'],
+        ]);
+    }
+
+    /**
      * @param  list<string>  $targetSlugs
      * @return array{checked_slug_count: int, ready_slug_count: int, rows: list<array<string, mixed>>}
      */
@@ -748,22 +995,30 @@ final class CareerAiImpactAssetImportService
      * @param  list<string>|null  $requestedSlugs
      * @return array<string, mixed>
      */
-    private function baseReport(string $file, ?array $requestedSlugs, bool $allSlugsFromFile): array
-    {
+    private function baseReport(
+        string $file,
+        ?array $requestedSlugs,
+        bool $allSlugsFromFile,
+        bool $enforcePreviewAllowlist = true,
+    ): array {
         return [
             'importer_version' => self::IMPORTER_VERSION,
             'asset_version' => 'career_risk_future_ai_impact_v5',
-            'status_policy' => 'dry_run_staging_preview_or_approved_transition_only_for_this_contract',
+            'status_policy' => 'dry_run_staging_preview_approved_transition_or_explicit_production_import',
             'production_import_allowed' => false,
             'production_import_gate' => [
-                'allowed' => false,
+                'allowed' => true,
                 'required_from_status' => 'approved',
-                'current_command_supports_production_import' => false,
+                'current_command_supports_production_import' => true,
+                'requires_confirm_production_import' => true,
+                'requires_exact_source_sha256' => true,
+                'requires_editorial_approval_artifacts' => true,
             ],
             'staging_write_supported' => true,
             'source_file' => $file,
             'requested_slugs' => $requestedSlugs,
             'all_slugs_from_file' => $allSlugsFromFile,
+            'preview_allowlist_enforced' => $enforcePreviewAllowlist,
         ];
     }
 
@@ -911,7 +1166,7 @@ final class CareerAiImpactAssetImportService
      * @param  list<string>  $errors
      * @return list<string>
      */
-    private function targetSlugs(?array $requestedSlugs, array &$errors): array
+    private function targetSlugs(?array $requestedSlugs, array &$errors, bool $enforcePreviewAllowlist = true): array
     {
         $allowlist = $this->previewService->previewSlugs();
         $target = $requestedSlugs === null || $requestedSlugs === []
@@ -921,9 +1176,11 @@ final class CareerAiImpactAssetImportService
                 $requestedSlugs
             )));
 
-        foreach ($target as $slug) {
-            if (! in_array($slug, $allowlist, true)) {
-                $errors[] = "{$slug}: slug is not in the AI Impact staging preview allowlist.";
+        if ($enforcePreviewAllowlist) {
+            foreach ($target as $slug) {
+                if (! in_array($slug, $allowlist, true)) {
+                    $errors[] = "{$slug}: slug is not in the AI Impact staging preview allowlist.";
+                }
             }
         }
 
@@ -953,7 +1210,50 @@ final class CareerAiImpactAssetImportService
             'dry_run_writes_database' => false,
             'staging_preview_write_supported_in_this_pr' => true,
             'production_import_requires_approved_status' => true,
+            'production_import_requires_exact_artifact_sha' => true,
+            'production_import_requires_explicit_confirmation' => true,
         ];
+    }
+
+    /**
+     * @param  list<string>  $targetKeys
+     * @return array<string, array<string, mixed>>
+     */
+    private function targetRowsFromFile(string $file, array $targetKeys): array
+    {
+        $targetKeyMap = array_fill_keys($targetKeys, true);
+        $rows = [];
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return $rows;
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            $key = $slug.'|'.$locale;
+            if (isset($targetKeyMap[$key])) {
+                $rows[$key] = $row;
+            }
+        }
+
+        fclose($handle);
+
+        return $rows;
     }
 
     private function normalizeSha256(?string $value): ?string

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -34,7 +34,22 @@ final class CareerAiImpactAssetPreviewService
         $normalizedSlug = $this->normalizeSlug($slug);
         $normalizedLocale = $this->normalizePreviewLocale($locale);
 
-        if ($normalizedLocale === null || ! $this->previewEnabled()) {
+        if ($normalizedLocale === null) {
+            return null;
+        }
+
+        $productionAsset = CareerJobAiImpactAsset::query()
+            ->where('career_job_slug', $normalizedSlug)
+            ->where('locale', $normalizedLocale)
+            ->where('asset_version', CareerJobAiImpactAsset::ASSET_VERSION_V5)
+            ->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)
+            ->first();
+
+        if ($productionAsset instanceof CareerJobAiImpactAsset) {
+            return $productionAsset;
+        }
+
+        if (! $this->previewEnabled()) {
             return null;
         }
 

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -229,8 +229,8 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame('fail', $decoded['decision']);
         $this->assertFalse((bool) $decoded['production_import_allowed']);
-        $this->assertFalse((bool) $decoded['staging_write_performed']);
-        $this->assertStringContainsString('Only staging_preview status is supported', implode(' ', $decoded['errors']));
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('--confirm-production-import is required', implode(' ', $decoded['errors']));
     }
 
     public function test_importer_force_approved_requires_explicit_manifest_and_confirmation(): void
@@ -379,6 +379,177 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertJsonPath('ai_impact_asset_v1.slug', 'accountants-and-auditors')
             ->assertJsonMissingPath('ai_impact_asset_v1.evidence_used')
             ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
+    }
+
+    public function test_importer_force_production_import_requires_confirmation_and_artifacts(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $this->assetRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/ai-impact-production-import-requires-confirmation.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('--confirm-production-import is required', implode(' ', $decoded['errors']));
+
+        $missingArtifactReport = storage_path('framework/testing/ai-impact-production-import-requires-artifacts.json');
+        $assetSha = hash_file('sha256', $file);
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--output' => $missingArtifactReport,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 0);
+        $decoded = json_decode((string) file_get_contents($missingArtifactReport), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('Approval manifest file is required', implode(' ', $decoded['errors']));
+        $this->assertStringContainsString('Editorial review report file is required', implode(' ', $decoded['errors']));
+    }
+
+    public function test_importer_force_production_import_writes_approved_package_and_serves_public_payload(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', false);
+        Config::set('career_ai_impact_assets.preview_slugs', []);
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+
+        $zhRow = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $enRow = $this->assetRow('accountants-and-auditors', 'en');
+        $file = $this->writeJsonl([$zhRow, $enRow]);
+        $assetSha = hash_file('sha256', $file);
+        $approvalManifest = $this->writeJsonArtifact($this->approvalManifest($assetSha, 2, 1));
+        $editorialReview = $this->writeJsonArtifact($this->editorialReviewReport($assetSha, 2, 1));
+        $approvalSha = hash_file('sha256', $approvalManifest);
+        $editorialSha = hash_file('sha256', $editorialReview);
+        $report = storage_path('framework/testing/ai-impact-production-import.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalSha,
+            '--editorial-review-report' => $editorialReview,
+            '--editorial-review-sha256' => $editorialSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_ai_impact_assets', 2);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            'preview_allowlisted' => false,
+            'source_artifact_sha256' => $assetSha,
+        ]);
+        $this->assertDatabaseHas('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            'preview_allowlisted' => false,
+            'source_artifact_sha256' => $assetSha,
+        ]);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('production_import', $decoded['mode']);
+        $this->assertTrue((bool) $decoded['production_import_allowed']);
+        $this->assertTrue((bool) $decoded['production_import_performed']);
+        $this->assertSame(2, $decoded['written_count']);
+        $this->assertSame(2, $decoded['created_count']);
+        $this->assertSame(0, $decoded['updated_count']);
+        $this->assertSame(2, $decoded['production_imported_count']);
+        $this->assertSame(['missing' => 2], $decoded['rollback_report']['previous_status_counts']);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('preview', true)
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('ai_impact_asset_v1.audit_fields')
+            ->assertJsonMissingPath('ai_impact_asset_v1.evidence_used')
+            ->assertJsonMissingPath('ai_impact_asset_v1.derived_from_synthesis')
+            ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
+    }
+
+    public function test_importer_force_production_import_rejects_unapproved_existing_rows(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'en');
+        $file = $this->writeJsonl([
+            $this->assetRow('accountants-and-auditors', 'zh-CN'),
+            $row,
+        ]);
+        $assetSha = hash_file('sha256', $file);
+        $approvalManifest = $this->writeJsonArtifact($this->approvalManifest($assetSha, 2, 1));
+        $editorialReview = $this->writeJsonArtifact($this->editorialReviewReport($assetSha, 2, 1));
+        $occupation = Occupation::query()->where('canonical_slug', 'accountants-and-auditors')->firstOrFail();
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+            'source_artifact_sha256' => $assetSha,
+        ]);
+
+        $report = storage_path('framework/testing/ai-impact-production-import-rejects-staging.json');
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--editorial-review-report' => $editorialReview,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseMissing('career_job_ai_impact_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'en',
+            'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+        ]);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('production import requires approved source rows or an empty production target', implode(' ', $decoded['errors']));
     }
 
     public function test_importer_dry_run_rejects_unexpected_source_sha(): void


### PR DESCRIPTION
## What changed
- Adds an explicit `production_imported` path to the AI Impact v5 importer behind `--confirm-production-import` and exact source SHA validation.
- Keeps staging preview and approved transition gates separate; production import requires the approved asset artifact plus editorial approval artifacts.
- Makes the AI Impact asset API prefer `production_imported` rows while preserving reader-safe projection and internal lineage stripping.
- Extends feature coverage for production confirmation, artifact requirements, production writes, public payload projection, and rejection of unapproved existing rows.

## Why
The 1046 AI Impact v5 production import has exact user approval for SHA `f22e0266f9b8aa904b00466c9cf751efa72835aebcee41c959d454ffacf96a92`, but the current importer intentionally supports only staging preview and approved transition. This PR adds the narrow production ops gate needed before the approved artifact can be imported.

## Validation
- `php -l backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php && php -l backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php && php -l backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php && php -l backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `./vendor/bin/pint --no-interaction app/Console/Commands/CareerImportAiImpactAssetsPreview.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`

## Deferred
- Does not run production import in this PR.
- Does not modify frontend rendering, sitemap, llms, canonical, noindex, or JSON-LD.
- Does not change AI Impact content assets or production data.
