### PR TITLE
feat(seo-intel): add GSC HK sidecar runner

### DIFF
--- a/backend/app/Console/Commands/SeoIntelCollectCommand.php
+++ b/backend/app/Console/Commands/SeoIntelCollectCommand.php
@@ -18,7 +18,11 @@ final class SeoIntelCollectCommand extends Command
         {--locale= : Filter collectors that support locale scoping}
         {--page-type= : Filter collectors that support page entity type scoping}
         {--canary : Use a deterministic bounded canary subset when supported}
-        {--gsc-live-preflight : Run the GSC read-only live adapter credential/readiness preflight without live API calls}';
+        {--gsc-live-preflight : Run the GSC read-only live adapter credential/readiness preflight without live API calls}
+        {--gsc-live-read : Execute a bounded GSC read-only live read without writes, queues, or submissions}
+        {--start-date= : GSC live read start date, YYYY-MM-DD}
+        {--end-date= : GSC live read end date, YYYY-MM-DD}
+        {--dimensions= : Comma-separated GSC dimensions, default query,page}';
 
     protected $description = 'Run a disabled-by-default Search Intelligence collector skeleton.';
 
@@ -35,6 +39,10 @@ final class SeoIntelCollectCommand extends Command
             'page_type' => $this->option('page-type'),
             'canary' => (bool) $this->option('canary'),
             'gsc_live_preflight' => (bool) $this->option('gsc-live-preflight'),
+            'gsc_live_read' => (bool) $this->option('gsc-live-read'),
+            'start_date' => $this->option('start-date'),
+            'end_date' => $this->option('end-date'),
+            'dimensions' => $this->option('dimensions'),
         ]);
 
         if ((bool) $this->option('json')) {

--- a/backend/app/Services/SeoIntel/Collectors/GscCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/GscCollector.php
@@ -56,6 +56,10 @@ final class GscCollector implements SeoIntelCollector
             );
         }
 
+        if ((bool) ($options['gsc_live_read'] ?? false)) {
+            return $this->collectLiveRead($options, $dryRun);
+        }
+
         $lagDays = (int) config('seo_intel.gsc_backfill_lag_days', 3);
         $windowDays = (int) config('seo_intel.gsc_default_window_days', 28);
         $rows = $this->fixtureRows();
