### PR TITLE
SEO-GSC-SIDECAR-RUNTIME-ENV-CACHE-BOUNDARY-01: Lock sidecar runtime env/cache boundary

### DIFF
--- a/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
+++ b/backend/docs/seo/generated/gsc-hk-sidecar-runner.v1.json
@@ -13,7 +13,9 @@
     "preflight": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-preflight --dry-run --no-write --json",
     "bounded_live_read": "php artisan seo-intel:collect --collector=gsc_foundation --gsc-live-read --dry-run --no-write --json --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250",
     "sidecar_wrapper_preflight": "php artisan seo-intel:gsc-sidecar-runner --mode=preflight --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts",
-    "sidecar_wrapper_live_read": "php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts"
+    "sidecar_wrapper_live_read": "php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts",
+    "sidecar_launcher_preflight": "backend/scripts/seo/gsc_sidecar_runner.sh --mode=preflight --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts",
+    "sidecar_launcher_live_read": "backend/scripts/seo/gsc_sidecar_runner.sh --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts"
   },
   "required_runtime_gates": [
     "SEO_INTEL_GSC_ENABLED=true",
@@ -254,7 +256,100 @@
       "queue_worker_activation": false
     }
   },
+  "sidecar_launcher_contract": {
+    "task": "SEO-GSC-SIDECAR-RUNTIME-ENV-CACHE-BOUNDARY-01",
+    "script": "backend/scripts/seo/gsc_sidecar_runner.sh",
+    "default_env_file": "/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env",
+    "env_file_override": "SIDECAR_ENV_FILE",
+    "default_app_config_cache": "/tmp/fermatmind-gsc-sidecar-config.php",
+    "app_config_cache_override": "SIDECAR_CONFIG_CACHE",
+    "production_env_edited_by_pr": false,
+    "scheduler_enabled": false,
+    "queue_worker_enabled": false,
+    "delegates_to": "php artisan seo-intel:gsc-sidecar-runner",
+    "allowed_env_file_values": [
+      "SEO_INTEL_GSC_ENABLED=true",
+      "SEO_INTEL_GSC_LIVE_API_ENABLED=true",
+      "SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=true",
+      "SEO_INTEL_GSC_PROPERTY_URL",
+      "SEO_INTEL_GSC_AUTH_MODE=service_account",
+      "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH",
+      "SIDECAR_CONFIG_CACHE"
+    ],
+    "forbidden_env_file_values": [
+      "service-account JSON content",
+      "private key content",
+      "access token",
+      "client email",
+      "raw query",
+      "raw URL",
+      "cookie",
+      "session",
+      "CMS credential",
+      "Search Channel credential"
+    ],
+    "fail_closed_if": [
+      "env file is missing or unreadable",
+      "APP_CONFIG_CACHE must not point under bootstrap/cache",
+      "required GSC env is missing",
+      "SEO_INTEL_GSC_AUTH_MODE is not service_account",
+      "SEO_INTEL_GSC_ACCESS_TOKEN is non-empty",
+      "SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON is non-empty"
+    ],
+    "negative_guarantees": {
+      "production_env_edit": false,
+      "scheduler_activation": false,
+      "queue_worker_activation": false,
+      "db_writes": false,
+      "seo_gsc_daily_import": false,
+      "opportunity_queue_enqueue": false,
+      "cms_write": false,
+      "search_channel_submit": false,
+      "gsc_url_inspection_request_indexing": false
+    }
+  },
+  "readmodel_dryrun_revalidation": {
+    "task": "GSC Readmodel Dry-run revalidation",
+    "observed_date": "2026-06-20",
+    "sidecar_origin_main_sha": "ae025183f1f3975103740ad80f27322a2afe2693",
+    "preflight": {
+      "path": "/opt/fermatmind/seo-gsc-runner/artifacts/gsc-preflight-wrapper-20260620T090151Z-success.json",
+      "byte_size": 3521,
+      "sha256": "0d2e2b2182c56059d57c56d57ffc8219ba358bad64a6a1825bfd43ad35f6e169",
+      "status": "success"
+    },
+    "live_read": {
+      "path": "/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-20260620T090231Z-success.json",
+      "byte_size": 7409,
+      "sha256": "5b1de9bd4f69a9678eef591d16000a268033b64eb1b22400e8c03a8f7b52ebb6",
+      "status": "success",
+      "data_quality_gate": "pass",
+      "items_seen": 25
+    },
+    "import_dryrun": {
+      "path": "/opt/fermatmind/seo-gsc-runner/artifacts/gsc-readmodel-import-dryrun-20260620T090231Z.json",
+      "byte_size": 4803,
+      "sha256": "cae112da93a7dcbe4d1afc59a7c5fc803bcb2fb859868a44920e84f30743efc4",
+      "ok": true,
+      "data_origin": "live_gsc_api",
+      "data_quality_gate": "pass",
+      "would_write": false,
+      "rows_would_insert": 3
+    },
+    "negative_guarantees": {
+      "db_write": false,
+      "scheduler_activation": false,
+      "queue_enqueue": false,
+      "cms_mutation": false,
+      "search_channel_enqueue": false,
+      "search_channel_submit": false,
+      "indexing_request": false,
+      "production_env_edit": false,
+      "secret_pattern_output": false
+    },
+    "next_write_capable_step": "SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01 remains held until separate operator approval"
+  },
   "requires_operator_approval_before_secret_install": true,
   "requires_operator_approval_before_live_read": true,
