### PR TITLE
SEO-AGENT-CODEX-REVIEW-RUNNER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentCodexReviewRunnerCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-codex-review-verdict.v1';
+
+    private const HANDOFF_SCHEMA_VERSION = 'seo-agent-codex-review-handoff.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:codex-review-runner
+        {--handoff= : Path to a seo-agent-codex-review-handoff.v1 JSON artifact}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Deterministic Codex review runner for SEO Agent handoff artifacts; writes verdict JSON only.';
+
+    public function handle(): int
+    {
+        $handoffPath = $this->handoffPath();
+        if ($handoffPath === null) {
+            return $this->finish($this->failureSummary('handoff_unreadable'));
+        }
+
+        $raw = (string) file_get_contents($handoffPath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $handoff = json_decode($raw, true);
+        if (! is_array($handoff)) {
+            return $this->finish($this->failureSummary('handoff_json_invalid'));
+        }
+
+        if (($handoff['schema_version'] ?? null) !== self::HANDOFF_SCHEMA_VERSION) {
+            return $this->finish($this->failureSummary('handoff_schema_invalid'));
+        }
+
+        if (($handoff['reviewer'] ?? null) !== 'codex' || (bool) ($handoff['execution_permission'] ?? true)) {
+            return $this->finish($this->failureSummary('handoff_review_boundary_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $verdict = $this->verdict($handoff, $handoffPath);
+        $artifactRef = $this->writeArtifact($artifactDir, 'seo-agent-codex-review-verdict-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json', $verdict);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'candidate_count' => count($verdict['candidate_verdicts']),
+            'worth_optimizing_count' => count(array_filter(
+                $verdict['candidate_verdicts'],
+                static fn (array $candidate): bool => ($candidate['worth_optimizing'] ?? false) === true
+            )),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function handoffPath(): ?string
+    {
+        $path = trim((string) $this->option('handoff'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $handoff
+     * @return array<string, mixed>
+     */
+    private function verdict(array $handoff, string $handoffPath): array
+    {
+        $candidates = array_values(array_filter(
+            (array) ($handoff['candidate_preview'] ?? []),
+            static fn ($candidate): bool => is_array($candidate)
+        ));
+
+        $candidateVerdicts = array_map(
+            fn (array $candidate): array => $this->candidateVerdict($candidate),
+            $candidates
+        );
+
+        $worthOptimizing = array_values(array_filter(
+            $candidateVerdicts,
+            static fn (array $verdict): bool => ($verdict['worth_optimizing'] ?? false) === true
+        ));
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'reviewer' => 'codex',
+            'review_mode' => 'deterministic_rules',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_handoff' => [
+                'path_hash' => hash('sha256', $handoffPath),
+                'sha256' => hash_file('sha256', $handoffPath) ?: '',
+                'schema_version' => (string) ($handoff['schema_version'] ?? ''),
+            ],
+            'candidate_count' => count($candidateVerdicts),
+            'candidate_verdicts' => $candidateVerdicts,
+            'worth_optimizing' => $worthOptimizing !== [],
+            'recommended_action' => $worthOptimizing !== [] ? 'cms_draft_package_dry_run' : 'defer',
+            'risk_flags' => $this->aggregateRiskFlags($candidateVerdicts),
+            'needs_human_approval' => true,
+            'forbidden_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'scheduler_activation',
+                'queue_worker_activation',
+                'external_model_api_call',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function candidateVerdict(array $candidate): array
+    {
+        $severity = (string) ($candidate['severity'] ?? '');
+        $sourceId = (string) ($candidate['source_id'] ?? '');
+        $subjectRef = (string) ($candidate['subject_ref'] ?? '');
+        $safePath = (string) ($candidate['safe_path'] ?? '');
+        $evidenceRefs = (array) ($candidate['evidence_refs'] ?? []);
+        $riskFlags = [];
+
+        if ($sourceId === '' || $subjectRef === '' || $safePath === '') {
+            $riskFlags[] = 'candidate_incomplete';
+        }
+        if ($evidenceRefs === []) {
+            $riskFlags[] = 'evidence_missing';
+        }
+        if (! in_array($severity, ['p1', 'p2', 'p3'], true)) {
+            $riskFlags[] = 'unsupported_severity';
+        }
+
+        $worthOptimizing = $riskFlags === [] && in_array($severity, ['p1', 'p2'], true);
+
+        return [
+            'source_id' => $sourceId !== '' ? $sourceId : hash('sha256', $subjectRef.$safePath.json_encode($candidate)),
+            'source_family' => (string) ($candidate['source_family'] ?? ''),
+            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'severity' => $severity,
+            'worth_optimizing' => $worthOptimizing,
+            'recommended_action' => $worthOptimizing ? 'cms_draft_package_dry_run' : 'defer',
+            'risk_flags' => $riskFlags,
+            'needs_human_approval' => true,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidateVerdicts
+     * @return list<string>
+     */
+    private function aggregateRiskFlags(array $candidateVerdicts): array
+    {
+        $flags = [];
+        foreach ($candidateVerdicts as $verdict) {
+            foreach ((array) ($verdict['risk_flags'] ?? []) as $flag) {
+                $flags[] = (string) $flag;
+            }
+        }
+
+        return array_values(array_unique($flags));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'worth_optimizing' => (bool) ($payload['worth_optimizing'] ?? false),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
@@ -199,12 +199,41 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             'subject_ref' => $subjectRef,
             'safe_path' => $safePath,
             'severity' => $severity,
+            'gap_types' => array_values(array_filter(
+                array_map('strval', (array) ($candidate['gap_types'] ?? [])),
+                static fn (string $gap): bool => $gap !== ''
+            )),
+            'evidence_refs' => $this->sanitizedEvidenceRefs($evidenceRefs),
             'worth_optimizing' => $worthOptimizing,
             'recommended_action' => $worthOptimizing ? 'cms_draft_package_dry_run' : 'defer',
             'risk_flags' => $riskFlags,
             'needs_human_approval' => true,
             'execution_permission' => false,
         ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $evidenceRefs
+     * @return list<array<string, string>>
+     */
+    private function sanitizedEvidenceRefs(array $evidenceRefs): array
+    {
+        $refs = [];
+        foreach ($evidenceRefs as $ref) {
+            if (! is_array($ref)) {
+                continue;
+            }
+
+            $refs[] = [
+                'code' => (string) ($ref['code'] ?? ''),
+                'field_status' => (string) ($ref['field_status'] ?? ''),
+            ];
+        }
+
+        return array_values(array_filter(
+            $refs,
+            static fn (array $ref): bool => $ref['code'] !== '' || $ref['field_status'] !== ''
+        ));
     }
 
     /**

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -168,6 +168,7 @@ use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
@@ -361,6 +362,7 @@ class Kernel extends ConsoleKernel
         ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoAgentCmsTdkGapScanCommand::class,
+        SeoAgentCodexReviewRunnerCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
@@ -1,0 +1,45 @@
+{
+  "version": "seo-agent-codex-review-runner.v1",
+  "task": "SEO-AGENT-CODEX-REVIEW-RUNNER-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:codex-review-runner",
+  "input_schema": "seo-agent-codex-review-handoff.v1",
+  "output_schema": "seo-agent-codex-review-verdict.v1",
+  "reviewer": "codex",
+  "review_mode": "deterministic_rules",
+  "external_model_api_call": false,
+  "rules": {
+    "p1_or_p2_complete_candidate": "cms_draft_package_dry_run",
+    "p3_or_incomplete_candidate": "defer",
+    "needs_human_approval": true,
+    "execution_permission": false
+  },
+  "forbidden_input_fields": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "external_model_api_call": false
+  },
+  "next_step": "Use accepted verdicts as input to a CMS draft package dry-run artifact only."
+}

--- a/backend/docs/seo/seo-agent-codex-review-runner.md
+++ b/backend/docs/seo/seo-agent-codex-review-runner.md
@@ -1,0 +1,24 @@
+# SEO Agent Codex Review Runner
+
+Task: `SEO-AGENT-CODEX-REVIEW-RUNNER-01`
+
+This command converts a sanitized `seo-agent-codex-review-handoff.v1` artifact into a deterministic review verdict. It does not call an external model, write CMS records, write databases, enqueue Search Channel records, submit indexing requests, or activate scheduler jobs.
+
+## Command
+
+```bash
+php artisan seo-agent:codex-review-runner --handoff=<path> --artifact-dir=<dir> --json
+```
+
+## Output
+
+The command writes `seo-agent-codex-review-verdict.v1` with:
+
+- `candidate_verdicts[]`
+- `worth_optimizing`
+- `recommended_action`
+- `risk_flags`
+- `needs_human_approval`
+- `execution_permission=false`
+
+Candidates with complete evidence and severity `p1` or `p2` may be recommended for `cms_draft_package_dry_run`. Candidates with severity `p3`, incomplete evidence, or unsupported shape are deferred.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCodexReviewRunnerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_writes_deterministic_verdict_without_db_writes_or_external_calls(): void
+    {
+        $this->createRows();
+        $artifactDir = $this->artifactDir();
+        $handoffPath = $this->writeHandoff([
+            $this->candidate('p1', 'title gap'),
+            $this->candidate('p2', 'description gap'),
+            $this->candidate('p3', 'low priority'),
+            [
+                'source_family' => 'cms_tdk_gap',
+                'source_id' => 'incomplete',
+                'severity' => 'p1',
+                'evidence_refs' => [],
+            ],
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:codex-review-runner', [
+            '--handoff' => $handoffPath,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $verdict = $this->readJson(data_get($summary, 'artifact.path'));
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('seo-agent-codex-review-verdict.v1', $verdict['schema_version'] ?? null);
+        $this->assertSame('deterministic_rules', $verdict['review_mode'] ?? null);
+        $this->assertFalse((bool) ($verdict['execution_permission'] ?? true));
+        $this->assertFalse((bool) data_get($verdict, 'negative_guarantees.external_model_api_call', true));
+        $this->assertSame(4, $verdict['candidate_count'] ?? null);
+        $this->assertTrue((bool) ($verdict['worth_optimizing'] ?? false));
+        $this->assertSame('cms_draft_package_dry_run', $verdict['recommended_action'] ?? null);
+
+        $candidateActions = array_column($verdict['candidate_verdicts'] ?? [], 'recommended_action');
+        $this->assertSame(['cms_draft_package_dry_run', 'cms_draft_package_dry_run', 'defer', 'defer'], $candidateActions);
+        $this->assertContains('candidate_incomplete', $verdict['risk_flags'] ?? []);
+        $this->assertContains('evidence_missing', $verdict['risk_flags'] ?? []);
+
+        $encoded = json_encode([$summary, $verdict], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_schema_and_forbidden_fields(): void
+    {
+        $invalidSchema = $this->writeJson(['schema_version' => 'wrong.v1']);
+
+        $exitCode = Artisan::call('seo-agent:codex-review-runner', [
+            '--handoff' => $invalidSchema,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('handoff_schema_invalid', $summary['issues'] ?? []);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+
+        $forbidden = $this->writeHandoff([
+            $this->candidate('p1', 'forbidden', ['raw_url' => '/private']),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:codex-review-runner', [
+            '--handoff' => $forbidden,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_review_runner_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-codex-review-runner.v1.json'));
+
+        $this->assertSame('seo-agent-codex-review-runner.v1', $artifact['version'] ?? null);
+        $this->assertSame('seo-agent-codex-review-handoff.v1', $artifact['input_schema'] ?? null);
+        $this->assertSame('seo-agent-codex-review-verdict.v1', $artifact['output_schema'] ?? null);
+        $this->assertSame('codex', $artifact['reviewer'] ?? null);
+        $this->assertFalse((bool) ($artifact['external_model_api_call'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function candidate(string $severity, string $label, array $extra = []): array
+    {
+        return [
+            'source_family' => 'cms_tdk_gap',
+            'source_id' => hash('sha256', $label),
+            'subject_type' => 'article',
+            'subject_ref' => 'article:1:zh-CN',
+            'safe_path' => '/zh/articles/'.$this->safeSlug($label),
+            'severity' => $severity,
+            'evidence_refs' => [
+                [
+                    'code' => 'missing_title',
+                    'field_status' => 'missing',
+                ],
+            ],
+            ...$extra,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     */
+    private function writeHandoff(array $candidates): string
+    {
+        return $this->writeJson([
+            'schema_version' => 'seo-agent-codex-review-handoff.v1',
+            'reviewer' => 'codex',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'candidate_count' => count($candidates),
+            'candidate_preview' => $candidates,
+            'negative_guarantees' => [
+                'database_write' => false,
+                'cms_write' => false,
+                'external_model_api_call' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(array $payload): string
+    {
+        $path = storage_path('framework/testing/seo-agent-codex-review-handoff-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-codex-review-runner-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function safeSlug(string $label): string
+    {
+        return trim(preg_replace('/[^a-z0-9]+/', '-', strtolower($label)) ?: 'candidate', '-');
+    }
+
+    private function createRows(): void
+    {
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'review-runner-db-sentinel',
+            'locale' => 'zh-CN',
+            'title' => 'Sentinel',
+            'excerpt' => 'Sentinel.',
+            'content_md' => 'Sentinel markdown body is not read or emitted by this command.',
+            'content_html' => '<p>Sentinel HTML body is not read or emitted by this command.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'review-runner-page-sentinel',
+            'path' => '/zh/review-runner-page-sentinel',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Sentinel',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
@@ -58,6 +58,8 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
 
         $candidateActions = array_column($verdict['candidate_verdicts'] ?? [], 'recommended_action');
         $this->assertSame(['cms_draft_package_dry_run', 'cms_draft_package_dry_run', 'defer', 'defer'], $candidateActions);
+        $this->assertSame(['missing_title'], data_get($verdict, 'candidate_verdicts.0.gap_types'));
+        $this->assertSame('missing_title', data_get($verdict, 'candidate_verdicts.0.evidence_refs.0.code'));
         $this->assertContains('candidate_incomplete', $verdict['risk_flags'] ?? []);
         $this->assertContains('evidence_missing', $verdict['risk_flags'] ?? []);
 
@@ -127,6 +129,7 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
             'subject_ref' => 'article:1:zh-CN',
             'safe_path' => '/zh/articles/'.$this->safeSlug($label),
             'severity' => $severity,
+            'gap_types' => ['missing_title'],
             'evidence_refs' => [
                 [
                     'code' => 'missing_title',

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1088,6 +1088,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_codex_review_runner_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCodexReviewRunnerCommand;',
+            '+        SeoAgentCodexReviewRunnerCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3598,6 +3612,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCodexReviewRunnerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4184,6 +4202,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4822,6 +4841,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsTdkGapScanCommand.php',
             'backend/app/Services/SeoAgent/CmsTdkGapReadonlyScanner.php',
+        ], true);
+    }
+
+    private function isSeoAgentCodexReviewRunnerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php',
         ], true);
     }
 
@@ -6423,6 +6449,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsTdkGapScanCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCodexReviewRunnerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCodexReviewRunnerCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:codex-review-runner` to convert `seo-agent-codex-review-handoff.v1` artifacts into deterministic `seo-agent-codex-review-verdict.v1` artifacts.
- Added generated contract docs for the Codex review runner.
- Registered the command and added focused feature tests for success, fail-closed schema/forbidden-field behavior, and no-write boundaries.

## Why
This creates the review-only decision step after SEO Agent opportunity discovery without calling an external model or granting execution permission.

## Validation
- `php artisan test --filter SeoAgentCodexReviewRunnerTest`
- `php -l app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php`
- `php -l tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-codex-review-runner.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No external LLM/API call.
- No CMS draft package generation.
- No CMS writes, DB writes, Search Channel enqueue/submit, indexing request, scheduler, or queue worker.

## Repository rule impact
Backend SEO Agent control-plane command only. No content authority, publishing, public SEO enumeration, or frontend behavior changes.
