### PR TITLE
SEO-GSC-READMODEL-IMPORTER-DRYRUN-01: add GSC readmodel importer dry-run

### DIFF
--- a/backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\GscReadModelArtifactDryRunImporter;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class SeoIntelGscReadModelImportDryRunCommand extends Command
+{
+    protected $signature = 'seo-intel:gsc-readmodel-import-dry-run
+        {--artifact= : Path to a sanitized GSC sidecar artifact}
+        {--limit=250 : Preview row limit, bounded 1..250}
+        {--dry-run : Required; this command never writes}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Validate a sanitized GSC sidecar artifact and preview future seo_gsc_daily rows without writing.';
+
+    public function handle(GscReadModelArtifactDryRunImporter $importer): int
+    {
+        if (! (bool) $this->option('dry-run')) {
+            $summary = $this->failureSummary('dry_run_required');
+            $this->emitSummary($summary);
+
+            return self::FAILURE;
+        }
+
+        $path = $this->artifactPath();
+        if ($path === null) {
+            $summary = $this->failureSummary('artifact_path_required');
+            $this->emitSummary($summary);
+
+            return self::FAILURE;
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            $summary = $this->failureSummary('artifact_json_invalid');
+            $this->emitSummary($summary);
+
+            return self::FAILURE;
+        }
+
+        if (! is_array($decoded)) {
+            $summary = $this->failureSummary('artifact_must_be_object');
+            $this->emitSummary($summary);
+
+            return self::FAILURE;
+        }
+
+        $summary = $importer->preview($decoded, $this->limit());
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function artifactPath(): ?string
+    {
+        $path = trim((string) $this->option('artifact'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) ? $path : null;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 250;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $code): array
+    {
+        return [
+            'schema_version' => 'gsc-readmodel-importer-dryrun.v1',
+            'task' => 'SEO-GSC-READMODEL-IMPORTER-DRYRUN-01',
+            'ok' => false,
+            'dry_run' => true,
+            'would_write' => false,
+            'target_table' => 'seo_gsc_daily',
+            'rows_previewed' => 0,
+            'rows_would_insert' => 0,
+            'preview_rows' => [],
+            'errors' => [$code],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? 'true' : 'false'));
+        $this->line('dry_run=true');
+        $this->line('would_write=false');
+        $this->line('target_table=seo_gsc_daily');
+        $this->line('rows_previewed='.(string) ($summary['rows_previewed'] ?? 0));
+        $this->line('rows_would_insert='.(string) ($summary['rows_would_insert'] ?? 0));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Services/SeoIntel/Collectors/GscCollector.php
+++ b/backend/app/Services/SeoIntel/Collectors/GscCollector.php
@@ -261,11 +261,18 @@ final class GscCollector implements SeoIntelCollector
             'canonical_url_hash' => $row['canonical_url_hash'] ?? null,
             'query_hash' => $row['query_hash'] ?? null,
             'query_display_masked' => $row['query_display_masked'] ?? null,
+            'locale' => $row['locale'] ?? null,
             'source_engine' => $row['source_engine'] ?? null,
+            'device' => $row['device'] ?? null,
+            'country' => $row['country'] ?? null,
+            'search_type' => $row['search_type'] ?? null,
             'clicks' => $row['clicks'] ?? null,
             'impressions' => $row['impressions'] ?? null,
             'ctr_ppm' => $row['ctr_ppm'] ?? null,
             'average_position_milli' => $row['average_position_milli'] ?? null,
+            'is_brand_query' => $row['is_brand_query'] ?? null,
+            'query_type' => $row['query_type'] ?? null,
+            'data_state' => $row['data_state'] ?? null,
         ], array_slice($rows, 0, 3)));
     }
 }

