### PR TITLE
SEO-AGENT-OPPORTUNITY-SOURCE-EXPANSION-01

### DIFF
--- a/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
+++ b/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
@@ -1,0 +1,108 @@
+{
+  "version": "seo-agent-opportunity-source-expansion.v1",
+  "task": "SEO-AGENT-OPPORTUNITY-SOURCE-EXPANSION-01",
+  "repo": "fap-api",
+  "type": "opportunity_source_contract",
+  "runtime_scanners_added": false,
+  "source_families": [
+    {
+      "id": "gsc_performance",
+      "status": "existing_read_model_source",
+      "inputs": ["seo_gsc_daily", "seo_urls", "gsc_data_quality_gate"],
+      "write_allowed": false
+    },
+    {
+      "id": "cms_tdk_gap",
+      "status": "future_readonly_source",
+      "detects": ["missing_title", "missing_meta_description", "missing_canonical", "missing_indexability_metadata"],
+      "write_allowed": false
+    },
+    {
+      "id": "cms_faq_gap",
+      "status": "future_readonly_source",
+      "detects": ["missing_faq_block", "thin_faq_block", "faq_schema_candidate"],
+      "write_allowed": false
+    },
+    {
+      "id": "cms_internal_link_gap",
+      "status": "future_readonly_source",
+      "detects": ["missing_internal_links", "missing_anchor_coverage", "orphan_candidate"],
+      "write_allowed": false
+    },
+    {
+      "id": "runtime_seo_qa",
+      "status": "future_readonly_source",
+      "detects": ["noindex", "canonical_mismatch", "json_ld_absent", "robots_conflict", "redirect_surprise", "http_status_issue"],
+      "write_allowed": false
+    },
+    {
+      "id": "sitemap_llms_gap",
+      "status": "future_readonly_source",
+      "detects": ["sitemap_missing_eligible_url", "sitemap_contains_ineligible_url", "llms_missing_eligible_url", "llms_contains_ineligible_url"],
+      "write_allowed": false
+    },
+    {
+      "id": "hreflang_canonical_gap",
+      "status": "future_readonly_source",
+      "detects": ["hreflang_missing", "hreflang_return_tag_missing", "locale_alternate_missing", "canonical_self_reference_missing"],
+      "write_allowed": false
+    }
+  ],
+  "candidate_shape": {
+    "required_fields": [
+      "source_family",
+      "source_id",
+      "subject_type",
+      "subject_ref",
+      "safe_path",
+      "severity",
+      "evidence_refs",
+      "recommended_next_step",
+      "allowed_action",
+      "blocked_actions"
+    ],
+    "severity_values": ["p0", "p1", "p2", "p3"],
+    "allowed_actions_without_separate_approval": [
+      "readonly_review",
+      "gpt_review_handoff",
+      "cms_draft_package_dry_run"
+    ]
+  },
+  "run_packet_required_before_downstream_action": "seo-agent-run-control-packet.v1",
+  "forbidden_output_fields": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "raw_payload",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "source_code_mutation": false,
+    "pr_train_metadata_change": false
+  },
+  "implementation_sequence": [
+    "cms_tdk_gap_readonly_scanner",
+    "cms_faq_gap_readonly_scanner",
+    "cms_internal_link_gap_readonly_scanner",
+    "runtime_seo_qa_readonly_scanner",
+    "sitemap_llms_gap_readonly_scanner",
+    "hreflang_canonical_gap_readonly_scanner"
+  ],
+  "next_step": "Implement one readonly source scanner at a time, starting with cms_tdk_gap, and require seo-agent-run-control-packet.v1 for GPT review handoff or CMS draft dry-run."
+}

--- a/backend/docs/seo/seo-agent-opportunity-source-expansion.md
+++ b/backend/docs/seo/seo-agent-opportunity-source-expansion.md
@@ -1,0 +1,53 @@
+# SEO Agent Opportunity Source Expansion
+
+Task: `SEO-AGENT-OPPORTUNITY-SOURCE-EXPANSION-01`
+
+This contract expands FermatMind SEO Agent opportunity discovery beyond GSC. It defines safe read-only source families that may produce opportunity candidates even when GSC volume is too low. It does not implement scanners, write CMS content, enqueue Search Channel records, submit indexing requests, activate scheduler, or mutate source code.
+
+## Source Families
+
+Allowed source families:
+
+- `gsc_performance`: existing GSC read model signals
+- `cms_tdk_gap`: CMS pages missing title, description, canonical metadata, or indexability metadata
+- `cms_faq_gap`: CMS pages missing FAQ blocks where the page type expects FAQ support
+- `cms_internal_link_gap`: CMS/page records missing approved internal-link targets or anchor coverage
+- `runtime_seo_qa`: public-page QA issues such as noindex, canonical mismatch, JSON-LD absence, robots conflicts, redirect surprises, or response status issues
+- `sitemap_llms_gap`: sitemap and `llms.txt` eligibility or enumeration gaps
+- `hreflang_canonical_gap`: hreflang, locale alternate, or canonical self-reference gaps
+
+## Candidate Shape
+
+Every source must emit sanitized opportunity candidates with:
+
+- `source_family`
+- `source_id`
+- `subject_type`
+- `subject_ref`
+- `safe_path`
+- `severity`
+- `evidence_refs`
+- `recommended_next_step`
+- `allowed_action`
+- `blocked_actions`
+
+Raw URLs, raw queries, credentials, tokens, private paths, raw payloads, and CMS draft content are forbidden in source output.
+
+## Scoring Boundary
+
+The expanded source contract is allowed to score and rank candidates, but not execute actions. Scores must remain explainable through evidence fields. A source candidate may only flow into GPT review or CMS draft dry-run after it is wrapped by `seo-agent-run-control-packet.v1`.
+
+## Execution Boundary
+
+The source expansion does not authorize:
+
+- CMS writes or publish
+- Search Channel enqueue or submission
+- indexing requests
+- sitemap submission
+- scheduler activation
+- queue workers
+- production environment changes
+- source-code mutation
+
+Future scanner PRs must implement one source family at a time and preserve this contract.