@@ -142,5 +146,126 @@ final class GscCollector implements SeoIntelCollector
                 'position' => 7.5,
             ],
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    private function collectLiveRead(array $options, bool $dryRun): SeoIntelCollectorResult
+    {
+        $request = $this->liveReadRequest($options);
+        $result = $this->liveAdapter->fetchSearchAnalyticsRows($request, [
+            ...$options,
+            'execute_live_read' => true,
+        ]);
+        $rows = is_array($result['rows'] ?? null) ? array_values($result['rows']) : [];
+        $datedRows = array_map(
+            fn (array $row): array => $row + ['date' => $request['endDate']],
+            $rows
+        );
+        $normalized = array_map(fn (array $row): array => $this->normalizer->normalize($row), $datedRows);
+        $qualityGate = $rows === [] ? null : $this->dataQualityGate->evaluate($normalized);
+        $status = (string) ($result['status'] ?? 'blocked');
+
+        return new SeoIntelCollectorResult(
+            collector: $this->name(),
+            status: $status,
+            dryRun: $dryRun,
+            writesAttempted: false,
+            writesCommitted: false,
+            externalCallsAttempted: (bool) ($result['external_calls_attempted'] ?? false),
+            itemsSeen: (int) ($result['rows_seen'] ?? count($rows)),
+            issues: array_values(array_map('strval', $result['issues'] ?? [])),
+            metadata: [
+                'mode' => 'gsc_live_readonly_sidecar_read',
+                'data_origin' => 'live_gsc_api',
+                'date_window' => [
+                    'start_date' => $request['startDate'],
+                    'end_date' => $request['endDate'],
+                ],
+                'dimensions' => $request['dimensions'],
+                'row_limit' => $request['rowLimit'],
+                'rows_seen' => count($rows),
+                'safe_row_preview' => $this->safeRowPreview($normalized),
+                'data_quality_gate' => $qualityGate,
+                'opportunity_queue_eligible' => false,
+                'cms_write_allowed' => false,
+                'search_channel_enqueue_allowed' => false,
+                'search_provider_submission_allowed' => false,
+                'indexing_request_allowed' => false,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'scheduler_enabled' => false,
+                'queue_worker_enabled' => false,
+                'preflight' => $result['preflight'] ?? null,
+                'http_status' => $result['http_status'] ?? null,
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{startDate:string,endDate:string,dimensions:list<string>,rowLimit:int}
+     */
+    private function liveReadRequest(array $options): array
+    {
+        $lagDays = (int) config('seo_intel.gsc_backfill_lag_days', 3);
+        $windowDays = (int) config('seo_intel.gsc_default_window_days', 28);
+        $endDate = $this->dateOption($options['end_date'] ?? null, now()->subDays($lagDays)->toDateString());
+        $startDate = $this->dateOption(
+            $options['start_date'] ?? null,
+            now()->subDays($lagDays + $windowDays - 1)->toDateString()
+        );
+        $dimensions = $this->dimensionsOption($options['dimensions'] ?? null);
+        $limit = (int) ($options['limit'] ?? config('seo_intel.gsc_readonly_adapter.default_limit', 250));
+        $maxLimit = (int) config('seo_intel.gsc_readonly_adapter.max_limit', 250);
+
+        return [
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+            'dimensions' => $dimensions,
+            'rowLimit' => max(1, min($limit, $maxLimit)),
+        ];
+    }
+
+    private function dateOption(mixed $value, string $fallback): string
+    {
+        $value = trim((string) $value);
+
+        return preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1 ? $value : $fallback;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dimensionsOption(mixed $value): array
+    {
+        $allowed = ['query', 'page', 'country', 'device', 'searchAppearance'];
+        $raw = trim((string) $value);
+        $dimensions = $raw === ''
+            ? ['query', 'page']
+            : array_values(array_filter(array_map('trim', explode(',', $raw))));
+        $dimensions = array_values(array_intersect($dimensions, $allowed));
+
+        return $dimensions === [] ? ['query', 'page'] : $dimensions;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    private function safeRowPreview(array $rows): array
+    {
+        return array_values(array_map(static fn (array $row): array => [
+            'report_date' => $row['report_date'] ?? null,
+            'canonical_url_hash' => $row['canonical_url_hash'] ?? null,
+            'query_hash' => $row['query_hash'] ?? null,
+            'query_display_masked' => $row['query_display_masked'] ?? null,
+            'source_engine' => $row['source_engine'] ?? null,
+            'clicks' => $row['clicks'] ?? null,
+            'impressions' => $row['impressions'] ?? null,
+            'ctr_ppm' => $row['ctr_ppm'] ?? null,
+            'average_position_milli' => $row['average_position_milli'] ?? null,
+        ], array_slice($rows, 0, 3)));
     }
 }

--- a/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
+++ b/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
@@ -1,0 +1,73 @@
+{
+  "version": "gsc-hk-sidecar-runner.v1",
+  "task": "SEO-GSC-HK-SIDECAR-RUNNER-01",
+  "type": "runtime_sidecar_contract",
+  "channel": "gsc",
+  "runner_region": "cn-hongkong",
+  "read_only": true,
+  "enabled_by_default": false,
+  "writes_enabled_by_default": false,
+  "scheduler_enabled_by_default": false,
+  "uses_88cn_web_process": false,
+  "allowed_commands": {
+    "preflight": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json",
+    "bounded_live_read": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250"
+  },
+  "required_runtime_gates": [
+    "SEO_INTEL_GSC_ENABLED=true",
+    "SEO_INTEL_GSC_LIVE_API_ENABLED=true",
+    "SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=true",
+    "SEO_INTEL_GSC_PROPERTY_URL",
+    "SEO_INTEL_GSC_AUTH_MODE=service_account",
+    "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH",
+    "--dry-run",
+    "--no-write",
+    "--gsc-live-read for bounded live reads"
+  ],
+  "allowed_outputs": [
+    "status",
+    "rows_seen",
+    "date_window",
+    "dimensions",
+    "http_status",
+    "readiness_metadata",
+    "data_quality_gate",
+    "canonical_url_hash",
+    "query_hash",
+    "query_display_masked",
+    "safe_metrics"
+  ],
+  "forbidden_outputs": [
+    "raw_query",
+    "raw_url",
+    "access_token",
+    "service_account_json",
+    "private_key",
+    "client_email",
+    "credential_path",
+    "cookie",
+    "session",
+    "order_id",
+    "payment_id",
+    "attempt_id"
+  ],
+  "negative_guarantees": {
+    "db_writes": false,
+    "seo_gsc_daily_import": false,
+    "cms_write": false,
+    "opportunity_queue_enqueue": false,
+    "search_channel_enqueue": false,
+    "search_channel_approve": false,
+    "search_channel_submit": false,
+    "gsc_url_inspection_request_indexing": false,
+    "gsc_sitemap_submit": false,
+    "baidu_call": false,
+    "indexnow_call": false,
+    "generic_proxy": false,
+    "production_env_edited_by_pr": false,
+    "deployment_changed_by_pr": false
+  },
+  "requires_operator_approval_before_secret_install": true,
+  "requires_operator_approval_before_live_read": true,
+  "next_allowed_step": "operator-approved secret install and bounded read-only live read from the Hong Kong sidecar host"
+}

--- a/backend/docs/seo/gsc-hk-sidecar-runner.md
+++ b/backend/docs/seo/gsc-hk-sidecar-runner.md
@@ -1,0 +1,126 @@
+# GSC Hong Kong Sidecar Runner
+
+Task: `SEO-GSC-HK-SIDECAR-RUNNER-01`
+
+This runbook defines the safe execution shape for Google Search Console live read-only collection when mainland production egress cannot reach Google OAuth or Search Console.
+
+## Decision
+
+Use a Hong Kong sidecar runner for GSC read-only collection.
+
+Do not move `fap-api` production to Hong Kong. Do not turn the 88CN production web app into a shared automation host. The runner must be isolated from the 88CN app process and may only execute bounded FermatMind SEO Intel read-only commands.
+
+## Verified Candidate Environment
+
+- Provider: Aliyun ECS
+- Region: China Hong Kong
+- Instance role: candidate sidecar runner
+- Observed OS: Ubuntu 24.04 LTS
+- Observed Google egress checks:
+  - `oauth2.googleapis.com:443` TCP connection succeeded
+  - `searchconsole.googleapis.com:443` TCP connection succeeded
+
+The IP address, SSH credentials, service-account JSON, credential paths, and account identifiers must stay out of repository files, generated artifacts, PR bodies, logs, and public dashboards.
+
+## Allowed Commands
+
+Credential/readiness preflight, no Google call:
+
+```bash
+php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json
+```
+
+Bounded live read, Google read-only call allowed:
+
+```bash
+php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250
+```
+
+## Required Runtime Gates
+
+- `SEO_INTEL_GSC_ENABLED=true`
+- `SEO_INTEL_GSC_LIVE_API_ENABLED=true`
+- `SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=true`
+- `SEO_INTEL_GSC_PROPERTY_URL=sc-domain:fermatmind.com`
+- `SEO_INTEL_GSC_AUTH_MODE=service_account`
+- `SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH` points to a root-readable or app-user-readable secret file outside git
+- command includes `--dry-run --no-write --json`
+- live read command includes explicit `--gsc-live-read`
+
+## Secret Placement
+
+The service-account JSON must be installed through an operator-approved secret channel only.
+
+Recommended shape:
+
+```text
+/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json
+```
+
+Permissions should allow only the runner user and root to read it. Do not store the secret under `/var/www/88cn`, the 88CN repository, the FermatMind repository checkout, shell history, generated artifacts, or PR attachments.
+
+## Output Boundary
+
+The runner may emit a sanitized JSON artifact containing:
+
+- command status
+- rows seen
+- date window
+- dimensions
+- HTTP status
+- readiness metadata
+- data-quality gate status
+- hashed canonical URL
+- hashed query
+- masked query display
+- clicks, impressions, CTR ppm, average-position milli
+
+The runner must not emit:
+
+- raw query
+- raw URL
+- access token
+- service-account JSON
+- private key
+- client email
+- credential path
+- cookie
+- session
+- search submission result
+- CMS content
+- order, payment, or attempt identifiers
+
+## Explicit Non-goals
+
+- no DB write
+- no `seo_gsc_daily` import/backfill
+- no opportunity queue enqueue
+- no Search Channel enqueue, approve, submit, or retry
+- no GSC URL Inspection request indexing
+- no sitemap submission
+- no CMS draft, publish, unpublish, or mutation
+- no 88CN runtime deployment
+- no generic proxy or arbitrary egress tunnel
+- no scheduler activation until a later approval
+
+## Next Approval Gate
+
+Before installing credentials or running the live read on the Hong Kong host, require explicit operator approval naming:
+
+- provider
+- host role
+- secret destination
+- exact env keys
+- exact command
+- date window
+- artifact destination
+
+Example approval phrase:
+
+```text
+CONFIRM_GSC_HK_SIDECAR_SECRET_INSTALL: provider=aliyun, region=cn-hongkong, host_role=gsc-sidecar-runner, secret_path=/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json
+```
+
+```text
+CONFIRM_GSC_HK_SIDECAR_LIVE_READ: property=sc-domain:fermatmind.com, start_date=YYYY-MM-DD, end_date=YYYY-MM-DD, limit=250, writes=false, queue=false, search_submit=false
+```

--- a/backend/docs/seo/gsc-live-readonly-adapter.md
+++ b/backend/docs/seo/gsc-live-readonly-adapter.md
@@ -14,6 +14,12 @@ Default `gsc_foundation` behavior remains fixture-only unless a caller explicitl
 php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json
 ```
 
+After credential preflight is ready, a bounded live read must still use a second explicit gate:
+
+```bash
+php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250
+```
+
 The preflight checks only sanitized readiness facts:
 
 - GSC collector enabled flag
@@ -39,6 +45,8 @@ The preflight does not call Google. It never prints access tokens, private keys,
 
 The adapter returns Search Analytics rows only to the caller. It does not persist rows. A later PR must separately approve any import/backfill into `seo_gsc_daily` and must pass `GscDataQualityGate` before opportunity scoring can use live rows.
 
+The `--gsc-live-read` command returns only sanitized artifacts: row counts, date window, dimensions, hashed URL/query identifiers, masked query display, safe metrics, readiness metadata, and data-quality gate state. It must not print raw query strings, raw URLs, credential paths, access tokens, service-account JSON, private keys, client emails, cookies, or session values.
+
 ## Supported Credential Shapes
 
 Allowed safe-secret sources:
@@ -61,6 +69,10 @@ Credentials must come from a safe secret channel. They must not be committed, pr
 - no production config mutation
 - no GSC-as-URL-Truth behavior
 
+## Hong Kong Sidecar Runner Boundary
+
+When mainland production egress cannot reach Google OAuth or Search Console, the approved safe architecture is a separate Hong Kong sidecar runner. The runner may execute only the read-only preflight and bounded live-read commands above from a secure runtime that can reach Google. It must not run inside the 88CN web application process, share 88CN PM2 process state, modify 88CN app files, proxy arbitrary traffic, write `seo_intel`, enqueue Search Channel records, mutate CMS, submit URLs, or request indexing.
+
 ## Next Safe Step
 
-After this PR is merged, the next safe operational step is a credential-side preflight using the command above in a secure environment. If the preflight reports `ready`, a later separately approved PR can add a bounded dry-run import/backfill path that normalizes live rows, writes only when explicitly approved, and keeps `GscDataQualityGate` as the opportunity-queue gate.
+After this PR is merged, the next safe operational step is a credential-side preflight using the command above in the Hong Kong sidecar environment. If the preflight reports `ready`, a bounded `--gsc-live-read` may produce a sanitized JSON artifact. Any import/backfill into `seo_gsc_daily` remains a later separately approved PR and must keep `GscDataQualityGate` as the opportunity-queue gate.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php
@@ -132,6 +132,74 @@ final class SeoIntelGscLiveReadonlyAdapterTest extends TestCase
     }
 
     #[Test]
+    public function gsc_live_read_command_returns_only_sanitized_artifact_without_writes_or_submissions(): void
+    {
+        $this->enableAccessTokenConfig();
+
+        Http::fake([
+            'searchconsole.googleapis.com/*' => Http::response([
+                'rows' => [
+                    [
+                        'keys' => ['mbti测试', 'https://fermatmind.com/zh/articles/mbti-basics'],
+                        'clicks' => 0,
+                        'impressions' => 6,
+                        'ctr' => 0,
+                        'position' => 9.0,
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $exitCode = Artisan::call('seo-intel:collect', [
+            '--collector' => 'gsc_foundation',
+            '--gsc-live-read' => true,
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--start-date' => '2026-06-01',
+            '--end-date' => '2026-06-17',
+            '--limit' => 500,
+        ]);
+
+        $output = trim(Artisan::output());
+        $decoded = json_decode($output, true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $decoded['status'] ?? null);
+        $this->assertSame('gsc_live_readonly_sidecar_read', data_get($decoded, 'metadata.mode'));
+        $this->assertTrue((bool) ($decoded['external_calls_attempted'] ?? false));
+        $this->assertFalse((bool) ($decoded['writes_attempted'] ?? true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.writes_committed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.cms_write_allowed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.search_channel_enqueue_allowed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.search_provider_submission_allowed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.indexing_request_allowed', true));
+        $this->assertFalse((bool) data_get($decoded, 'metadata.opportunity_queue_eligible', true));
+        $this->assertSame(1, $decoded['items_seen'] ?? null);
+        $this->assertSame(250, data_get($decoded, 'metadata.row_limit'));
+        $this->assertSame('2026-06-01', data_get($decoded, 'metadata.date_window.start_date'));
+        $this->assertSame('2026-06-17', data_get($decoded, 'metadata.date_window.end_date'));
+        $this->assertSame('live_gsc_api', data_get($decoded, 'metadata.data_quality_gate.data_origins.0'));
+        $this->assertNotEmpty(data_get($decoded, 'metadata.safe_row_preview.0.query_hash'));
+        $this->assertNotEmpty(data_get($decoded, 'metadata.safe_row_preview.0.canonical_url_hash'));
+        $this->assertSame('m****试', data_get($decoded, 'metadata.safe_row_preview.0.query_display_masked'));
+        $this->assertStringNotContainsString('mbti测试', $output);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $output);
+        $this->assertStringNotContainsString('secret-gsc-token', $output);
+        $this->assertStringNotContainsString('Authorization', $output);
+
+        Http::assertSent(function (Request $request): bool {
+            return str_contains($request->url(), 'searchconsole.googleapis.com/webmasters/v3/sites/sc-domain%3Afermatmind.com/searchAnalytics/query')
+                && $request->hasHeader('Authorization', 'Bearer secret-gsc-token')
+                && $request['rowLimit'] === 250
+                && $request['startDate'] === '2026-06-01'
+                && $request['endDate'] === '2026-06-17'
+                && $request['dimensions'] === ['query', 'page']
+                && $request['type'] === 'web';
+        });
+    }
+
+    #[Test]
     public function generated_contract_locks_no_write_no_submission_boundary(): void
     {
         $artifact = json_decode(
@@ -153,6 +221,32 @@ final class SeoIntelGscLiveReadonlyAdapterTest extends TestCase
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_submit', true));
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.gsc_url_inspection_request_indexing', true));
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.gsc_sitemap_submit', true));
+    }
+
+    #[Test]
+    public function hk_sidecar_runner_contract_locks_isolated_readonly_boundary(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/gsc-hk-sidecar-runner.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('gsc-hk-sidecar-runner.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GSC-HK-SIDECAR-RUNNER-01', $artifact['task'] ?? null);
+        $this->assertSame('cn-hongkong', $artifact['runner_region'] ?? null);
+        $this->assertTrue((bool) ($artifact['read_only'] ?? false));
+        $this->assertFalse((bool) ($artifact['uses_88cn_web_process'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.db_writes', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.seo_gsc_daily_import', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.opportunity_queue_enqueue', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.gsc_url_inspection_request_indexing', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.generic_proxy', true));
+        $this->assertTrue((bool) ($artifact['requires_operator_approval_before_secret_install'] ?? false));
+        $this->assertTrue((bool) ($artifact['requires_operator_approval_before_live_read'] ?? false));
     }
 
     private function enableAccessTokenConfig(): void


### PR DESCRIPTION
## What changed
- Added an explicit `--gsc-live-read` gate to `seo-intel:collect` for bounded Google Search Console read-only live reads.
- Routed GSC live-read output through sanitized metadata only: row counts, date window, dimensions, hashed URL/query identifiers, masked query display, safe metrics, readiness metadata, and data-quality gate state.
- Added the Hong Kong sidecar runner runbook and generated contract artifact.
- Expanded GSC live readonly adapter tests to lock no DB writes, no CMS writes, no opportunity/Search Channel enqueue, no search submission, no indexing request, no raw URL/query output, and no credential output.

## Why
Mainland Aliyun production egress cannot reach Google OAuth/Search Console. The safe architecture is an isolated Hong Kong sidecar runner that can execute only GSC read-only preflight/live-read commands, without coupling FermatMind SEO collection to the 88CN production web process or enabling writes/submissions.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/SeoIntelCollectCommand.php app/Services/SeoIntel/Collectors/GscCollector.php tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php`
- `python3 -m json.tool backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null && python3 -m json.tool backend/docs/seo/generated/gsc-live-readonly-adapter.v1.json >/dev/null && git diff --check`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscCollectorTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php --no-ansi`
- `cd backend && php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json` returned blocked by default with `external_calls_attempted=false` and `writes_attempted=false`.

## Intentionally deferred
- No production env changes.
- No secret install.
- No DB writes or `seo_gsc_daily` import/backfill.
- No scheduler activation.
- No CMS draft/publish/mutation.
- No opportunity queue enqueue.
- No Search Channel enqueue/approve/submit.
- No GSC indexing request or sitemap submit.
- No 88CN runtime deployment or generic proxy.

## Repository rule impact
This keeps GSC as backend SEO Intel feedback/readiness only. It does not change content authority, sitemap/llms behavior, CMS publication state, URL Truth authority, or search submission policy.