--- a/backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php
+++ b/backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Carbon;
+
+final class GscReadModelArtifactDryRunImporter
+{
+    private const SCHEMA_VERSION = 'gsc-readmodel-importer-dryrun.v1';
+
+    /**
+     * @var list<string>
+     */
+    private const FORBIDDEN_FIELDS = [
+        'raw_query',
+        'raw_url',
+        'query',
+        'page',
+        'canonical_url',
+        'url',
+        'credential_path',
+        'token',
+        'access_token',
+        'api_key',
+        'client_email',
+        'service_account_json',
+        'private_key',
+        'cookie',
+        'session',
+        'raw_payload',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    public function preview(array $artifact, int $limit = 250): array
+    {
+        $limit = max(1, min($limit, 250));
+        $errors = $this->validateArtifact($artifact);
+
+        $safeRows = data_get($artifact, 'payload.metadata.safe_row_preview', []);
+        $previewRows = [];
+        if (is_array($safeRows)) {
+            foreach (array_slice(array_values($safeRows), 0, $limit) as $index => $row) {
+                if (! is_array($row)) {
+                    $errors[] = 'safe_row_preview.'.$index.'_must_be_object';
+
+                    continue;
+                }
+
+                $rowErrors = $this->validateSafeRow($row, $index);
+                if ($rowErrors !== []) {
+                    $errors = [...$errors, ...$rowErrors];
+
+                    continue;
+                }
+
+                $previewRows[] = $this->previewRow($row, $artifact);
+            }
+        }
+
+        $errors = array_values(array_unique($errors));
+        $ok = $errors === [] && $previewRows !== [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-GSC-READMODEL-IMPORTER-DRYRUN-01',
+            'ok' => $ok,
+            'dry_run' => true,
+            'would_write' => false,
+            'target_table' => 'seo_gsc_daily',
+            'rows_previewed' => count($previewRows),
+            'rows_would_insert' => $ok ? count($previewRows) : 0,
+            'data_origin' => data_get($artifact, 'payload.metadata.data_origin'),
+            'data_quality_gate' => data_get($artifact, 'payload.metadata.data_quality_gate.status'),
+            'source_engine' => data_get($artifact, 'payload.metadata.safe_row_preview.0.source_engine'),
+            'date_window' => data_get($artifact, 'payload.metadata.date_window'),
+            'forbidden_fields_checked' => self::FORBIDDEN_FIELDS,
+            'forbidden_fields_found' => $this->forbiddenFieldHits($artifact),
+            'negative_guarantees' => [
+                'database_write' => false,
+                'seo_gsc_daily_write' => false,
+                'scheduler_activation' => false,
+                'opportunity_queue_enqueue' => false,
+                'cms_write' => false,
+                'search_channel_enqueue' => false,
+                'search_provider_submission' => false,
+                'indexing_request' => false,
+                'live_gsc_api_call' => false,
+            ],
+            'preview_rows' => $ok ? $previewRows : [],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return list<string>
+     */
+    private function validateArtifact(array $artifact): array
+    {
+        $errors = [];
+
+        if ($this->forbiddenFieldHits($artifact) !== []) {
+            $errors[] = 'forbidden_field_present';
+        }
+
+        if ((string) data_get($artifact, 'payload.metadata.data_origin') !== 'live_gsc_api') {
+            $errors[] = 'data_origin_must_be_live_gsc_api';
+        }
+
+        if ((string) data_get($artifact, 'payload.metadata.data_quality_gate.status') !== 'pass') {
+            $errors[] = 'data_quality_gate_must_pass';
+        }
+
+        if ((string) data_get($artifact, 'payload.status') !== 'success') {
+            $errors[] = 'artifact_payload_status_must_be_success';
+        }
+
+        foreach ([
+            'payload.writes_attempted',
+            'payload.writes_committed',
+            'payload.metadata.writes_attempted',
+            'payload.metadata.writes_committed',
+            'payload.metadata.cms_write_allowed',
+            'payload.metadata.search_channel_enqueue_allowed',
+            'payload.metadata.indexing_request_allowed',
+        ] as $flag) {
+            if ($this->boolValue(data_get($artifact, $flag))) {
+                $errors[] = str_replace('.', '_', $flag).'_must_be_false';
+            }
+        }
+
+        $safeRows = data_get($artifact, 'payload.metadata.safe_row_preview');
+        if (! is_array($safeRows) || $safeRows === []) {
+            $errors[] = 'safe_row_preview_required';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function validateSafeRow(array $row, int $index): array
+    {
+        $errors = [];
+
+        foreach (['report_date', 'canonical_url_hash', 'query_hash', 'source_engine', 'clicks', 'impressions'] as $field) {
+            if (! array_key_exists($field, $row) || $row[$field] === null || $row[$field] === '') {
+                $errors[] = 'safe_row_preview.'.$index.'.'.$field.'_required';
+            }
+        }
+
+        if ((string) ($row['source_engine'] ?? '') !== 'google') {
+            $errors[] = 'safe_row_preview.'.$index.'.source_engine_must_be_google';
+        }
+
+        foreach (['canonical_url_hash', 'query_hash'] as $hashField) {
+            $value = (string) ($row[$hashField] ?? '');
+            if (preg_match('/^[a-f0-9]{64}$/', $value) !== 1) {
+                $errors[] = 'safe_row_preview.'.$index.'.'.$hashField.'_must_be_sha256';
+            }
+        }
+
+        foreach (['clicks', 'impressions'] as $metricField) {
+            if (! is_numeric($row[$metricField] ?? null) || (int) $row[$metricField] < 0) {
+                $errors[] = 'safe_row_preview.'.$index.'.'.$metricField.'_must_be_non_negative';
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    private function previewRow(array $row, array $artifact): array
+    {
+        return [
+            'report_date' => substr((string) $row['report_date'], 0, 10),
+            'canonical_url_hash' => (string) $row['canonical_url_hash'],
+            'canonical_url' => null,
+            'query_hash' => (string) $row['query_hash'],
+            'query_display_masked' => $this->nullableString($row['query_display_masked'] ?? null),
+            'locale' => $this->nullableString($row['locale'] ?? null),
+            'source_engine' => 'google',
+            'device' => $this->nullableString($row['device'] ?? null),
+            'country' => $this->nullableString($row['country'] ?? null),
+            'search_type' => $this->nullableString($row['search_type'] ?? null),
+            'clicks' => max(0, (int) $row['clicks']),
+            'impressions' => max(0, (int) $row['impressions']),
+            'ctr_ppm' => $this->nullableNonNegativeInt($row['ctr_ppm'] ?? null),
+            'average_position_milli' => $this->nullableNonNegativeInt($row['average_position_milli'] ?? null),
+            'is_brand_query' => $this->boolValue($row['is_brand_query'] ?? false),
+            'query_type' => $this->nullableString($row['query_type'] ?? null) ?? 'unknown',
+            'data_state' => $this->nullableString($row['data_state'] ?? null) ?? 'final',
+            'collected_at' => Carbon::now('UTC')->toIso8601String(),
+            'metadata_json' => [
+                'data_origin' => 'live_gsc_api',
+                'row_source' => 'live_gsc_api',
+                'source_artifact_schema' => (string) ($artifact['schema_version'] ?? ''),
+                'source_artifact_mode' => (string) ($artifact['mode'] ?? ''),
+                'purchase_attribution_allowed' => false,
+                'dry_run_import_preview' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenFieldHits(array $payload): array
+    {
+        $hits = [];
+        $this->collectForbiddenFieldHits($payload, '', $hits);
+
+        return array_values(array_unique($hits));
+    }
+
+    /**
+     * @param  array<string, mixed>|list<mixed>  $value
+     * @param  list<string>  $hits
+     */
+    private function collectForbiddenFieldHits(array $value, string $path, array &$hits): void
+    {
+        foreach ($value as $key => $child) {
+            $keyString = (string) $key;
+            $normalized = mb_strtolower(trim($keyString), 'UTF-8');
+            $childPath = $path === '' ? $keyString : $path.'.'.$keyString;
+
+            if (in_array($normalized, self::FORBIDDEN_FIELDS, true)) {
+                $hits[] = $childPath;
+            }
+
+            if (is_array($child)) {
+                $this->collectForbiddenFieldHits($child, $childPath, $hits);
+            }
+        }
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function nullableNonNegativeInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    private function boolValue(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return in_array(mb_strtolower(trim((string) $value), 'UTF-8'), ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/docs/seo/generated/gsc-readmodel-importer-dryrun.v1.json
+++ b/backend/docs/seo/generated/gsc-readmodel-importer-dryrun.v1.json
@@ -1,0 +1,89 @@
+{
+  "version": "gsc-readmodel-importer-dryrun.v1",
+  "task": "SEO-GSC-READMODEL-IMPORTER-DRYRUN-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-intel:gsc-readmodel-import-dry-run",
+  "dry_run_required": true,
+  "write_mode_available": false,
+  "input": {
+    "artifact_kind": "sanitized_hk_gsc_sidecar_wrapper_artifact",
+    "required_status": "success",
+    "required_data_origin": "live_gsc_api",
+    "required_data_quality_gate": "pass",
+    "required_rows_path": "payload.metadata.safe_row_preview"
+  },
+  "target_table": {
+    "name": "seo_gsc_daily",
+    "status": "future_import_preview_only",
+    "write_allowed_in_this_pr": false
+  },
+  "validation": {
+    "forbidden_fields_checked_recursively": [
+      "raw_query",
+      "raw_url",
+      "query",
+      "page",
+      "canonical_url",
+      "url",
+      "credential_path",
+      "token",
+      "access_token",
+      "api_key",
+      "client_email",
+      "service_account_json",
+      "private_key",
+      "cookie",
+      "session",
+      "raw_payload"
+    ],
+    "required_false_flags": [
+      "payload.writes_attempted",
+      "payload.writes_committed",
+      "payload.metadata.writes_attempted",
+      "payload.metadata.writes_committed",
+      "payload.metadata.cms_write_allowed",
+      "payload.metadata.search_channel_enqueue_allowed",
+      "payload.metadata.indexing_request_allowed"
+    ],
+    "required_safe_row_fields": [
+      "report_date",
+      "canonical_url_hash",
+      "query_hash",
+      "source_engine",
+      "clicks",
+      "impressions"
+    ]
+  },
+  "preview_output": {
+    "schema_version": "gsc-readmodel-importer-dryrun.v1",
+    "dry_run": true,
+    "would_write": false,
+    "target_table": "seo_gsc_daily",
+    "rows_previewed": "bounded_1_to_250",
+    "canonical_url": "null_until_separate_backend_url_truth_join_is_approved",
+    "metadata_json": {
+      "data_origin": "live_gsc_api",
+      "row_source": "live_gsc_api",
+      "purchase_attribution_allowed": false,
+      "dry_run_import_preview": true
+    }
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "seo_gsc_daily_write": false,
+    "migration_added": false,
+    "scheduler_activation": false,
+    "queue_worker_activation": false,
+    "opportunity_queue_enqueue": false,
+    "cms_write": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "search_provider_submission": false,
+    "gsc_url_inspection_request_indexing": false,
+    "sitemap_submission": false,
+    "live_gsc_api_call": false,
+    "credential_read_print_or_store": false,
+    "production_env_change": false
+  },
+  "next_allowed_step": "Deploy dry-run command to sidecar runtime and run importer preflight against the latest sanitized live-read artifact; write-mode import, scheduler, opportunity queue, CMS, and search/indexing remain held."
+}

--- a/backend/docs/seo/gsc-readmodel-importer-dryrun.md
+++ b/backend/docs/seo/gsc-readmodel-importer-dryrun.md
@@ -1,0 +1,95 @@
+# GSC Read Model Importer Dry-Run
+
+Task: `SEO-GSC-READMODEL-IMPORTER-DRYRUN-01`
+
+## Purpose
+
+This PR adds a dry-run-only preflight for sanitized Hong Kong GSC sidecar artifacts.
+
+The command reads a sanitized sidecar artifact, validates the read-model boundary, and previews the future `seo_gsc_daily` rows that a later approved importer could write.
+
+This PR does not write `seo_gsc_daily`, add a scheduler, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Google APIs, or change production environment variables.
+
+## Command
+
+```bash
+php artisan seo-intel:gsc-readmodel-import-dry-run \
+  --artifact=/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-YYYYMMDDTHHMMSSZ-success.json \
+  --dry-run \
+  --json
+```
+
+`--dry-run` is required. Without it, the command fails closed.
+
+## Required Artifact Gates
+
+The input artifact must satisfy all of these conditions:
+
+- `payload.status=success`
+- `payload.metadata.data_origin=live_gsc_api`
+- `payload.metadata.data_quality_gate.status=pass`
+- `payload.metadata.safe_row_preview` exists and contains sanitized rows
+- `payload.writes_attempted=false`
+- `payload.writes_committed=false`
+- `payload.metadata.cms_write_allowed=false`
+- `payload.metadata.search_channel_enqueue_allowed=false`
+- `payload.metadata.indexing_request_allowed=false`
+
+## Forbidden Fields
+
+The importer recursively rejects artifacts containing these exact field names:
+
+- `raw_query`
+- `raw_url`
+- `query`
+- `page`
+- `canonical_url`
+- `url`
+- `credential_path`
+- `token`
+- `access_token`
+- `api_key`
+- `client_email`
+- `service_account_json`
+- `private_key`
+- `cookie`
+- `session`
+- `raw_payload`
+
+Allowed row preview fields remain sanitized: hashed canonical URL, hashed query, masked query display, report date, source engine, device, country, search type, clicks, impressions, CTR ppm, average-position milli, query type, brand flag, and data state.
+
+## Preview Output
+
+The output includes:
+
+- `target_table=seo_gsc_daily`
+- `dry_run=true`
+- `would_write=false`
+- `rows_previewed`
+- `rows_would_insert`
+- sanitized `preview_rows`
+- negative guarantees for DB, scheduler, queue, CMS, Search Channel, indexing, and live GSC calls
+
+The preview rows deliberately set `canonical_url=null` because raw URLs are not allowed in sidecar artifacts. Future write-mode import remains blocked until a separate approved PR defines whether `seo_gsc_daily.canonical_url` stays null or is safely joined from backend URL truth by hash.
+
+## Negative Guarantees
+
+- no database write
+- no `seo_gsc_daily` write
+- no migration
+- no scheduler activation
+- no queue worker activation
+- no opportunity queue enqueue
+- no CMS draft or CMS write
+- no Search Channel enqueue, approval, retry, or submission
+- no GSC URL Inspection request indexing
+- no sitemap submission
+- no live GSC API call
+- no credential read, print, storage, or mutation
+- no raw query, raw URL, token, client email, credential path, cookie, session, service-account JSON, or raw payload accepted
+
+## Next Allowed Work
+
+After this PR, the next safe step is operator-reviewed deployment of the dry-run command to the sidecar runtime and a dry-run preflight against the latest sanitized live-read artifact.
+
+Write-mode read-model import, scheduler activation, opportunity queue consumption, CMS drafting, and search/indexing actions remain separate holds.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelImporterDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelImporterDryRunTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\GscReadModelArtifactDryRunImporter;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscReadModelImporterDryRunTest extends TestCase
+{
+    #[Test]
+    public function importer_previews_future_seo_gsc_daily_rows_without_writing(): void
+    {
+        $artifact = $this->validArtifact();
+        $summary = (new GscReadModelArtifactDryRunImporter)->preview($artifact);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) ($summary['dry_run'] ?? false));
+        $this->assertFalse((bool) ($summary['would_write'] ?? true));
+        $this->assertSame('seo_gsc_daily', $summary['target_table'] ?? null);
+        $this->assertSame(1, $summary['rows_previewed'] ?? null);
+        $this->assertSame(1, $summary['rows_would_insert'] ?? null);
+        $this->assertSame('live_gsc_api', $summary['data_origin'] ?? null);
+        $this->assertSame('pass', $summary['data_quality_gate'] ?? null);
+
+        $row = data_get($summary, 'preview_rows.0');
+        $this->assertIsArray($row);
+        $this->assertSame('2026-06-17', $row['report_date'] ?? null);
+        $this->assertSame(hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'), $row['canonical_url_hash'] ?? null);
+        $this->assertNull($row['canonical_url'] ?? null);
+        $this->assertSame(hash('sha256', 'mbti测试'), $row['query_hash'] ?? null);
+        $this->assertSame('m****试', $row['query_display_masked'] ?? null);
+        $this->assertSame('google', $row['source_engine'] ?? null);
+        $this->assertSame(0, $row['clicks'] ?? null);
+        $this->assertSame(60, $row['impressions'] ?? null);
+        $this->assertSame('live_gsc_api', data_get($row, 'metadata_json.data_origin'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.database_write', true));
+    }
+
+    #[Test]
+    public function artisan_command_reads_artifact_and_outputs_json_preview_without_db_write(): void
+    {
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        $exitCode = Artisan::call('seo-intel:gsc-readmodel-import-dry-run', [
+            '--artifact' => $artifactPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertIsArray($decoded);
+        $this->assertSame('gsc-readmodel-importer-dryrun.v1', $decoded['schema_version'] ?? null);
+        $this->assertTrue((bool) ($decoded['ok'] ?? false));
+        $this->assertFalse((bool) ($decoded['would_write'] ?? true));
+        $this->assertSame(1, $decoded['rows_would_insert'] ?? null);
+        $this->assertStringNotContainsString('mbti测试', Artisan::output());
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', Artisan::output());
+        $this->assertStringNotContainsString('secret-gsc-token', Artisan::output());
+    }
+
+    #[Test]
+    public function command_requires_explicit_dry_run(): void
+    {
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        $exitCode = Artisan::call('seo-intel:gsc-readmodel-import-dry-run', [
+            '--artifact' => $artifactPath,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertIsArray($decoded);
+        $this->assertSame(['dry_run_required'], $decoded['errors'] ?? null);
+        $this->assertFalse((bool) ($decoded['would_write'] ?? true));
+    }
+
+    #[Test]
+    public function importer_fails_closed_when_forbidden_fields_are_present(): void
+    {
+        $artifact = $this->validArtifact();
+        $artifact['payload']['metadata']['safe_row_preview'][0]['raw_query'] = 'mbti测试';
+        $artifact['payload']['metadata']['preflight']['client_email'] = 'reader@example.invalid';
+        $artifact['payload']['metadata']['preflight']['credential_path'] = '/secret/path.json';
+
+        $summary = (new GscReadModelArtifactDryRunImporter)->preview($artifact);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertSame(0, $summary['rows_would_insert'] ?? null);
+        $this->assertContains('forbidden_field_present', $summary['errors'] ?? []);
+        $this->assertContains('payload.metadata.safe_row_preview.0.raw_query', $summary['forbidden_fields_found'] ?? []);
+        $this->assertContains('payload.metadata.preflight.client_email', $summary['forbidden_fields_found'] ?? []);
+        $this->assertContains('payload.metadata.preflight.credential_path', $summary['forbidden_fields_found'] ?? []);
+        $this->assertSame([], $summary['preview_rows'] ?? null);
+    }
+
+    #[Test]
+    public function importer_requires_live_origin_and_passing_quality_gate(): void
+    {
+        $artifact = $this->validArtifact();
+        data_set($artifact, 'payload.metadata.data_origin', 'fixture');
+        data_set($artifact, 'payload.metadata.data_quality_gate.status', 'blocked');
+
+        $summary = (new GscReadModelArtifactDryRunImporter)->preview($artifact);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('data_origin_must_be_live_gsc_api', $summary['errors'] ?? []);
+        $this->assertContains('data_quality_gate_must_pass', $summary['errors'] ?? []);
+        $this->assertSame(0, $summary['rows_would_insert'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validArtifact(): array
+    {
+        return [
+            'schema_version' => 'gsc-hk-sidecar-runner-wrapper.v1',
+            'task' => 'SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01',
+            'mode' => 'live-read',
+            'payload' => [
+                'collector' => 'gsc_foundation',
+                'status' => 'success',
+                'dry_run' => true,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'external_calls_attempted' => true,
+                'items_seen' => 1,
+                'metadata' => [
+                    'mode' => 'gsc_live_readonly_sidecar_read',
+                    'data_origin' => 'live_gsc_api',
+                    'date_window' => [
+                        'start_date' => '2026-06-17',
+                        'end_date' => '2026-06-17',
+                    ],
+                    'data_quality_gate' => [
+                        'status' => 'pass',
+                        'opportunity_queue_eligible' => true,
+                    ],
+                    'safe_row_preview' => [[
+                        'report_date' => '2026-06-17',
+                        'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
+                        'query_hash' => hash('sha256', 'mbti测试'),
+                        'query_display_masked' => 'm****试',
+                        'locale' => 'zh-CN',
+                        'source_engine' => 'google',
+                        'device' => null,
+                        'country' => null,
+                        'search_type' => 'web',
+                        'clicks' => 0,
+                        'impressions' => 60,
+                        'ctr_ppm' => 0,
+                        'average_position_milli' => 9000,
+                        'is_brand_query' => false,
+                        'query_type' => 'non_brand',
+                        'data_state' => 'final',
+                    ]],
+                    'opportunity_queue_eligible' => false,
+                    'cms_write_allowed' => false,
+                    'search_channel_enqueue_allowed' => false,
+                    'indexing_request_allowed' => false,
+                    'writes_attempted' => false,
+                    'writes_committed' => false,
+                    'scheduler_enabled' => false,
+                    'queue_worker_enabled' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function writeArtifact(array $artifact): string
+    {
+        $dir = storage_path('framework/testing/gsc-readmodel-importer-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/artifact.json';
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -890,9 +890,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_seo_intel_gsc_foundation_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
+            'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
@@ -4689,9 +4691,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoIntelGscFoundationFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
+            'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',


### PR DESCRIPTION
## What changed
- Added `php artisan seo-intel:gsc-readmodel-import-dry-run` for dry-run-only validation of sanitized HK GSC sidecar artifacts.
- Added `GscReadModelArtifactDryRunImporter` to validate `data_origin=live_gsc_api`, `data_quality_gate=pass`, forbidden fields, write-boundary flags, and sanitized row preview shape before producing future `seo_gsc_daily` row previews.
- Expanded GSC safe row preview with sanitized fields needed for dry-run read-model preview.
- Added docs and generated contract evidence for `SEO-GSC-READMODEL-IMPORTER-DRYRUN-01`.

## Why
This closes the next safe step after the sidecar runner and read-model consumption contract: preview how live sanitized GSC artifacts would map into `seo_gsc_daily` without importing, scheduling, queueing, CMS mutation, or search/indexing side effects.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SeoIntel/SeoIntelGscReadModelImporterDryRunTest.php tests/Feature/SeoIntel/SeoIntelGscDataQualityGateTest.php tests/Feature/SeoIntel/SeoIntelGscReadModelConsumptionContractTest.php tests/Feature/SeoIntel/SeoIntelGscSidecarRunnerTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_intel_gsc --no-ansi`
- `cd backend && php artisan list --raw | rg "seo-intel:gsc-readmodel-import-dry-run"`
- `cd backend && ./vendor/bin/pint --test app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php app/Services/SeoIntel/Collectors/GscCollector.php tests/Feature/SeoIntel/SeoIntelGscReadModelImporterDryRunTest.php`
- `python3 -m json.tool backend/docs/seo/generated/gsc-readmodel-importer-dryrun.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/gsc-live-readmodel-consumption-contract.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No DB writes or `seo_gsc_daily` import.
- No migration.
- No scheduler or queue worker activation.
- No opportunity queue consumption/enqueue.
- No CMS draft/write/publish action.
- No Search Channel enqueue/approval/submit/retry.
- No GSC URL Inspection request indexing or sitemap submission.
- No live GSC API call and no production env change.

## Repository rule impact
Backend read-model boundary only. CMS/content authority and search/indexing execution remain unchanged and held for separate approval.
