### PR TITLE
SEO-AGENT-CMS-DRAFT-PACKAGE-DRYRUN-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentCmsDraftPackageDryRunCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const VERDICT_SCHEMA_VERSION = 'seo-agent-codex-review-verdict.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:cms-draft-package-dry-run
+        {--verdict= : Path to a seo-agent-codex-review-verdict.v1 JSON artifact}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Build a CMS draft package dry-run artifact from Codex review verdicts without writing CMS or DB rows.';
+
+    public function handle(): int
+    {
+        $verdictPath = $this->verdictPath();
+        if ($verdictPath === null) {
+            return $this->finish($this->failureSummary('verdict_unreadable'));
+        }
+
+        $raw = (string) file_get_contents($verdictPath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $verdict = json_decode($raw, true);
+        if (! is_array($verdict)) {
+            return $this->finish($this->failureSummary('verdict_json_invalid'));
+        }
+
+        if (($verdict['schema_version'] ?? null) !== self::VERDICT_SCHEMA_VERSION) {
+            return $this->finish($this->failureSummary('verdict_schema_invalid'));
+        }
+
+        if ((bool) ($verdict['execution_permission'] ?? true)) {
+            return $this->finish($this->failureSummary('verdict_execution_boundary_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $package = $this->package($verdict, $verdictPath);
+        $artifactRef = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-package-dry-run-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json', $package);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'draft_brief_count' => count($package['draft_briefs']),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function verdictPath(): ?string
+    {
+        $path = trim((string) $this->option('verdict'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $verdict
+     * @return array<string, mixed>
+     */
+    private function package(array $verdict, string $verdictPath): array
+    {
+        $candidateVerdicts = array_values(array_filter(
+            (array) ($verdict['candidate_verdicts'] ?? []),
+            static fn ($candidate): bool => is_array($candidate)
+                && ($candidate['recommended_action'] ?? null) === 'cms_draft_package_dry_run'
+                && ($candidate['worth_optimizing'] ?? false) === true
+                && ($candidate['execution_permission'] ?? false) === false
+        ));
+
+        $draftBriefs = array_map(
+            fn (array $candidate): array => $this->draftBrief($candidate),
+            $candidateVerdicts
+        );
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'run_mode' => 'cms_draft_package_dry_run',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'input_verdict' => [
+                'path_hash' => hash('sha256', $verdictPath),
+                'sha256' => hash_file('sha256', $verdictPath) ?: '',
+                'schema_version' => (string) ($verdict['schema_version'] ?? ''),
+            ],
+            'draft_brief_count' => count($draftBriefs),
+            'draft_briefs' => $draftBriefs,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'forbidden_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'scheduler_activation',
+                'queue_worker_activation',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function draftBrief(array $candidate): array
+    {
+        $gapCodes = $this->gapCodes($candidate);
+
+        return [
+            'source_id' => (string) ($candidate['source_id'] ?? ''),
+            'source_family' => (string) ($candidate['source_family'] ?? ''),
+            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'severity' => (string) ($candidate['severity'] ?? ''),
+            'gap_codes' => $gapCodes,
+            'target_fields' => $this->targetFields($gapCodes),
+            'draft_instructions' => [
+                'prepare_field_level_proposal_only',
+                'do_not_generate_final_body_copy',
+                'preserve_existing_slug_and_canonical_unless_separately_approved',
+                'run_claim_gate_before_any_cms_write',
+            ],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+            'blocked_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function gapCodes(array $candidate): array
+    {
+        $codes = array_map('strval', (array) ($candidate['gap_types'] ?? []));
+        foreach ((array) ($candidate['evidence_refs'] ?? []) as $ref) {
+            if (is_array($ref) && ($ref['code'] ?? '') !== '') {
+                $codes[] = (string) $ref['code'];
+            }
+        }
+
+        return array_values(array_unique(array_filter($codes, static fn (string $code): bool => $code !== '')));
+    }
+
+    /**
+     * @param  list<string>  $gapCodes
+     * @return list<string>
+     */
+    private function targetFields(array $gapCodes): array
+    {
+        $fields = [];
+        foreach ($gapCodes as $code) {
+            $fields[] = match ($code) {
+                'missing_title' => 'seo_title',
+                'missing_meta_description' => 'seo_description',
+                'missing_canonical' => 'canonical_url_or_path',
+                'missing_indexability_metadata' => 'is_indexable_or_robots',
+                'missing_faq_items', 'missing_visible_faq' => 'faq_items',
+                'faq_schema_enabled_without_visible_faq' => 'faq_schema_eligible',
+                default => 'manual_review_required',
+            };
+        }
+
+        return array_values(array_unique($fields));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'cms_write_allowed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -169,6 +169,7 @@ use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
+use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
@@ -363,6 +364,7 @@ class Kernel extends ConsoleKernel
         MediaAssetsImportSeoImageBundle::class,
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
+        SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
@@ -1,0 +1,36 @@
+{
+  "version": "seo-agent-cms-draft-package-dry-run.v1",
+  "task": "SEO-AGENT-CMS-DRAFT-PACKAGE-DRYRUN-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-draft-package-dry-run",
+  "input_schema": "seo-agent-codex-review-verdict.v1",
+  "output_schema": "seo-agent-cms-draft-package-dry-run.v1",
+  "dry_run": true,
+  "cms_write_allowed": false,
+  "generates_final_copy": false,
+  "draft_brief_fields": [
+    "source_id",
+    "source_family",
+    "subject_type",
+    "subject_ref",
+    "safe_path",
+    "gap_codes",
+    "target_fields",
+    "draft_instructions",
+    "claim_gate_required",
+    "human_approval_required"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false
+  },
+  "next_step": "A later separately approved task may turn a dry-run brief into a bounded CMS draft write canary."
+}

--- a/backend/docs/seo/seo-agent-cms-draft-package-dryrun.md
+++ b/backend/docs/seo/seo-agent-cms-draft-package-dryrun.md
@@ -1,0 +1,15 @@
+# SEO Agent CMS Draft Package Dry-run
+
+Task: `SEO-AGENT-CMS-DRAFT-PACKAGE-DRYRUN-01`
+
+This command converts a `seo-agent-codex-review-verdict.v1` artifact into a CMS draft package dry-run artifact. It generates field-level draft briefs only. It does not write CMS records, create revisions, generate final copy, enqueue search actions, request indexing, or activate schedulers.
+
+## Command
+
+```bash
+php artisan seo-agent:cms-draft-package-dry-run --verdict=<path> --artifact-dir=<dir> --json
+```
+
+## Output
+
+The command writes `seo-agent-cms-draft-package-dry-run.v1` with `draft_briefs[]`. Each brief contains the target subject, safe path, gap codes, target fields, draft instructions, claim-gate requirement, and human-approval requirement.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_writes_draft_briefs_without_generating_copy_or_writing_cms(): void
+    {
+        $this->createRows();
+        $artifactDir = $this->artifactDir();
+        $verdictPath = $this->writeVerdict([
+            $this->candidateVerdict('cms_draft_package_dry_run', true, ['missing_title', 'missing_meta_description']),
+            $this->candidateVerdict('defer', false, ['missing_canonical']),
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => $verdictPath,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $package = $this->readJson(data_get($summary, 'artifact.path'));
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $package['schema_version'] ?? null);
+        $this->assertTrue((bool) ($package['dry_run'] ?? false));
+        $this->assertFalse((bool) ($package['cms_write_allowed'] ?? true));
+        $this->assertFalse((bool) ($package['execution_permission'] ?? true));
+        $this->assertSame(1, $package['draft_brief_count'] ?? null);
+
+        $brief = $package['draft_briefs'][0] ?? [];
+        $this->assertSame('article:1:zh-CN', $brief['subject_ref'] ?? null);
+        $this->assertSame('/zh/articles/draft-package-candidate', $brief['safe_path'] ?? null);
+        $this->assertSame(['missing_title', 'missing_meta_description'], $brief['gap_codes'] ?? null);
+        $this->assertSame(['seo_title', 'seo_description'], $brief['target_fields'] ?? null);
+        $this->assertTrue((bool) ($brief['claim_gate_required'] ?? false));
+        $this->assertTrue((bool) ($brief['human_approval_required'] ?? false));
+
+        $encoded = json_encode([$summary, $package], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($package, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_schema_and_forbidden_fields(): void
+    {
+        $invalidSchema = $this->writeJson(['schema_version' => 'wrong.v1']);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => $invalidSchema,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('verdict_schema_invalid', $summary['issues'] ?? []);
+
+        $forbidden = $this->writeVerdict([
+            $this->candidateVerdict('cms_draft_package_dry_run', true, ['missing_title'], ['cms_draft_body' => 'forbidden']),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => $forbidden,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_dry_run_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json'));
+
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $artifact['version'] ?? null);
+        $this->assertSame('seo-agent-codex-review-verdict.v1', $artifact['input_schema'] ?? null);
+        $this->assertTrue((bool) ($artifact['dry_run'] ?? false));
+        $this->assertFalse((bool) ($artifact['cms_write_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['generates_final_copy'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function candidateVerdict(string $recommendedAction, bool $worthOptimizing, array $gapTypes, array $extra = []): array
+    {
+        return [
+            'source_id' => hash('sha256', $recommendedAction.implode(',', $gapTypes)),
+            'source_family' => 'cms_tdk_gap',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:1:zh-CN',
+            'safe_path' => '/zh/articles/draft-package-candidate',
+            'severity' => $worthOptimizing ? 'p1' : 'p3',
+            'gap_types' => $gapTypes,
+            'evidence_refs' => array_map(
+                static fn (string $gap): array => [
+                    'code' => $gap,
+                    'field_status' => 'missing',
+                ],
+                $gapTypes
+            ),
+            'worth_optimizing' => $worthOptimizing,
+            'recommended_action' => $recommendedAction,
+            'risk_flags' => [],
+            'needs_human_approval' => true,
+            'execution_permission' => false,
+            ...$extra,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidateVerdicts
+     */
+    private function writeVerdict(array $candidateVerdicts): string
+    {
+        return $this->writeJson([
+            'schema_version' => 'seo-agent-codex-review-verdict.v1',
+            'reviewer' => 'codex',
+            'review_mode' => 'deterministic_rules',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'candidate_count' => count($candidateVerdicts),
+            'candidate_verdicts' => $candidateVerdicts,
+            'worth_optimizing' => true,
+            'recommended_action' => 'cms_draft_package_dry_run',
+            'needs_human_approval' => true,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(array $payload): string
+    {
+        $path = storage_path('framework/testing/seo-agent-cms-draft-package-verdict-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-cms-draft-package-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function createRows(): void
+    {
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'draft-package-db-sentinel',
+            'locale' => 'zh-CN',
+            'title' => 'Sentinel',
+            'excerpt' => 'Sentinel.',
+            'content_md' => 'Sentinel markdown body is not read or emitted by this command.',
+            'content_html' => '<p>Sentinel HTML body is not read or emitted by this command.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'draft-package-page-sentinel',
+            'path' => '/zh/draft-package-page-sentinel',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Sentinel',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1102,6 +1102,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_draft_package_dry_run_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsDraftPackageDryRunCommand;',
+            '+        SeoAgentCmsDraftPackageDryRunCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3616,6 +3630,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsDraftPackageDryRunFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4203,6 +4221,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4848,6 +4867,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsDraftPackageDryRunFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
         ], true);
     }
 
@@ -6471,6 +6497,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCodexReviewRunnerCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsDraftPackageDryRunCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:cms-draft-package-dry-run` to convert review verdicts into `seo-agent-cms-draft-package-dry-run.v1` artifacts.
- Added generated contract docs and focused feature tests for dry-run package generation.
- Registered the command without adding scheduler or queue behavior.

## Why
This creates the next L4 SEO Agent handoff step: Codex-approved candidates can become editable CMS draft briefs while still avoiding CMS writes or final copy generation.

## Validation
- `php artisan test --filter SeoAgentCmsDraftPackageDryRunTest`
- `php -l app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php`
- `php -l tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No final SEO copy generation.
- No CMS writes or revision creation.
- No Search Channel enqueue/submit, indexing request, scheduler, or queue worker.

## Repository rule impact
Backend SEO Agent dry-run artifact only. No content authority, publishing, public SEO enumeration, or frontend behavior changes.
