### PR TITLE
SEO-OPPORTUNITY-QUEUE-LIVE-READONLY-VERIFY-01

### DIFF
--- a/backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
+++ b/backend/app/Services/SeoIntel/OpsDashboard/SeoOpportunityQueueReadService.php
@@ -55,30 +55,43 @@ final class SeoOpportunityQueueReadService extends AbstractSeoDashboardReadServi
     private function gscRows(): array
     {
         return $this->table('seo_gsc_daily')
+            ->leftJoinSub(
+                $this->table('seo_urls')
+                    ->select('canonical_url_hash')
+                    ->selectRaw('MIN(canonical_url) AS canonical_url')
+                    ->groupBy('canonical_url_hash'),
+                'url_truth',
+                function ($join): void {
+                    $join->on('seo_gsc_daily.canonical_url_hash', '=', 'url_truth.canonical_url_hash');
+                }
+            )
             ->select([
-                'report_date',
-                'canonical_url_hash',
-                'canonical_url',
-                'query_hash',
-                'query_display_masked',
-                'locale',
-                'source_engine',
-                'clicks',
-                'impressions',
-                'ctr_ppm',
-                'average_position_milli',
-                'is_brand_query',
-                'query_type',
-                'metadata_json',
+                'seo_gsc_daily.report_date',
+                'seo_gsc_daily.canonical_url_hash',
+                'seo_gsc_daily.canonical_url AS gsc_canonical_url',
+                'url_truth.canonical_url AS url_truth_canonical_url',
+                'seo_gsc_daily.query_hash',
+                'seo_gsc_daily.query_display_masked',
+                'seo_gsc_daily.locale',
+                'seo_gsc_daily.source_engine',
+                'seo_gsc_daily.clicks',
+                'seo_gsc_daily.impressions',
+                'seo_gsc_daily.ctr_ppm',
+                'seo_gsc_daily.average_position_milli',
+                'seo_gsc_daily.is_brand_query',
+                'seo_gsc_daily.query_type',
+                'seo_gsc_daily.metadata_json',
             ])
-            ->where('source_engine', 'google')
-            ->orderByDesc('report_date')
+            ->where('seo_gsc_daily.source_engine', 'google')
+            ->orderByDesc('seo_gsc_daily.report_date')
             ->limit(500)
             ->get()
             ->map(fn (object $row): array => [
                 'report_date' => (string) $row->report_date,
                 'canonical_url_hash' => (string) $row->canonical_url_hash,
-                'canonical_url' => is_string($row->canonical_url ?? null) ? $row->canonical_url : null,
+                'canonical_url' => is_string($row->url_truth_canonical_url ?? null)
+                    ? $row->url_truth_canonical_url
+                    : (is_string($row->gsc_canonical_url ?? null) ? $row->gsc_canonical_url : null),
                 'query_hash' => (string) $row->query_hash,
                 'query_display_masked' => is_string($row->query_display_masked ?? null) ? $row->query_display_masked : null,
                 'locale' => is_string($row->locale ?? null) ? $row->locale : null,

--- a/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
+++ b/backend/docs/seo/generated/seo-opportunity-queue-readonly.v1.json
@@ -10,6 +10,13 @@
     "seo_gsc_daily",
     "seo_urls"
   ],
+  "url_truth_resolution": {
+    "mode": "read_only_resolver_by_canonical_url_hash",
+    "resolver_table": "seo_urls",
+    "metric_source_table": "seo_gsc_daily",
+    "supports_null_gsc_canonical_url": true,
+    "raw_canonical_url_response_allowed": false
+  },
   "candidate_fields": [
     "opportunity_id",
     "canonical_path",
@@ -55,6 +62,7 @@
     "direct_sidecar_artifact_consumption_allowed": false,
     "allowed_source": "seo_intel read model rows after gsc data_quality_gate=pass",
     "sidecar_artifact_role": "evidence_and_future_import_input_candidate_only",
+    "dry_run_preview_consumption_allowed": false,
     "queue_item_creation_allowed": false
   },
   "production_operation_performed": false,

--- a/backend/docs/seo/opportunity-queue-readonly.md
+++ b/backend/docs/seo/opportunity-queue-readonly.md
@@ -29,6 +29,10 @@ The read model can return candidate rows only when `GscDataQualityGate` passes o
 
 Candidate rows expose safe aliases only: canonical path, URL hash, query hash, masked query, locale, report date, metrics, and a human-review next step.
 
+`seo_urls` is used only as a read-only URL truth resolver by `canonical_url_hash`. This keeps opportunity display working for live GSC canary imports where `seo_gsc_daily.canonical_url` remains `null` because sanitized sidecar artifacts cannot carry raw URLs. The API may return the resolved safe path, but it must not return the raw canonical URL.
+
+The opportunity queue must consume `seo_intel` read-model rows after `GscDataQualityGate=pass`. It must not directly consume sidecar artifacts, dry-run importer previews, service-account paths, tokens, or raw Search Console payloads.
+
 ## Boundary
 
 The read-only opportunity queue is not an execution queue. A later PR must separately define and approve CMS draft dry-runs or Search Channel readiness before any write action.

--- a/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoDashApi01ReadOnlyApiContractTest.php
@@ -181,6 +181,11 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
             data_get($queueArtifact, 'sidecar_artifact_boundary.allowed_source'),
         );
         $this->assertFalse((bool) data_get($queueArtifact, 'sidecar_artifact_boundary.queue_item_creation_allowed', true));
+        $this->assertSame(
+            'read_only_resolver_by_canonical_url_hash',
+            data_get($queueArtifact, 'url_truth_resolution.mode'),
+        );
+        $this->assertFalse((bool) data_get($queueArtifact, 'url_truth_resolution.raw_canonical_url_response_allowed', true));
 
         $response = $this->actingAs($admin, (string) config('admin.guard', 'admin'))
             ->getJson('/api/v0.5/ops/seo-intel/opportunity-queue?limit=5')
@@ -210,6 +215,10 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
             'order_no',
             'attempt_id',
             'payment_id',
+            'client_email',
+            'private_key',
+            'Bearer',
+            'gsc-service-account.json',
         ] as $forbidden) {
             $this->assertStringNotContainsString($forbidden, $json);
         }
