### PR TITLE
SEO-AGENT-RUN-CONTROL-PACKET-02

### DIFF
--- a/backend/docs/seo/generated/seo-agent-run-control-packet.v1.json
+++ b/backend/docs/seo/generated/seo-agent-run-control-packet.v1.json
@@ -1,0 +1,98 @@
+{
+  "version": "seo-agent-run-control-packet.v1",
+  "task": "SEO-AGENT-RUN-CONTROL-PACKET-02",
+  "repo": "fap-api",
+  "type": "control_plane_contract",
+  "runtime_execution_enabled": false,
+  "required_fields": [
+    "run_id",
+    "run_mode",
+    "trigger",
+    "scope",
+    "input_refs",
+    "evidence_refs",
+    "model_review",
+    "approval",
+    "forbidden_actions",
+    "allowed_actions",
+    "output_artifacts",
+    "negative_guarantees",
+    "next_step"
+  ],
+  "allowed_run_modes": [
+    "readonly_discovery",
+    "gpt_review_handoff",
+    "cms_draft_dry_run",
+    "controlled_canary_write",
+    "post_action_review"
+  ],
+  "allowed_approval_states": [
+    "not_requested",
+    "review_requested",
+    "approved_for_dry_run_only",
+    "approved_for_single_canary_write",
+    "approved_for_publish_or_submit",
+    "rejected"
+  ],
+  "default_approval_state": "not_requested",
+  "model_review": {
+    "reviewer": "gpt_5_5_pro",
+    "role": "review_only",
+    "execution_permission": false,
+    "required_output": "verdict_json"
+  },
+  "artifact_requirements": {
+    "required_metadata": [
+      "path",
+      "size",
+      "sha256",
+      "schema_version",
+      "sanitized_summary"
+    ],
+    "forbidden_content": [
+      "raw_query",
+      "raw_url",
+      "credential_path",
+      "service_account_json",
+      "client_email",
+      "private_key",
+      "token",
+      "cookie",
+      "session"
+    ]
+  },
+  "forbidden_actions_by_default": [
+    "cms_write",
+    "cms_publish",
+    "search_channel_enqueue",
+    "search_channel_submit",
+    "indexing_request",
+    "sitemap_submission",
+    "scheduler_activation",
+    "queue_worker_activation",
+    "production_env_update",
+    "source_code_mutation",
+    "bulk_import"
+  ],
+  "allowed_actions_without_separate_approval": [
+    "readonly_scan",
+    "evidence_artifact_write",
+    "gpt_review_handoff_artifact",
+    "cms_draft_package_dry_run"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "source_code_mutation": false,
+    "pr_train_metadata_change": false
+  },
+  "next_step": "Use this packet contract as the required envelope for GPT 5.5 Pro review handoff and CMS draft dry-run package generation."
+}

--- a/backend/docs/seo/seo-agent-run-control-packet.md
+++ b/backend/docs/seo/seo-agent-run-control-packet.md
@@ -1,0 +1,71 @@
+# SEO Agent Run Control Packet
+
+Task: `SEO-AGENT-RUN-CONTROL-PACKET-02`
+
+This contract defines the standard JSON packet for each FermatMind SEO Agent run. It is a control-plane artifact only. It does not enable runtime execution, CMS writes, Search Channel submissions, indexing requests, queue workers, scheduler jobs, migrations, or production environment changes.
+
+## Purpose
+
+Each SEO Agent run must preserve a durable packet that explains:
+
+- why the run started
+- what evidence was used
+- which model or reviewer produced recommendations
+- which actions are forbidden
+- what approval state the run is in
+- which output artifacts were generated
+
+The packet is the handoff boundary between read-only discovery, GPT 5.5 Pro review, CMS draft generation, and any later controlled execution.
+
+## Required Shape
+
+The packet must use schema `seo-agent-run-control-packet.v1` and include:
+
+- `run_id`
+- `run_mode`
+- `trigger`
+- `scope`
+- `input_refs`
+- `evidence_refs`
+- `model_review`
+- `approval`
+- `forbidden_actions`
+- `allowed_actions`
+- `output_artifacts`
+- `negative_guarantees`
+- `next_step`
+
+## Approval States
+
+Allowed approval states:
+
+- `not_requested`
+- `review_requested`
+- `approved_for_dry_run_only`
+- `approved_for_single_canary_write`
+- `approved_for_publish_or_submit`
+- `rejected`
+
+Default state must be `not_requested`.
+
+## Forbidden by Default
+
+The following actions must stay forbidden unless a later task adds a separate exact approval gate:
+
+- CMS write or publish
+- Search Channel enqueue or submit
+- indexing request
+- sitemap submission
+- scheduler activation
+- queue worker activation
+- production environment update
+- direct source-code mutation
+- bulk import
+
+## Output Artifacts
+
+Output artifacts must be identified by path, byte size, SHA256, schema version, and sanitized summary. Artifacts must not include raw query, raw URL, credential path, service-account JSON, client email, private key, token, cookie, or session values.
+
+## Next Step
+
+After this contract, future PRs may generate concrete packets for GPT 5.5 Pro review and CMS draft dry-run packages. Execution remains held until separate approvals are implemented.

