### PR TITLE
SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01: add read-only runner wrapper

### DIFF
--- a/backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+
+final class SeoIntelGscSidecarRunnerCommand extends Command
+{
+    protected $signature = 'seo-intel:gsc-sidecar-runner
+        {--mode=preflight : Runner mode: preflight or live-read}
+        {--start-date= : Required for live-read, YYYY-MM-DD}
+        {--end-date= : Required for live-read, YYYY-MM-DD}
+        {--limit=250 : Required for live-read, bounded 1..250}
+        {--dimensions=query,page : Required for live-read, comma-separated GSC dimensions}
+        {--artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts : Directory for sanitized JSON artifacts}';
+
+    protected $description = 'Run the HK GSC sidecar read-only wrapper around seo-intel:collect.';
+
+    public function handle(): int
+    {
+        $mode = trim((string) $this->option('mode'));
+        if (! in_array($mode, ['preflight', 'live-read'], true)) {
+            $this->error('error=invalid_mode');
+
+            return self::FAILURE;
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null || ! $this->ensureArtifactDir($artifactDir)) {
+            $this->error('error=artifact_dir_unwritable');
+
+            return self::FAILURE;
+        }
+
+        $arguments = [
+            '--collector' => 'gsc_foundation',
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+        ];
+
+        if ($mode === 'preflight') {
+            $arguments['--gsc-live-preflight'] = true;
+        } else {
+            $liveReadArguments = $this->liveReadArguments();
+            if ($liveReadArguments === null) {
+                return self::FAILURE;
+            }
+
+            $arguments = [
+                ...$arguments,
+                ...$liveReadArguments,
+                '--gsc-live-read' => true,
+            ];
+        }
+
+        $exitCode = Artisan::call('seo-intel:collect', $arguments);
+        $rawOutput = trim(Artisan::output());
+        $payload = json_decode($rawOutput, true);
+
+        if (! is_array($payload)) {
+            $this->error('error=collector_output_not_json');
+
+            return self::FAILURE;
+        }
+
+        $artifact = $this->artifactPayload($mode, $arguments, $payload);
+        $artifactPath = $this->artifactPath($artifactDir, $mode, $payload);
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        if (! is_string($encoded) || file_put_contents($artifactPath, $encoded."\n") === false) {
+            $this->error('error=artifact_write_failed');
+
+            return self::FAILURE;
+        }
+
+        $byteSize = filesize($artifactPath);
+        $sha256 = hash_file('sha256', $artifactPath);
+
+        if (! is_int($byteSize) || ! is_string($sha256)) {
+            $this->error('error=artifact_digest_failed');
+
+            return self::FAILURE;
+        }
+
+        $boundaryFailure = $this->boundaryFailure($payload);
+        $this->line('artifact_path='.$artifactPath);
+        $this->line('artifact_size='.$byteSize);
+        $this->line('artifact_sha256='.$sha256);
+        $this->line('status='.(string) ($payload['status'] ?? 'unknown'));
+        $this->line('collector='.(string) ($payload['collector'] ?? 'unknown'));
+        $this->line('dry_run='.($this->boolValue($payload['dry_run'] ?? null) ? 'true' : 'false'));
+        $this->line('writes_attempted='.($this->boolValue($payload['writes_attempted'] ?? null) ? 'true' : 'false'));
+        $this->line('writes_committed='.($this->boolValue($payload['writes_committed'] ?? null) ? 'true' : 'false'));
+        $this->line('external_calls_attempted='.($this->boolValue($payload['external_calls_attempted'] ?? null) ? 'true' : 'false'));
+
+        if (isset($payload['items_seen'])) {
+            $this->line('items_seen='.(string) $payload['items_seen']);
+        }
+
+        if ($boundaryFailure !== null) {
+            $this->error('error='.$boundaryFailure);
+
+            return self::FAILURE;
+        }
+
+        return $exitCode === self::SUCCESS ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $path = trim((string) $this->option('artifact-dir'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        return rtrim($path, '/');
+    }
+
+    private function ensureArtifactDir(string $artifactDir): bool
+    {
+        if (! is_dir($artifactDir) && ! mkdir($artifactDir, 0750, true) && ! is_dir($artifactDir)) {
+            return false;
+        }
+
+        return is_writable($artifactDir);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function liveReadArguments(): ?array
+    {
+        $startDate = $this->dateOption('start-date');
+        $endDate = $this->dateOption('end-date');
+        if ($startDate === null || $endDate === null) {
+            $this->error('error=live_read_dates_required');
+
+            return null;
+        }
+
+        if ($startDate > $endDate) {
+            $this->error('error=live_read_date_order_invalid');
+
+            return null;
+        }
+
+        $limit = $this->limitOption();
+        if ($limit === null) {
+            $this->error('error=live_read_limit_invalid');
+
+            return null;
+        }
+
+        $dimensions = trim((string) $this->option('dimensions'));
+        if ($dimensions === '') {
+            $this->error('error=live_read_dimensions_required');
+
+            return null;
+        }
+
+        return [
+            '--start-date' => $startDate,
+            '--end-date' => $endDate,
+            '--limit' => $limit,
+            '--dimensions' => $dimensions,
+        ];
+    }
+
+    private function dateOption(string $name): ?string
+    {
+        $value = trim((string) $this->option($name));
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) !== 1) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function limitOption(): ?int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return null;
+        }
+
+        $limit = (int) $raw;
+
+        return $limit >= 1 && $limit <= 250 ? $limit : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function artifactPayload(string $mode, array $arguments, array $payload): array
+    {
+        return [
+            'schema_version' => 'gsc-hk-sidecar-runner-wrapper.v1',
+            'task' => 'SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01',
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'mode' => $mode,
+            'collector_command' => [
+                'name' => 'seo-intel:collect',
+                'forced_flags' => [
+                    '--collector=gsc_foundation',
+                    '--dry-run',
+                    '--no-write',
+                    '--json',
+                    $mode === 'preflight' ? '--gsc-live-preflight' : '--gsc-live-read',
+                ],
+                'live_read_options' => [
+                    'start_date' => $arguments['--start-date'] ?? null,
+                    'end_date' => $arguments['--end-date'] ?? null,
+                    'limit' => $arguments['--limit'] ?? null,
+                    'dimensions' => $arguments['--dimensions'] ?? null,
+                ],
+            ],
+            'summary' => [
+                'status' => $payload['status'] ?? null,
+                'collector' => $payload['collector'] ?? null,
+                'dry_run' => $payload['dry_run'] ?? null,
+                'writes_attempted' => $payload['writes_attempted'] ?? null,
+                'writes_committed' => $payload['writes_committed'] ?? null,
+                'external_calls_attempted' => $payload['external_calls_attempted'] ?? null,
+                'items_seen' => $payload['items_seen'] ?? null,
+                'data_quality_gate' => data_get($payload, 'metadata.data_quality_gate.status'),
+                'date_window' => data_get($payload, 'metadata.date_window'),
+            ],
+            'boundary_check' => [
+                'passed' => $this->boundaryFailure($payload) === null,
+                'forbidden_true_fields' => [
+                    'writes_attempted',
+                    'writes_committed',
+                    'metadata.writes_attempted',
+                    'metadata.writes_committed',
+                    'metadata.cms_write_allowed',
+                    'metadata.search_channel_enqueue_allowed',
+                    'metadata.indexing_request_allowed',
+                ],
+            ],
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function artifactPath(string $artifactDir, string $mode, array $payload): string
+    {
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $status = preg_replace('/[^a-z0-9_-]+/i', '-', (string) ($payload['status'] ?? 'unknown'));
+
+        return sprintf('%s/gsc-%s-wrapper-%s-%s.json', $artifactDir, $mode, $timestamp, $status);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function boundaryFailure(array $payload): ?string
+    {
+        foreach ([
+            'writes_attempted' => $payload['writes_attempted'] ?? null,
+            'writes_committed' => $payload['writes_committed'] ?? null,
+            'metadata.writes_attempted' => data_get($payload, 'metadata.writes_attempted'),
+            'metadata.writes_committed' => data_get($payload, 'metadata.writes_committed'),
+            'metadata.cms_write_allowed' => data_get($payload, 'metadata.cms_write_allowed'),
+            'metadata.search_channel_enqueue_allowed' => data_get($payload, 'metadata.search_channel_enqueue_allowed'),
+            'metadata.indexing_request_allowed' => data_get($payload, 'metadata.indexing_request_allowed'),
+        ] as $field => $value) {
+            if ($this->boolValue($value)) {
+                return 'forbidden_boundary_true:'.$field;
+            }
+        }
+
+        return null;
+    }
+
+    private function boolValue(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if (is_string($value)) {
+            return in_array(strtolower($value), ['1', 'true', 'yes'], true);
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
+++ b/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
@@ -11,7 +11,9 @@
   "uses_88cn_web_process": false,
   "allowed_commands": {
     "preflight": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json",
-    "bounded_live_read": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250"
+    "bounded_live_read": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250",
+    "sidecar_wrapper_preflight": "php artisan seo-intel:gsc-sidecar-runner --mode=preflight --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts",
+    "sidecar_wrapper_live_read": "php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts"
   },
   "required_runtime_gates": [
     "SEO_INTEL_GSC_ENABLED=true",
@@ -22,7 +24,9 @@
     "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH",
     "--dry-run",
     "--no-write",
-    "--gsc-live-read for bounded live reads"
+    "--gsc-live-read for bounded live reads",
+    "sidecar wrapper must call only seo-intel:collect --collector=gsc_foundation",
+    "sidecar wrapper must fail if forbidden write/CMS/search/indexing boundaries are true"
   ],
   "allowed_outputs": [
     "status",
@@ -187,6 +191,68 @@
       "raw_url",
       "runtime_env_secret"
     ]
+  },
+  "runner_wrapper_contract": {
+    "task": "SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01",
+    "command": "php artisan seo-intel:gsc-sidecar-runner",
+    "schema_version": "gsc-hk-sidecar-runner-wrapper.v1",
+    "enabled_by_default": false,
+    "scheduler_enabled": false,
+    "queue_worker_enabled": false,
+    "supported_modes": [
+      "preflight",
+      "live-read"
+    ],
+    "required_live_read_options": [
+      "--start-date",
+      "--end-date",
+      "--limit",
+      "--dimensions",
+      "--artifact-dir"
+    ],
+    "limit_bounds": [
+      1,
+      250
+    ],
+    "internal_command": "seo-intel:collect",
+    "forced_collector": "gsc_foundation",
+    "forced_flags": [
+      "--dry-run",
+      "--no-write",
+      "--json",
+      "--gsc-live-preflight for preflight",
+      "--gsc-live-read for live-read"
+    ],
+    "artifact_output": {
+      "writes_sanitized_json": true,
+      "prints_artifact_path": true,
+      "prints_byte_size": true,
+      "prints_sha256": true,
+      "prints_safe_summary": true,
+      "prints_raw_rows": false,
+      "prints_credentials": false
+    },
+    "fail_closed_if_true": [
+      "writes_attempted",
+      "writes_committed",
+      "metadata.writes_attempted",
+      "metadata.writes_committed",
+      "metadata.cms_write_allowed",
+      "metadata.search_channel_enqueue_allowed",
+      "metadata.indexing_request_allowed"
+    ],
+    "negative_guarantees": {
+      "db_writes": false,
+      "seo_gsc_daily_import": false,
+      "cms_write": false,
+      "opportunity_queue_enqueue": false,
+      "search_channel_enqueue": false,
+      "search_channel_submit": false,
+      "gsc_url_inspection_request_indexing": false,
+      "gsc_sitemap_submit": false,
+      "scheduler_activation": false,
+      "queue_worker_activation": false
+    }
   },
   "requires_operator_approval_before_secret_install": true,
   "requires_operator_approval_before_live_read": true,

--- a/backend/docs/seo/gsc-hk-sidecar-runner.md
+++ b/backend/docs/seo/gsc-hk-sidecar-runner.md
@@ -36,6 +36,16 @@ Bounded live read, Google read-only call allowed:
 php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250
 ```
 
+Repeatable sidecar wrapper:
+
+```bash
+php artisan seo-intel:gsc-sidecar-runner --mode=preflight --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts
+```
+
+```bash
+php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts
+```
+
 ## Required Runtime Gates
 
 - `SEO_INTEL_GSC_ENABLED=true`
@@ -46,6 +56,9 @@ php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-r
 - `SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH` points to a root-readable or app-user-readable secret file outside git
 - command includes `--dry-run --no-write --json`
 - live read command includes explicit `--gsc-live-read`
+- sidecar wrapper must call only `seo-intel:collect --collector=gsc_foundation`
+- sidecar wrapper must force `--dry-run --no-write --json`
+- sidecar wrapper must fail if the collector reports any write, CMS, Search Channel, or indexing boundary as enabled
 
 ## Secret Placement
 
@@ -124,6 +137,38 @@ Sanitized live-read summary:
 This runtime evidence PR records the already-completed sidecar verification only. It did not change production `fap-api` environment variables, enable a scheduler, write a database row, import `seo_gsc_daily`, enqueue an opportunity, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Baidu, or call IndexNow.
 
 No service-account JSON content, private key, access token, client email, cookie, session, raw query, raw URL, or runtime environment secret was committed, printed into this evidence package, or attached to the PR.
+
+## Runner Wrapper Contract
+
+Task: `SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01`
+
+`php artisan seo-intel:gsc-sidecar-runner` is the only approved repeatable wrapper for the Hong Kong GSC sidecar runtime. The wrapper exists to replace manual command assembly with a bounded, auditable command surface.
+
+Wrapper guarantees:
+
+- accepts only `--mode=preflight` or `--mode=live-read`
+- live-read requires explicit `--start-date`, `--end-date`, `--limit`, `--dimensions`, and `--artifact-dir`
+- live-read limits must stay within `1..250`
+- internally invokes only `seo-intel:collect --collector=gsc_foundation`
+- always forces `--dry-run --no-write --json`
+- preflight always forces `--gsc-live-preflight`
+- live-read always forces `--gsc-live-read`
+- writes a sanitized JSON artifact to the requested artifact directory
+- prints only artifact path, byte size, SHA256, and safe summary fields
+- fails closed if any forbidden boundary reports enabled or attempted writes
+
+Forbidden wrapper outcomes:
+
+- no DB write
+- no `seo_gsc_daily` import/backfill
+- no opportunity queue enqueue
+- no CMS write or draft mutation
+- no Search Channel enqueue, approval, retry, or submission
+- no GSC URL Inspection request indexing
+- no sitemap submission
+- no scheduler activation
+- no queue worker activation
+- no raw query, raw URL, credential, token, client email, cookie, session, or private key output
 
 ## Output Boundary
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscSidecarRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscSidecarRunnerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscSidecarRunnerTest extends TestCase
+{
+    #[Test]
+    public function sidecar_runner_preflight_writes_artifact_without_external_calls_or_writes(): void
+    {
+        Http::fake();
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-intel:gsc-sidecar-runner', [
+            '--mode' => 'preflight',
+            '--artifact-dir' => $artifactDir,
+        ]);
+
+        $output = trim(Artisan::output());
+        $artifactPath = $this->singleArtifactPath($artifactDir);
+        $artifact = $this->jsonArtifact($artifactPath);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringNotContainsString('Authorization', $output);
+        $this->assertSame('gsc-hk-sidecar-runner-wrapper.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01', $artifact['task'] ?? null);
+        $this->assertSame('preflight', $artifact['mode'] ?? null);
+        $this->assertSame('seo-intel:collect', data_get($artifact, 'collector_command.name'));
+        $this->assertContains('--dry-run', data_get($artifact, 'collector_command.forced_flags'));
+        $this->assertContains('--no-write', data_get($artifact, 'collector_command.forced_flags'));
+        $this->assertContains('--gsc-live-preflight', data_get($artifact, 'collector_command.forced_flags'));
+        $this->assertTrue((bool) data_get($artifact, 'boundary_check.passed'));
+        $this->assertSame('blocked', data_get($artifact, 'payload.status'));
+        $this->assertFalse((bool) data_get($artifact, 'payload.external_calls_attempted', true));
+        $this->assertFalse((bool) data_get($artifact, 'payload.writes_attempted', true));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function sidecar_runner_live_read_writes_sanitized_artifact_and_summary(): void
+    {
+        $this->enableAccessTokenConfig();
+        $artifactDir = $this->artifactDir();
+
+        Http::fake([
+            'searchconsole.googleapis.com/*' => Http::response([
+                'rows' => [
+                    [
+                        'keys' => ['mbti测试', 'https://fermatmind.com/zh/articles/mbti-basics'],
+                        'clicks' => 0,
+                        'impressions' => 60,
+                        'ctr' => 0,
+                        'position' => 9.0,
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $exitCode = Artisan::call('seo-intel:gsc-sidecar-runner', [
+            '--mode' => 'live-read',
+            '--start-date' => '2026-06-17',
+            '--end-date' => '2026-06-17',
+            '--limit' => 25,
+            '--dimensions' => 'query,page',
+            '--artifact-dir' => $artifactDir,
+        ]);
+
+        $output = trim(Artisan::output());
+        $artifactPath = $this->singleArtifactPath($artifactDir);
+        $artifact = $this->jsonArtifact($artifactPath);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringNotContainsString('mbti测试', $output);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $output);
+        $this->assertStringNotContainsString('secret-gsc-token', $output);
+        $this->assertStringNotContainsString('Authorization', $output);
+
+        $this->assertSame('live-read', $artifact['mode'] ?? null);
+        $this->assertContains('--gsc-live-read', data_get($artifact, 'collector_command.forced_flags'));
+        $this->assertSame('2026-06-17', data_get($artifact, 'collector_command.live_read_options.start_date'));
+        $this->assertSame('2026-06-17', data_get($artifact, 'collector_command.live_read_options.end_date'));
+        $this->assertSame(25, data_get($artifact, 'collector_command.live_read_options.limit'));
+        $this->assertSame('query,page', data_get($artifact, 'collector_command.live_read_options.dimensions'));
+        $this->assertTrue((bool) data_get($artifact, 'boundary_check.passed'));
+        $this->assertSame('success', data_get($artifact, 'payload.status'));
+        $this->assertTrue((bool) data_get($artifact, 'payload.external_calls_attempted'));
+        $this->assertFalse((bool) data_get($artifact, 'payload.writes_attempted', true));
+        $this->assertFalse((bool) data_get($artifact, 'payload.writes_committed', true));
+        $this->assertFalse((bool) data_get($artifact, 'payload.metadata.cms_write_allowed', true));
+        $this->assertFalse((bool) data_get($artifact, 'payload.metadata.search_channel_enqueue_allowed', true));
+        $this->assertFalse((bool) data_get($artifact, 'payload.metadata.indexing_request_allowed', true));
+        $this->assertSame('pass', data_get($artifact, 'payload.metadata.data_quality_gate.status'));
+        $this->assertSame('m****试', data_get($artifact, 'payload.metadata.safe_row_preview.0.query_display_masked'));
+
+        $artifactText = (string) file_get_contents($artifactPath);
+        $this->assertStringNotContainsString('mbti测试', $artifactText);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $artifactText);
+        $this->assertStringNotContainsString('secret-gsc-token', $artifactText);
+        $this->assertStringNotContainsString('Authorization', $artifactText);
+
+        Http::assertSent(function (Request $request): bool {
+            return str_contains($request->url(), 'searchconsole.googleapis.com/webmasters/v3/sites/sc-domain%3Afermatmind.com/searchAnalytics/query')
+                && $request->hasHeader('Authorization', 'Bearer secret-gsc-token')
+                && $request['rowLimit'] === 25
+                && $request['startDate'] === '2026-06-17'
+                && $request['endDate'] === '2026-06-17'
+                && $request['dimensions'] === ['query', 'page']
+                && $request['type'] === 'web';
+        });
+    }
+
+    #[Test]
+    public function sidecar_runner_rejects_invalid_live_read_bounds_before_artifact_write(): void
+    {
+        Http::fake();
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-intel:gsc-sidecar-runner', [
+            '--mode' => 'live-read',
+            '--start-date' => '2026-06-17',
+            '--end-date' => '2026-06-17',
+            '--limit' => 251,
+            '--dimensions' => 'query,page',
+            '--artifact-dir' => $artifactDir,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('error=live_read_limit_invalid', Artisan::output());
+        $this->assertSame([], File::files($artifactDir));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function generated_contract_locks_sidecar_wrapper_boundary(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/gsc-hk-sidecar-runner.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01', data_get($artifact, 'runner_wrapper_contract.task'));
+        $this->assertSame('php artisan seo-intel:gsc-sidecar-runner', data_get($artifact, 'runner_wrapper_contract.command'));
+        $this->assertSame('seo-intel:collect', data_get($artifact, 'runner_wrapper_contract.internal_command'));
+        $this->assertSame('gsc_foundation', data_get($artifact, 'runner_wrapper_contract.forced_collector'));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.scheduler_enabled', true));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.queue_worker_enabled', true));
+        $this->assertContains('--dry-run', data_get($artifact, 'runner_wrapper_contract.forced_flags'));
+        $this->assertContains('--no-write', data_get($artifact, 'runner_wrapper_contract.forced_flags'));
+        $this->assertContains('writes_attempted', data_get($artifact, 'runner_wrapper_contract.fail_closed_if_true'));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.db_writes', true));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.seo_gsc_daily_import', true));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.opportunity_queue_enqueue', true));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.search_channel_submit', true));
+    }
+
+    private function enableAccessTokenConfig(): void
+    {
+        config([
+            'seo_intel.gsc_enabled' => true,
+            'seo_intel.gsc_live_api_enabled' => true,
+            'seo_intel.allow_external_api_calls' => true,
+            'seo_intel.gsc_property_url' => 'sc-domain:fermatmind.com',
+            'seo_intel.gsc_readonly_adapter.auth_mode' => 'access_token',
+            'seo_intel.gsc_readonly_adapter.access_token' => 'secret-gsc-token',
+            'seo_intel.gsc_readonly_adapter.default_limit' => 250,
+            'seo_intel.gsc_readonly_adapter.max_limit' => 250,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/gsc-sidecar-runner-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function singleArtifactPath(string $artifactDir): string
+    {
+        $files = File::files($artifactDir);
+        $this->assertCount(1, $files);
+        $path = $files[0]->getPathname();
+
+        $this->assertFileExists($path);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonArtifact(string $artifactPath): array
+    {
+        $artifact = json_decode((string) file_get_contents($artifactPath), true);
+        $this->assertIsArray($artifact);
+
+        return $artifact;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -890,6 +890,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_seo_intel_gsc_foundation_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
@@ -4688,6 +4689,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoIntelGscFoundationFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',


### PR DESCRIPTION
## What changed
- Added `php artisan seo-intel:gsc-sidecar-runner` as the repeatable HK GSC sidecar wrapper.
- The wrapper forces `seo-intel:collect --collector=gsc_foundation --dry-run --no-write --json` and chooses only `--gsc-live-preflight` or `--gsc-live-read`.
- Added feature coverage for preflight artifacts, live-read sanitized artifacts, bounds validation, and generated contract locks.
- Updated the HK sidecar runbook and generated contract with the wrapper boundary.

## Why
This replaces manual sidecar command assembly with a safe, auditable wrapper while preserving the existing read-only GSC collector path.

## Validation
- `cd backend && php artisan test --filter SeoIntelGscLiveReadonlyAdapterTest`
- `cd backend && php artisan test --filter SeoIntelGscSidecarRunnerTest`
- `cd backend && python3 -m json.tool docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null`
- `git diff --check`
- `cd backend && php artisan list --raw | rg '^seo-intel:gsc-sidecar-runner'`\n\n## Intentionally deferred\n- No production env changes.\n- No scheduler activation.\n- No DB writes or `seo_gsc_daily` import.\n- No opportunity queue enqueue.\n- No CMS mutation.\n- No Search Channel enqueue/approve/submit.\n- No GSC indexing request, sitemap submission, Baidu call, or IndexNow call.\n- No new real GSC live read in this PR.\n\n## Repository rule impact\nBackend remains the SEO Intel authority. This adds a backend-only operational command and documentation; it does not change public APIs, CMS authority, publishing state, search submission behavior, or SEO/GEO public enumeration.