### PR TITLE
SEO-GSC-LIVE-READONLY-ADAPTER-01: add GSC live readonly adapter preflight

### DIFF
--- a/backend/app/Console/Commands/SeoIntelCollectCommand.php
+++ b/backend/app/Console/Commands/SeoIntelCollectCommand.php
@@ -17,7 +17,8 @@ final class SeoIntelCollectCommand extends Command
         {--limit= : Bound collectors that support deterministic canaries}
         {--locale= : Filter collectors that support locale scoping}
         {--page-type= : Filter collectors that support page entity type scoping}
-        {--canary : Use a deterministic bounded canary subset when supported}';
+        {--canary : Use a deterministic bounded canary subset when supported}
+        {--gsc-live-preflight : Run the GSC read-only live adapter credential/readiness preflight without live API calls}';
 
     protected $description = 'Run a disabled-by-default Search Intelligence collector skeleton.';
 
@@ -33,6 +34,7 @@ final class SeoIntelCollectCommand extends Command
             'locale' => $this->option('locale'),
             'page_type' => $this->option('page-type'),
             'canary' => (bool) $this->option('canary'),
+            'gsc_live_preflight' => (bool) $this->option('gsc-live-preflight'),
         ]);
 
         if ((bool) $this->option('json')) {

--- a/backend/app/Services/SeoIntel/Collectors/GscCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/GscCollector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\SeoIntel\Collectors;
 
 use App\Services\SeoIntel\GscDataQualityGate;
+use App\Services\SeoIntel\GscReadonlyLiveAdapter;
 use App\Services\SeoIntel\GscSearchAnalyticsRowNormalizer;
 use App\Services\SeoIntel\SeoIntelCollector;
 use App\Services\SeoIntel\SeoIntelCollectorResult;
@@ -14,6 +15,7 @@ final class GscCollector implements SeoIntelCollector
     public function __construct(
         private readonly GscSearchAnalyticsRowNormalizer $normalizer,
         private readonly GscDataQualityGate $dataQualityGate,
+        private readonly GscReadonlyLiveAdapter $liveAdapter,
     ) {}
 
     public function name(): string
@@ -27,6 +29,33 @@ final class GscCollector implements SeoIntelCollector
     public function collect(array $options = []): SeoIntelCollectorResult
     {
         $dryRun = (bool) ($options['dry_run'] ?? true);
+        if ((bool) ($options['gsc_live_preflight'] ?? false)) {
+            $preflight = $this->liveAdapter->preflight($options);
+            $blocked = ($preflight['status'] ?? 'blocked') !== 'ready';
+
+            return new SeoIntelCollectorResult(
+                collector: $this->name(),
+                status: $blocked ? 'blocked' : 'success',
+                dryRun: $dryRun,
+                writesAttempted: false,
+                writesCommitted: false,
+                externalCallsAttempted: false,
+                itemsSeen: 0,
+                issues: array_values(array_map('strval', $preflight['issues'] ?? [])),
+                metadata: [
+                    'mode' => 'gsc_live_readonly_credential_preflight',
+                    'data_origin_if_executed' => 'live_gsc_api',
+                    'live_readiness' => $preflight,
+                    'opportunity_queue_eligible' => false,
+                    'cms_write_allowed' => false,
+                    'search_channel_enqueue_allowed' => false,
+                    'search_provider_submission_allowed' => false,
+                    'writes_attempted' => false,
+                    'external_calls_attempted' => false,
+                ],
+            );
+        }
+
         $lagDays = (int) config('seo_intel.gsc_backfill_lag_days', 3);
         $windowDays = (int) config('seo_intel.gsc_default_window_days', 28);
         $rows = $this->fixtureRows();

--- a/backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php
+++ b/backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class GscReadonlyLiveAdapter
+{
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    public function preflight(array $options = []): array
+    {
+        $credential = $this->credentialState();
+        $property = $this->propertyUrl();
+        $issues = [];
+
+        if (! (bool) config('seo_intel.gsc_enabled', false)) {
+            $issues[] = 'gsc_enabled_false';
+        }
+
+        if (! (bool) config('seo_intel.gsc_live_api_enabled', false)) {
+            $issues[] = 'gsc_live_api_disabled';
+        }
+
+        if ($property === null) {
+            $issues[] = 'gsc_property_url_missing';
+        }
+
+        if (! $this->externalApiCallsAllowed($options)) {
+            $issues[] = 'external_api_gate_disabled';
+        }
+
+        if (! (bool) $credential['credential_valid']) {
+            $issues = [...$issues, ...$credential['issues']];
+        }
+
+        $issues = array_values(array_unique(array_map('strval', $issues)));
+
+        return [
+            'status' => $issues === [] ? 'ready' : 'blocked',
+            'read_only' => true,
+            'adapter' => 'google_search_console_searchanalytics_readonly',
+            'data_origin_if_executed' => 'live_gsc_api',
+            'property_configured' => $property !== null,
+            'property_hash' => $property === null ? null : hash('sha256', $property),
+            'auth_mode' => $credential['auth_mode'],
+            'credential_source' => $credential['credential_source'],
+            'credential_valid' => $credential['credential_valid'],
+            'credential_checks' => $credential['credential_checks'],
+            'gsc_enabled' => (bool) config('seo_intel.gsc_enabled', false),
+            'gsc_live_api_enabled' => (bool) config('seo_intel.gsc_live_api_enabled', false),
+            'external_api_calls_allowed' => $this->externalApiCallsAllowed($options),
+            'live_read_allowed' => $issues === [],
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'cms_write_allowed' => false,
+            'search_channel_enqueue_allowed' => false,
+            'search_provider_submission_allowed' => false,
+            'indexing_request_allowed' => false,
+            'scheduler_enabled' => false,
+            'queue_worker_enabled' => false,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $request
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    public function fetchSearchAnalyticsRows(array $request, array $options = []): array
+    {
+        $preflight = $this->preflight($options);
+        if (($preflight['status'] ?? 'blocked') !== 'ready') {
+            return [
+                'status' => 'blocked',
+                'rows' => [],
+                'external_calls_attempted' => false,
+                'writes_attempted' => false,
+                'issues' => $preflight['issues'] ?? ['gsc_live_readiness_blocked'],
+                'preflight' => $preflight,
+            ];
+        }
+
+        if (! (bool) ($options['execute_live_read'] ?? false)) {
+            return [
+                'status' => 'blocked',
+                'rows' => [],
+                'external_calls_attempted' => false,
+                'writes_attempted' => false,
+                'issues' => ['live_read_not_explicitly_requested'],
+                'preflight' => $preflight,
+            ];
+        }
+
+        $token = $this->accessToken();
+        if ($token === '') {
+            return [
+                'status' => 'blocked',
+                'rows' => [],
+                'external_calls_attempted' => $this->authMode() === 'service_account',
+                'writes_attempted' => false,
+                'issues' => ['gsc_access_token_resolution_failed'],
+                'preflight' => $preflight,
+            ];
+        }
+
+        $endpoint = sprintf(
+            (string) config('seo_intel.gsc_readonly_adapter.search_analytics_endpoint'),
+            rawurlencode((string) $this->propertyUrl())
+        );
+
+        $payload = $this->safeSearchAnalyticsPayload($request);
+        $response = Http::acceptJson()
+            ->withToken($token)
+            ->timeout(max(1, (int) config('seo_intel.gsc_readonly_adapter.timeout_seconds', 10)))
+            ->post($endpoint, $payload);
+
+        if (! $response->successful()) {
+            return [
+                'status' => 'blocked',
+                'rows' => [],
+                'external_calls_attempted' => true,
+                'writes_attempted' => false,
+                'http_status' => $response->status(),
+                'issues' => ['gsc_searchanalytics_request_failed'],
+                'preflight' => $preflight,
+            ];
+        }
+
+        $rows = $this->rowsFromResponse($response->json());
+
+        return [
+            'status' => 'success',
+            'rows' => $rows,
+            'rows_seen' => count($rows),
+            'external_calls_attempted' => true,
+            'writes_attempted' => false,
+            'http_status' => $response->status(),
+            'preflight' => $preflight,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     auth_mode:string,
+     *     credential_source:string,
+     *     credential_valid:bool,
+     *     credential_checks:array<string,bool>,
+     *     issues:list<string>
+     * }
+     */
+    private function credentialState(): array
+    {
+        $mode = $this->authMode();
+        $checks = [
+            'access_token_present' => $this->accessTokenConfigured(),
+            'service_account_json_present' => $this->serviceAccountJson() !== null,
+            'service_account_client_email_present' => false,
+            'service_account_private_key_present' => false,
+            'token_uri_present' => false,
+        ];
+        $issues = [];
+        $source = 'none';
+
+        if ($mode === 'access_token') {
+            $source = 'access_token_env';
+            if (! $checks['access_token_present']) {
+                $issues[] = 'gsc_access_token_missing';
+            }
+
+            return [
+                'auth_mode' => $mode,
+                'credential_source' => $source,
+                'credential_valid' => $issues === [],
+                'credential_checks' => $checks,
+                'issues' => $issues,
+            ];
+        }
+
+        if ($mode === 'service_account') {
+            $decoded = $this->serviceAccountJson();
+            $source = $this->serviceAccountJsonSource();
+
+            if ($decoded === null) {
+                $issues[] = 'gsc_service_account_json_missing_or_invalid';
+            } else {
+                $checks['service_account_client_email_present'] = $this->nonEmptyString($decoded['client_email'] ?? null);
+                $checks['service_account_private_key_present'] = $this->nonEmptyString($decoded['private_key'] ?? null);
+                $checks['token_uri_present'] = $this->nonEmptyString($decoded['token_uri'] ?? null)
+                    || $this->nonEmptyString(config('seo_intel.gsc_readonly_adapter.token_uri'));
+
+                foreach ([
+                    'service_account_client_email_present' => 'gsc_service_account_client_email_missing',
+                    'service_account_private_key_present' => 'gsc_service_account_private_key_missing',
+                    'token_uri_present' => 'gsc_token_uri_missing',
+                ] as $check => $issue) {
+                    if (! $checks[$check]) {
+                        $issues[] = $issue;
+                    }
+                }
+            }
+
+            return [
+                'auth_mode' => $mode,
+                'credential_source' => $source,
+                'credential_valid' => $issues === [],
+                'credential_checks' => $checks,
+                'issues' => $issues,
+            ];
+        }
+
+        return [
+            'auth_mode' => $mode,
+            'credential_source' => $source,
+            'credential_valid' => false,
+            'credential_checks' => $checks,
+            'issues' => ['gsc_auth_mode_disabled_or_unsupported'],
+        ];
+    }
+
+    private function accessToken(): string
+    {
+        if ($this->authMode() === 'access_token') {
+            return trim((string) config('seo_intel.gsc_readonly_adapter.access_token', ''));
+        }
+
+        $serviceAccount = $this->serviceAccountJson();
+        if ($serviceAccount === null) {
+            return '';
+        }
+
+        $tokenUri = (string) ($serviceAccount['token_uri'] ?? config('seo_intel.gsc_readonly_adapter.token_uri'));
+        $jwt = $this->serviceAccountJwt($serviceAccount, $tokenUri);
+        $response = Http::asForm()
+            ->timeout(max(1, (int) config('seo_intel.gsc_readonly_adapter.timeout_seconds', 10)))
+            ->post($tokenUri, [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => $jwt,
+            ]);
+
+        if (! $response->successful()) {
+            return '';
+        }
+
+        return trim((string) ($response->json('access_token') ?? ''));
+    }
+
+    /**
+     * @param  array<string, mixed>  $serviceAccount
+     */
+    private function serviceAccountJwt(array $serviceAccount, string $tokenUri): string
+    {
+        $now = time();
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'], JSON_THROW_ON_ERROR));
+        $claims = $this->base64UrlEncode(json_encode([
+            'iss' => (string) $serviceAccount['client_email'],
+            'scope' => (string) config('seo_intel.gsc_readonly_adapter.scope'),
+            'aud' => $tokenUri,
+            'iat' => $now,
+            'exp' => $now + 3600,
+        ], JSON_THROW_ON_ERROR));
+        $unsigned = $header.'.'.$claims;
+        $signature = '';
+
+        openssl_sign($unsigned, $signature, (string) $serviceAccount['private_key'], OPENSSL_ALGO_SHA256);
+
+        return $unsigned.'.'.$this->base64UrlEncode($signature);
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function serviceAccountJson(): ?array
+    {
+        $raw = trim((string) config('seo_intel.gsc_readonly_adapter.service_account_json', ''));
+        $path = trim((string) config('seo_intel.gsc_readonly_adapter.service_account_json_path', ''));
+
+        if ($raw === '' && $path !== '' && is_file($path)) {
+            $raw = (string) file_get_contents($path);
+        }
+
+        if (str_starts_with($raw, 'base64:')) {
+            $decoded = base64_decode(substr($raw, 7), true);
+            $raw = is_string($decoded) ? $decoded : '';
+        }
+
+        if ($raw === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function serviceAccountJsonSource(): string
+    {
+        if (trim((string) config('seo_intel.gsc_readonly_adapter.service_account_json', '')) !== '') {
+            return 'service_account_json_env';
+        }
+
+        if (trim((string) config('seo_intel.gsc_readonly_adapter.service_account_json_path', '')) !== '') {
+            return 'service_account_json_path';
+        }
+
+        return 'none';
+    }
+
+    private function authMode(): string
+    {
+        return mb_strtolower(trim((string) config('seo_intel.gsc_readonly_adapter.auth_mode', 'disabled')), 'UTF-8');
+    }
+
+    private function propertyUrl(): ?string
+    {
+        $property = trim((string) config('seo_intel.gsc_property_url', ''));
+
+        return $property === '' ? null : $property;
+    }
+
+    private function accessTokenConfigured(): bool
+    {
+        return trim((string) config('seo_intel.gsc_readonly_adapter.access_token', '')) !== '';
+    }
+
+    private function externalApiCallsAllowed(array $options): bool
+    {
+        if (array_key_exists('allow_external_api_calls', $options)) {
+            return (bool) config('seo_intel.allow_external_api_calls', false)
+                && (bool) $options['allow_external_api_calls'];
+        }
+
+        return (bool) config('seo_intel.allow_external_api_calls', false);
+    }
+
+    private function nonEmptyString(mixed $value): bool
+    {
+        return is_string($value) && trim($value) !== '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     */
+    private function safeSearchAnalyticsPayload(array $request): array
+    {
+        $limit = max(1, min(
+            (int) ($request['rowLimit'] ?? config('seo_intel.gsc_readonly_adapter.default_limit', 250)),
+            (int) config('seo_intel.gsc_readonly_adapter.max_limit', 250)
+        ));
+
+        return [
+            'startDate' => substr((string) ($request['startDate'] ?? now()->subDays(30)->toDateString()), 0, 10),
+            'endDate' => substr((string) ($request['endDate'] ?? now()->subDays(3)->toDateString()), 0, 10),
+            'dimensions' => array_values(array_intersect(
+                is_array($request['dimensions'] ?? null) ? $request['dimensions'] : ['query', 'page'],
+                ['query', 'page', 'country', 'device', 'searchAppearance']
+            )),
+            'type' => 'web',
+            'rowLimit' => $limit,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rowsFromResponse(mixed $payload): array
+    {
+        $rows = is_array($payload) && is_array($payload['rows'] ?? null) ? $payload['rows'] : [];
+
+        return array_values(array_map(static function (array $row): array {
+            $keys = is_array($row['keys'] ?? null) ? array_values($row['keys']) : [];
+
+            return [
+                'query' => isset($keys[0]) ? (string) $keys[0] : null,
+                'page' => isset($keys[1]) ? (string) $keys[1] : null,
+                'clicks' => (int) ($row['clicks'] ?? 0),
+                'impressions' => (int) ($row['impressions'] ?? 0),
+                'ctr' => isset($row['ctr']) ? (float) $row['ctr'] : null,
+                'position' => isset($row['position']) ? (float) $row['position'] : null,
+                'data_origin' => 'live_gsc_api',
+                'row_source' => 'live_gsc_api',
+            ];
+        }, $rows));
+    }
+}

--- a/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
+++ b/backend/app/Services/SeoIntel/SeoIntelCollectorManager.php
@@ -126,6 +126,7 @@ final class SeoIntelCollectorManager
                     new GscQueryClassifier,
                 ),
                 new GscDataQualityGate,
+                new GscReadonlyLiveAdapter,
             );
         }
 

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -7,7 +7,7 @@ return [
     'write_enabled' => env('SEO_INTEL_WRITE_ENABLED', false),
     'collectors_enabled' => env('SEO_INTEL_COLLECTORS_ENABLED', false),
     'dry_run_default' => env('SEO_INTEL_DRY_RUN_DEFAULT', true),
-    'allow_external_api_calls' => false,
+    'allow_external_api_calls' => env('SEO_INTEL_ALLOW_EXTERNAL_API_CALLS', false),
     'allow_production_crawl' => false,
     'allow_production_log_read' => false,
     'allowed_collectors' => [
@@ -205,10 +205,25 @@ return [
         'keyword_purchase_attribution_allowed' => false,
     ],
     'gsc_enabled' => env('SEO_INTEL_GSC_ENABLED', false),
-    'gsc_live_api_enabled' => false,
+    'gsc_live_api_enabled' => env('SEO_INTEL_GSC_LIVE_API_ENABLED', false),
     'gsc_property_url' => env('SEO_INTEL_GSC_PROPERTY_URL', null),
     'gsc_backfill_lag_days' => 3,
     'gsc_default_window_days' => 28,
+    'gsc_readonly_adapter' => [
+        'auth_mode' => env('SEO_INTEL_GSC_AUTH_MODE', 'disabled'),
+        'service_account_json' => env('SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON', ''),
+        'service_account_json_path' => env('SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH', ''),
+        'access_token' => env('SEO_INTEL_GSC_ACCESS_TOKEN', ''),
+        'token_uri' => env('SEO_INTEL_GSC_TOKEN_URI', 'https://oauth2.googleapis.com/token'),
+        'search_analytics_endpoint' => env(
+            'SEO_INTEL_GSC_SEARCH_ANALYTICS_ENDPOINT',
+            'https://searchconsole.googleapis.com/webmasters/v3/sites/%s/searchAnalytics/query'
+        ),
+        'scope' => env('SEO_INTEL_GSC_SCOPE', 'https://www.googleapis.com/auth/webmasters.readonly'),
+        'timeout_seconds' => (int) env('SEO_INTEL_GSC_TIMEOUT_SECONDS', 10),
+        'default_limit' => (int) env('SEO_INTEL_GSC_DEFAULT_LIMIT', 250),
+        'max_limit' => (int) env('SEO_INTEL_GSC_MAX_LIMIT', 250),
+    ],
     'gsc_foundation' => [
         'source_engine' => 'google',
         'brand_query_terms' => [

--- a/backend/docs/seo/generated/gsc-live-readonly-adapter.v1.json
+++ b/backend/docs/seo/generated/gsc-live-readonly-adapter.v1.json
@@ -1,0 +1,67 @@
+{
+  "version": "gsc-live-readonly-adapter.v1",
+  "task": "SEO-GSC-LIVE-READONLY-ADAPTER-01",
+  "type": "runtime_adapter_preflight_contract",
+  "channel": "gsc",
+  "read_only": true,
+  "enabled_by_default": false,
+  "live_api_enabled_by_default": false,
+  "writes_enabled_by_default": false,
+  "preflight_command": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json",
+  "adapter": {
+    "class": "App\\Services\\SeoIntel\\GscReadonlyLiveAdapter",
+    "api": "Google Search Console Search Analytics",
+    "data_origin_if_executed": "live_gsc_api",
+    "requires_explicit_execute_live_read": true,
+    "persists_rows": false
+  },
+  "required_gates": [
+    "seo_intel.gsc_enabled",
+    "seo_intel.gsc_live_api_enabled",
+    "seo_intel.allow_external_api_calls",
+    "seo_intel.gsc_property_url",
+    "seo_intel.gsc_readonly_adapter.auth_mode",
+    "safe_secret_channel_credentials",
+    "execute_live_read"
+  ],
+  "supported_auth_modes": [
+    "access_token",
+    "service_account"
+  ],
+  "safe_secret_sources": [
+    "SEO_INTEL_GSC_ACCESS_TOKEN",
+    "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON",
+    "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH"
+  ],
+  "forbidden_outputs": [
+    "access_token",
+    "private_key",
+    "client_email",
+    "credential_json",
+    "credential_path",
+    "cookie",
+    "session",
+    "raw_ip",
+    "order_id",
+    "attempt_id",
+    "payment_id"
+  ],
+  "negative_guarantees": {
+    "db_writes": false,
+    "cms_write": false,
+    "opportunity_queue_enqueue": false,
+    "search_channel_enqueue": false,
+    "search_channel_approve": false,
+    "search_channel_submit": false,
+    "gsc_url_inspection_request_indexing": false,
+    "gsc_sitemap_submit": false,
+    "baidu_call": false,
+    "indexnow_call": false,
+    "scheduler_enabled": false,
+    "queue_worker_enabled": false,
+    "production_env_edited": false,
+    "sitemap_changed": false,
+    "llms_changed": false
+  },
+  "next_allowed_step": "secure-environment credential preflight; live row import/backfill remains a separate approval"
+}

--- a/backend/docs/seo/gsc-live-readonly-adapter.md
+++ b/backend/docs/seo/gsc-live-readonly-adapter.md
@@ -1,0 +1,66 @@
+# GSC Live Read-only Adapter
+
+Task: `SEO-GSC-LIVE-READONLY-ADAPTER-01`
+
+This PR adds the first backend read-only Google Search Console adapter boundary for FermatMind SEO Agent.
+
+It does not enable live GSC by default, write `seo_intel`, create CMS drafts, enqueue Search Channel records, submit URLs, request indexing, activate schedulers, edit production environment files, or expose credentials.
+
+## Runtime Boundary
+
+Default `gsc_foundation` behavior remains fixture-only unless a caller explicitly asks for the live preflight:
+
+```bash
+php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json
+```
+
+The preflight checks only sanitized readiness facts:
+
+- GSC collector enabled flag
+- GSC live API enabled flag
+- configured GSC property
+- configured auth mode
+- presence and shape of either an access token or service-account credential
+- external API gate configuration
+
+The preflight does not call Google. It never prints access tokens, private keys, client emails, cookies, sessions, raw credential paths, or raw credential JSON.
+
+## Live Read Adapter
+
+`GscReadonlyLiveAdapter` contains a read-only Search Analytics client guarded by all of these gates:
+
+- `seo_intel.gsc_enabled=true`
+- `seo_intel.gsc_live_api_enabled=true`
+- `seo_intel.allow_external_api_calls=true`
+- configured `seo_intel.gsc_property_url`
+- valid `seo_intel.gsc_readonly_adapter.auth_mode`
+- valid credential presence
+- explicit runtime option `execute_live_read=true`
+
+The adapter returns Search Analytics rows only to the caller. It does not persist rows. A later PR must separately approve any import/backfill into `seo_gsc_daily` and must pass `GscDataQualityGate` before opportunity scoring can use live rows.
+
+## Supported Credential Shapes
+
+Allowed safe-secret sources:
+
+- `SEO_INTEL_GSC_AUTH_MODE=access_token` with `SEO_INTEL_GSC_ACCESS_TOKEN`
+- `SEO_INTEL_GSC_AUTH_MODE=service_account` with `SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON`
+- `SEO_INTEL_GSC_AUTH_MODE=service_account` with `SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH`
+
+Credentials must come from a safe secret channel. They must not be committed, printed, logged, pasted into docs, stored in generated artifacts, or exposed in PR bodies.
+
+## Explicit Non-goals
+
+- no CMS write
+- no opportunity queue enqueue
+- no Search Channel enqueue, approve, submit, or retry
+- no GSC URL Inspection request indexing
+- no sitemap submission
+- no Baidu or IndexNow call
+- no scheduler or queue worker activation
+- no production config mutation
+- no GSC-as-URL-Truth behavior
+
+## Next Safe Step
+
+After this PR is merged, the next safe operational step is a credential-side preflight using the command above in a secure environment. If the preflight reports `ready`, a later separately approved PR can add a bounded dry-run import/backfill path that normalizes live rows, writes only when explicitly approved, and keeps `GscDataQualityGate` as the opportunity-queue gate.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\GscReadonlyLiveAdapter;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscLiveReadonlyAdapterTest extends TestCase
+{
+    #[Test]
+    public function gsc_live_preflight_is_blocked_by_default_without_external_calls_or_writes(): void
+    {
+        Http::fake();
+
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'gsc_foundation',
+            '--gsc-live-preflight' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $output = trim(Artisan::output());
+        $decoded = json_decode($output, true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $decoded['status'] ?? null);
+        $this->assertSame('gsc_live_readonly_credential_preflight', data_get($decoded, 'metadata.mode'));
+        $this->assertContains('gsc_enabled_false', $decoded['issues'] ?? []);
+        $this->assertContains('gsc_live_api_disabled', $decoded['issues'] ?? []);
+        $this->assertContains('gsc_property_url_missing', $decoded['issues'] ?? []);
+        $this->assertContains('external_api_gate_disabled', $decoded['issues'] ?? []);
+        $this->assertFalse((bool) ($decoded['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($decoded['writes_attempted'] ?? true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.search_channel_enqueue_allowed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.search_provider_submission_allowed', true));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function gsc_live_preflight_can_be_ready_without_printing_credentials_or_calling_google(): void
+    {
+        Http::fake();
+        $this->enableAccessTokenConfig();
+
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'gsc_foundation',
+            '--gsc-live-preflight' => true,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $output = trim(Artisan::output());
+        $decoded = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $decoded['status'] ?? null);
+        $this->assertSame('ready', data_get($decoded, 'metadata.live_readiness.status'));
+        $this->assertSame('access_token', data_get($decoded, 'metadata.live_readiness.auth_mode'));
+        $this->assertSame('access_token_env', data_get($decoded, 'metadata.live_readiness.credential_source'));
+        $this->assertTrue((bool) data_get($decoded, 'metadata.live_readiness.credential_valid'));
+        $this->assertTrue((bool) data_get($decoded, 'metadata.live_readiness.live_read_allowed'));
+        $this->assertFalse((bool) ($decoded['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($decoded['writes_attempted'] ?? true));
+        $this->assertStringNotContainsString('secret-gsc-token', $output);
+        $this->assertStringNotContainsString('Authorization', $output);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function readonly_adapter_fetches_searchanalytics_rows_only_after_explicit_live_read_gate(): void
+    {
+        $this->enableAccessTokenConfig();
+
+        Http::fake([
+            'searchconsole.googleapis.com/*' => Http::response([
+                'rows' => [
+                    [
+                        'keys' => ['mbti测试', 'https://fermatmind.com/zh/articles/mbti-basics'],
+                        'clicks' => 0,
+                        'impressions' => 6,
+                        'ctr' => 0,
+                        'position' => 9.0,
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $adapter = new GscReadonlyLiveAdapter;
+
+        $blocked = $adapter->fetchSearchAnalyticsRows([
+            'startDate' => '2026-06-01',
+            'endDate' => '2026-06-17',
+            'dimensions' => ['query', 'page'],
+        ], [
+            'allow_external_api_calls' => true,
+        ]);
+
+        $this->assertSame('blocked', $blocked['status'] ?? null);
+        $this->assertContains('live_read_not_explicitly_requested', $blocked['issues'] ?? []);
+        $this->assertFalse((bool) ($blocked['external_calls_attempted'] ?? true));
+        Http::assertNothingSent();
+
+        $result = $adapter->fetchSearchAnalyticsRows([
+            'startDate' => '2026-06-01',
+            'endDate' => '2026-06-17',
+            'dimensions' => ['query', 'page'],
+            'rowLimit' => 500,
+        ], [
+            'allow_external_api_calls' => true,
+            'execute_live_read' => true,
+        ]);
+
+        $this->assertSame('success', $result['status'] ?? null);
+        $this->assertTrue((bool) ($result['external_calls_attempted'] ?? false));
+        $this->assertFalse((bool) ($result['writes_attempted'] ?? true));
+        $this->assertSame(1, $result['rows_seen'] ?? null);
+        $this->assertSame('live_gsc_api', $result['rows'][0]['data_origin'] ?? null);
+        $this->assertSame('https://fermatmind.com/zh/articles/mbti-basics', $result['rows'][0]['page'] ?? null);
+
+        Http::assertSent(function (Request $request): bool {
+            return str_contains($request->url(), 'searchconsole.googleapis.com/webmasters/v3/sites/sc-domain%3Afermatmind.com/searchAnalytics/query')
+                && $request->hasHeader('Authorization', 'Bearer secret-gsc-token')
+                && $request['rowLimit'] === 250
+                && $request['type'] === 'web';
+        });
+    }
+
+    #[Test]
+    public function generated_contract_locks_no_write_no_submission_boundary(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/gsc-live-readonly-adapter.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('gsc-live-readonly-adapter.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GSC-LIVE-READONLY-ADAPTER-01', $artifact['task'] ?? null);
+        $this->assertTrue((bool) ($artifact['read_only'] ?? false));
+        $this->assertFalse((bool) ($artifact['enabled_by_default'] ?? true));
+        $this->assertFalse((bool) ($artifact['live_api_enabled_by_default'] ?? true));
+        $this->assertFalse((bool) ($artifact['writes_enabled_by_default'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.db_writes', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.opportunity_queue_enqueue', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.gsc_url_inspection_request_indexing', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.gsc_sitemap_submit', true));
+    }
+
+    private function enableAccessTokenConfig(): void
+    {
+        config([
+            'seo_intel.gsc_enabled' => true,
+            'seo_intel.gsc_live_api_enabled' => true,
+            'seo_intel.allow_external_api_calls' => true,
+            'seo_intel.gsc_property_url' => 'sc-domain:fermatmind.com',
+            'seo_intel.gsc_readonly_adapter.auth_mode' => 'access_token',
+            'seo_intel.gsc_readonly_adapter.access_token' => 'secret-gsc-token',
+            'seo_intel.gsc_readonly_adapter.default_limit' => 250,
+            'seo_intel.gsc_readonly_adapter.max_limit' => 250,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -881,6 +881,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
@@ -4674,6 +4675,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',


### PR DESCRIPTION
## What changed

- Added `GscReadonlyLiveAdapter` for Google Search Console Search Analytics read-only credential preflight and explicitly gated live reads.
- Added `--gsc-live-preflight` to `seo-intel:collect` for safe readiness output through the existing `gsc_foundation` collector.
- Added env-backed config gates for live GSC reads while keeping defaults disabled.
- Added docs and a generated contract artifact locking the no-write/no-submit boundary.
- Added focused feature tests for default blocked preflight, configured ready preflight, explicit live-read gate, and contract guarantees.
- Updated the BigFive runtime-freeze classifier allowlist so this SeoIntel GSC read-only adapter is treated like existing GSC foundation files.

## Why

This creates the minimum safe bridge from fixture-only GSC foundation work toward real GSC credential readiness. It lets operators prove credentials and gating are configured without writing DB rows, creating CMS drafts, enqueueing opportunity/search work, or submitting anything to providers.

## Validation

- `cd backend && php -l app/Services/SeoIntel/GscReadonlyLiveAdapter.php`
- `cd backend && ./vendor/bin/pint app/Services/SeoIntel/GscReadonlyLiveAdapter.php tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php --no-interaction`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter 'runtime_paths_have_no_uncommitted_diff|seo_intel_gsc_foundation' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel --filter 'Gsc|SeoDashApi01ReadOnlyApiContractTest' --no-ansi`
- `cd backend && php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json --no-ansi`
- `cd backend && SEO_INTEL_GSC_ENABLED=true SEO_INTEL_GSC_LIVE_API_ENABLED=true SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=true SEO_INTEL_GSC_PROPERTY_URL='sc-domain:fermatmind.com' SEO_INTEL_GSC_AUTH_MODE=access_token SEO_INTEL_GSC_ACCESS_TOKEN='redacted-test-token' php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json --no-ansi`
- `cd backend && php artisan route:list --path=seo-intel --no-ansi`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- remote-equivalent BigFive gate locally after the first failed GitHub run: `bash scripts/ci/verify_big5_norms.sh && php -d memory_limit=1024M artisan content:lint --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan content:compile --pack=BIG5_OCEAN --pack-version=v1 && php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi`

## Intentionally deferred

- No DB writes or live GSC row import/backfill.
- No opportunity queue creation or scoring.
- No CMS draft package creation or CMS writes.
- No Search Channel enqueue, approve, submit, retry, IndexNow, Baidu, sitemap submit, or URL indexing request.
- No scheduler, queue worker, route, migration, or production env change.

## Runtime command

```bash
php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json
```