--- a/backend/tests/Feature/SeoIntel/SeoAgentRunControlPacketContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentRunControlPacketContractTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentRunControlPacketContractTest extends TestCase
+{
+    #[Test]
+    public function generated_contract_defines_run_packet_fields_and_approval_states(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/seo-agent-run-control-packet.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('seo-agent-run-control-packet.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-AGENT-RUN-CONTROL-PACKET-02', $artifact['task'] ?? null);
+        $this->assertFalse((bool) ($artifact['runtime_execution_enabled'] ?? true));
+
+        foreach ([
+            'run_id',
+            'run_mode',
+            'trigger',
+            'scope',
+            'input_refs',
+            'evidence_refs',
+            'model_review',
+            'approval',
+            'forbidden_actions',
+            'allowed_actions',
+            'output_artifacts',
+            'negative_guarantees',
+            'next_step',
+        ] as $field) {
+            $this->assertContains($field, $artifact['required_fields'] ?? [], $field);
+        }
+
+        $this->assertContains('readonly_discovery', $artifact['allowed_run_modes'] ?? []);
+        $this->assertContains('gpt_review_handoff', $artifact['allowed_run_modes'] ?? []);
+        $this->assertContains('cms_draft_dry_run', $artifact['allowed_run_modes'] ?? []);
+        $this->assertSame('not_requested', $artifact['default_approval_state'] ?? null);
+        $this->assertContains('approved_for_single_canary_write', $artifact['allowed_approval_states'] ?? []);
+    }
+
+    #[Test]
+    public function contract_keeps_gpt_review_and_execution_boundaries_separate(): void
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/seo-agent-run-control-packet.v1.json')),
+            true
+        );
+
+        $this->assertSame('gpt_5_5_pro', data_get($artifact, 'model_review.reviewer'));
+        $this->assertSame('review_only', data_get($artifact, 'model_review.role'));
+        $this->assertFalse((bool) data_get($artifact, 'model_review.execution_permission', true));
+
+        foreach ([
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'production_env_update',
+            'source_code_mutation',
+            'bulk_import',
+        ] as $action) {
+            $this->assertContains($action, $artifact['forbidden_actions_by_default'] ?? [], $action);
+        }
+
+        foreach ([
+            'raw_query',
+            'raw_url',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'token',
+            'cookie',
+            'session',
+        ] as $forbiddenContent) {
+            $this->assertContains($forbiddenContent, data_get($artifact, 'artifact_requirements.forbidden_content', []), $forbiddenContent);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'production_env_change',
+            'source_code_mutation',
+            'pr_train_metadata_change',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define the standard SEO Agent run control packet contract
- add generated JSON for required inputs, evidence refs, GPT review handoff, approval state, forbidden actions, and output artifacts
- add focused tests locking review-only GPT boundary and disabled execution actions

## Validation
- python3 -m json.tool docs/seo/generated/seo-agent-run-control-packet.v1.json >/dev/null
- php artisan test --filter SeoAgentRunControlPacketContractTest
- git diff --check

## Intentionally deferred
- no runtime command added
- no DB writes or migrations
- no CMS writes or publishing
- no Search Channel submit
- no indexing request
- no scheduler or queue worker activation
- no PR-train metadata changes
