### PR TITLE
SEO-GSC-WEEKLY-READONLY-AUTOMATION-PLAN-01

### DIFF
--- a/backend/docs/seo/generated/gsc-weekly-readonly-automation-plan.v1.json
+++ b/backend/docs/seo/generated/gsc-weekly-readonly-automation-plan.v1.json
@@ -1,0 +1,64 @@
+{
+  "version": "gsc-weekly-readonly-automation-plan.v1",
+  "task": "SEO-GSC-WEEKLY-READONLY-AUTOMATION-PLAN-01",
+  "repo": "fap-api",
+  "type": "manual_readonly_runner_contract",
+  "script": "backend/scripts/seo/gsc_weekly_readonly_runner.sh",
+  "scheduler_activation": false,
+  "production_cron_activation": false,
+  "queue_worker_activation": false,
+  "default_runtime": {
+    "artifact_dir": "/opt/fermatmind/seo-gsc-runner/artifacts",
+    "window_days": 28,
+    "allowed_window_days": [7, 28],
+    "limit": 250,
+    "limit_bounds": [1, 250],
+    "dimensions": "query,page",
+    "end_date_default": "utc_today_minus_3_days"
+  },
+  "workflow": [
+    "gsc_sidecar_preflight",
+    "gsc_live_read_readonly",
+    "gsc_readmodel_import_dryrun",
+    "opportunity_threshold_precheck_artifact"
+  ],
+  "output_schema": "gsc-weekly-readonly-run.v1",
+  "opportunity_contract": {
+    "min_impressions": 50,
+    "max_ctr_ppm": 10000,
+    "position_milli_window": [8000, 20000],
+    "query_type_required": "non_brand",
+    "brand_query_allowed": false
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "seo_gsc_daily_write": false,
+    "controlled_import_execute": false,
+    "scheduler_activation": false,
+    "production_cron_activation": false,
+    "queue_worker_started": false,
+    "opportunity_queue_enqueue": false,
+    "cms_write": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "google_indexing_api_call": false,
+    "production_env_change": false,
+    "pr_train_metadata_change": false
+  },
+  "allowed_external_call": {
+    "google_search_console_search_analytics_readonly": true,
+    "google_indexing_api": false,
+    "search_channel": false,
+    "cms": false
+  },
+  "next_step_if_candidates_found": "Generate a separate controlled import canary plan with --limit=10 and wait for exact human approval before --execute.",
+  "held_items": [
+    "batch25_importer_limit",
+    "laravel_scheduler_activation",
+    "production_cron_activation",
+    "cms_draft_generation",
+    "search_channel_submission",
+    "indexing_request",
+    "automatic_tdk_or_content_mutation"
+  ]
+}

--- a/backend/docs/seo/gsc-weekly-readonly-automation-plan.md
+++ b/backend/docs/seo/gsc-weekly-readonly-automation-plan.md
@@ -1,0 +1,53 @@
+# GSC Weekly Read-only Automation Plan
+
+Task: `SEO-GSC-WEEKLY-READONLY-AUTOMATION-PLAN-01`
+
+This contract adds a manual weekly read-only runner for the Hong Kong GSC sidecar. It does not enable Laravel scheduler, production cron, queue workers, CMS mutation, Search Channel submission, indexing requests, or `seo_gsc_daily` writes.
+
+## Manual Runner
+
+```bash
+WINDOW_DAYS=28 \
+ARTIFACT_DIR=/opt/fermatmind/seo-gsc-runner/artifacts \
+backend/scripts/seo/gsc_weekly_readonly_runner.sh
+```
+
+The runner performs:
+
+1. GSC sidecar preflight.
+2. Read-only GSC live read through `gsc_sidecar_runner.sh`.
+3. `seo-intel:gsc-readmodel-import-dry-run`.
+4. A sanitized opportunity precheck evidence artifact.
+
+Default behavior:
+
+- `WINDOW_DAYS=28`
+- `LIMIT=250`
+- `DIMENSIONS=query,page`
+- `END_DATE=UTC today - 3 days`
+- `START_DATE=END_DATE - WINDOW_DAYS + 1`
+
+`WINDOW_DAYS` may be `7` or `28`. `LIMIT` must be within `1..250`. The only allowed dimensions are `query,page`.
+
+## Evidence Contract
+
+The final evidence artifact uses schema `gsc-weekly-readonly-run.v1` and records:
+
+- live-read artifact path, size, and SHA256
+- dry-run importer artifact path, size, and SHA256
+- `data_origin`
+- `data_quality_gate`
+- `rows_would_insert`
+- opportunity candidate count
+- miss reason counts
+- negative guarantees
+
+The evidence must not contain raw query, raw URL, credential path, service-account JSON, client email, private key, token, cookie, or session values.
+
+## Boundaries
+
+This runner may call the Google Search Console Search Analytics API in read-only mode. It must not call Google Indexing API, URL Inspection indexing, Search Channel, CMS APIs, queue workers, scheduler, or any write-capable importer.
+
+If candidates are found, the next step is still a separate `seo-intel:gsc-readmodel-import-canary --limit=10 --json` plan and a separate exact human approval before any `--execute` write.
+
+Batch25, scheduler activation, CMS draft generation, Search Channel submission, indexing requests, and automatic TDK/content mutation remain held for later approval.