@@ -568,7 +577,7 @@ final class SeoDashApi01ReadOnlyApiContractTest extends TestCase
         DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
             'report_date' => now()->subDays(4)->toDateString(),
             'canonical_url_hash' => $hash,
-            'canonical_url' => 'https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types',
+            'canonical_url' => null,
             'query_hash' => hash('sha256', 'mbti career clarity'),
             'query_display_masked' => 'm**********y',
             'locale' => 'en',


### PR DESCRIPTION
## What changed
- Updated the private Ops opportunity queue read service to resolve safe `canonical_path` through a read-only `seo_urls` resolver keyed by `canonical_url_hash`.
- Kept GSC metrics sourced from `seo_gsc_daily`; `seo_urls` is only used as URL truth for path display.
- Extended the API contract test so the opportunity row has `seo_gsc_daily.canonical_url = null`, matching controlled GSC canary import behavior.
- Updated the readonly contract docs and generated JSON to state that direct sidecar artifact or dry-run preview consumption is not allowed.

## Why
The controlled GSC canary importer intentionally keeps raw URLs out of `seo_gsc_daily` rows. The opportunity queue must still display a safe path after a gate-pass live row exists, without exposing raw canonical URLs or turning the read model into an execution queue.

## Validation
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test --filter SeoDashApi01ReadOnlyApiContractTest
python3 -m json.tool docs/seo/generated/seo-opportunity-queue-readonly.v1.json >/dev/null
git diff --check
php artisan route:list --path=api/v0.5/ops/seo-intel/opportunity-queue
```

## Intentionally deferred
- No DB writes.
- No migration.
- No scheduler.
- No opportunity queue enqueue or execution.
- No CMS writes.
- No Search Channel or indexing submission.
- No live Google API call.
- Runtime verification remains blocked until `seo_gsc_daily` contains an approved gate-pass live canary row.

## Repository rule impact
This preserves backend `seo_intel` read model authority. No content ownership, publishing SOP, CMS model, media asset, sitemap, llms, or frontend fallback behavior changes.
