### PR TITLE
SEO-GSC-READMODEL-IDEMPOTENCY-KEY-01: add GSC readmodel idempotency key

### DIFF
--- a/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
+++ b/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
@@ -198,13 +198,7 @@ final class GscReadModelControlledImportCanary
     {
         return DB::connection($connection)
             ->table(self::TARGET_TABLE)
-            ->where('report_date', (string) ($row['report_date'] ?? ''))
-            ->where('canonical_url_hash', (string) ($row['canonical_url_hash'] ?? ''))
-            ->where('query_hash', (string) ($row['query_hash'] ?? ''))
-            ->where('source_engine', (string) ($row['source_engine'] ?? 'google'))
-            ->where('device', $row['device'] ?? null)
-            ->where('country', $row['country'] ?? null)
-            ->where('search_type', $row['search_type'] ?? null)
+            ->where('idempotency_key', $this->idempotencyKey($row))
             ->exists();
     }
 
@@ -221,6 +215,7 @@ final class GscReadModelControlledImportCanary
         $metadata['canary_task'] = self::TASK;
 
         return [
+            'idempotency_key' => $this->idempotencyKey($row),
             'report_date' => (string) $row['report_date'],
             'canonical_url_hash' => (string) $row['canonical_url_hash'],
             'canonical_url' => null,
@@ -257,9 +252,40 @@ final class GscReadModelControlledImportCanary
             'seo_gsc_daily_write_allowed' => $writeAllowed,
             'target_table' => self::TARGET_TABLE,
             'max_rows_per_execution' => self::LIMIT,
+            'idempotency_key_fields' => [
+                'report_date',
+                'canonical_url_hash',
+                'query_hash',
+                'source_engine',
+                'device',
+                'country',
+                'search_type',
+            ],
+            'idempotency_unique_index' => 'seo_gsc_daily_idempotency_key_unique',
             'database_write_outside_seo_gsc_daily_allowed' => false,
             'canonical_url_policy' => 'null_until_separate_backend_url_truth_join_is_approved',
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function idempotencyKey(array $row): string
+    {
+        return hash('sha256', implode('|', [
+            $this->normalized((string) ($row['report_date'] ?? '')),
+            $this->normalized((string) ($row['canonical_url_hash'] ?? '')),
+            $this->normalized((string) ($row['query_hash'] ?? '')),
+            $this->normalized((string) ($row['source_engine'] ?? 'google')),
+            $this->normalized($row['device'] ?? null),
+            $this->normalized($row['country'] ?? null),
+            $this->normalized($row['search_type'] ?? null),
+        ]));
+    }
+
+    private function normalized(mixed $value): string
+    {
+        return trim((string) ($value ?? ''));
     }
 
     /**

--- a/backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php
+++ b/backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected $connection = 'seo_intel';
+
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection);
+
+        if (! $schema->hasTable('seo_gsc_daily')) {
+            return;
+        }
+
+        if (! $schema->hasColumn('seo_gsc_daily', 'idempotency_key')) {
+            $schema->table('seo_gsc_daily', function (Blueprint $table): void {
+                $table->char('idempotency_key', 64)->nullable()->after('id');
+            });
+        }
+
+        DB::connection($this->connection)
+            ->table('seo_gsc_daily')
+            ->whereNull('idempotency_key')
+            ->orderBy('id')
+            ->chunkById(500, function ($rows): void {
+                foreach ($rows as $row) {
+                    DB::connection($this->connection)
+                        ->table('seo_gsc_daily')
+                        ->where('id', $row->id)
+                        ->update([
+                            'idempotency_key' => $this->idempotencyKey([
+                                'report_date' => $row->report_date,
+                                'canonical_url_hash' => $row->canonical_url_hash,
+                                'query_hash' => $row->query_hash,
+                                'source_engine' => $row->source_engine,
+                                'device' => $row->device,
+                                'country' => $row->country,
+                                'search_type' => $row->search_type,
+                            ]),
+                        ]);
+                }
+            });
+
+        $schema->table('seo_gsc_daily', function (Blueprint $table): void {
+            $table->unique('idempotency_key', 'seo_gsc_daily_idempotency_key_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function idempotencyKey(array $row): string
+    {
+        return hash('sha256', implode('|', [
+            $this->normalized($row['report_date'] ?? ''),
+            $this->normalized($row['canonical_url_hash'] ?? ''),
+            $this->normalized($row['query_hash'] ?? ''),
+            $this->normalized($row['source_engine'] ?? 'google'),
+            $this->normalized($row['device'] ?? ''),
+            $this->normalized($row['country'] ?? ''),
+            $this->normalized($row['search_type'] ?? ''),
+        ]));
+    }
+
+    private function normalized(mixed $value): string
+    {
+        return trim((string) ($value ?? ''));
+    }
+};

--- a/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
+++ b/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
@@ -60,12 +60,16 @@
     "table": "seo_gsc_daily",
     "write_scope": "single_row_canary_only",
     "canonical_url_policy": "null_until_separate_backend_url_truth_join_is_approved",
-    "migration_added_in_this_pr": false,
-    "unique_index_added_in_this_pr": false
+    "migration_added_in_this_pr": true,
+    "migration_scope": "seo_gsc_daily.idempotency_key only",
+    "unique_index_added_in_this_pr": true,
+    "unique_index": "seo_gsc_daily_idempotency_key_unique"
   },
   "idempotency": {
-    "schema_unique_constraint_available": false,
-    "application_existing_row_check": [
+    "schema_unique_constraint_available": true,
+    "idempotency_key_column": "idempotency_key",
+    "idempotency_key_algorithm": "sha256(report_date|canonical_url_hash|query_hash|source_engine|device|country|search_type)",
+    "idempotency_key_fields": [
       "report_date",
       "canonical_url_hash",
       "query_hash",
@@ -73,6 +77,9 @@
       "device",
       "country",
       "search_type"
+    ],
+    "application_existing_row_check": [
+      "idempotency_key"
     ],
     "existing_row_behavior": "skip_and_report_rows_skipped_existing"
   },
@@ -97,7 +104,7 @@
   },
   "negative_guarantees": {
     "database_write_outside_seo_gsc_daily": false,
-    "migration_added": false,
+    "schema_change_outside_seo_gsc_daily_idempotency_key": false,
     "scheduler_activation": false,
     "queue_worker_activation": false,
     "opportunity_queue_enqueue": false,
@@ -114,7 +121,6 @@
   "held_after_this_pr": [
     "production execute canary until separate explicit approval",
     "batch read model import",
-    "unique-key idempotency migration",
     "scheduler activation",
     "opportunity queue execution",
     "CMS draft package",

--- a/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
+++ b/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
@@ -8,7 +8,9 @@ This PR adds the first write-capable GSC read-model importer, limited to a singl
 
 The command reads a sanitized Hong Kong GSC sidecar live-read artifact, reuses the dry-run importer validation gates, and writes at most one row only when the operator provides `--execute`, an exact artifact SHA256 confirmation, and the exact generated write confirmation phrase.
 
-This PR does not add a scheduler, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Google APIs, change production environment variables, add a migration, or add a unique index.
+The follow-up idempotency PR adds a dedicated `idempotency_key` column and unique index so future small-batch imports can skip existing rows deterministically. It does not change the write limit: the command remains limited to one row until a separate batch10 PR is approved.
+
+This PR family does not add a scheduler, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Google APIs, or change production environment variables.
 
 ## Command
 
@@ -58,13 +60,18 @@ Allowed write target:
 
 The inserted row comes from the dry-run `preview_rows` shape. `canonical_url` remains `null` because raw URLs are not allowed in sidecar artifacts. The row metadata records `data_origin=live_gsc_api`, `row_source=live_gsc_api`, the source artifact SHA256, and the canary task id.
 
-Before insert, the importer checks for an existing row with the same `report_date`, `canonical_url_hash`, `query_hash`, `source_engine`, `device`, `country`, and `search_type`. Existing rows are skipped and reported as `rows_skipped_existing=1`.
+Before insert, the importer computes `idempotency_key=sha256(report_date|canonical_url_hash|query_hash|source_engine|device|country|search_type)`. Existing rows with the same idempotency key are skipped and reported as `rows_skipped_existing=1`.
+
+Schema boundary:
+
+- column: `seo_gsc_daily.idempotency_key`
+- unique index: `seo_gsc_daily_idempotency_key_unique`
+- existing rows are backfilled by the forward migration before the unique index is created
 
 ## Negative Guarantees
 
 - no database write outside `seo_gsc_daily`
-- no migration
-- no unique index or schema change
+- no schema change outside `seo_gsc_daily.idempotency_key`
 - no scheduler activation
 - no queue worker activation
 - no opportunity queue enqueue
@@ -80,4 +87,4 @@ Before insert, the importer checks for an existing row with the same `report_dat
 
 After merge, the next operational step is deploying `main` to the HK sidecar runner and running the dry-run canary plan. A real `--execute` canary write still requires separate explicit approval.
 
-Batch import, unique-key idempotency, scheduler activation, opportunity queue execution, CMS drafting, and search/indexing actions remain separate holds.
+Batch import, scheduler activation, opportunity queue execution, CMS drafting, and search/indexing actions remain separate holds.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
@@ -195,6 +195,7 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
         $rows = DB::connection('seo_intel')->table('seo_gsc_daily')->get();
         $this->assertCount(1, $rows);
         $this->assertSame('2026-06-17', (string) $rows[0]->report_date);
+        $this->assertSame($this->expectedIdempotencyKey(), $rows[0]->idempotency_key);
         $this->assertSame(hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'), $rows[0]->canonical_url_hash);
         $this->assertNull($rows[0]->canonical_url);
         $this->assertSame(hash('sha256', 'mbti测试'), $rows[0]->query_hash);
@@ -229,6 +230,50 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
         $this->assertSame(1, $payload['rows_skipped_existing'] ?? null);
         $this->assertSame(1, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
         Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function migration_backfills_idempotency_key_and_adds_unique_index_for_existing_rows(): void
+    {
+        Schema::connection('seo_intel')->drop('seo_gsc_daily');
+        $this->createSeoGscDailyTable(includeIdempotencyKey: false);
+
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'report_date' => '2026-06-17',
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
+            'canonical_url' => null,
+            'query_hash' => hash('sha256', 'mbti测试'),
+            'query_display_masked' => 'm****试',
+            'locale' => 'zh-CN',
+            'source_engine' => 'google',
+            'device' => null,
+            'country' => null,
+            'search_type' => 'web',
+            'clicks' => 0,
+            'impressions' => 60,
+            'ctr_ppm' => 0,
+            'average_position_milli' => 9000,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'data_state' => 'final',
+            'metadata_json' => json_encode(['data_origin' => 'live_gsc_api'], JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+
+        $migration = require base_path('database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php');
+        $migration->up();
+
+        $row = DB::connection('seo_intel')->table('seo_gsc_daily')->first();
+        $this->assertSame($this->expectedIdempotencyKey(), $row->idempotency_key);
+
+        $indexes = DB::connection('seo_intel')->select("PRAGMA index_list('seo_gsc_daily')");
+        $uniqueIndexNames = array_map(
+            static fn (object $index): string => (bool) $index->unique ? (string) $index->name : '',
+            $indexes,
+        );
+
+        $this->assertContains('seo_gsc_daily_idempotency_key_unique', $uniqueIndexNames);
     }
 
     /**
@@ -319,10 +364,13 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
         return $path;
     }
 
-    private function createSeoGscDailyTable(): void
+    private function createSeoGscDailyTable(bool $includeIdempotencyKey = true): void
     {
-        Schema::connection('seo_intel')->create('seo_gsc_daily', function (Blueprint $table): void {
+        Schema::connection('seo_intel')->create('seo_gsc_daily', function (Blueprint $table) use ($includeIdempotencyKey): void {
             $table->id();
+            if ($includeIdempotencyKey) {
+                $table->char('idempotency_key', 64)->nullable()->unique('seo_gsc_daily_idempotency_key_unique');
+            }
             $table->date('report_date');
             $table->char('canonical_url_hash', 64)->nullable();
             $table->text('canonical_url')->nullable();
@@ -344,5 +392,18 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
             $table->json('metadata_json')->nullable();
             $table->timestamps();
         });
+    }
+
+    private function expectedIdempotencyKey(): string
+    {
+        return hash('sha256', implode('|', [
+            '2026-06-17',
+            hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
+            hash('sha256', 'mbti测试'),
+            'google',
+            '',
+            '',
+            'web',
+        ]));
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -901,6 +901,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
             'backend/database/migrations/2026_05_17_000900_create_seo_gsc_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -4704,6 +4705,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/GscQueryClassifier.php',
             'backend/app/Services/SeoIntel/GscSearchAnalyticsRowNormalizer.php',
             'backend/database/migrations/2026_05_17_000900_create_seo_gsc_daily_table.php',
+            'backend/database/migrations/seo_intel/2026_06_20_130000_add_idempotency_key_to_seo_gsc_daily_table.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added a forward-only `seo_intel.seo_gsc_daily` migration for `idempotency_key` plus the `seo_gsc_daily_idempotency_key_unique` unique index.
- Backfilled existing rows using `sha256(report_date|canonical_url_hash|query_hash|source_engine|device|country|search_type)`.
- Updated the controlled GSC import canary to insert and dedupe by `idempotency_key` while keeping the write limit at exactly 1 row.
- Updated the canary contract docs/generated JSON and focused tests.
- Updated the BigFive runtime-freeze classifier allowlist for this scoped `seo_intel` GSC migration.

## Why
This creates the formal idempotency foundation required before the next PR expands the controlled importer from 1 row to batch10.

## Validation
```bash
cd backend
php artisan test --filter SeoIntelGscReadModelControlledImportCanaryTest
php artisan test --filter '/test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_seo_intel_gsc_foundation_files/'
python3 -m json.tool docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json >/dev/null
git diff --check
```

## Intentionally deferred
- No batch10 importer behavior in this PR.
- No scheduler activation.
- No queue/opportunity enqueue.
- No CMS draft or CMS write.
- No Search Channel submit, indexing request, sitemap submission, or Google live API call.
- No production env changes.

## Repository rule impact
This is a backend `seo_intel` read-model schema/import safety change. It does not alter CMS/backend content authority, public APIs, publishing workflows, media handling, sitemap/llms enumeration, or frontend fallback behavior.
