### PR TITLE
SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01: controlled seo_gsc_daily canary importer

### DIFF
--- a/backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\GscReadModelControlledImportCanary;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class SeoIntelGscReadModelImportCanaryCommand extends Command
+{
+    protected $signature = 'seo-intel:gsc-readmodel-import-canary
+        {--artifact= : Path to a sanitized GSC sidecar live-read artifact}
+        {--limit=1 : Canary row limit; must be exactly 1}
+        {--execute : Execute the bounded canary write}
+        {--confirm-artifact-sha256= : Required for --execute; must match artifact SHA256}
+        {--confirm-write= : Required exact confirmation phrase for --execute}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Validate a sanitized GSC artifact and optionally write one controlled seo_gsc_daily canary row.';
+
+    public function handle(GscReadModelControlledImportCanary $canary): int
+    {
+        $path = $this->artifactPath();
+        if ($path === null) {
+            return $this->finish($this->failureSummary('artifact_path_required'));
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return $this->finish($this->failureSummary('artifact_json_invalid'));
+        }
+
+        if (! is_array($decoded)) {
+            return $this->finish($this->failureSummary('artifact_must_be_object'));
+        }
+
+        $sha256 = (string) hash_file('sha256', $path);
+        $limit = $this->limit();
+        if ($limit === null) {
+            return $this->finish([
+                ...$this->failureSummary('limit_must_be_exactly_1'),
+                'artifact_sha256' => $sha256,
+                'required_confirmation_phrase' => $canary->confirmationPhrase($sha256),
+            ]);
+        }
+
+        $summary = (bool) $this->option('execute')
+            ? $canary->execute(
+                $decoded,
+                $sha256,
+                $limit,
+                $this->nullableString($this->option('confirm-artifact-sha256')),
+                $this->nullableString($this->option('confirm-write')),
+            )
+            : $canary->plan($decoded, $sha256, $limit);
+
+        return $this->finish($summary);
+    }
+
+    private function artifactPath(): ?string
+    {
+        $path = trim((string) $this->option('artifact'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) ? $path : null;
+    }
+
+    private function limit(): ?int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return null;
+        }
+
+        $limit = (int) $raw;
+
+        return $limit === 1 ? 1 : null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue): array
+    {
+        return [
+            'schema_version' => GscReadModelControlledImportCanary::SCHEMA_VERSION,
+            'task' => GscReadModelControlledImportCanary::TASK,
+            'status' => 'blocked',
+            'mode' => 'canary_preflight_blocked',
+            'ok' => false,
+            'dry_run' => ! (bool) $this->option('execute'),
+            'execute' => (bool) $this->option('execute'),
+            'would_write' => false,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'target_table' => GscReadModelControlledImportCanary::TARGET_TABLE,
+            'rows_previewed' => 0,
+            'rows_would_insert' => 0,
+            'rows_inserted' => 0,
+            'rows_skipped_existing' => 0,
+            'issues' => [$issue],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+            $this->line('mode='.(string) ($summary['mode'] ?? 'unknown'));
+            $this->line('dry_run='.((bool) ($summary['dry_run'] ?? true) ? 'true' : 'false'));
+            $this->line('writes_committed='.((bool) ($summary['writes_committed'] ?? false) ? 'true' : 'false'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
+++ b/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class GscReadModelControlledImportCanary
+{
+    public const SCHEMA_VERSION = 'gsc-readmodel-controlled-import-canary.v1';
+
+    public const TASK = 'SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01';
+
+    public const TARGET_TABLE = 'seo_gsc_daily';
+
+    private const LIMIT = 1;
+
+    public function __construct(private readonly GscReadModelArtifactDryRunImporter $dryRunImporter) {}
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    public function plan(array $artifact, string $artifactSha256, int $limit): array
+    {
+        $issues = $this->limitIssues($limit);
+        $preview = $this->dryRunImporter->preview($artifact, self::LIMIT);
+
+        if (($preview['ok'] ?? false) !== true) {
+            $issues[] = 'dry_run_importer_validation_failed';
+        }
+
+        $issues = array_values(array_unique($issues));
+        $ok = $issues === [];
+        $rows = $ok ? array_slice((array) ($preview['preview_rows'] ?? []), 0, self::LIMIT) : [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => $ok ? 'success' : 'blocked',
+            'mode' => 'dry_run_canary_plan',
+            'ok' => $ok,
+            'dry_run' => true,
+            'execute' => false,
+            'would_write' => $ok,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'target_connection' => (string) config('seo_intel.connection', 'seo_intel'),
+            'target_table' => self::TARGET_TABLE,
+            'artifact_sha256' => $artifactSha256,
+            'required_confirmation_phrase' => $this->confirmationPhrase($artifactSha256),
+            'rows_previewed' => count($rows),
+            'rows_would_insert' => $ok ? count($rows) : 0,
+            'rows_inserted' => 0,
+            'rows_skipped_existing' => 0,
+            'write_boundary' => $this->writeBoundary(writeAllowed: false),
+            'data_origin' => $preview['data_origin'] ?? null,
+            'data_quality_gate' => $preview['data_quality_gate'] ?? null,
+            'date_window' => $preview['date_window'] ?? null,
+            'preview_rows' => $rows,
+            'dry_run_importer_errors' => (array) ($preview['errors'] ?? []),
+            'issues' => $issues,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    public function execute(
+        array $artifact,
+        string $artifactSha256,
+        int $limit,
+        ?string $confirmedArtifactSha256,
+        ?string $confirmedWritePhrase,
+    ): array {
+        $plan = $this->plan($artifact, $artifactSha256, $limit);
+        $issues = (array) ($plan['issues'] ?? []);
+
+        if ($confirmedArtifactSha256 === null || ! hash_equals($artifactSha256, $confirmedArtifactSha256)) {
+            $issues[] = 'artifact_sha256_confirmation_required';
+        }
+
+        $expectedConfirmation = $this->confirmationPhrase($artifactSha256);
+        if ($confirmedWritePhrase === null || ! hash_equals($expectedConfirmation, $confirmedWritePhrase)) {
+            $issues[] = 'exact_write_confirmation_required';
+        }
+
+        $issues = array_values(array_unique($issues));
+        if ($issues !== []) {
+            return [
+                ...$plan,
+                'status' => 'blocked',
+                'mode' => 'canary_execute_blocked',
+                'ok' => false,
+                'dry_run' => false,
+                'execute' => true,
+                'would_write' => false,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'rows_inserted' => 0,
+                'rows_skipped_existing' => 0,
+                'write_boundary' => $this->writeBoundary(writeAllowed: false),
+                'issues' => $issues,
+                'negative_guarantees' => $this->negativeGuarantees(),
+            ];
+        }
+
+        $row = (array) data_get($plan, 'preview_rows.0', []);
+        if ($row === []) {
+            return [
+                ...$plan,
+                'status' => 'blocked',
+                'mode' => 'canary_execute_blocked',
+                'ok' => false,
+                'dry_run' => false,
+                'execute' => true,
+                'would_write' => false,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'rows_inserted' => 0,
+                'rows_skipped_existing' => 0,
+                'write_boundary' => $this->writeBoundary(writeAllowed: false),
+                'issues' => ['preview_row_required'],
+                'negative_guarantees' => $this->negativeGuarantees(),
+            ];
+        }
+
+        $connection = (string) config('seo_intel.connection', 'seo_intel');
+        $query = DB::connection($connection)->table(self::TARGET_TABLE);
+
+        if ($this->matchingRowExists($connection, $row)) {
+            return [
+                ...$plan,
+                'status' => 'success',
+                'mode' => 'canary_execute',
+                'ok' => true,
+                'dry_run' => false,
+                'execute' => true,
+                'would_write' => false,
+                'writes_attempted' => true,
+                'writes_committed' => false,
+                'rows_would_insert' => 0,
+                'rows_inserted' => 0,
+                'rows_skipped_existing' => 1,
+                'write_boundary' => $this->writeBoundary(writeAllowed: true),
+                'issues' => [],
+                'negative_guarantees' => $this->negativeGuarantees(),
+            ];
+        }
+
+        $now = Carbon::now('UTC')->toDateTimeString();
+        $query->insert($this->insertPayload($row, $artifactSha256, $now));
+
+        return [
+            ...$plan,
+            'status' => 'success',
+            'mode' => 'canary_execute',
+            'ok' => true,
+            'dry_run' => false,
+            'execute' => true,
+            'would_write' => false,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'rows_would_insert' => 0,
+            'rows_inserted' => 1,
+            'rows_skipped_existing' => 0,
+            'write_boundary' => $this->writeBoundary(writeAllowed: true),
+            'issues' => [],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    public function confirmationPhrase(string $artifactSha256): string
+    {
+        return sprintf(
+            'I explicitly approve %s to write at most 1 row to seo_gsc_daily from artifact sha256 %s; no scheduler, no queue, no CMS, no search, no indexing.',
+            self::TASK,
+            $artifactSha256,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function limitIssues(int $limit): array
+    {
+        return $limit === self::LIMIT ? [] : ['limit_must_be_exactly_1'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function matchingRowExists(string $connection, array $row): bool
+    {
+        return DB::connection($connection)
+            ->table(self::TARGET_TABLE)
+            ->where('report_date', (string) ($row['report_date'] ?? ''))
+            ->where('canonical_url_hash', (string) ($row['canonical_url_hash'] ?? ''))
+            ->where('query_hash', (string) ($row['query_hash'] ?? ''))
+            ->where('source_engine', (string) ($row['source_engine'] ?? 'google'))
+            ->where('device', $row['device'] ?? null)
+            ->where('country', $row['country'] ?? null)
+            ->where('search_type', $row['search_type'] ?? null)
+            ->exists();
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function insertPayload(array $row, string $artifactSha256, string $now): array
+    {
+        $metadata = (array) ($row['metadata_json'] ?? []);
+        $metadata['source_artifact_sha256'] = $artifactSha256;
+        $metadata['controlled_import_canary'] = true;
+        $metadata['dry_run_import_preview'] = false;
+        $metadata['canary_task'] = self::TASK;
+
+        return [
+            'report_date' => (string) $row['report_date'],
+            'canonical_url_hash' => (string) $row['canonical_url_hash'],
+            'canonical_url' => null,
+            'query_hash' => (string) $row['query_hash'],
+            'query_display_masked' => $row['query_display_masked'] ?? null,
+            'locale' => $row['locale'] ?? null,
+            'source_engine' => 'google',
+            'device' => $row['device'] ?? null,
+            'country' => $row['country'] ?? null,
+            'search_type' => $row['search_type'] ?? null,
+            'clicks' => max(0, (int) ($row['clicks'] ?? 0)),
+            'impressions' => max(0, (int) ($row['impressions'] ?? 0)),
+            'ctr_ppm' => $row['ctr_ppm'] ?? null,
+            'average_position_milli' => $row['average_position_milli'] ?? null,
+            'is_brand_query' => (bool) ($row['is_brand_query'] ?? false),
+            'query_type' => (string) ($row['query_type'] ?? 'unknown'),
+            'data_state' => (string) ($row['data_state'] ?? 'final'),
+            'collected_at' => $now,
+            'metadata_json' => json_encode($metadata, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    /**
+     * @return array<string, mixed>
+     */
+    private function writeBoundary(bool $writeAllowed): array
+    {
+        return [
+            'seo_gsc_daily_write_allowed' => $writeAllowed,
+            'target_table' => self::TARGET_TABLE,
+            'max_rows_per_execution' => self::LIMIT,
+            'database_write_outside_seo_gsc_daily_allowed' => false,
+            'canonical_url_policy' => 'null_until_separate_backend_url_truth_join_is_approved',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write_outside_seo_gsc_daily' => false,
+            'seo_gsc_daily_write_beyond_single_canary_row' => false,
+            'migration_added' => false,
+            'scheduler_activation' => false,
+            'queue_worker_activation' => false,
+            'opportunity_queue_enqueue' => false,
+            'cms_write' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'search_provider_submission' => false,
+            'gsc_url_inspection_request_indexing' => false,
+            'sitemap_submission' => false,
+            'live_gsc_api_call' => false,
+            'credential_read_print_or_store' => false,
+            'production_env_change' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
+++ b/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
@@ -1,0 +1,124 @@
+{
+  "version": "gsc-readmodel-controlled-import-canary.v1",
+  "task": "SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-intel:gsc-readmodel-import-canary",
+  "ad_hoc_pr": true,
+  "pr_train_manifest_update": false,
+  "write_mode_available": true,
+  "default_mode": "dry_run_canary_plan",
+  "execute_requires": [
+    "--execute",
+    "--limit=1",
+    "--confirm-artifact-sha256=<artifact_sha256>",
+    "--confirm-write=<exact_generated_confirmation_phrase>",
+    "--json"
+  ],
+  "input": {
+    "artifact_kind": "sanitized_hk_gsc_sidecar_wrapper_live_read_artifact",
+    "required_status": "success",
+    "required_data_origin": "live_gsc_api",
+    "required_data_quality_gate": "pass",
+    "required_rows_path": "payload.metadata.safe_row_preview",
+    "max_rows_per_execution": 1
+  },
+  "validation": {
+    "dry_run_importer_must_pass": true,
+    "artifact_sha256_confirmation_required": true,
+    "exact_write_confirmation_required": true,
+    "limit_must_equal": 1,
+    "forbidden_fields_rejected_recursively": [
+      "raw_query",
+      "raw_url",
+      "query",
+      "page",
+      "canonical_url",
+      "url",
+      "credential_path",
+      "token",
+      "access_token",
+      "api_key",
+      "client_email",
+      "service_account_json",
+      "private_key",
+      "cookie",
+      "session",
+      "raw_payload"
+    ],
+    "required_false_flags": [
+      "payload.writes_attempted",
+      "payload.writes_committed",
+      "payload.metadata.writes_attempted",
+      "payload.metadata.writes_committed",
+      "payload.metadata.cms_write_allowed",
+      "payload.metadata.search_channel_enqueue_allowed",
+      "payload.metadata.indexing_request_allowed"
+    ]
+  },
+  "target": {
+    "connection": "seo_intel",
+    "table": "seo_gsc_daily",
+    "write_scope": "single_row_canary_only",
+    "canonical_url_policy": "null_until_separate_backend_url_truth_join_is_approved",
+    "migration_added_in_this_pr": false,
+    "unique_index_added_in_this_pr": false
+  },
+  "idempotency": {
+    "schema_unique_constraint_available": false,
+    "application_existing_row_check": [
+      "report_date",
+      "canonical_url_hash",
+      "query_hash",
+      "source_engine",
+      "device",
+      "country",
+      "search_type"
+    ],
+    "existing_row_behavior": "skip_and_report_rows_skipped_existing"
+  },
+  "output": {
+    "schema_version": "gsc-readmodel-controlled-import-canary.v1",
+    "status_values": [
+      "success",
+      "blocked"
+    ],
+    "dry_run_plan_fields": [
+      "artifact_sha256",
+      "required_confirmation_phrase",
+      "rows_would_insert",
+      "preview_rows"
+    ],
+    "execute_fields": [
+      "writes_attempted",
+      "writes_committed",
+      "rows_inserted",
+      "rows_skipped_existing"
+    ]
+  },
+  "negative_guarantees": {
+    "database_write_outside_seo_gsc_daily": false,
+    "migration_added": false,
+    "scheduler_activation": false,
+    "queue_worker_activation": false,
+    "opportunity_queue_enqueue": false,
+    "cms_write": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "search_provider_submission": false,
+    "gsc_url_inspection_request_indexing": false,
+    "sitemap_submission": false,
+    "live_gsc_api_call": false,
+    "credential_read_print_or_store": false,
+    "production_env_change": false
+  },
+  "held_after_this_pr": [
+    "production execute canary until separate explicit approval",
+    "batch read model import",
+    "unique-key idempotency migration",
+    "scheduler activation",
+    "opportunity queue execution",
+    "CMS draft package",
+    "Search Channel enqueue or submit",
+    "indexing request or sitemap submission"
+  ]
+}

--- a/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
+++ b/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
@@ -1,0 +1,83 @@
+# GSC Read Model Controlled Import Canary
+
+Task: `SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01`
+
+## Purpose
+
+This PR adds the first write-capable GSC read-model importer, limited to a single controlled canary row in `seo_gsc_daily`.
+
+The command reads a sanitized Hong Kong GSC sidecar live-read artifact, reuses the dry-run importer validation gates, and writes at most one row only when the operator provides `--execute`, an exact artifact SHA256 confirmation, and the exact generated write confirmation phrase.
+
+This PR does not add a scheduler, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Google APIs, change production environment variables, add a migration, or add a unique index.
+
+## Command
+
+Dry-run canary plan:
+
+```bash
+php artisan seo-intel:gsc-readmodel-import-canary \
+  --artifact=/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-YYYYMMDDTHHMMSSZ-success.json \
+  --limit=1 \
+  --json
+```
+
+Bounded canary execution:
+
+```bash
+php artisan seo-intel:gsc-readmodel-import-canary \
+  --artifact=/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-20260620T093059Z-success.json \
+  --limit=1 \
+  --confirm-artifact-sha256=00238a3132d5399fa1d3aaf992451b87da9e4062d82077c75dc317cf33045d0d \
+  --confirm-write="I explicitly approve SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01 to write at most 1 row to seo_gsc_daily from artifact sha256 00238a3132d5399fa1d3aaf992451b87da9e4062d82077c75dc317cf33045d0d; no scheduler, no queue, no CMS, no search, no indexing." \
+  --execute \
+  --json
+```
+
+The production execution command remains held until a separate explicit operator approval.
+
+## Required Gates
+
+- `--limit=1`; any other value fails closed.
+- Artifact SHA256 must match `--confirm-artifact-sha256`.
+- `--confirm-write` must exactly match the command-generated confirmation phrase.
+- Dry-run importer validation must pass:
+  - `payload.status=success`
+  - `payload.metadata.data_origin=live_gsc_api`
+  - `payload.metadata.data_quality_gate.status=pass`
+  - no forbidden raw or credential fields
+  - no upstream write, CMS, Search Channel, or indexing flags
+  - at least one sanitized preview row
+
+## Write Boundary
+
+Allowed write target:
+
+- connection: `seo_intel`
+- table: `seo_gsc_daily`
+- maximum rows per execution: `1`
+
+The inserted row comes from the dry-run `preview_rows` shape. `canonical_url` remains `null` because raw URLs are not allowed in sidecar artifacts. The row metadata records `data_origin=live_gsc_api`, `row_source=live_gsc_api`, the source artifact SHA256, and the canary task id.
+
+Before insert, the importer checks for an existing row with the same `report_date`, `canonical_url_hash`, `query_hash`, `source_engine`, `device`, `country`, and `search_type`. Existing rows are skipped and reported as `rows_skipped_existing=1`.
+
+## Negative Guarantees
+
+- no database write outside `seo_gsc_daily`
+- no migration
+- no unique index or schema change
+- no scheduler activation
+- no queue worker activation
+- no opportunity queue enqueue
+- no CMS draft or CMS write
+- no Search Channel enqueue, approval, retry, or submission
+- no GSC URL Inspection request indexing
+- no sitemap submission
+- no live GSC API call
+- no credential read, print, storage, or mutation
+- no production environment change
+
+## Next Allowed Work
+
+After merge, the next operational step is deploying `main` to the HK sidecar runner and running the dry-run canary plan. A real `--execute` canary write still requires separate explicit approval.
+
+Batch import, unique-key idempotency, scheduler activation, opportunity queue execution, CMS drafting, and search/indexing actions remain separate holds.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\GscReadModelControlledImportCanary;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoGscDailyTable();
+    }
+
+    #[Test]
+    public function dry_run_outputs_canary_plan_without_database_write(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame('dry_run_canary_plan', $payload['mode'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertTrue((bool) ($payload['would_write'] ?? false));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(1, $payload['rows_would_insert'] ?? null);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        $this->assertStringContainsString(hash_file('sha256', $artifactPath), (string) ($payload['required_confirmation_phrase'] ?? ''));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_blocks_without_exact_confirmations_and_writes_nothing(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('artifact_sha256_confirmation_required', $payload['issues'] ?? []);
+        $this->assertContains('exact_write_confirmation_required', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_blocks_when_artifact_sha256_does_not_match(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+        $sha256 = hash_file('sha256', $artifactPath);
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--confirm-artifact-sha256' => str_repeat('0', 64),
+            '--confirm-write' => app(GscReadModelControlledImportCanary::class)->confirmationPhrase((string) $sha256),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('artifact_sha256_confirmation_required', $payload['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function canary_reuses_dry_run_importer_for_forbidden_field_gate(): void
+    {
+        Http::fake();
+        $artifact = $this->validArtifact();
+        data_set($artifact, 'payload.metadata.safe_row_preview.0.raw_query', 'mbti test');
+        data_set($artifact, 'payload.metadata.preflight.client_email', 'reader@example.invalid');
+        $artifactPath = $this->writeArtifact($artifact);
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('dry_run_importer_validation_failed', $payload['issues'] ?? []);
+        $this->assertContains('forbidden_field_present', $payload['dry_run_importer_errors'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function canary_requires_live_origin_and_passing_data_quality_gate(): void
+    {
+        Http::fake();
+        $artifact = $this->validArtifact();
+        data_set($artifact, 'payload.metadata.data_origin', 'fixture');
+        data_set($artifact, 'payload.metadata.data_quality_gate.status', 'blocked');
+        $artifactPath = $this->writeArtifact($artifact);
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('data_origin_must_be_live_gsc_api', $payload['dry_run_importer_errors'] ?? []);
+        $this->assertContains('data_quality_gate_must_pass', $payload['dry_run_importer_errors'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function canary_fails_closed_when_limit_is_not_exactly_one(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 2,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertSame(['limit_must_be_exactly_1'], $payload['issues'] ?? null);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_inserts_one_sanitized_row_only_after_exact_confirmations(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+        $sha256 = (string) hash_file('sha256', $artifactPath);
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--confirm-artifact-sha256' => $sha256,
+            '--confirm-write' => app(GscReadModelControlledImportCanary::class)->confirmationPhrase($sha256),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame('canary_execute', $payload['mode'] ?? null);
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertSame(1, $payload['rows_inserted'] ?? null);
+        $this->assertSame(0, $payload['rows_skipped_existing'] ?? null);
+
+        $rows = DB::connection('seo_intel')->table('seo_gsc_daily')->get();
+        $this->assertCount(1, $rows);
+        $this->assertSame('2026-06-17', (string) $rows[0]->report_date);
+        $this->assertSame(hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'), $rows[0]->canonical_url_hash);
+        $this->assertNull($rows[0]->canonical_url);
+        $this->assertSame(hash('sha256', 'mbti测试'), $rows[0]->query_hash);
+        $this->assertSame('m****试', $rows[0]->query_display_masked);
+        $this->assertSame(60, (int) $rows[0]->impressions);
+        $this->assertStringNotContainsString('mbti测试', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_is_idempotent_for_the_same_canary_key(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+        $sha256 = (string) hash_file('sha256', $artifactPath);
+        $arguments = [
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--confirm-artifact-sha256' => $sha256,
+            '--confirm-write' => app(GscReadModelControlledImportCanary::class)->confirmationPhrase($sha256),
+            '--execute' => true,
+            '--json' => true,
+        ];
+
+        $this->runCanaryCommand($arguments);
+        [$exitCode, $payload] = $this->runCanaryCommand($arguments);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(0, $payload['rows_inserted'] ?? null);
+        $this->assertSame(1, $payload['rows_skipped_existing'] ?? null);
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runCanaryCommand(array $arguments): array
+    {
+        $exitCode = Artisan::call('seo-intel:gsc-readmodel-import-canary', $arguments);
+        $rawOutput = trim(Artisan::output());
+
+        $this->assertNotSame('', $rawOutput);
+        $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $rawOutput];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validArtifact(): array
+    {
+        return [
+            'schema_version' => 'gsc-hk-sidecar-runner-wrapper.v1',
+            'task' => 'SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01',
+            'mode' => 'live-read',
+            'payload' => [
+                'collector' => 'gsc_foundation',
+                'status' => 'success',
+                'dry_run' => true,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'external_calls_attempted' => true,
+                'items_seen' => 1,
+                'metadata' => [
+                    'mode' => 'gsc_live_readonly_sidecar_read',
+                    'data_origin' => 'live_gsc_api',
+                    'date_window' => [
+                        'start_date' => '2026-06-17',
+                        'end_date' => '2026-06-17',
+                    ],
+                    'data_quality_gate' => [
+                        'status' => 'pass',
+                        'opportunity_queue_eligible' => true,
+                    ],
+                    'safe_row_preview' => [[
+                        'report_date' => '2026-06-17',
+                        'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
+                        'query_hash' => hash('sha256', 'mbti测试'),
+                        'query_display_masked' => 'm****试',
+                        'locale' => 'zh-CN',
+                        'source_engine' => 'google',
+                        'device' => null,
+                        'country' => null,
+                        'search_type' => 'web',
+                        'clicks' => 0,
+                        'impressions' => 60,
+                        'ctr_ppm' => 0,
+                        'average_position_milli' => 9000,
+                        'is_brand_query' => false,
+                        'query_type' => 'non_brand',
+                        'data_state' => 'final',
+                    ]],
+                    'opportunity_queue_eligible' => false,
+                    'cms_write_allowed' => false,
+                    'search_channel_enqueue_allowed' => false,
+                    'indexing_request_allowed' => false,
+                    'writes_attempted' => false,
+                    'writes_committed' => false,
+                    'scheduler_enabled' => false,
+                    'queue_worker_enabled' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function writeArtifact(array $artifact): string
+    {
+        $dir = storage_path('framework/testing/gsc-readmodel-canary-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/artifact.json';
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    private function createSeoGscDailyTable(): void
+    {
+        Schema::connection('seo_intel')->create('seo_gsc_daily', function (Blueprint $table): void {
+            $table->id();
+            $table->date('report_date');
+            $table->char('canonical_url_hash', 64)->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->char('query_hash', 64)->nullable();
+            $table->string('query_display_masked', 255)->nullable();
+            $table->string('locale', 16)->nullable();
+            $table->string('source_engine', 64)->default('google');
+            $table->string('device', 32)->nullable();
+            $table->string('country', 16)->nullable();
+            $table->string('search_type', 32)->nullable();
+            $table->unsignedInteger('clicks')->default(0);
+            $table->unsignedInteger('impressions')->default(0);
+            $table->unsignedInteger('ctr_ppm')->nullable();
+            $table->unsignedInteger('average_position_milli')->nullable();
+            $table->boolean('is_brand_query')->default(false);
+            $table->string('query_type', 32)->default('unknown');
+            $table->string('data_state', 32)->default('final');
+            $table->timestamp('collected_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -890,9 +890,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_seo_intel_gsc_foundation_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
@@ -4691,9 +4693,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoIntelGscFoundationFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
+            'backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',


### PR DESCRIPTION
## Summary
- add `seo-intel:gsc-readmodel-import-canary` as a fail-closed, one-row `seo_gsc_daily` canary importer
- reuse the existing sanitized GSC dry-run importer gates before any write
- document the canary contract and generated JSON evidence

## Why
This is the first controlled write path from HK sidecar live GSC artifacts into the backend read model. It stays deliberately bounded: max one row, exact artifact SHA confirmation, exact write phrase, no scheduler, no queue, no CMS, no Search Channel, no indexing, no live Google call.

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter SeoIntelGscReadModelImporterDryRunTest
php artisan test --filter SeoIntelGscReadModelControlledImportCanaryTest
python3 -m json.tool docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json >/dev/null
git diff --check
./vendor/bin/pint --test app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php app/Services/SeoIntel/GscReadModelControlledImportCanary.php tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
```

## Intentionally deferred
- no production `--execute` run in this PR
- no migration or unique index
- no scheduler activation
- no opportunity queue execution
- no CMS draft/write
- no Search Channel enqueue/submit
- no indexing request or sitemap submission

## Repository rule impact
This adds a backend-only SEO Intel read-model canary importer. It does not change public content ownership, publishing SOP, frontend fallback behavior, sitemap/llms enumeration, or CMS authority rules.