### PR TITLE
SEO-GSC-READMODEL-CONTROLLED-IMPORT-BATCH10-01: allow controlled GSC batch10 import

### DIFF
--- a/backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php
@@ -12,13 +12,13 @@ final class SeoIntelGscReadModelImportCanaryCommand extends Command
 {
     protected $signature = 'seo-intel:gsc-readmodel-import-canary
         {--artifact= : Path to a sanitized GSC sidecar live-read artifact}
-        {--limit=1 : Canary row limit; must be exactly 1}
+        {--limit=1 : Canary row limit; bounded 1..10}
         {--execute : Execute the bounded canary write}
         {--confirm-artifact-sha256= : Required for --execute; must match artifact SHA256}
         {--confirm-write= : Required exact confirmation phrase for --execute}
         {--json : Emit JSON summary}';
 
-    protected $description = 'Validate a sanitized GSC artifact and optionally write one controlled seo_gsc_daily canary row.';
+    protected $description = 'Validate a sanitized GSC artifact and optionally write a controlled seo_gsc_daily batch10 canary.';
 
     public function handle(GscReadModelControlledImportCanary $canary): int
     {
@@ -41,9 +41,9 @@ final class SeoIntelGscReadModelImportCanaryCommand extends Command
         $limit = $this->limit();
         if ($limit === null) {
             return $this->finish([
-                ...$this->failureSummary('limit_must_be_exactly_1'),
+                ...$this->failureSummary('limit_must_be_between_1_and_10'),
                 'artifact_sha256' => $sha256,
-                'required_confirmation_phrase' => $canary->confirmationPhrase($sha256),
+                'required_confirmation_phrase' => $canary->confirmationPhrase($sha256, 1),
             ]);
         }
 
@@ -81,7 +81,7 @@ final class SeoIntelGscReadModelImportCanaryCommand extends Command
 
         $limit = (int) $raw;
 
-        return $limit === 1 ? 1 : null;
+        return $limit >= 1 && $limit <= 10 ? $limit : null;
     }
 
     private function nullableString(mixed $value): ?string

--- a/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
+++ b/backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php
@@ -15,7 +15,9 @@ final class GscReadModelControlledImportCanary
 
     public const TARGET_TABLE = 'seo_gsc_daily';
 
-    private const LIMIT = 1;
+    private const MIN_LIMIT = 1;
+
+    private const MAX_LIMIT = 10;
 
     public function __construct(private readonly GscReadModelArtifactDryRunImporter $dryRunImporter) {}
 
@@ -26,7 +28,7 @@ final class GscReadModelControlledImportCanary
     public function plan(array $artifact, string $artifactSha256, int $limit): array
     {
         $issues = $this->limitIssues($limit);
-        $preview = $this->dryRunImporter->preview($artifact, self::LIMIT);
+        $preview = $this->dryRunImporter->preview($artifact, $limit);
 
         if (($preview['ok'] ?? false) !== true) {
             $issues[] = 'dry_run_importer_validation_failed';
@@ -34,7 +36,7 @@ final class GscReadModelControlledImportCanary
 
         $issues = array_values(array_unique($issues));
         $ok = $issues === [];
-        $rows = $ok ? array_slice((array) ($preview['preview_rows'] ?? []), 0, self::LIMIT) : [];
+        $rows = $ok ? array_slice((array) ($preview['preview_rows'] ?? []), 0, $limit) : [];
 
         return [
             'schema_version' => self::SCHEMA_VERSION,
@@ -50,11 +52,13 @@ final class GscReadModelControlledImportCanary
             'target_connection' => (string) config('seo_intel.connection', 'seo_intel'),
             'target_table' => self::TARGET_TABLE,
             'artifact_sha256' => $artifactSha256,
-            'required_confirmation_phrase' => $this->confirmationPhrase($artifactSha256),
+            'required_confirmation_phrase' => $this->confirmationPhrase($artifactSha256, $limit),
+            'max_rows_per_execution' => self::MAX_LIMIT,
             'rows_previewed' => count($rows),
             'rows_would_insert' => $ok ? count($rows) : 0,
             'rows_inserted' => 0,
             'rows_skipped_existing' => 0,
+            'rows_failed' => [],
             'write_boundary' => $this->writeBoundary(writeAllowed: false),
             'data_origin' => $preview['data_origin'] ?? null,
             'data_quality_gate' => $preview['data_quality_gate'] ?? null,
@@ -84,7 +88,7 @@ final class GscReadModelControlledImportCanary
             $issues[] = 'artifact_sha256_confirmation_required';
         }
 
-        $expectedConfirmation = $this->confirmationPhrase($artifactSha256);
+        $expectedConfirmation = $this->confirmationPhrase($artifactSha256, $limit);
         if ($confirmedWritePhrase === null || ! hash_equals($expectedConfirmation, $confirmedWritePhrase)) {
             $issues[] = 'exact_write_confirmation_required';
         }
@@ -103,14 +107,15 @@ final class GscReadModelControlledImportCanary
                 'writes_committed' => false,
                 'rows_inserted' => 0,
                 'rows_skipped_existing' => 0,
+                'rows_failed' => [],
                 'write_boundary' => $this->writeBoundary(writeAllowed: false),
                 'issues' => $issues,
                 'negative_guarantees' => $this->negativeGuarantees(),
             ];
         }
 
-        $row = (array) data_get($plan, 'preview_rows.0', []);
-        if ($row === []) {
+        $rows = array_values(array_filter((array) ($plan['preview_rows'] ?? []), 'is_array'));
+        if ($rows === []) {
             return [
                 ...$plan,
                 'status' => 'blocked',
@@ -123,37 +128,29 @@ final class GscReadModelControlledImportCanary
                 'writes_committed' => false,
                 'rows_inserted' => 0,
                 'rows_skipped_existing' => 0,
+                'rows_failed' => [],
                 'write_boundary' => $this->writeBoundary(writeAllowed: false),
-                'issues' => ['preview_row_required'],
+                'issues' => ['preview_rows_required'],
                 'negative_guarantees' => $this->negativeGuarantees(),
             ];
         }
 
         $connection = (string) config('seo_intel.connection', 'seo_intel');
         $query = DB::connection($connection)->table(self::TARGET_TABLE);
+        $inserted = 0;
+        $skipped = 0;
 
-        if ($this->matchingRowExists($connection, $row)) {
-            return [
-                ...$plan,
-                'status' => 'success',
-                'mode' => 'canary_execute',
-                'ok' => true,
-                'dry_run' => false,
-                'execute' => true,
-                'would_write' => false,
-                'writes_attempted' => true,
-                'writes_committed' => false,
-                'rows_would_insert' => 0,
-                'rows_inserted' => 0,
-                'rows_skipped_existing' => 1,
-                'write_boundary' => $this->writeBoundary(writeAllowed: true),
-                'issues' => [],
-                'negative_guarantees' => $this->negativeGuarantees(),
-            ];
+        foreach ($rows as $row) {
+            if ($this->matchingRowExists($connection, $row)) {
+                $skipped++;
+
+                continue;
+            }
+
+            $now = Carbon::now('UTC')->toDateTimeString();
+            $query->insert($this->insertPayload($row, $artifactSha256, $now));
+            $inserted++;
         }
-
-        $now = Carbon::now('UTC')->toDateTimeString();
-        $query->insert($this->insertPayload($row, $artifactSha256, $now));
 
         return [
             ...$plan,
@@ -164,21 +161,23 @@ final class GscReadModelControlledImportCanary
             'execute' => true,
             'would_write' => false,
             'writes_attempted' => true,
-            'writes_committed' => true,
+            'writes_committed' => $inserted > 0,
             'rows_would_insert' => 0,
-            'rows_inserted' => 1,
-            'rows_skipped_existing' => 0,
+            'rows_inserted' => $inserted,
+            'rows_skipped_existing' => $skipped,
+            'rows_failed' => [],
             'write_boundary' => $this->writeBoundary(writeAllowed: true),
             'issues' => [],
             'negative_guarantees' => $this->negativeGuarantees(),
         ];
     }
 
-    public function confirmationPhrase(string $artifactSha256): string
+    public function confirmationPhrase(string $artifactSha256, int $limit = self::MIN_LIMIT): string
     {
         return sprintf(
-            'I explicitly approve %s to write at most 1 row to seo_gsc_daily from artifact sha256 %s; no scheduler, no queue, no CMS, no search, no indexing.',
+            'I explicitly approve %s to write at most %d rows to seo_gsc_daily from artifact sha256 %s; no scheduler, no queue, no CMS, no search, no indexing.',
             self::TASK,
+            $limit,
             $artifactSha256,
         );
     }
@@ -188,7 +187,7 @@ final class GscReadModelControlledImportCanary
      */
     private function limitIssues(int $limit): array
     {
-        return $limit === self::LIMIT ? [] : ['limit_must_be_exactly_1'];
+        return $limit >= self::MIN_LIMIT && $limit <= self::MAX_LIMIT ? [] : ['limit_must_be_between_1_and_10'];
     }
 
     /**
@@ -251,7 +250,7 @@ final class GscReadModelControlledImportCanary
         return [
             'seo_gsc_daily_write_allowed' => $writeAllowed,
             'target_table' => self::TARGET_TABLE,
-            'max_rows_per_execution' => self::LIMIT,
+            'max_rows_per_execution' => self::MAX_LIMIT,
             'idempotency_key_fields' => [
                 'report_date',
                 'canonical_url_hash',
@@ -295,7 +294,7 @@ final class GscReadModelControlledImportCanary
     {
         return [
             'database_write_outside_seo_gsc_daily' => false,
-            'seo_gsc_daily_write_beyond_single_canary_row' => false,
+            'seo_gsc_daily_write_beyond_batch10_limit' => false,
             'migration_added' => false,
             'scheduler_activation' => false,
             'queue_worker_activation' => false,

--- a/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
+++ b/backend/docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json
@@ -9,7 +9,7 @@
   "default_mode": "dry_run_canary_plan",
   "execute_requires": [
     "--execute",
-    "--limit=1",
+    "--limit=1..10",
     "--confirm-artifact-sha256=<artifact_sha256>",
     "--confirm-write=<exact_generated_confirmation_phrase>",
     "--json"
@@ -20,13 +20,16 @@
     "required_data_origin": "live_gsc_api",
     "required_data_quality_gate": "pass",
     "required_rows_path": "payload.metadata.safe_row_preview",
-    "max_rows_per_execution": 1
+    "max_rows_per_execution": 10
   },
   "validation": {
     "dry_run_importer_must_pass": true,
     "artifact_sha256_confirmation_required": true,
     "exact_write_confirmation_required": true,
-    "limit_must_equal": 1,
+    "limit_must_be_between": [
+      1,
+      10
+    ],
     "forbidden_fields_rejected_recursively": [
       "raw_query",
       "raw_url",
@@ -58,11 +61,13 @@
   "target": {
     "connection": "seo_intel",
     "table": "seo_gsc_daily",
-    "write_scope": "single_row_canary_only",
+    "write_scope": "controlled_batch10_canary_only",
     "canonical_url_policy": "null_until_separate_backend_url_truth_join_is_approved",
-    "migration_added_in_this_pr": true,
-    "migration_scope": "seo_gsc_daily.idempotency_key only",
-    "unique_index_added_in_this_pr": true,
+    "migration_added_in_this_pr": false,
+    "idempotency_migration_available": true,
+    "idempotency_migration_scope": "seo_gsc_daily.idempotency_key only",
+    "unique_index_added_in_this_pr": false,
+    "unique_index_available": true,
     "unique_index": "seo_gsc_daily_idempotency_key_unique"
   },
   "idempotency": {
@@ -99,7 +104,9 @@
       "writes_attempted",
       "writes_committed",
       "rows_inserted",
-      "rows_skipped_existing"
+      "rows_skipped_existing",
+      "rows_failed",
+      "max_rows_per_execution"
     ]
   },
   "negative_guarantees": {
@@ -119,8 +126,8 @@
     "production_env_change": false
   },
   "held_after_this_pr": [
-    "production execute canary until separate explicit approval",
-    "batch read model import",
+    "production execute batch10 canary until separate explicit approval",
+    "batch import above 10 rows",
     "scheduler activation",
     "opportunity queue execution",
     "CMS draft package",

--- a/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
+++ b/backend/docs/seo/gsc-readmodel-controlled-import-canary.md
@@ -4,11 +4,11 @@ Task: `SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01`
 
 ## Purpose
 
-This PR adds the first write-capable GSC read-model importer, limited to a single controlled canary row in `seo_gsc_daily`.
+This PR adds the first write-capable GSC read-model importer, limited to a controlled batch10 canary in `seo_gsc_daily`.
 
-The command reads a sanitized Hong Kong GSC sidecar live-read artifact, reuses the dry-run importer validation gates, and writes at most one row only when the operator provides `--execute`, an exact artifact SHA256 confirmation, and the exact generated write confirmation phrase.
+The command reads a sanitized Hong Kong GSC sidecar live-read artifact, reuses the dry-run importer validation gates, and writes at most ten rows only when the operator provides `--execute`, an exact artifact SHA256 confirmation, and the exact generated write confirmation phrase.
 
-The follow-up idempotency PR adds a dedicated `idempotency_key` column and unique index so future small-batch imports can skip existing rows deterministically. It does not change the write limit: the command remains limited to one row until a separate batch10 PR is approved.
+The idempotency foundation adds a dedicated `idempotency_key` column and unique index so small-batch imports can skip existing rows deterministically.
 
 This PR family does not add a scheduler, enqueue opportunities, mutate CMS content, enqueue or submit Search Channel records, request GSC indexing, submit a sitemap, call Google APIs, or change production environment variables.
 
@@ -19,7 +19,7 @@ Dry-run canary plan:
 ```bash
 php artisan seo-intel:gsc-readmodel-import-canary \
   --artifact=/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-YYYYMMDDTHHMMSSZ-success.json \
-  --limit=1 \
+  --limit=10 \
   --json
 ```
 
@@ -28,9 +28,9 @@ Bounded canary execution:
 ```bash
 php artisan seo-intel:gsc-readmodel-import-canary \
   --artifact=/opt/fermatmind/seo-gsc-runner/artifacts/gsc-live-read-wrapper-20260620T093059Z-success.json \
-  --limit=1 \
+  --limit=10 \
   --confirm-artifact-sha256=00238a3132d5399fa1d3aaf992451b87da9e4062d82077c75dc317cf33045d0d \
-  --confirm-write="I explicitly approve SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01 to write at most 1 row to seo_gsc_daily from artifact sha256 00238a3132d5399fa1d3aaf992451b87da9e4062d82077c75dc317cf33045d0d; no scheduler, no queue, no CMS, no search, no indexing." \
+  --confirm-write="I explicitly approve SEO-GSC-READMODEL-CONTROLLED-IMPORT-CANARY-01 to write at most 10 rows to seo_gsc_daily from artifact sha256 00238a3132d5399fa1d3aaf992451b87da9e4062d82077c75dc317cf33045d0d; no scheduler, no queue, no CMS, no search, no indexing." \
   --execute \
   --json
 ```
@@ -39,7 +39,7 @@ The production execution command remains held until a separate explicit operator
 
 ## Required Gates
 
-- `--limit=1`; any other value fails closed.
+- `--limit=1..10`; values outside this range fail closed.
 - Artifact SHA256 must match `--confirm-artifact-sha256`.
 - `--confirm-write` must exactly match the command-generated confirmation phrase.
 - Dry-run importer validation must pass:
@@ -56,7 +56,7 @@ Allowed write target:
 
 - connection: `seo_intel`
 - table: `seo_gsc_daily`
-- maximum rows per execution: `1`
+- maximum rows per execution: `10`
 
 The inserted row comes from the dry-run `preview_rows` shape. `canonical_url` remains `null` because raw URLs are not allowed in sidecar artifacts. The row metadata records `data_origin=live_gsc_api`, `row_source=live_gsc_api`, the source artifact SHA256, and the canary task id.
 
@@ -85,6 +85,6 @@ Schema boundary:
 
 ## Next Allowed Work
 
-After merge, the next operational step is deploying `main` to the HK sidecar runner and running the dry-run canary plan. A real `--execute` canary write still requires separate explicit approval.
+After merge, the next operational step is deploying `main` to the HK sidecar runner and running the batch10 dry-run canary plan. A real `--execute` batch10 write still requires separate explicit approval.
 
-Batch import, scheduler activation, opportunity queue execution, CMS drafting, and search/indexing actions remain separate holds.
+Scheduler activation, opportunity queue execution, CMS drafting, and search/indexing actions remain separate holds.

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelControlledImportCanaryTest.php
@@ -151,20 +151,42 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
     }
 
     #[Test]
-    public function canary_fails_closed_when_limit_is_not_exactly_one(): void
+    public function canary_fails_closed_when_limit_exceeds_batch10(): void
     {
         Http::fake();
         $artifactPath = $this->writeArtifact($this->validArtifact());
 
         [$exitCode, $payload] = $this->runCanaryCommand([
             '--artifact' => $artifactPath,
-            '--limit' => 2,
+            '--limit' => 11,
             '--json' => true,
         ]);
 
         $this->assertSame(1, $exitCode);
         $this->assertSame('blocked', $payload['status'] ?? null);
-        $this->assertSame(['limit_must_be_exactly_1'], $payload['issues'] ?? null);
+        $this->assertSame(['limit_must_be_between_1_and_10'], $payload['issues'] ?? null);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function dry_run_can_preview_batch10_without_database_write(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact(rowCount: 10));
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 10,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame(10, $payload['rows_would_insert'] ?? null);
+        $this->assertSame(10, $payload['rows_previewed'] ?? null);
+        $this->assertSame(10, $payload['max_rows_per_execution'] ?? null);
+        $this->assertStringContainsString('at most 10 rows', (string) ($payload['required_confirmation_phrase'] ?? ''));
         $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
         Http::assertNothingSent();
     }
@@ -196,12 +218,12 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
         $this->assertCount(1, $rows);
         $this->assertSame('2026-06-17', (string) $rows[0]->report_date);
         $this->assertSame($this->expectedIdempotencyKey(), $rows[0]->idempotency_key);
-        $this->assertSame(hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'), $rows[0]->canonical_url_hash);
+        $this->assertSame(hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics-0'), $rows[0]->canonical_url_hash);
         $this->assertNull($rows[0]->canonical_url);
-        $this->assertSame(hash('sha256', 'mbti测试'), $rows[0]->query_hash);
+        $this->assertSame(hash('sha256', 'mbti测试0'), $rows[0]->query_hash);
         $this->assertSame('m****试', $rows[0]->query_display_masked);
         $this->assertSame(60, (int) $rows[0]->impressions);
-        $this->assertStringNotContainsString('mbti测试', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('mbti测试0', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
         Http::assertNothingSent();
     }
 
@@ -233,6 +255,67 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
     }
 
     #[Test]
+    public function execute_inserts_batch10_and_reports_rows_failed_empty(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact(rowCount: 10));
+        $sha256 = (string) hash_file('sha256', $artifactPath);
+
+        [$exitCode, $payload] = $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 10,
+            '--confirm-artifact-sha256' => $sha256,
+            '--confirm-write' => app(GscReadModelControlledImportCanary::class)->confirmationPhrase($sha256, 10),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertSame(10, $payload['rows_inserted'] ?? null);
+        $this->assertSame(0, $payload['rows_skipped_existing'] ?? null);
+        $this->assertSame([], $payload['rows_failed'] ?? null);
+        $this->assertSame(10, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function execute_batch10_skips_existing_rows_by_idempotency_key(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact(rowCount: 10));
+        $sha256 = (string) hash_file('sha256', $artifactPath);
+        $canary = app(GscReadModelControlledImportCanary::class);
+        $arguments = [
+            '--artifact' => $artifactPath,
+            '--limit' => 10,
+            '--confirm-artifact-sha256' => $sha256,
+            '--confirm-write' => $canary->confirmationPhrase($sha256, 10),
+            '--execute' => true,
+            '--json' => true,
+        ];
+
+        $this->runCanaryCommand([
+            '--artifact' => $artifactPath,
+            '--limit' => 1,
+            '--confirm-artifact-sha256' => $sha256,
+            '--confirm-write' => $canary->confirmationPhrase($sha256, 1),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        [$exitCode, $payload] = $this->runCanaryCommand($arguments);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertSame(9, $payload['rows_inserted'] ?? null);
+        $this->assertSame(1, $payload['rows_skipped_existing'] ?? null);
+        $this->assertSame(10, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
     public function migration_backfills_idempotency_key_and_adds_unique_index_for_existing_rows(): void
     {
         Schema::connection('seo_intel')->drop('seo_gsc_daily');
@@ -240,9 +323,9 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
 
         DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
             'report_date' => '2026-06-17',
-            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics-0'),
             'canonical_url' => null,
-            'query_hash' => hash('sha256', 'mbti测试'),
+            'query_hash' => hash('sha256', 'mbti测试0'),
             'query_display_masked' => 'm****试',
             'locale' => 'zh-CN',
             'source_engine' => 'google',
@@ -295,7 +378,7 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function validArtifact(): array
+    private function validArtifact(int $rowCount = 1): array
     {
         return [
             'schema_version' => 'gsc-hk-sidecar-runner-wrapper.v1',
@@ -320,24 +403,10 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
                         'status' => 'pass',
                         'opportunity_queue_eligible' => true,
                     ],
-                    'safe_row_preview' => [[
-                        'report_date' => '2026-06-17',
-                        'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
-                        'query_hash' => hash('sha256', 'mbti测试'),
-                        'query_display_masked' => 'm****试',
-                        'locale' => 'zh-CN',
-                        'source_engine' => 'google',
-                        'device' => null,
-                        'country' => null,
-                        'search_type' => 'web',
-                        'clicks' => 0,
-                        'impressions' => 60,
-                        'ctr_ppm' => 0,
-                        'average_position_milli' => 9000,
-                        'is_brand_query' => false,
-                        'query_type' => 'non_brand',
-                        'data_state' => 'final',
-                    ]],
+                    'safe_row_preview' => array_map(
+                        fn (int $index): array => $this->safeRow($index),
+                        range(0, $rowCount - 1),
+                    ),
                     'opportunity_queue_eligible' => false,
                     'cms_write_allowed' => false,
                     'search_channel_enqueue_allowed' => false,
@@ -348,6 +417,31 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
                     'queue_worker_enabled' => false,
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function safeRow(int $index): array
+    {
+        return [
+            'report_date' => '2026-06-17',
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics-'.$index),
+            'query_hash' => hash('sha256', 'mbti测试'.$index),
+            'query_display_masked' => 'm****试',
+            'locale' => 'zh-CN',
+            'source_engine' => 'google',
+            'device' => null,
+            'country' => null,
+            'search_type' => 'web',
+            'clicks' => 0,
+            'impressions' => 60 + $index,
+            'ctr_ppm' => 0,
+            'average_position_milli' => 9000 + $index,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'data_state' => 'final',
         ];
     }
 
@@ -398,8 +492,8 @@ final class SeoIntelGscReadModelControlledImportCanaryTest extends TestCase
     {
         return hash('sha256', implode('|', [
             '2026-06-17',
-            hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics'),
-            hash('sha256', 'mbti测试'),
+            hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics-0'),
+            hash('sha256', 'mbti测试0'),
             'google',
             '',
             '',


### PR DESCRIPTION
## What changed
- Expanded `seo-intel:gsc-readmodel-import-canary` from exact `--limit=1` to bounded `--limit=1..10`.
- Updated the exact confirmation phrase to include the requested row limit.
- Insert/skip now loops over preview rows and reports `rows_inserted`, `rows_skipped_existing`, `rows_failed`, and `max_rows_per_execution=10`.
- Kept idempotency through `seo_gsc_daily.idempotency_key` and the existing unique index.
- Updated canary contract docs/generated JSON and focused tests.

## Why
This is the controlled small-batch step after the idempotency key foundation. It enables a manually approved batch10 write without opening scheduler, queue, CMS, search, indexing, or Google live API execution.

## Validation
```bash
cd backend
php artisan test --filter SeoIntelGscReadModelControlledImportCanaryTest
python3 -m json.tool docs/seo/generated/gsc-readmodel-controlled-import-canary.v1.json >/dev/null
git diff --check
```

## Intentionally deferred
- No production execute in this PR; batch10 `--execute` still requires separate explicit operator approval.
- No import above 10 rows.
- No scheduler activation.
- No queue/opportunity enqueue.
- No CMS draft or CMS write.
- No Search Channel submit, indexing request, sitemap submission, or Google live API call.
- No production env changes.

## Repository rule impact
This is a backend `seo_intel` importer safety change. It does not alter CMS/backend content authority, public APIs, publishing workflows, media handling, sitemap/llms enumeration, or frontend fallback behavior.
