### PR TITLE
SEO-GSC-HK-SIDECAR-CREDENTIAL-PREFLIGHT-01: record credential placement evidence

### DIFF
--- a/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
+++ b/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
@@ -67,7 +67,53 @@
     "production_env_edited_by_pr": false,
     "deployment_changed_by_pr": false
   },
+  "credential_placement_evidence": {
+    "task": "SEO-GSC-HK-SIDECAR-CREDENTIAL-PREFLIGHT-01",
+    "observed_date": "2026-06-20",
+    "status": "secret_placed_on_isolated_hk_sidecar_runner",
+    "secret_path": "/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json",
+    "sha256": "97c1e4c44be769ec66ec1df5f8b816e114262edcd234f2df7fe6e9a835ced02c",
+    "byte_size": 2422,
+    "directory": {
+      "owner": "root",
+      "group": "fm-seo-gsc",
+      "mode": "0750"
+    },
+    "file": {
+      "owner": "root",
+      "group": "fm-seo-gsc",
+      "mode": "0640"
+    },
+    "verification_commands": [
+      "sha256sum",
+      "wc -c",
+      "ls -ld",
+      "ls -l"
+    ],
+    "forbidden_evidence": [
+      "service_account_json",
+      "private_key",
+      "access_token",
+      "client_email",
+      "cookie",
+      "session",
+      "raw_credential_value",
+      "runtime_env_secret"
+    ],
+    "runtime_actions_performed": {
+      "live_gsc_read": false,
+      "google_api_call": false,
+      "db_write": false,
+      "seo_intel_write": false,
+      "opportunity_queue_enqueue": false,
+      "search_channel_enqueue": false,
+      "search_channel_submit": false,
+      "cms_mutation": false,
+      "production_env_edit": false,
+      "scheduler_activation": false
+    }
+  },
   "requires_operator_approval_before_secret_install": true,
   "requires_operator_approval_before_live_read": true,
-  "next_allowed_step": "operator-approved secret install and bounded read-only live read from the Hong Kong sidecar host"
+  "next_allowed_step": "credential preflight without Google API calls, then separately approved bounded read-only live read from the Hong Kong sidecar host"
 }

--- a/backend/docs/seo/gsc-hk-sidecar-runner.md
+++ b/backend/docs/seo/gsc-hk-sidecar-runner.md
@@ -59,6 +59,28 @@ Recommended shape:
 
 Permissions should allow only the runner user and root to read it. Do not store the secret under `/var/www/88cn`, the 88CN repository, the FermatMind repository checkout, shell history, generated artifacts, or PR attachments.
 
+## Credential Placement Evidence
+
+Task: `SEO-GSC-HK-SIDECAR-CREDENTIAL-PREFLIGHT-01`
+
+On 2026-06-20, the service-account JSON was placed on the Hong Kong sidecar runner at the approved isolated secret path:
+
+```text
+/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json
+```
+
+Non-sensitive verification evidence:
+
+- SHA256: `97c1e4c44be769ec66ec1df5f8b816e114262edcd234f2df7fe6e9a835ced02c`
+- File size: `2422` bytes
+- Secret directory owner/group/mode: `root:fm-seo-gsc` / `0750`
+- Secret file owner/group/mode: `root:fm-seo-gsc` / `0640`
+- Verification commands were limited to `sha256sum`, `wc -c`, `ls -ld`, and `ls -l`.
+
+No service-account JSON content, private key, access token, client email, cookie, session, raw credential value, or runtime environment secret was committed, printed into this evidence package, or attached to the PR.
+
+This evidence PR did not execute a live GSC read, call Google APIs, write `seo_intel`, enqueue an opportunity, enqueue or submit Search Channel records, mutate CMS, edit production environment variables, or activate a scheduler.
+
 ## Output Boundary
 
 The runner may emit a sanitized JSON artifact containing:


### PR DESCRIPTION
## What changed
- Recorded non-sensitive Hong Kong GSC sidecar credential placement evidence in `backend/docs/seo/gsc-hk-sidecar-runner.md`.
- Added matching generated JSON evidence in `backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json`.
- Captured only safe metadata: approved secret path, SHA256, byte size, owner/group/mode, verification command names, and negative runtime guarantees.

## Why
This closes the minimum evidence loop after the service-account key was placed on the isolated Hong Kong sidecar runner. It preserves the boundary before any Google live read or downstream SEO Agent execution.

## Validation commands
```bash
python3 -m json.tool backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null
git diff --check -- backend/docs/seo/gsc-hk-sidecar-runner.md backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
```

## Intentionally deferred / not performed
- No service-account JSON, private key, access token, client email, cookie, session, raw credential value, or runtime env secret was committed or attached.
- No Google API call or GSC live read was executed.
- No DB write or `seo_intel` write.
- No opportunity queue enqueue.
- No Search Channel enqueue, approval, submit, or retry.
- No CMS mutation.
- No production env edit.
- No scheduler activation.

## Repository rule impact
Docs/evidence only. Runtime authority and CMS/search authority remain unchanged.
