### PR TITLE
SEO-GSC-LIVE-READMODEL-CONSUMPTION-CONTRACT-01: define live GSC read-model boundary

### DIFF
--- a/backend/docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json
+++ b/backend/docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json
@@ -1,0 +1,91 @@
+{
+  "version": "gsc-live-readmodel-consumption-contract.v1",
+  "task": "SEO-GSC-LIVE-READMODEL-CONSUMPTION-CONTRACT-01",
+  "repo": "fap-api",
+  "channel": "gsc",
+  "read_only_contract": true,
+  "runtime_behavior_changed": false,
+  "live_api_call_in_this_pr": false,
+  "credential_operation_in_this_pr": false,
+  "migration_added": false,
+  "scheduler_enabled": false,
+  "queue_worker_enabled": false,
+  "seo_gsc_daily_write": false,
+  "opportunity_queue_enqueue": false,
+  "cms_mutation_allowed": false,
+  "search_channel_action_allowed": false,
+  "indexing_request_allowed": false,
+  "production_env_changed": false,
+  "required_before_future_read_model_import": {
+    "data_origin": "live_gsc_api",
+    "data_quality_gate": "pass",
+    "source_engine": "google",
+    "sanitized_fields_only": true,
+    "gsc_finalization_lag_required": true,
+    "freshness_window_required": true,
+    "hashed_identifiers_required": [
+      "canonical_url_hash",
+      "query_hash"
+    ]
+  },
+  "allowed_sanitized_fields": [
+    "report_date",
+    "canonical_url_hash",
+    "query_hash",
+    "query_display_masked",
+    "locale",
+    "source_engine",
+    "device",
+    "country",
+    "search_type",
+    "clicks",
+    "impressions",
+    "ctr_ppm",
+    "average_position_milli",
+    "is_brand_query",
+    "query_type",
+    "data_state",
+    "data_origin",
+    "row_source"
+  ],
+  "forbidden_artifact_fields": [
+    "raw_query",
+    "raw_url",
+    "credential_path",
+    "token",
+    "access_token",
+    "api_key",
+    "client_email",
+    "service_account_json",
+    "cookie",
+    "session",
+    "raw_payload"
+  ],
+  "future_read_model_target": {
+    "table": "seo_gsc_daily",
+    "status": "future_import_target_only",
+    "importer_added_in_this_pr": false,
+    "write_allowed_in_this_pr": false
+  },
+  "opportunity_queue_boundary": {
+    "direct_sidecar_artifact_consumption_allowed": false,
+    "allowed_source": "seo_intel read model rows after gsc data_quality_gate=pass",
+    "queue_execution_allowed": false,
+    "cms_draft_allowed": false,
+    "search_submission_allowed": false
+  },
+  "negative_guarantees": {
+    "live_gsc_api_call": false,
+    "credential_read_print_or_store": false,
+    "seo_gsc_daily_import": false,
+    "database_write": false,
+    "scheduler_activation": false,
+    "opportunity_queue_enqueue": false,
+    "cms_write": false,
+    "search_channel_enqueue": false,
+    "search_provider_submission": false,
+    "gsc_url_inspection_request_indexing": false,
+    "sitemap_submission": false
+  },
+  "next_allowed_step": "dry-run-only read model importer design or preflight PR; no scheduler, opportunity queue execution, CMS mutation, or search/indexing submission without separate approval"
+}

--- a/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
+++ b/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
@@ -51,6 +51,12 @@
     "external_calls_attempted": false,
     "writes_attempted": false
   },
+  "sidecar_artifact_boundary": {
+    "direct_sidecar_artifact_consumption_allowed": false,
+    "allowed_source": "seo_intel read model rows after gsc data_quality_gate=pass",
+    "sidecar_artifact_role": "evidence_and_future_import_input_candidate_only",
+    "queue_item_creation_allowed": false
+  },
   "production_operation_performed": false,
   "migration_added": false,
   "collector_enabled": false,