--- a/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentOpportunitySourceExpansionContractTest extends TestCase
+{
+    #[Test]
+    public function generated_contract_declares_non_gsc_opportunity_source_families(): void
+    {
+        $artifact = $this->artifact();
+        $sourceIds = array_column($artifact['source_families'] ?? [], 'id');
+
+        foreach ([
+            'gsc_performance',
+            'cms_tdk_gap',
+            'cms_faq_gap',
+            'cms_internal_link_gap',
+            'runtime_seo_qa',
+            'sitemap_llms_gap',
+            'hreflang_canonical_gap',
+        ] as $sourceId) {
+            $this->assertContains($sourceId, $sourceIds, $sourceId);
+        }
+
+        $this->assertFalse((bool) ($artifact['runtime_scanners_added'] ?? true));
+        $this->assertSame('seo-agent-run-control-packet.v1', $artifact['run_packet_required_before_downstream_action'] ?? null);
+        $this->assertContains('cms_tdk_gap_readonly_scanner', $artifact['implementation_sequence'] ?? []);
+    }
+
+    #[Test]
+    public function candidate_shape_is_sanitized_and_review_only_by_default(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'source_family',
+            'source_id',
+            'subject_type',
+            'subject_ref',
+            'safe_path',
+            'severity',
+            'evidence_refs',
+            'recommended_next_step',
+            'allowed_action',
+            'blocked_actions',
+        ] as $field) {
+            $this->assertContains($field, data_get($artifact, 'candidate_shape.required_fields', []), $field);
+        }
+
+        foreach (['p0', 'p1', 'p2', 'p3'] as $severity) {
+            $this->assertContains($severity, data_get($artifact, 'candidate_shape.severity_values', []), $severity);
+        }
+
+        foreach ([
+            'readonly_review',
+            'gpt_review_handoff',
+            'cms_draft_package_dry_run',
+        ] as $allowedAction) {
+            $this->assertContains($allowedAction, data_get($artifact, 'candidate_shape.allowed_actions_without_separate_approval', []), $allowedAction);
+        }
+
+        foreach ([
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'token',
+            'cookie',
+            'session',
+            'raw_payload',
+            'cms_draft_body',
+        ] as $forbiddenField) {
+            $this->assertContains($forbiddenField, $artifact['forbidden_output_fields'] ?? [], $forbiddenField);
+        }
+    }
+
+    #[Test]
+    public function contract_keeps_all_execution_surfaces_disabled(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ($artifact['source_families'] ?? [] as $source) {
+            $this->assertFalse((bool) ($source['write_allowed'] ?? true), (string) ($source['id'] ?? 'unknown'));
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_started',
+            'production_env_change',
+            'source_code_mutation',
+            'pr_train_metadata_change',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json')),
+            true
+        );
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('seo-agent-opportunity-source-expansion.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-AGENT-OPPORTUNITY-SOURCE-EXPANSION-01', $artifact['task'] ?? null);
+
+        return $artifact;
+    }
+}


### PR DESCRIPTION
## Summary
- define expanded SEO Agent opportunity source families beyond GSC
- add generated JSON contract for CMS TDK gaps, FAQ gaps, internal link gaps, runtime SEO QA, sitemap/llms gaps, and hreflang/canonical gaps
- add focused tests locking sanitized candidate shape and disabled execution surfaces

## Validation
- python3 -m json.tool docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json >/dev/null
- php artisan test --filter SeoAgentOpportunitySourceExpansionContractTest
- php artisan test --filter SeoAgentRunControlPacketContractTest
- git diff --check

## Intentionally deferred
- no runtime scanner implementation in this PR
- no DB writes or migrations
- no CMS writes or publishing
- no Search Channel enqueue/submit
- no indexing request
- no scheduler or queue worker activation
- no PR-train metadata changes