-  "next_allowed_step": "sidecar runner wrapper or read-model boundary PR; do not enable scheduler, write DB, enqueue opportunities, mutate CMS, or submit search without a separate approval"
+  "next_allowed_step": "deploy/sync launcher to HK sidecar and rerun read-only preflight/live-read/dry-run through the launcher; do not enable scheduler, write DB, enqueue opportunities, mutate CMS, or submit search without a separate approval"
 }

--- a/backend/docs/seo/gsc-hk-sidecar-runner.md
+++ b/backend/docs/seo/gsc-hk-sidecar-runner.md
@@ -46,6 +46,16 @@ php artisan seo-intel:gsc-sidecar-runner --mode=preflight --artifact-dir=/opt/fe
 php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts
 ```
 
+Preferred sidecar launcher:
+
+```bash
+backend/scripts/seo/gsc_sidecar_runner.sh --mode=preflight --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts
+```
+
+```bash
+backend/scripts/seo/gsc_sidecar_runner.sh --mode=live-read --start-date=YYYY-MM-DD --end-date=YYYY-MM-DD --limit=250 --dimensions=query,page --artifact-dir=/opt/fermatmind/seo-gsc-runner/artifacts
+```
+
 ## Required Runtime Gates
 
 - `SEO_INTEL_GSC_ENABLED=true`
@@ -59,6 +69,10 @@ php artisan seo-intel:gsc-sidecar-runner --mode=live-read --start-date=YYYY-MM-D
 - sidecar wrapper must call only `seo-intel:collect --collector=gsc_foundation`
 - sidecar wrapper must force `--dry-run --no-write --json`
 - sidecar wrapper must fail if the collector reports any write, CMS, Search Channel, or indexing boundary as enabled
+- sidecar launcher must load runtime gates from `/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env` unless `SIDECAR_ENV_FILE` overrides it
+- sidecar launcher must set `APP_CONFIG_CACHE=${SIDECAR_CONFIG_CACHE:-/tmp/fermatmind-gsc-sidecar-config.php}` before Laravel starts
+- sidecar launcher must fail closed if `APP_CONFIG_CACHE` points under `bootstrap/cache`
+- sidecar launcher must fail closed if inline service-account JSON or access-token env values are present
 
 ## Secret Placement
 
@@ -169,6 +183,47 @@ Forbidden wrapper outcomes:
 - no scheduler activation
 - no queue worker activation
 - no raw query, raw URL, credential, token, client email, cookie, session, or private key output
+
+## Sidecar Runtime Env and Config Cache Boundary
+
+Task: `SEO-GSC-SIDECAR-RUNTIME-ENV-CACHE-BOUNDARY-01`
+
+`backend/scripts/seo/gsc_sidecar_runner.sh` is the approved launcher for repeatable HK sidecar execution. It exists to replace manual inline environment assembly with a bounded process-level entrypoint.
+
+Launcher guarantees:
+
+- defaults to `/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env`
+- supports `SIDECAR_ENV_FILE=/path/to/env` for operator-controlled sidecar env placement
+- sets `APP_CONFIG_CACHE` before Laravel bootstraps
+- defaults `APP_CONFIG_CACHE` to `/tmp/fermatmind-gsc-sidecar-config.php`
+- rejects `APP_CONFIG_CACHE` under `bootstrap/cache`
+- requires the GSC live-read gates and service-account path to be present
+- rejects inline service-account JSON and access-token env values
+- delegates only to `php artisan seo-intel:gsc-sidecar-runner "$@"`
+
+The sidecar env file may contain non-secret runtime switches, the GSC property, auth mode, and a service-account JSON file path. It must not contain service-account JSON content, private key content, access tokens, client email values, raw query data, raw URL data, cookies, sessions, or CMS/search credentials.
+
+The PR that introduced this launcher did not change production `fap-api` environment variables, run a live read, write a database row, import `seo_gsc_daily`, enqueue an opportunity, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Baidu, call IndexNow, enable a scheduler, or enable a queue worker.
+
+## Readmodel Dry-run Revalidation Evidence
+
+Task: `GSC Readmodel Dry-run revalidation`
+
+On 2026-06-20, the HK sidecar runner was synced to `origin/main` at `ae025183f1f3975103740ad80f27322a2afe2693` and a read-only chain was verified:
+
+- Preflight artifact: `/opt/fermatmind/seo-gsc-runner/artifacts/gsc-preflight-wrapper-20260620T090151Z-success.json`
+  - File size: `3521` bytes
+  - SHA256: `0d2e2b2182c56059d57c56d57ffc8219ba358bad64a6a1825bfd43ad35f6e169`
+- Read-only live read artifact: `/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-20260620T090231Z-success.json`
+  - File size: `7409` bytes
+  - SHA256: `5b1de9bd4f69a9678eef591d16000a268033b64eb1b22400e8c03a8f7b52ebb6`
+  - Summary: `status=success`, `data_quality_gate=pass`, `items_seen=25`
+- Readmodel dry-run importer artifact: `/opt/fermatmind/seo-gsc-runner/artifacts/gsc-readmodel-import-dryrun-20260620T090231Z.json`
+  - File size: `4803` bytes
+  - SHA256: `cae112da93a7dcbe4d1afc59a7c5fc803bcb2fb859868a44920e84f30743efc4`
+  - Summary: `ok=true`, `data_origin=live_gsc_api`, `data_quality_gate=pass`, `would_write=false`, `rows_would_insert=3`
+
+The same revalidation confirmed no DB write, scheduler, queue, CMS, Search Channel, indexing, production env mutation, or secret-pattern output. `SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01` remains held until a separate operator approval explicitly authorizes a write-capable canary.
 
 ## Output Boundary
 

--- a/backend/scripts/seo/gsc_sidecar_runner.sh
+++ b/backend/scripts/seo/gsc_sidecar_runner.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SIDECAR_ENV_FILE="${SIDECAR_ENV_FILE:-/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env}"
+SIDECAR_CONFIG_CACHE_DEFAULT="/tmp/fermatmind-gsc-sidecar-config.php"
+
+fail() {
+  printf 'error=%s\n' "$1" >&2
+  exit 1
+}
+
+if [[ ! -r "${SIDECAR_ENV_FILE}" ]]; then
+  fail "sidecar_env_file_unreadable"
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "${SIDECAR_ENV_FILE}"
+set +a
+
+APP_CONFIG_CACHE="${SIDECAR_CONFIG_CACHE:-${SIDECAR_CONFIG_CACHE_DEFAULT}}"
+
+case "${APP_CONFIG_CACHE}" in
+  ""|*"${BACKEND_DIR}/bootstrap/cache/"*|*"/bootstrap/cache/"*)
+    fail "sidecar_config_cache_forbidden"
+    ;;
+esac
+
+required_env=(
+  SEO_INTEL_GSC_ENABLED
+  SEO_INTEL_GSC_LIVE_API_ENABLED
+  SEO_INTEL_ALLOW_EXTERNAL_API_CALLS
+  SEO_INTEL_GSC_PROPERTY_URL
+  SEO_INTEL_GSC_AUTH_MODE
+  SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH
+)
+
+for key in "${required_env[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    fail "sidecar_required_env_missing"
+  fi
+done
+
+if [[ "${SEO_INTEL_GSC_ENABLED}" != "true" ]]; then
+  fail "sidecar_gsc_enabled_not_true"
+fi
+
+if [[ "${SEO_INTEL_GSC_LIVE_API_ENABLED}" != "true" ]]; then
+  fail "sidecar_gsc_live_api_enabled_not_true"
+fi
+
+if [[ "${SEO_INTEL_ALLOW_EXTERNAL_API_CALLS}" != "true" ]]; then
+  fail "sidecar_external_api_calls_not_true"
+fi
+
+if [[ "${SEO_INTEL_GSC_AUTH_MODE}" != "service_account" ]]; then
+  fail "sidecar_auth_mode_not_service_account"
+fi
+
+if [[ -n "${SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON:-}" ]]; then
+  fail "sidecar_inline_service_account_json_forbidden"
+fi
+
+if [[ -n "${SEO_INTEL_GSC_ACCESS_TOKEN:-}" ]]; then
+  fail "sidecar_access_token_forbidden"
+fi
+
+export APP_CONFIG_CACHE
+export SEO_INTEL_GSC_ENABLED
+export SEO_INTEL_GSC_LIVE_API_ENABLED
+export SEO_INTEL_ALLOW_EXTERNAL_API_CALLS
+export SEO_INTEL_GSC_PROPERTY_URL
+export SEO_INTEL_GSC_AUTH_MODE
+export SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH
+
+cd "${BACKEND_DIR}"
+exec php artisan seo-intel:gsc-sidecar-runner "$@"

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscSidecarRuntimeEnvBoundaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscSidecarRuntimeEnvBoundaryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscSidecarRuntimeEnvBoundaryTest extends TestCase
+{
+    #[Test]
+    public function sidecar_launcher_locks_env_file_and_config_cache_boundary(): void
+    {
+        $scriptPath = base_path('scripts/seo/gsc_sidecar_runner.sh');
+
+        $this->assertFileExists($scriptPath);
+        $this->assertTrue(is_executable($scriptPath), 'sidecar launcher must be executable');
+
+        $script = (string) file_get_contents($scriptPath);
+
+        $this->assertStringContainsString('SIDECAR_ENV_FILE="${SIDECAR_ENV_FILE:-/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env}"', $script);
+        $this->assertStringContainsString('APP_CONFIG_CACHE="${SIDECAR_CONFIG_CACHE:-${SIDECAR_CONFIG_CACHE_DEFAULT}}"', $script);
+        $this->assertStringContainsString('sidecar_config_cache_forbidden', $script);
+        $this->assertStringContainsString('/bootstrap/cache/', $script);
+        $this->assertStringContainsString('SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH', $script);
+        $this->assertStringContainsString('sidecar_inline_service_account_json_forbidden', $script);
+        $this->assertStringContainsString('sidecar_access_token_forbidden', $script);
+        $this->assertStringContainsString('exec php artisan seo-intel:gsc-sidecar-runner "$@"', $script);
+
+        $this->assertStringNotContainsString('seo-intel:collect', $script);
+        $this->assertStringNotContainsString('BEGIN PRIVATE KEY', $script);
+        $this->assertStringNotContainsString('private_key', $script);
+        $this->assertStringNotContainsString('client_email', $script);
+        $this->assertStringNotContainsString('ya29.', $script);
+        $this->assertStringNotContainsString('Bearer ', $script);
+    }
+
+    #[Test]
+    public function generated_contract_records_runtime_env_cache_boundary_and_negative_guarantees(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/gsc-hk-sidecar-runner.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+
+        $this->assertSame('backend/scripts/seo/gsc_sidecar_runner.sh', data_get($artifact, 'sidecar_launcher_contract.script'));
+        $this->assertSame('/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env', data_get($artifact, 'sidecar_launcher_contract.default_env_file'));
+        $this->assertSame('/tmp/fermatmind-gsc-sidecar-config.php', data_get($artifact, 'sidecar_launcher_contract.default_app_config_cache'));
+        $this->assertFalse((bool) data_get($artifact, 'sidecar_launcher_contract.production_env_edited_by_pr', true));
+        $this->assertFalse((bool) data_get($artifact, 'sidecar_launcher_contract.scheduler_enabled', true));
+        $this->assertSame('php artisan seo-intel:gsc-sidecar-runner', data_get($artifact, 'sidecar_launcher_contract.delegates_to'));
+        $this->assertContains('APP_CONFIG_CACHE must not point under bootstrap/cache', data_get($artifact, 'sidecar_launcher_contract.fail_closed_if'));
+        $this->assertContains('SEO_INTEL_GSC_ACCESS_TOKEN is non-empty', data_get($artifact, 'sidecar_launcher_contract.fail_closed_if'));
+        $this->assertContains('SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON is non-empty', data_get($artifact, 'sidecar_launcher_contract.fail_closed_if'));
+
+        $this->assertSame(3, data_get($artifact, 'readmodel_dryrun_revalidation.import_dryrun.rows_would_insert'));
+        $this->assertSame('pass', data_get($artifact, 'readmodel_dryrun_revalidation.import_dryrun.data_quality_gate'));
+        $this->assertFalse((bool) data_get($artifact, 'readmodel_dryrun_revalidation.import_dryrun.would_write', true));
+
+        foreach ([
+            'db_writes',
+            'seo_gsc_daily_import',
+            'opportunity_queue_enqueue',
+            'cms_write',
+            'search_channel_submit',
+            'scheduler_activation',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'runner_wrapper_contract.negative_guarantees.'.$field, true), $field);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Added `backend/scripts/seo/gsc_sidecar_runner.sh` as the approved HK GSC sidecar launcher.
- The launcher reads sidecar runtime gates from `/opt/fermatmind/seo-gsc-runner/env/gsc-sidecar.env` by default, supports `SIDECAR_ENV_FILE`, and sets `APP_CONFIG_CACHE` before Laravel boots.
- Added fail-closed guards for missing/unreadable env file, forbidden `bootstrap/cache` config cache, missing required GSC env, wrong auth mode, inline service-account JSON, and access-token env values.
- Updated the HK sidecar runbook and generated JSON contract with the launcher boundary and the latest read-only revalidation artifacts.
- Added a focused contract test for the launcher and generated contract guarantees.

## Why

The latest HK sidecar revalidation passed only after using process-scoped env plus `APP_CONFIG_CACHE=/tmp/...`. This PR makes that runtime boundary explicit and repeatable without editing production `fap-api` env or relying on manually assembled inline commands.

## Validation

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
bash -n scripts/seo/gsc_sidecar_runner.sh
php artisan test --filter SeoIntelGscSidecarRunnerTest
php artisan test --filter SeoIntelGscSidecarRuntimeEnvBoundaryTest
python3 -m json.tool docs/seo/generated/gsc-hk-sidecar-runner.v1.json >/dev/null
git diff --check
```

## Intentionally deferred

- No PR-train manifest/state updates; this is an ad-hoc scoped PR.
- No production environment mutation.
- No live GSC read in this PR.
- No DB write or `seo_gsc_daily` import.
- No scheduler or queue worker activation.
- No opportunity queue enqueue.
- No CMS mutation.
- No Search Channel enqueue/submit.
- No indexing request or sitemap submission.
- `SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01` remains held until separate operator approval.