--- a/backend/docs/seo/gsc-live-readmodel-consumption-contract.md
+++ b/backend/docs/seo/gsc-live-readmodel-consumption-contract.md
@@ -1,0 +1,68 @@
+# GSC Live Read Model Consumption Contract
+
+Task: `SEO-GSC-LIVE-READMODEL-CONSUMPTION-CONTRACT-01`
+
+## Purpose
+
+This contract defines how sanitized live Google Search Console sidecar artifacts may become backend `seo_intel` read model input in a future PR.
+
+This PR does not import sidecar artifacts, write `seo_gsc_daily`, add migrations, add scheduler wiring, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request indexing, or call Google APIs.
+
+## Allowed Future Consumption Boundary
+
+A live GSC sidecar artifact may be considered for future read model import only when all of these are true:
+
+- `data_origin=live_gsc_api`
+- `data_quality_gate=pass`
+- source engine is `google`
+- artifact rows contain sanitized fields only
+- metric rows use hashed identifiers for canonical URL and query matching
+- report dates satisfy the GSC finalization lag and freshness windows defined by `SEO-GSC-DATA-QUALITY-01`
+- the importer target is the backend `seo_intel` read model, not CMS, Search Channel, indexing, or the opportunity queue directly
+
+## Forbidden Artifact Fields
+
+Sidecar artifacts must not expose or forward these fields into a contract-visible read model package:
+
+- raw query
+- raw URL
+- credential path
+- token
+- access token
+- API key
+- client email
+- service account JSON
+- cookie
+- session
+- raw payload
+
+## Read Model Boundary
+
+`seo_gsc_daily` remains the future backend read model import target for live GSC rows.
+
+This PR does not add an importer command and does not write `seo_gsc_daily`. A later importer PR must be dry-run first, must preserve sanitized-only fields, must pass the GSC data quality gate, and must remain separate from opportunity queue execution.
+
+## Opportunity Queue Boundary
+
+The opportunity queue must never consume sidecar artifacts directly. It may only read already-imported `seo_intel` read model rows that passed the GSC data quality gate.
+
+Sidecar artifacts are evidence and import input candidates only. They are not queue items, CMS draft packages, search submissions, indexing requests, or execution approvals.
+
+## Negative Guarantees
+
+- no live GSC API call in this PR
+- no credential read, print, storage, or mutation
+- no `seo_gsc_daily` write
+- no migration
+- no scheduler activation
+- no queue worker activation
+- no opportunity queue enqueue
+- no CMS draft or CMS write
+- no Search Channel enqueue, approval, or submission
+- no GSC URL Inspection indexing request
+- no sitemap submission
+- no production environment change
+
+## Next Allowed Work
+
+After this contract is merged, the next safe implementation step is a dry-run-only read model importer design or preflight PR. That future PR must still avoid scheduler activation, opportunity queue execution, CMS mutation, and search/indexing submission unless separately approved.

--- a/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
@@ -173,6 +173,14 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
     public function opportunity_queue_endpoint_is_gsc_quality_gated_and_read_only(): void
     {
         $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_SEO_INTEL_READ]);
+        $queueArtifact = $this->opportunityQueueArtifact();
+
+        $this->assertFalse((bool) data_get($queueArtifact, 'sidecar_artifact_boundary.direct_sidecar_artifact_consumption_allowed', true));
+        $this->assertSame(
+            'seo_intel read model rows after gsc data_quality_gate=pass',
+            data_get($queueArtifact, 'sidecar_artifact_boundary.allowed_source'),
+        );
+        $this->assertFalse((bool) data_get($queueArtifact, 'sidecar_artifact_boundary.queue_item_creation_allowed', true));
 
         $response = $this->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->getJson('/api/v0.5/ops/seo-intel/opportunity-queue?limit=5')
