### PR TITLE
SEO-AGENT-CMS-TDK-GAP-READONLY-SCANNER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\CmsTdkGapReadonlyScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentCmsTdkGapScanCommand extends Command
+{
+    protected $signature = 'seo-agent:cms-tdk-gap-scan
+        {--surface=all : Surface to scan: articles, content-pages, or all}
+        {--limit=100 : Candidate limit, bounded 1..250}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only CMS TDK gap scanner that emits SEO Agent control packet and Codex review handoff artifacts.';
+
+    public function handle(CmsTdkGapReadonlyScanner $scanner): int
+    {
+        $surface = trim((string) $this->option('surface'));
+        if (! in_array($surface, ['articles', 'content-pages', 'all'], true)) {
+            return $this->finish($this->failureSummary('invalid_surface'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $scannerArtifact = $scanner->scan($surface, $this->limit());
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $scannerRef = $this->writeArtifact($artifactDir, 'seo-agent-cms-tdk-gap-scan-'.$timestamp.'.json', $scannerArtifact);
+        $packet = $this->runControlPacket($scannerArtifact, $scannerRef);
+        $packetRef = $this->writeArtifact($artifactDir, 'seo-agent-run-control-packet-'.$timestamp.'.json', $packet);
+        $handoff = $this->codexReviewHandoff($scannerArtifact, $scannerRef, $packetRef);
+        $handoffRef = $this->writeArtifact($artifactDir, 'seo-agent-codex-review-handoff-'.$timestamp.'.json', $handoff);
+
+        return $this->finish([
+            'schema_version' => CmsTdkGapReadonlyScanner::SCHEMA_VERSION,
+            'task' => CmsTdkGapReadonlyScanner::TASK,
+            'ok' => true,
+            'status' => 'success',
+            'surface' => $surface,
+            'candidate_count' => $scannerArtifact['candidate_count'] ?? 0,
+            'artifacts' => [
+                'scanner' => $scannerRef,
+                'run_control_packet' => $packetRef,
+                'codex_review_handoff' => $handoffRef,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? $payload['version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $scannerArtifact
+     * @param  array<string, mixed>  $scannerRef
+     * @return array<string, mixed>
+     */
+    private function runControlPacket(array $scannerArtifact, array $scannerRef): array
+    {
+        return [
+            'schema_version' => 'seo-agent-run-control-packet.v1',
+            'run_id' => 'cms-tdk-gap-'.Carbon::now('UTC')->format('YmdHis'),
+            'run_mode' => 'readonly_discovery',
+            'trigger' => 'manual_cli',
+            'scope' => [
+                'source_family' => 'cms_tdk_gap',
+                'surface' => (string) ($scannerArtifact['surface'] ?? 'all'),
+                'write_scope' => 'none',
+            ],
+            'input_refs' => [
+                'command' => 'php artisan seo-agent:cms-tdk-gap-scan',
+                'surface' => (string) ($scannerArtifact['surface'] ?? 'all'),
+                'limit' => (int) ($scannerArtifact['limit'] ?? 100),
+            ],
+            'evidence_refs' => [$scannerRef],
+            'model_review' => [
+                'reviewer' => 'codex',
+                'role' => 'review_only',
+                'execution_permission' => false,
+                'required_output' => 'seo-agent-codex-review-handoff.v1',
+            ],
+            'approval' => [
+                'status' => 'not_requested',
+                'approved_actions' => [],
+            ],
+            'forbidden_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'sitemap_submission',
+                'scheduler_activation',
+                'queue_worker_activation',
+                'production_env_update',
+                'source_code_mutation',
+            ],
+            'allowed_actions' => [
+                'readonly_scan',
+                'evidence_artifact_write',
+                'codex_review_handoff_artifact',
+            ],
+            'output_artifacts' => [
+                'scanner' => $scannerRef,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'next_step' => 'Codex may review the handoff JSON and recommend dry-run-only CMS draft package scope; it must not execute changes.',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $scannerArtifact
+     * @param  array<string, mixed>  $scannerRef
+     * @param  array<string, mixed>  $packetRef
+     * @return array<string, mixed>
+     */
+    private function codexReviewHandoff(array $scannerArtifact, array $scannerRef, array $packetRef): array
+    {
+        return [
+            'schema_version' => 'seo-agent-codex-review-handoff.v1',
+            'task' => CmsTdkGapReadonlyScanner::TASK,
+            'reviewer' => 'codex',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_control_packet' => $packetRef,
+            'input_candidates' => $scannerRef,
+            'candidate_count' => (int) ($scannerArtifact['candidate_count'] ?? 0),
+            'review_output_contract' => [
+                'worth_optimizing' => 'boolean',
+                'recommended_action' => 'readonly_review|cms_draft_package_dry_run|defer',
+                'risk_flags' => 'list<string>',
+                'needs_human_approval' => 'boolean',
+            ],
+            'candidate_preview' => array_slice((array) ($scannerArtifact['candidates'] ?? []), 0, 20),
+            'forbidden_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'scheduler_activation',
+                'queue_worker_activation',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue): array
+    {
+        return [
+            'schema_version' => CmsTdkGapReadonlyScanner::SCHEMA_VERSION,
+            'task' => CmsTdkGapReadonlyScanner::TASK,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            'candidate_count' => 0,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            foreach ((array) ($summary['artifacts'] ?? []) as $name => $artifact) {
+                if (is_array($artifact)) {
+                    $this->line($name.'_artifact_path='.(string) ($artifact['path'] ?? ''));
+                    $this->line($name.'_artifact_size='.(string) ($artifact['size'] ?? 0));
+                    $this->line($name.'_artifact_sha256='.(string) ($artifact['sha256'] ?? ''));
+                }
+            }
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'source_code_mutation' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -169,6 +169,7 @@ use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
+use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
@@ -359,6 +360,7 @@ class Kernel extends ConsoleKernel
         ArticleUpdateImageMetadata::class,
         ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
+        SeoAgentCmsTdkGapScanCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php
+++ b/backend/app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoAgent;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+
+final class CmsTdkGapReadonlyScanner
+{
+    public const SCHEMA_VERSION = 'seo-agent-cms-tdk-gap-readonly-scanner.v1';
+
+    public const TASK = 'SEO-AGENT-CMS-TDK-GAP-READONLY-SCANNER-01';
+
+    private const BLOCKED_ACTIONS = [
+        'cms_write',
+        'cms_publish',
+        'search_channel_enqueue',
+        'search_channel_submit',
+        'indexing_request',
+        'scheduler_activation',
+        'queue_worker_activation',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function scan(string $surface = 'all', int $limit = 100): array
+    {
+        $surface = in_array($surface, ['articles', 'content-pages', 'all'], true) ? $surface : 'all';
+        $limit = max(1, min($limit, 250));
+        $candidates = [];
+
+        if ($surface === 'articles' || $surface === 'all') {
+            foreach ($this->articleCandidates($limit) as $candidate) {
+                $candidates[] = $candidate;
+                if (count($candidates) >= $limit) {
+                    break;
+                }
+            }
+        }
+
+        if (($surface === 'content-pages' || $surface === 'all') && count($candidates) < $limit) {
+            foreach ($this->contentPageCandidates($limit - count($candidates)) as $candidate) {
+                $candidates[] = $candidate;
+                if (count($candidates) >= $limit) {
+                    break;
+                }
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => 'success',
+            'source_family' => 'cms_tdk_gap',
+            'run_mode' => 'readonly_discovery',
+            'surface' => $surface,
+            'limit' => $limit,
+            'candidate_count' => count($candidates),
+            'candidates' => $candidates,
+            'candidate_shape' => [
+                'required_fields' => [
+                    'source_family',
+                    'source_id',
+                    'subject_type',
+                    'subject_ref',
+                    'safe_path',
+                    'severity',
+                    'evidence_refs',
+                    'recommended_next_step',
+                    'allowed_action',
+                    'blocked_actions',
+                ],
+            ],
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function articleCandidates(int $limit): array
+    {
+        $rows = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['seoMeta' => static fn ($query) => $query->withoutGlobalScopes()])
+            ->published()
+            ->orderBy('id')
+            ->limit($limit * 3)
+            ->get();
+
+        $candidates = [];
+        foreach ($rows as $article) {
+            $seoMeta = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            $gaps = [];
+
+            if (! $seoMeta instanceof ArticleSeoMeta) {
+                $gaps[] = 'missing_indexability_metadata';
+                $gaps[] = 'missing_title';
+                $gaps[] = 'missing_meta_description';
+                $gaps[] = 'missing_canonical';
+            } else {
+                if (trim((string) $seoMeta->seo_title) === '') {
+                    $gaps[] = 'missing_title';
+                }
+                if (trim((string) $seoMeta->seo_description) === '') {
+                    $gaps[] = 'missing_meta_description';
+                }
+                if (trim((string) $seoMeta->canonical_url) === '') {
+                    $gaps[] = 'missing_canonical';
+                }
+                if ($seoMeta->getAttribute('is_indexable') === null) {
+                    $gaps[] = 'missing_indexability_metadata';
+                }
+            }
+
+            $gaps = array_values(array_unique($gaps));
+            if ($gaps === []) {
+                continue;
+            }
+
+            $candidates[] = $this->candidate(
+                subjectType: 'article',
+                subjectRef: 'article:'.(int) $article->id.':'.(string) $article->locale,
+                safePath: $this->articleSafePath($article),
+                locale: (string) $article->locale,
+                isIndexable: (bool) $article->is_indexable,
+                gapTypes: $gaps,
+            );
+
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function contentPageCandidates(int $limit): array
+    {
+        $rows = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->publishedPublic()
+            ->orderBy('id')
+            ->limit($limit * 3)
+            ->get();
+
+        $candidates = [];
+        foreach ($rows as $page) {
+            $gaps = [];
+
+            if (trim((string) $page->seo_title) === '') {
+                $gaps[] = 'missing_title';
+            }
+            if (trim((string) $page->seo_description) === '' && trim((string) $page->meta_description) === '') {
+                $gaps[] = 'missing_meta_description';
+            }
+            if (trim((string) $page->canonical_path) === '') {
+                $gaps[] = 'missing_canonical';
+            }
+            if ($page->getAttribute('is_indexable') === null) {
+                $gaps[] = 'missing_indexability_metadata';
+            }
+
+            $gaps = array_values(array_unique($gaps));
+            if ($gaps === []) {
+                continue;
+            }
+
+            $candidates[] = $this->candidate(
+                subjectType: 'content_page',
+                subjectRef: 'content_page:'.(int) $page->id.':'.(string) $page->locale,
+                safePath: $this->contentPageSafePath($page),
+                locale: (string) $page->locale,
+                isIndexable: (bool) $page->is_indexable,
+                gapTypes: $gaps,
+            );
+
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @return array<string, mixed>
+     */
+    private function candidate(string $subjectType, string $subjectRef, string $safePath, string $locale, bool $isIndexable, array $gapTypes): array
+    {
+        $sourcePayload = implode('|', [$subjectType, $subjectRef, $safePath, implode(',', $gapTypes)]);
+
+        return [
+            'source_family' => 'cms_tdk_gap',
+            'source_id' => hash('sha256', $sourcePayload),
+            'subject_type' => $subjectType,
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'locale' => $locale,
+            'severity' => $this->severity($gapTypes, $isIndexable),
+            'gap_types' => $gapTypes,
+            'evidence_refs' => array_map(
+                static fn (string $gap): array => [
+                    'code' => $gap,
+                    'field_status' => 'missing',
+                ],
+                $gapTypes
+            ),
+            'recommended_next_step' => 'codex_review_required_before_cms_draft',
+            'allowed_action' => 'readonly_review',
+            'blocked_actions' => self::BLOCKED_ACTIONS,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     */
+    private function severity(array $gapTypes, bool $isIndexable): string
+    {
+        if ($isIndexable && (in_array('missing_title', $gapTypes, true) || in_array('missing_canonical', $gapTypes, true))) {
+            return 'p1';
+        }
+
+        if (in_array('missing_meta_description', $gapTypes, true) || in_array('missing_indexability_metadata', $gapTypes, true)) {
+            return 'p2';
+        }
+
+        return 'p3';
+    }
+
+    private function articleSafePath(Article $article): string
+    {
+        $slug = $this->safeSlug((string) $article->slug);
+        if ($slug === '') {
+            $slug = 'article-'.substr(hash('sha256', (string) $article->id), 0, 12);
+        }
+
+        return str_starts_with(strtolower((string) $article->locale), 'zh')
+            ? '/zh/articles/'.$slug
+            : '/articles/'.$slug;
+    }
+
+    private function contentPageSafePath(ContentPage $page): string
+    {
+        $path = trim((string) $page->path);
+        if ($path === '') {
+            $path = '/'.$this->safeSlug((string) $page->slug);
+        }
+
+        if (preg_match('#^https?://#i', $path) === 1) {
+            $parsedPath = parse_url($path, PHP_URL_PATH);
+            $path = is_string($parsedPath) && $parsedPath !== '' ? $parsedPath : '/content-page-'.substr(hash('sha256', (string) $page->id), 0, 12);
+        }
+
+        $path = '/'.ltrim(strtok($path, '?#') ?: $path, '/');
+
+        return preg_replace('#/+#', '/', $path) ?: '/';
+    }
+
+    private function safeSlug(string $slug): string
+    {
+        $slug = trim($slug, "/ \t\n\r\0\x0B");
+        $slug = preg_replace('/[^A-Za-z0-9._~%-]+/', '-', $slug) ?: '';
+
+        return trim($slug, '-');
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'source_code_mutation' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/seo-agent-cms-tdk-gap-readonly-scanner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-tdk-gap-readonly-scanner.v1.json
@@ -1,0 +1,99 @@
+{
+  "version": "seo-agent-cms-tdk-gap-readonly-scanner.v1",
+  "task": "SEO-AGENT-CMS-TDK-GAP-READONLY-SCANNER-01",
+  "repo": "fap-api",
+  "type": "runtime_readonly_scanner_contract",
+  "command": "php artisan seo-agent:cms-tdk-gap-scan",
+  "source_family": "cms_tdk_gap",
+  "surfaces": [
+    "articles",
+    "content-pages",
+    "all"
+  ],
+  "default_surface": "all",
+  "default_limit": 100,
+  "max_limit": 250,
+  "detects": [
+    "missing_title",
+    "missing_meta_description",
+    "missing_canonical",
+    "missing_indexability_metadata"
+  ],
+  "output_artifacts": [
+    "seo-agent-cms-tdk-gap-readonly-scanner.v1",
+    "seo-agent-run-control-packet.v1",
+    "seo-agent-codex-review-handoff.v1"
+  ],
+  "candidate_shape": {
+    "required_fields": [
+      "source_family",
+      "source_id",
+      "subject_type",
+      "subject_ref",
+      "safe_path",
+      "severity",
+      "evidence_refs",
+      "recommended_next_step",
+      "allowed_action",
+      "blocked_actions"
+    ],
+    "source_family": "cms_tdk_gap",
+    "allowed_subject_types": [
+      "article",
+      "content_page"
+    ],
+    "severity_values": [
+      "p1",
+      "p2",
+      "p3"
+    ],
+    "allowed_action": "readonly_review"
+  },
+  "run_control_packet": {
+    "schema_version": "seo-agent-run-control-packet.v1",
+    "run_mode": "readonly_discovery",
+    "approval_status": "not_requested"
+  },
+  "codex_review_handoff": {
+    "schema_version": "seo-agent-codex-review-handoff.v1",
+    "reviewer": "codex",
+    "role": "review_only",
+    "execution_permission": false,
+    "required_output_fields": [
+      "worth_optimizing",
+      "recommended_action",
+      "risk_flags",
+      "needs_human_approval"
+    ]
+  },
+  "forbidden_output_fields": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "raw_payload",
+    "cms_draft_body",
+    "content_md",
+    "content_html"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "source_code_mutation": false,
+    "pr_train_metadata_change": false
+  },
+  "next_step": "Codex reviews the handoff artifact and may recommend a CMS draft package dry-run only after human approval."
+}

--- a/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
+++ b/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
@@ -3,7 +3,10 @@
   "task": "SEO-AGENT-OPPORTUNITY-SOURCE-EXPANSION-01",
   "repo": "fap-api",
   "type": "opportunity_source_contract",
-  "runtime_scanners_added": false,
+  "runtime_scanners_added": true,
+  "implemented_runtime_scanners": [
+    "cms_tdk_gap_readonly_scanner"
+  ],
   "source_families": [
     {
       "id": "gsc_performance",
@@ -13,7 +16,9 @@
     },
     {
       "id": "cms_tdk_gap",
-      "status": "future_readonly_source",
+      "status": "implemented_readonly_source",
+      "runtime_scanner": "cms_tdk_gap_readonly_scanner",
+      "command": "php artisan seo-agent:cms-tdk-gap-scan",
       "detects": ["missing_title", "missing_meta_description", "missing_canonical", "missing_indexability_metadata"],
       "write_allowed": false
     },

--- a/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
+++ b/backend/docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json
@@ -69,7 +69,7 @@
     "severity_values": ["p0", "p1", "p2", "p3"],
     "allowed_actions_without_separate_approval": [
       "readonly_review",
-      "gpt_review_handoff",
+      "codex_review_handoff",
       "cms_draft_package_dry_run"
     ]
   },
@@ -109,5 +109,5 @@
     "sitemap_llms_gap_readonly_scanner",
     "hreflang_canonical_gap_readonly_scanner"
   ],
-  "next_step": "Implement one readonly source scanner at a time, starting with cms_tdk_gap, and require seo-agent-run-control-packet.v1 for GPT review handoff or CMS draft dry-run."
+  "next_step": "Implement one readonly source scanner at a time, starting with cms_tdk_gap, and require seo-agent-run-control-packet.v1 for Codex review handoff or CMS draft dry-run."
 }

--- a/backend/docs/seo/generated/seo-agent-run-control-packet.v1.json
+++ b/backend/docs/seo/generated/seo-agent-run-control-packet.v1.json
@@ -21,7 +21,7 @@
   ],
   "allowed_run_modes": [
     "readonly_discovery",
-    "gpt_review_handoff",
+    "codex_review_handoff",
     "cms_draft_dry_run",
     "controlled_canary_write",
     "post_action_review"
@@ -36,7 +36,7 @@
   ],
   "default_approval_state": "not_requested",
   "model_review": {
-    "reviewer": "gpt_5_5_pro",
+    "reviewer": "codex",
     "role": "review_only",
     "execution_permission": false,
     "required_output": "verdict_json"
@@ -77,7 +77,7 @@
   "allowed_actions_without_separate_approval": [
     "readonly_scan",
     "evidence_artifact_write",
-    "gpt_review_handoff_artifact",
+    "codex_review_handoff_artifact",
     "cms_draft_package_dry_run"
   ],
   "negative_guarantees": {
@@ -94,5 +94,5 @@
     "source_code_mutation": false,
     "pr_train_metadata_change": false
   },
-  "next_step": "Use this packet contract as the required envelope for GPT 5.5 Pro review handoff and CMS draft dry-run package generation."
+  "next_step": "Use this packet contract as the required envelope for Codex review handoff and CMS draft dry-run package generation."
 }

--- a/backend/docs/seo/seo-agent-cms-tdk-gap-readonly-scanner.md
+++ b/backend/docs/seo/seo-agent-cms-tdk-gap-readonly-scanner.md
@@ -1,0 +1,33 @@
+# SEO Agent CMS TDK Gap Readonly Scanner
+
+`SEO-AGENT-CMS-TDK-GAP-READONLY-SCANNER-01` is the first runtime opportunity source for the FermatMind SEO Agent control loop.
+
+It scans public, published CMS article and content-page surfaces for missing SEO title, description, canonical, and indexability metadata. It only emits sanitized opportunity candidates plus run-control and Codex review handoff artifacts.
+
+## Command
+
+```bash
+php artisan seo-agent:cms-tdk-gap-scan \
+  --surface=all \
+  --limit=100 \
+  --artifact-dir=/opt/fermatmind/seo-agent/artifacts \
+  --json
+```
+
+Supported surfaces:
+
+- `articles`
+- `content-pages`
+- `all`
+
+The command writes three sanitized JSON artifacts:
+
+- `seo-agent-cms-tdk-gap-readonly-scanner.v1`
+- `seo-agent-run-control-packet.v1`
+- `seo-agent-codex-review-handoff.v1`
+
+## Boundary
+
+The scanner is read-only. It must not write CMS rows, publish content, enqueue search work, submit indexing requests, start queues, activate scheduler jobs, or mutate source code.
+
+The Codex handoff is review-only. It can recommend whether a candidate is worth optimizing and what dry-run action should be considered next, but it has no execution permission.

--- a/backend/docs/seo/seo-agent-opportunity-source-expansion.md
+++ b/backend/docs/seo/seo-agent-opportunity-source-expansion.md
@@ -35,7 +35,7 @@ Raw URLs, raw queries, credentials, tokens, private paths, raw payloads, and CMS
 
 ## Scoring Boundary
 
-The expanded source contract is allowed to score and rank candidates, but not execute actions. Scores must remain explainable through evidence fields. A source candidate may only flow into GPT review or CMS draft dry-run after it is wrapped by `seo-agent-run-control-packet.v1`.
+The expanded source contract is allowed to score and rank candidates, but not execute actions. Scores must remain explainable through evidence fields. A source candidate may only flow into Codex review or CMS draft dry-run after it is wrapped by `seo-agent-run-control-packet.v1`.
 
 ## Execution Boundary
 

--- a/backend/docs/seo/seo-agent-run-control-packet.md
+++ b/backend/docs/seo/seo-agent-run-control-packet.md
@@ -15,7 +15,7 @@ Each SEO Agent run must preserve a durable packet that explains:
 - what approval state the run is in
 - which output artifacts were generated
 
-The packet is the handoff boundary between read-only discovery, GPT 5.5 Pro review, CMS draft generation, and any later controlled execution.
+The packet is the handoff boundary between read-only discovery, Codex review, CMS draft generation, and any later controlled execution.
 
 ## Required Shape
 
@@ -68,4 +68,4 @@ Output artifacts must be identified by path, byte size, SHA256, schema version, 
 
 ## Next Step
 
-After this contract, future PRs may generate concrete packets for GPT 5.5 Pro review and CMS draft dry-run packages. Execution remains held until separate approvals are implemented.
+After this contract, future PRs may generate concrete packets for Codex review and CMS draft dry-run packages. Execution remains held until separate approvals are implemented.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsTdkGapReadonlyScannerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsTdkGapReadonlyScannerTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+use App\Services\SeoAgent\CmsTdkGapReadonlyScanner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsTdkGapReadonlyScannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function scanner_finds_article_and_content_page_tdk_gaps_without_returning_raw_content(): void
+    {
+        $missingArticle = $this->createArticle('zh-missing-seo-meta');
+        $completeArticle = $this->createArticle('zh-complete-seo-meta');
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $completeArticle->id,
+            'locale' => 'zh-CN',
+            'seo_title' => 'Complete SEO title',
+            'seo_description' => 'Complete SEO description.',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/zh-complete-seo-meta',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+        $page = $this->createContentPage('tdk-gap-page');
+
+        $artifact = (new CmsTdkGapReadonlyScanner)->scan('all', 10);
+
+        $this->assertSame('seo-agent-cms-tdk-gap-readonly-scanner.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('cms_tdk_gap', $artifact['source_family'] ?? null);
+        $this->assertSame(2, $artifact['candidate_count'] ?? null);
+
+        $candidateRefs = array_column($artifact['candidates'] ?? [], 'subject_ref');
+        $this->assertContains('article:'.$missingArticle->id.':zh-CN', $candidateRefs);
+        $this->assertContains('content_page:'.$page->id.':zh-CN', $candidateRefs);
+        $this->assertNotContains('article:'.$completeArticle->id.':zh-CN', $candidateRefs);
+
+        $articleCandidate = collect($artifact['candidates'])->firstWhere('subject_ref', 'article:'.$missingArticle->id.':zh-CN');
+        $this->assertSame('/zh/articles/zh-missing-seo-meta', $articleCandidate['safe_path'] ?? null);
+        $this->assertSame('p1', $articleCandidate['severity'] ?? null);
+        $this->assertContains('missing_title', $articleCandidate['gap_types'] ?? []);
+        $this->assertContains('missing_meta_description', $articleCandidate['gap_types'] ?? []);
+        $this->assertContains('missing_canonical', $articleCandidate['gap_types'] ?? []);
+        $this->assertContains('missing_indexability_metadata', $articleCandidate['gap_types'] ?? []);
+
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        $this->assertStringNotContainsString('https://fermatmind.com', $encoded);
+        $this->assertStringNotContainsString('raw_url', $encoded);
+        $this->assertStringNotContainsString('raw_query', $encoded);
+        $this->assertStringNotContainsString('content_md', $encoded);
+        $this->assertStringNotContainsString('content_html', $encoded);
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.database_write', true));
+    }
+
+    #[Test]
+    public function command_writes_scanner_packet_and_codex_review_handoff_artifacts_without_db_writes(): void
+    {
+        $this->createArticle('zh-command-gap');
+        $this->createContentPage('command-gap-page');
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-tdk-gap-scan', [
+            '--surface' => 'all',
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $files = File::files($artifactDir);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertIsArray($summary);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(2, $summary['candidate_count'] ?? null);
+        $this->assertCount(3, $files);
+
+        $scanner = $this->readJson(data_get($summary, 'artifacts.scanner.path'));
+        $packet = $this->readJson(data_get($summary, 'artifacts.run_control_packet.path'));
+        $handoff = $this->readJson(data_get($summary, 'artifacts.codex_review_handoff.path'));
+
+        $this->assertSame('seo-agent-cms-tdk-gap-readonly-scanner.v1', $scanner['schema_version'] ?? null);
+        $this->assertSame('seo-agent-run-control-packet.v1', $packet['schema_version'] ?? null);
+        $this->assertSame('readonly_discovery', $packet['run_mode'] ?? null);
+        $this->assertSame('not_requested', data_get($packet, 'approval.status'));
+        $this->assertSame('codex', data_get($packet, 'model_review.reviewer'));
+        $this->assertFalse((bool) data_get($packet, 'model_review.execution_permission', true));
+
+        $this->assertSame('seo-agent-codex-review-handoff.v1', $handoff['schema_version'] ?? null);
+        $this->assertSame('codex', $handoff['reviewer'] ?? null);
+        $this->assertSame('review_only', $handoff['role'] ?? null);
+        $this->assertFalse((bool) ($handoff['execution_permission'] ?? true));
+
+        $combined = implode("\n", array_map(
+            static fn ($file): string => (string) file_get_contents($file->getPathname()),
+            $files
+        ));
+
+        foreach ([
+            'https://fermatmind.com',
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'content_md',
+            'content_html',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($packet, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($handoff, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function generated_contract_documents_readonly_boundaries_and_codex_handoff(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-tdk-gap-readonly-scanner.v1.json'));
+
+        $this->assertSame('seo-agent-cms-tdk-gap-readonly-scanner.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-tdk-gap-scan', $artifact['command'] ?? null);
+        $this->assertSame('cms_tdk_gap', $artifact['source_family'] ?? null);
+        $this->assertSame('codex', data_get($artifact, 'codex_review_handoff.reviewer'));
+        $this->assertFalse((bool) data_get($artifact, 'codex_review_handoff.execution_permission', true));
+
+        foreach ([
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'token',
+            'cms_draft_body',
+            'content_md',
+            'content_html',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_output_fields'] ?? [], $field);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Readable title',
+            'excerpt' => 'Reader-facing excerpt.',
+            'content_md' => 'Article body must never be emitted by the scanner.',
+            'content_html' => '<p>Article body must never be emitted by the scanner.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function createContentPage(string $slug): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => '/zh/'.$slug,
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Content page',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'content_md' => 'Content page body must never be emitted.',
+            'content_html' => '<p>Content page body must never be emitted.</p>',
+            'seo_title' => null,
+            'seo_description' => null,
+            'meta_description' => null,
+            'canonical_path' => null,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-cms-tdk-gap-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
@@ -27,9 +27,14 @@ final class SeoAgentOpportunitySourceExpansionContractTest extends TestCase
             $this->assertContains($sourceId, $sourceIds, $sourceId);
         }
 
-        $this->assertFalse((bool) ($artifact['runtime_scanners_added'] ?? true));
+        $this->assertTrue((bool) ($artifact['runtime_scanners_added'] ?? false));
+        $this->assertContains('cms_tdk_gap_readonly_scanner', $artifact['implemented_runtime_scanners'] ?? []);
         $this->assertSame('seo-agent-run-control-packet.v1', $artifact['run_packet_required_before_downstream_action'] ?? null);
         $this->assertContains('cms_tdk_gap_readonly_scanner', $artifact['implementation_sequence'] ?? []);
+
+        $cmsTdkSource = collect($artifact['source_families'] ?? [])->firstWhere('id', 'cms_tdk_gap');
+        $this->assertSame('implemented_readonly_source', $cmsTdkSource['status'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-tdk-gap-scan', $cmsTdkSource['command'] ?? null);
     }
 
     #[Test]

--- a/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentOpportunitySourceExpansionContractTest.php
@@ -63,7 +63,7 @@ final class SeoAgentOpportunitySourceExpansionContractTest extends TestCase
 
         foreach ([
             'readonly_review',
-            'gpt_review_handoff',
+            'codex_review_handoff',
             'cms_draft_package_dry_run',
         ] as $allowedAction) {
             $this->assertContains($allowedAction, data_get($artifact, 'candidate_shape.allowed_actions_without_separate_approval', []), $allowedAction);

--- a/backend/tests/Feature/SeoIntel/SeoAgentRunControlPacketContractTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentRunControlPacketContractTest.php
@@ -41,21 +41,21 @@ final class SeoAgentRunControlPacketContractTest extends TestCase
         }
 
         $this->assertContains('readonly_discovery', $artifact['allowed_run_modes'] ?? []);
-        $this->assertContains('gpt_review_handoff', $artifact['allowed_run_modes'] ?? []);
+        $this->assertContains('codex_review_handoff', $artifact['allowed_run_modes'] ?? []);
         $this->assertContains('cms_draft_dry_run', $artifact['allowed_run_modes'] ?? []);
         $this->assertSame('not_requested', $artifact['default_approval_state'] ?? null);
         $this->assertContains('approved_for_single_canary_write', $artifact['allowed_approval_states'] ?? []);
     }
 
     #[Test]
-    public function contract_keeps_gpt_review_and_execution_boundaries_separate(): void
+    public function contract_keeps_codex_review_and_execution_boundaries_separate(): void
     {
         $artifact = json_decode(
             (string) file_get_contents(base_path('docs/seo/generated/seo-agent-run-control-packet.v1.json')),
             true
         );
 
-        $this->assertSame('gpt_5_5_pro', data_get($artifact, 'model_review.reviewer'));
+        $this->assertSame('codex', data_get($artifact, 'model_review.reviewer'));
         $this->assertSame('review_only', data_get($artifact, 'model_review.role'));
         $this->assertFalse((bool) data_get($artifact, 'model_review.execution_permission', true));
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1073,6 +1073,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_tdk_gap_readonly_scanner_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsTdkGapScanCommand;',
+            '+        SeoAgentCmsTdkGapScanCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3579,6 +3594,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsTdkGapReadonlyScannerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4164,6 +4183,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4794,6 +4814,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Middleware/EnsureSeoIntelReadAuthorized.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php',
             'backend/app/Support/Rbac/PermissionNames.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php',
+            'backend/app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php',
         ], true);
     }
 
@@ -6373,6 +6401,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\b(ArticleDiscoverabilityRelease|ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsTdkGapScanCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added a read-only `seo-agent:cms-tdk-gap-scan` Artisan command for CMS article/content-page TDK gap discovery.
- Emits sanitized scanner, run control packet, and Codex review-only handoff artifacts.
- Updated the opportunity source contract to mark `cms_tdk_gap` as the first implemented readonly runtime scanner.
- Added a narrow BigFive runtime-freeze classifier exception for this SEO Agent readonly scanner and its exact Kernel registration lines.

## Why
This creates the first executable L4 SEO Agent opportunity-source loop while keeping optimization actions review-only and manually gated.

## Validation
- `php artisan test --filter SeoAgentCmsTdkGapReadonlyScannerTest`
- `php artisan test --filter SeoAgentRunControlPacketContractTest`
- `php artisan test --filter SeoAgentOpportunitySourceExpansionContractTest`
- `php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-tdk-gap-readonly-scanner.v1.json >/dev/null`
- `python3 -m json.tool docs/seo/generated/seo-agent-opportunity-source-expansion.v1.json >/dev/null`
- `php -l app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php`
- `php -l app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php`
- `php -l tests/Feature/SeoIntel/SeoAgentCmsTdkGapReadonlyScannerTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `git diff --check`

## Intentionally deferred
- No CMS writes or CMS draft package generation.
- No scheduler, queue worker, Search Channel submit/enqueue, Google Indexing API, or source-code mutation.
- No GPT 5.5 Pro/API call; this PR only creates the Codex review handoff JSON artifact.