### PR TITLE
SEO-GSC-HK-SIDECAR-PHP84-EVIDENCE-PR-01: record PHP 8.4 sidecar evidence

### DIFF
--- a/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
+++ b/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
@@ -113,7 +113,82 @@
       "scheduler_activation": false
     }
   },
+  "php84_runtime_evidence": {
+    "task": "SEO-GSC-HK-SIDECAR-PHP84-RUNTIME-01",
+    "observed_date": "2026-06-20",
+    "status": "php84_runtime_and_readonly_gsc_live_read_verified",
+    "runtime": {
+      "php_cli_version": "8.4.22",
+      "laravel_framework_version": "12.62.0",
+      "composer_install_without_ignore_platform_req_php": true,
+      "verified_cli_extensions": [
+        "bcmath",
+        "curl",
+        "intl",
+        "mbstring",
+        "pdo_mysql",
+        "pdo_sqlite",
+        "xml",
+        "zip"
+      ]
+    },
+    "secret_path": "/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json",
+    "artifacts": {
+      "preflight": {
+        "path": "/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-preflight-php84-20260620.json",
+        "byte_size": 1406,
+        "sha256": "b48731deca0e7af7d3d10014dcb4a75765893fc2849d75fc0b539ee137dee800"
+      },
+      "read_only_live_read": {
+        "path": "/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-php84-20260620-window-20260617.json",
+        "byte_size": 2970,
+        "sha256": "d08502f806672e26609f5af7b3ac5c354f464478f64e2cf8498dca821f738999"
+      }
+    },
+    "live_read_summary": {
+      "status": "success",
+      "collector": "gsc_foundation",
+      "dry_run": true,
+      "no_write": true,
+      "external_calls_attempted": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "rows_seen": 25,
+      "date_window": {
+        "start_date": "2026-06-17",
+        "end_date": "2026-06-17"
+      },
+      "mode": "gsc_live_readonly_sidecar_read",
+      "data_quality_gate": "pass"
+    },
+    "runtime_actions_performed": {
+      "production_env_edit": false,
+      "scheduler_activation": false,
+      "db_write": false,
+      "seo_intel_write": false,
+      "seo_gsc_daily_import": false,
+      "opportunity_queue_enqueue": false,
+      "cms_mutation": false,
+      "search_channel_enqueue": false,
+      "search_channel_submit": false,
+      "gsc_url_inspection_request_indexing": false,
+      "gsc_sitemap_submit": false,
+      "baidu_call": false,
+      "indexnow_call": false
+    },
+    "forbidden_evidence": [
+      "service_account_json",
+      "private_key",
+      "access_token",
+      "client_email",
+      "cookie",
+      "session",
+      "raw_query",
+      "raw_url",
+      "runtime_env_secret"
+    ]
+  },
   "requires_operator_approval_before_secret_install": true,
   "requires_operator_approval_before_live_read": true,
-  "next_allowed_step": "credential preflight without Google API calls, then separately approved bounded read-only live read from the Hong Kong sidecar host"
+  "next_allowed_step": "sidecar runner wrapper or read-model boundary PR; do not enable scheduler, write DB, enqueue opportunities, mutate CMS, or submit search without a separate approval"
 }

--- a/backend/docs/seo/gsc-hk-sidecar-runner.md
+++ b/backend/docs/seo/gsc-hk-sidecar-runner.md
@@ -81,6 +81,50 @@ No service-account JSON content, private key, access token, client email, cookie
 
 This evidence PR did not execute a live GSC read, call Google APIs, write `seo_intel`, enqueue an opportunity, enqueue or submit Search Channel records, mutate CMS, edit production environment variables, or activate a scheduler.
 
+## PHP 8.4 Runtime Evidence
+
+Task: `SEO-GSC-HK-SIDECAR-PHP84-RUNTIME-01`
+
+On 2026-06-20, the Hong Kong sidecar runner runtime was upgraded for sidecar-only execution:
+
+- PHP CLI version: `8.4.22`
+- Laravel runtime smoke: `Laravel Framework 12.62.0`
+- Composer completed without `--ignore-platform-req=php`
+- Verified CLI extensions included `bcmath`, `curl`, `intl`, `mbstring`, `pdo_mysql`, `pdo_sqlite`, `xml`, and `zip`
+
+The existing service-account JSON remained at the approved isolated secret path:
+
+```text
+/opt/fermatmind/seo-gsc-runner/secrets/gsc-service-account.json
+```
+
+New sanitized evidence artifacts were generated on the sidecar host:
+
+- Preflight artifact: `/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-preflight-php84-20260620.json`
+  - File size: `1406` bytes
+  - SHA256: `b48731deca0e7af7d3d10014dcb4a75765893fc2849d75fc0b539ee137dee800`
+- Read-only live read artifact: `/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-php84-20260620-window-20260617.json`
+  - File size: `2970` bytes
+  - SHA256: `d08502f806672e26609f5af7b3ac5c354f464478f64e2cf8498dca821f738999`
+
+Sanitized live-read summary:
+
+- `status=success`
+- `collector=gsc_foundation`
+- `dry_run=true`
+- `no_write=true`
+- `external_calls_attempted=true`
+- `writes_attempted=false`
+- `writes_committed=false`
+- `rows_seen=25`
+- `date_window=2026-06-17..2026-06-17`
+- `mode=gsc_live_readonly_sidecar_read`
+- `data_quality_gate=pass`
+
+This runtime evidence PR records the already-completed sidecar verification only. It did not change production `fap-api` environment variables, enable a scheduler, write a database row, import `seo_gsc_daily`, enqueue an opportunity, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Baidu, or call IndexNow.
+
+No service-account JSON content, private key, access token, client email, cookie, session, raw query, raw URL, or runtime environment secret was committed, printed into this evidence package, or attached to the PR.
+
 ## Output Boundary
 
 The runner may emit a sanitized JSON artifact containing:


### PR DESCRIPTION
## What changed
- Added PHP 8.4.22 sidecar runtime evidence to `backend/docs/seo/gsc-hk-sidecar-runner.md`.
- Added structured generated evidence in `backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json`.
- Recorded composer success without `--ignore-platform-req=php`, sanitized preflight/live-read artifact paths, byte sizes, SHA256 values, and `data_quality_gate=pass`.

## Why
This closes the evidence package for the HK GSC sidecar PHP 8.4 runtime verification before any later runner wrapper, read-model bridge, scheduler, DB write, opportunity queue, CMS, or search/indexing work.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null`
- `git diff --check -- backend/docs/seo/gsc-hk-sidecar-runner.md backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json`

## Intentionally deferred
- No server changes in this PR.
- No new GSC live read in this PR.
- No production `fap-api` env changes.
- No scheduler activation.
- No DB writes or `seo_gsc_daily` import.
- No opportunity queue enqueue.
- No CMS mutation.
- No Search Channel enqueue/approve/submit.
- No GSC indexing request, sitemap submission, Baidu call, or IndexNow call.

## Repository rule impact
Docs/evidence-only. Backend remains the authority for SEO Intel execution boundaries; this PR does not change runtime behavior, CMS authority, publishing state, or public SEO enumeration.