@@ -273,6 +281,22 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
     private function artifact(): array
     {
         $path = base_path('docs/seo/generated/seo-dash-api-01-readonly-api-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function opportunityQueueArtifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-opportunity-queue-readonly.v1.json');
 
         $this->assertFileExists($path);
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelConsumptionContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelConsumptionContractTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscReadModelConsumptionContractTest extends TestCase
+{
+    #[Test]
+    public function artifact_requires_live_gsc_origin_quality_gate_and_sanitized_fields_only(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('gsc-live-readmodel-consumption-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-GSC-LIVE-READMODEL-CONSUMPTION-CONTRACT-01', $artifact['task'] ?? null);
+        $this->assertTrue((bool) ($artifact['read_only_contract'] ?? false));
+        $this->assertFalse((bool) ($artifact['runtime_behavior_changed'] ?? true));
+
+        $this->assertSame('live_gsc_api', data_get($artifact, 'required_before_future_read_model_import.data_origin'));
+        $this->assertSame('pass', data_get($artifact, 'required_before_future_read_model_import.data_quality_gate'));
+        $this->assertSame('google', data_get($artifact, 'required_before_future_read_model_import.source_engine'));
+        $this->assertTrue((bool) data_get($artifact, 'required_before_future_read_model_import.sanitized_fields_only'));
+
+        foreach (['canonical_url_hash', 'query_hash'] as $requiredHash) {
+            $this->assertContains($requiredHash, data_get($artifact, 'required_before_future_read_model_import.hashed_identifiers_required', []));
+            $this->assertContains($requiredHash, $artifact['allowed_sanitized_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function raw_query_raw_url_credentials_and_tokens_are_forbidden(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'raw_query',
+            'raw_url',
+            'credential_path',
+            'token',
+            'access_token',
+            'api_key',
+            'client_email',
+            'service_account_json',
+            'cookie',
+            'session',
+            'raw_payload',
+        ] as $forbiddenField) {
+            $this->assertContains($forbiddenField, $artifact['forbidden_artifact_fields'] ?? []);
+            $this->assertNotContains($forbiddenField, $artifact['allowed_sanitized_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function read_model_target_is_future_only_and_opportunity_queue_cannot_read_sidecar_artifacts_directly(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo_gsc_daily', data_get($artifact, 'future_read_model_target.table'));
+        $this->assertSame('future_import_target_only', data_get($artifact, 'future_read_model_target.status'));
+        $this->assertFalse((bool) data_get($artifact, 'future_read_model_target.importer_added_in_this_pr', true));
+        $this->assertFalse((bool) data_get($artifact, 'future_read_model_target.write_allowed_in_this_pr', true));
+
+        $this->assertFalse((bool) data_get($artifact, 'opportunity_queue_boundary.direct_sidecar_artifact_consumption_allowed', true));
+        $this->assertSame(
+            'seo_intel read model rows after gsc data_quality_gate=pass',
+            data_get($artifact, 'opportunity_queue_boundary.allowed_source'),
+        );
+
+        foreach ([
+            'queue_execution_allowed',
+            'cms_draft_allowed',
+            'search_submission_allowed',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'opportunity_queue_boundary.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function negative_guarantees_block_runtime_writes_scheduler_cms_search_and_indexing(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'live_gsc_api_call',
+            'credential_read_print_or_store',
+            'seo_gsc_daily_import',
+            'database_write',
+            'scheduler_activation',
+            'opportunity_queue_enqueue',
+            'cms_write',
+            'search_channel_enqueue',
+            'search_provider_submission',
+            'gsc_url_inspection_request_indexing',
+            'sitemap_submission',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$flag, true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function docs_lock_no_import_no_queue_no_cms_no_search_language(): void
+    {
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/gsc-live-readmodel-consumption-contract.md')));
+        $artifactJson = strtolower((string) file_get_contents(base_path('docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json')));
+        $combined = $doc."\n".$artifactJson;
+
+        foreach ([
+            'data_origin=live_gsc_api',
+            'data_quality_gate=pass',
+            'sanitized fields only',
+            'future backend read model import target',
+            'must never consume sidecar artifacts directly',
+            'no live gsc api call in this pr',
+            'no credential read, print, storage, or mutation',
+            'no opportunity queue enqueue',
+            'no cms draft or cms write',
+            'no search channel enqueue, approval, or submission',
+        ] as $requiredText) {
+            $this->assertStringContainsString($requiredText, $combined);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added the `SEO-GSC-LIVE-READMODEL-CONSUMPTION-CONTRACT-01` contract document and generated JSON artifact.
- Locked the future live GSC read-model consumption boundary: `data_origin=live_gsc_api`, `data_quality_gate=pass`, sanitized fields only, hashed canonical/query identifiers.
- Added a focused contract test for the new artifact and docs.
- Strengthened the existing opportunity queue generated contract/test to state that sidecar artifacts cannot be consumed directly by `/api/v0.5/ops/seo-intel/opportunity-queue`.

## Why
This closes the boundary between HK sidecar evidence artifacts and backend `seo_intel` read model consumption before any importer, scheduler, or opportunity queue work is considered.

## Validation
```bash
cd backend
php artisan test --filter SeoIntelGscDataQualityGateTest
php artisan test --filter SeoDashApi01ReadOnlyApiContractTest
php artisan test --filter SeoIntelGscReadModelConsumptionContractTest
python3 -m json.tool docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json >/dev/null
python3 -m json.tool docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null
git diff --check
```

## Intentionally deferred
- No live GSC API call.
- No credential read, print, storage, or mutation.
- No `seo_gsc_daily` import/write and no importer command.
- No migrations.
- No scheduler or queue worker activation.
- No opportunity queue enqueue or execution.
- No CMS draft/write.
- No Search Channel enqueue/approval/submission.
- No GSC URL Inspection indexing request or sitemap submission.
- No production environment changes.