--- a/backend/scripts/seo/gsc_weekly_readonly_runner.sh
+++ b/backend/scripts/seo/gsc_weekly_readonly_runner.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ARTIFACT_DIR="${ARTIFACT_DIR:-/opt/fermatmind/seo-gsc-runner/artifacts}"
+WINDOW_DAYS="${WINDOW_DAYS:-28}"
+LIMIT="${LIMIT:-250}"
+DIMENSIONS="${DIMENSIONS:-query,page}"
+END_DATE="${END_DATE:-$(date -u -d '3 days ago' +%F)}"
+START_DATE="${START_DATE:-$(date -u -d "${END_DATE} - $((WINDOW_DAYS - 1)) days" +%F)}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+
+fail() {
+  printf 'error=%s\n' "$1" >&2
+  exit 1
+}
+
+case "${WINDOW_DAYS}" in
+  7|28) ;;
+  *) fail "weekly_window_days_must_be_7_or_28" ;;
+esac
+
+case "${LIMIT}" in
+  ''|*[!0-9]*) fail "weekly_limit_must_be_integer" ;;
+  *) ;;
+esac
+
+if (( LIMIT < 1 || LIMIT > 250 )); then
+  fail "weekly_limit_must_be_between_1_and_250"
+fi
+
+if [[ "${DIMENSIONS}" != "query,page" ]]; then
+  fail "weekly_dimensions_must_be_query_page"
+fi
+
+mkdir -p "${ARTIFACT_DIR}"
+cd "${BACKEND_DIR}"
+
+PREFLIGHT_LOG="${ARTIFACT_DIR}/gsc-weekly-readonly-preflight-${TS}.log"
+LIVE_LOG="${ARTIFACT_DIR}/gsc-weekly-readonly-live-read-${TS}.log"
+DRYRUN_ARTIFACT="${ARTIFACT_DIR}/gsc-weekly-readonly-dryrun-${TS}.json"
+EVIDENCE_ARTIFACT="${ARTIFACT_DIR}/gsc-weekly-readonly-opportunity-precheck-${TS}.json"
+
+scripts/seo/gsc_sidecar_runner.sh \
+  --mode=preflight \
+  --artifact-dir="${ARTIFACT_DIR}" >"${PREFLIGHT_LOG}" 2>&1
+
+scripts/seo/gsc_sidecar_runner.sh \
+  --mode=live-read \
+  --start-date="${START_DATE}" \
+  --end-date="${END_DATE}" \
+  --limit="${LIMIT}" \
+  --dimensions="${DIMENSIONS}" \
+  --artifact-dir="${ARTIFACT_DIR}" >"${LIVE_LOG}" 2>&1
+
+LIVE_ARTIFACT="$(ls -t "${ARTIFACT_DIR}"/gsc-live-read-wrapper-*-success.json 2>/dev/null | head -1)"
+
+php artisan seo-intel:gsc-readmodel-import-dry-run \
+  --artifact="${LIVE_ARTIFACT}" \
+  --limit="${LIMIT}" \
+  --dry-run \
+  --json >"${DRYRUN_ARTIFACT}"
+
+python3 - "${LIVE_ARTIFACT}" "${DRYRUN_ARTIFACT}" "${EVIDENCE_ARTIFACT}" "${PREFLIGHT_LOG}" "${LIVE_LOG}" "${START_DATE}" "${END_DATE}" "${WINDOW_DAYS}" "${LIMIT}" <<'PY'
+import datetime
+import hashlib
+import json
+import os
+import sys
+
+live_path, dryrun_path, evidence_path, preflight_log, live_log, start_date, end_date, window_days, limit = sys.argv[1:]
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+def file_stat(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return {
+        "path": path,
+        "size": os.path.getsize(path),
+        "sha256": digest.hexdigest(),
+    }
+
+def data_get(value, dotted, default=None):
+    current = value
+    for part in dotted.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return default
+    return current
+
+dryrun = load_json(dryrun_path)
+live = load_json(live_path)
+rows = dryrun.get("preview_rows") or []
+miss_reasons = {}
+candidate_rows = []
+
+for index, row in enumerate(rows, 1):
+    reasons = []
+    impressions = int(row.get("impressions") or 0)
+    clicks = int(row.get("clicks") or 0)
+    ctr_ppm = row.get("ctr_ppm")
+    position_milli = row.get("average_position_milli")
+    is_brand = bool(row.get("is_brand_query"))
+    query_type = str(row.get("query_type") or "unknown")
+
+    if impressions < 50:
+        reasons.append("impressions_below_50")
+    if ctr_ppm is None:
+        reasons.append("ctr_ppm_missing")
+    elif int(ctr_ppm) > 10000:
+        reasons.append("ctr_ppm_above_10000")
+    if position_milli is None:
+        reasons.append("position_milli_missing")
+    elif int(position_milli) < 8000:
+        reasons.append("position_above_window_rank_better_than_8")
+    elif int(position_milli) > 20000:
+        reasons.append("position_below_window_rank_worse_than_20")
+    if is_brand:
+        reasons.append("brand_query")
+    if query_type != "non_brand":
+        reasons.append("query_type_not_non_brand")
+
+    if reasons:
+        for reason in reasons:
+            miss_reasons[reason] = miss_reasons.get(reason, 0) + 1
+    else:
+        candidate_rows.append({
+            "row_index": index,
+            "report_date": row.get("report_date"),
+            "canonical_url_hash": row.get("canonical_url_hash"),
+            "query_hash": row.get("query_hash"),
+            "query_display_masked": row.get("query_display_masked"),
+            "impressions": impressions,
+            "clicks": clicks,
+            "ctr_ppm": ctr_ppm,
+            "average_position_milli": position_milli,
+            "query_type": query_type,
+            "is_brand_query": is_brand,
+        })
+
+if candidate_rows:
+    diagnosis = "has_current_threshold_candidates"
+elif not rows:
+    diagnosis = "no_rows_returned_or_importer_blocked"
+elif miss_reasons.get("impressions_below_50", 0) == len(rows):
+    diagnosis = "data_volume_insufficient_all_rows_below_impression_threshold"
+else:
+    diagnosis = "mixed_threshold_miss"
+
+evidence = {
+    "schema_version": "gsc-weekly-readonly-run.v1",
+    "task": "SEO-GSC-WEEKLY-READONLY-AUTOMATION-PLAN-01",
+    "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "mode": "manual_weekly_readonly_runner",
+    "date_window": {
+        "start_date": start_date,
+        "end_date": end_date,
+        "window_days": int(window_days),
+    },
+    "runtime": {
+        "artifact_dir": os.path.dirname(evidence_path),
+        "limit": int(limit),
+        "dimensions": "query,page",
+    },
+    "artifacts": {
+        "preflight_log": file_stat(preflight_log),
+        "live_log": file_stat(live_log),
+        "live_read": file_stat(live_path),
+        "dryrun_importer": file_stat(dryrun_path),
+    },
+    "live_read": {
+        "data_origin": data_get(live, "payload.metadata.data_origin"),
+        "data_quality_gate": data_get(live, "payload.metadata.data_quality_gate.status"),
+        "items_seen": data_get(live, "payload.items_seen") or data_get(live, "payload.metadata.items_seen"),
+    },
+    "dryrun_importer": {
+        "ok": dryrun.get("ok"),
+        "would_write": dryrun.get("would_write"),
+        "rows_previewed": dryrun.get("rows_previewed"),
+        "rows_would_insert": dryrun.get("rows_would_insert"),
+        "data_origin": dryrun.get("data_origin"),
+        "data_quality_gate": dryrun.get("data_quality_gate"),
+    },
+    "opportunity_contract": {
+        "min_impressions": 50,
+        "max_ctr_ppm": 10000,
+        "position_milli_window": [8000, 20000],
+        "query_type_required": "non_brand",
+        "brand_query_allowed": False,
+    },
+    "opportunity_precheck": {
+        "rows_evaluated": len(rows),
+        "candidate_count": len(candidate_rows),
+        "top_candidates_sanitized": sorted(
+            candidate_rows,
+            key=lambda item: (item["impressions"], -(item["ctr_ppm"] or 0)),
+            reverse=True,
+        )[:10],
+        "miss_reason_counts": dict(sorted(miss_reasons.items())),
+        "diagnosis": diagnosis,
+    },
+    "negative_guarantees": {
+        "database_write": False,
+        "seo_gsc_daily_write": False,
+        "controlled_import_execute": False,
+        "scheduler_activation": False,
+        "queue_worker_started": False,
+        "opportunity_queue_enqueue": False,
+        "cms_write": False,
+        "search_channel_submit": False,
+        "indexing_request": False,
+        "google_indexing_api_call": False,
+        "live_gsc_api_call": True,
+    },
+}
+
+with open(evidence_path, "w", encoding="utf-8") as handle:
+    json.dump(evidence, handle, ensure_ascii=False, indent=2)
+    handle.write("\n")
+PY
+
+python3 -m json.tool "${LIVE_ARTIFACT}" >/dev/null
+python3 -m json.tool "${DRYRUN_ARTIFACT}" >/dev/null
+python3 -m json.tool "${EVIDENCE_ARTIFACT}" >/dev/null
+
+printf 'evidence_path=%s\n' "${EVIDENCE_ARTIFACT}"
+wc -c "${EVIDENCE_ARTIFACT}" | awk '{print "evidence_size="$1}'
+sha256sum "${EVIDENCE_ARTIFACT}" | awk '{print "evidence_sha256="$1}'

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscWeeklyReadonlyAutomationPlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscWeeklyReadonlyAutomationPlanTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscWeeklyReadonlyAutomationPlanTest extends TestCase
+{
+    #[Test]
+    public function weekly_readonly_runner_is_manual_bounded_and_readonly(): void
+    {
+        $scriptPath = base_path('scripts/seo/gsc_weekly_readonly_runner.sh');
+
+        $this->assertFileExists($scriptPath);
+        $this->assertTrue(is_executable($scriptPath), 'weekly readonly runner must be executable');
+
+        $script = (string) file_get_contents($scriptPath);
+
+        $this->assertStringContainsString('WINDOW_DAYS="${WINDOW_DAYS:-28}"', $script);
+        $this->assertStringContainsString('7|28', $script);
+        $this->assertStringContainsString('LIMIT="${LIMIT:-250}"', $script);
+        $this->assertStringContainsString('DIMENSIONS="${DIMENSIONS:-query,page}"', $script);
+        $this->assertStringContainsString('scripts/seo/gsc_sidecar_runner.sh', $script);
+        $this->assertStringContainsString('--mode=preflight', $script);
+        $this->assertStringContainsString('--mode=live-read', $script);
+        $this->assertStringContainsString('seo-intel:gsc-readmodel-import-dry-run', $script);
+        $this->assertStringContainsString('--dry-run', $script);
+        $this->assertStringContainsString('gsc-weekly-readonly-run.v1', $script);
+
+        $this->assertStringNotContainsString('--execute', $script);
+        $this->assertStringNotContainsString('seo-intel:gsc-readmodel-import-canary', $script);
+        $this->assertStringNotContainsString('schedule:run', $script);
+        $this->assertStringNotContainsString('queue:work', $script);
+        $this->assertStringNotContainsString('BEGIN PRIVATE KEY', $script);
+        $this->assertStringNotContainsString('client_email', $script);
+        $this->assertStringNotContainsString('Bearer ', $script);
+        $this->assertStringNotContainsString('ya29.', $script);
+    }
+
+    #[Test]
+    public function generated_contract_keeps_scheduler_writes_and_execution_actions_disabled(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/gsc-weekly-readonly-automation-plan.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('gsc-weekly-readonly-automation-plan.v1', $artifact['version'] ?? null);
+        $this->assertSame('backend/scripts/seo/gsc_weekly_readonly_runner.sh', $artifact['script'] ?? null);
+        $this->assertSame(28, data_get($artifact, 'default_runtime.window_days'));
+        $this->assertSame([7, 28], data_get($artifact, 'default_runtime.allowed_window_days'));
+        $this->assertSame(250, data_get($artifact, 'default_runtime.limit'));
+        $this->assertSame('query,page', data_get($artifact, 'default_runtime.dimensions'));
+        $this->assertContains('gsc_live_read_readonly', $artifact['workflow'] ?? []);
+        $this->assertContains('gsc_readmodel_import_dryrun', $artifact['workflow'] ?? []);
+        $this->assertSame('gsc-weekly-readonly-run.v1', $artifact['output_schema'] ?? null);
+
+        foreach ([
+            'database_write',
+            'seo_gsc_daily_write',
+            'controlled_import_execute',
+            'scheduler_activation',
+            'production_cron_activation',
+            'queue_worker_started',
+            'opportunity_queue_enqueue',
+            'cms_write',
+            'search_channel_submit',
+            'indexing_request',
+            'google_indexing_api_call',
+            'production_env_change',
+            'pr_train_metadata_change',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+
+        $this->assertTrue((bool) data_get($artifact, 'allowed_external_call.google_search_console_search_analytics_readonly'));
+        $this->assertFalse((bool) data_get($artifact, 'allowed_external_call.google_indexing_api', true));
+        $this->assertContains('laravel_scheduler_activation', $artifact['held_items'] ?? []);
+        $this->assertContains('automatic_tdk_or_content_mutation', $artifact['held_items'] ?? []);
+    }
+}


### PR DESCRIPTION
## Summary
- add a manual HK sidecar weekly read-only runner for GSC preflight, live-read, dry-run import preview, and opportunity threshold evidence
- document the weekly read-only contract and generated JSON guarantees
- add focused tests that lock no scheduler, no DB write, no queue, no CMS, no search, and no indexing boundaries

## Validation
- bash -n scripts/seo/gsc_weekly_readonly_runner.sh
- python3 -m json.tool docs/seo/generated/gsc-weekly-readonly-automation-plan.v1.json >/dev/null
- php artisan test --filter SeoIntelGscWeeklyReadonlyAutomationPlanTest
- php artisan test --filter SeoIntelGscSidecarRuntimeEnvBoundaryTest
- git diff --check

## Runtime evidence from HK sidecar before this PR
- 7d finalized window: data_quality_gate=pass, rows_would_insert=3, candidate_count=0
- 28d finalized window: data_quality_gate=pass, rows_would_insert=3, candidate_count=0
- diagnosis: data_volume_insufficient_all_rows_below_impression_threshold

## Intentionally deferred
- no scheduler or production cron activation
- no DB writes or controlled import execute
- no opportunity queue enqueue
- no CMS draft/write
- no Search Channel submit
- no indexing request
- no batch25 importer expansion
