### PR TITLE
SEO-AGENT-RUNTIME-SEO-QA-READONLY-SCANNER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php
+++ b/backend/app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\RuntimeSeoQaReadonlyScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentRuntimeSeoQaScanCommand extends Command
+{
+    protected $signature = 'seo-agent:runtime-seo-qa-scan
+        {--source=cms-indexable : Source to scan. Only cms-indexable is supported}
+        {--limit=50 : Target limit, bounded 1..100}
+        {--artifact-dir= : Directory for sanitized JSON artifact}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only runtime SEO QA scanner for CMS indexable public paths.';
+
+    public function handle(RuntimeSeoQaReadonlyScanner $scanner): int
+    {
+        $source = trim((string) $this->option('source'));
+        if ($source !== 'cms-indexable') {
+            return $this->finish($this->failureSummary('invalid_source'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $artifact = $scanner->scan($source, $this->limit());
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $artifactRef = $this->writeArtifact($artifactDir, 'seo-agent-runtime-seo-qa-scan-'.$timestamp.'.json', $artifact);
+
+        return $this->finish([
+            'schema_version' => RuntimeSeoQaReadonlyScanner::SCHEMA_VERSION,
+            'task' => RuntimeSeoQaReadonlyScanner::TASK,
+            'ok' => true,
+            'status' => 'success',
+            'source' => $source,
+            'targets_checked' => (int) ($artifact['targets_checked'] ?? 0),
+            'candidate_count' => (int) ($artifact['candidate_count'] ?? 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 50;
+        }
+
+        return max(1, min((int) $raw, 100));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'targets_checked' => (int) ($payload['targets_checked'] ?? 0),
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue): array
+    {
+        return [
+            'schema_version' => RuntimeSeoQaReadonlyScanner::SCHEMA_VERSION,
+            'task' => RuntimeSeoQaReadonlyScanner::TASK,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            'candidate_count' => 0,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            $artifact = (array) ($summary['artifact'] ?? []);
+            if ($artifact !== []) {
+                $this->line('artifact_path='.(string) ($artifact['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($artifact['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($artifact['sha256'] ?? ''));
+            }
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -172,6 +172,7 @@ use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
+use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
@@ -365,6 +366,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
+        SeoAgentRuntimeSeoQaScanCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php
+++ b/backend/app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoAgent;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use Illuminate\Support\Facades\Http;
+
+final class RuntimeSeoQaReadonlyScanner
+{
+    public const SCHEMA_VERSION = 'seo-agent-runtime-seo-qa-readonly-scanner.v1';
+
+    public const TASK = 'SEO-AGENT-RUNTIME-SEO-QA-READONLY-SCANNER-01';
+
+    private const BLOCKED_ACTIONS = [
+        'cms_write',
+        'cms_publish',
+        'search_channel_enqueue',
+        'search_channel_submit',
+        'indexing_request',
+        'scheduler_activation',
+        'queue_worker_activation',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function scan(string $source = 'cms-indexable', int $limit = 50): array
+    {
+        $source = $source === 'cms-indexable' ? $source : 'cms-indexable';
+        $limit = max(1, min($limit, 100));
+        $candidates = [];
+
+        foreach ($this->cmsIndexableTargets($limit) as $target) {
+            $qa = $this->inspectTarget($target);
+            $issues = $qa['issues'];
+
+            if ($issues !== []) {
+                $candidates[] = $this->candidate($target, $issues, $qa['evidence_refs']);
+            }
+
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => 'success',
+            'source_family' => 'runtime_seo_qa',
+            'run_mode' => 'readonly_discovery',
+            'source' => $source,
+            'limit' => $limit,
+            'targets_checked' => count($this->cmsIndexableTargets($limit)),
+            'candidate_count' => count($candidates),
+            'candidates' => $candidates,
+            'checks' => [
+                'http_status',
+                'redirect_status',
+                'canonical_tag',
+                'meta_robots_noindex',
+                'x_robots_tag_noindex',
+                'json_ld_presence',
+            ],
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return list<array{subject_type:string, subject_ref:string, safe_path:string, locale:string}>
+     */
+    private function cmsIndexableTargets(int $limit): array
+    {
+        $targets = [];
+
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->published()
+            ->where('is_indexable', true)
+            ->orderBy('id')
+            ->limit($limit)
+            ->get();
+
+        foreach ($articles as $article) {
+            $targets[] = [
+                'subject_type' => 'article',
+                'subject_ref' => 'article:'.(int) $article->id.':'.(string) $article->locale,
+                'safe_path' => $this->articleSafePath($article),
+                'locale' => (string) $article->locale,
+            ];
+
+            if (count($targets) >= $limit) {
+                return $targets;
+            }
+        }
+
+        $pages = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->publishedPublic()
+            ->where('is_indexable', true)
+            ->orderBy('id')
+            ->limit($limit - count($targets))
+            ->get();
+
+        foreach ($pages as $page) {
+            $targets[] = [
+                'subject_type' => 'content_page',
+                'subject_ref' => 'content_page:'.(int) $page->id.':'.(string) $page->locale,
+                'safe_path' => $this->contentPageSafePath($page),
+                'locale' => (string) $page->locale,
+            ];
+
+            if (count($targets) >= $limit) {
+                break;
+            }
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param  array{subject_type:string, subject_ref:string, safe_path:string, locale:string}  $target
+     * @return array{issues:list<string>, evidence_refs:list<array<string, mixed>>}
+     */
+    private function inspectTarget(array $target): array
+    {
+        $issues = [];
+        $evidence = [];
+        $response = Http::withOptions(['allow_redirects' => false])
+            ->timeout(10)
+            ->get($this->publicUrlForSafePath($target['safe_path']));
+
+        $status = $response->status();
+        $body = (string) $response->body();
+        $headers = $response->headers();
+
+        if ($status !== 200) {
+            $issues[] = $status >= 300 && $status < 400 ? 'redirect_present' : 'http_status_not_200';
+            $evidence[] = [
+                'code' => $issues[array_key_last($issues)],
+                'status_code' => $status,
+            ];
+        }
+
+        $robots = $this->metaRobots($body);
+        if ($robots !== null && str_contains(strtolower($robots), 'noindex')) {
+            $issues[] = 'noindex_present';
+            $evidence[] = [
+                'code' => 'noindex_present',
+                'field_status' => 'present',
+            ];
+        }
+
+        $xRobots = implode(',', (array) ($headers['X-Robots-Tag'] ?? $headers['x-robots-tag'] ?? []));
+        if ($xRobots !== '' && str_contains(strtolower($xRobots), 'noindex')) {
+            $issues[] = 'x_robots_noindex';
+            $evidence[] = [
+                'code' => 'x_robots_noindex',
+                'field_status' => 'present',
+            ];
+        }
+
+        $canonicalPath = $this->canonicalPath($body);
+        if ($canonicalPath === null) {
+            $issues[] = 'missing_canonical';
+            $evidence[] = [
+                'code' => 'missing_canonical',
+                'field_status' => 'missing',
+            ];
+        } elseif ($canonicalPath !== $target['safe_path']) {
+            $issues[] = 'canonical_mismatch';
+            $evidence[] = [
+                'code' => 'canonical_mismatch',
+                'expected_safe_path_hash' => hash('sha256', $target['safe_path']),
+                'observed_safe_path_hash' => hash('sha256', $canonicalPath),
+            ];
+        }
+
+        if (! $this->hasJsonLd($body)) {
+            $issues[] = 'missing_json_ld';
+            $evidence[] = [
+                'code' => 'missing_json_ld',
+                'field_status' => 'missing',
+            ];
+        }
+
+        return [
+            'issues' => array_values(array_unique($issues)),
+            'evidence_refs' => $evidence,
+        ];
+    }
+
+    /**
+     * @param  array{subject_type:string, subject_ref:string, safe_path:string, locale:string}  $target
+     * @param  list<string>  $issues
+     * @param  list<array<string, mixed>>  $evidenceRefs
+     * @return array<string, mixed>
+     */
+    private function candidate(array $target, array $issues, array $evidenceRefs): array
+    {
+        $sourcePayload = implode('|', [$target['subject_type'], $target['subject_ref'], $target['safe_path'], implode(',', $issues)]);
+
+        return [
+            'source_family' => 'runtime_seo_qa',
+            'source_id' => hash('sha256', $sourcePayload),
+            'subject_type' => $target['subject_type'],
+            'subject_ref' => $target['subject_ref'],
+            'safe_path' => $target['safe_path'],
+            'locale' => $target['locale'],
+            'severity' => $this->severity($issues),
+            'gap_types' => $issues,
+            'evidence_refs' => $evidenceRefs,
+            'recommended_next_step' => 'codex_review_required_before_runtime_seo_fix',
+            'allowed_action' => 'readonly_review',
+            'blocked_actions' => self::BLOCKED_ACTIONS,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $issues
+     */
+    private function severity(array $issues): string
+    {
+        if (array_intersect($issues, ['http_status_not_200', 'noindex_present', 'x_robots_noindex', 'missing_canonical', 'canonical_mismatch']) !== []) {
+            return 'p1';
+        }
+
+        if (in_array('redirect_present', $issues, true)) {
+            return 'p2';
+        }
+
+        return 'p3';
+    }
+
+    private function publicUrlForSafePath(string $safePath): string
+    {
+        $host = rtrim((string) config('seo_intel.public_canonical_host', 'https://fermatmind.com'), '/');
+
+        return $host.'/'.ltrim($safePath, '/');
+    }
+
+    private function articleSafePath(Article $article): string
+    {
+        $slug = $this->safeSlug((string) $article->slug);
+        if ($slug === '') {
+            $slug = 'article-'.substr(hash('sha256', (string) $article->id), 0, 12);
+        }
+
+        return str_starts_with(strtolower((string) $article->locale), 'zh')
+            ? '/zh/articles/'.$slug
+            : '/articles/'.$slug;
+    }
+
+    private function contentPageSafePath(ContentPage $page): string
+    {
+        $path = trim((string) $page->path);
+        if ($path === '') {
+            $path = '/'.$this->safeSlug((string) $page->slug);
+        }
+
+        if (preg_match('#^https?://#i', $path) === 1) {
+            $parsedPath = parse_url($path, PHP_URL_PATH);
+            $path = is_string($parsedPath) && $parsedPath !== '' ? $parsedPath : '/content-page-'.substr(hash('sha256', (string) $page->id), 0, 12);
+        }
+
+        $path = '/'.ltrim(strtok($path, '?#') ?: $path, '/');
+
+        return preg_replace('#/+#', '/', $path) ?: '/';
+    }
+
+    private function safeSlug(string $slug): string
+    {
+        $slug = trim($slug, "/ \t\n\r\0\x0B");
+        $slug = preg_replace('/[^A-Za-z0-9._~%-]+/', '-', $slug) ?: '';
+
+        return trim($slug, '-');
+    }
+
+    private function canonicalPath(string $body): ?string
+    {
+        if (preg_match('/<link\b[^>]*rel=["\']canonical["\'][^>]*href=["\']([^"\']+)["\'][^>]*>/i', $body, $matches) !== 1
+            && preg_match('/<link\b[^>]*href=["\']([^"\']+)["\'][^>]*rel=["\']canonical["\'][^>]*>/i', $body, $matches) !== 1) {
+            return null;
+        }
+
+        $path = parse_url((string) $matches[1], PHP_URL_PATH);
+        if (! is_string($path) || trim($path) === '') {
+            return null;
+        }
+
+        return preg_replace('#/+#', '/', '/'.ltrim($path, '/')) ?: null;
+    }
+
+    private function metaRobots(string $body): ?string
+    {
+        if (preg_match('/<meta\b[^>]*name=["\']robots["\'][^>]*content=["\']([^"\']+)["\'][^>]*>/i', $body, $matches) !== 1
+            && preg_match('/<meta\b[^>]*content=["\']([^"\']+)["\'][^>]*name=["\']robots["\'][^>]*>/i', $body, $matches) !== 1) {
+            return null;
+        }
+
+        return (string) $matches[1];
+    }
+
+    private function hasJsonLd(string $body): bool
+    {
+        return preg_match('/<script\b[^>]*type=["\']application\/ld\+json["\'][^>]*>/i', $body) === 1;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/seo-agent-runtime-seo-qa-readonly-scanner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-runtime-seo-qa-readonly-scanner.v1.json
@@ -1,0 +1,76 @@
+{
+  "version": "seo-agent-runtime-seo-qa-readonly-scanner.v1",
+  "task": "SEO-AGENT-RUNTIME-SEO-QA-READONLY-SCANNER-01",
+  "command": "php artisan seo-agent:runtime-seo-qa-scan",
+  "source_family": "runtime_seo_qa",
+  "run_mode": "readonly_discovery",
+  "supported_sources": [
+    "cms-indexable"
+  ],
+  "candidate_fields": [
+    "source_family",
+    "source_id",
+    "subject_type",
+    "subject_ref",
+    "safe_path",
+    "locale",
+    "severity",
+    "gap_types",
+    "evidence_refs",
+    "recommended_next_step",
+    "allowed_action",
+    "blocked_actions"
+  ],
+  "checks": [
+    "http_status",
+    "redirect_status",
+    "canonical_tag",
+    "meta_robots_noindex",
+    "x_robots_tag_noindex",
+    "json_ld_presence"
+  ],
+  "forbidden_output_fields": [
+    "raw_url",
+    "full_url",
+    "raw_html",
+    "html",
+    "body",
+    "cookie",
+    "authorization",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "Bearer "
+  ],
+  "allowed_actions": [
+    "readonly_http_qa",
+    "evidence_artifact_write",
+    "codex_review_handoff_future"
+  ],
+  "blocked_actions": [
+    "cms_write",
+    "cms_publish",
+    "search_channel_enqueue",
+    "search_channel_submit",
+    "indexing_request",
+    "scheduler_activation",
+    "queue_worker_activation"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "pr_train_metadata_change": false
+  }
+}

--- a/backend/docs/seo/seo-agent-runtime-seo-qa-readonly-scanner.md
+++ b/backend/docs/seo/seo-agent-runtime-seo-qa-readonly-scanner.md
@@ -1,0 +1,37 @@
+# SEO Agent Runtime SEO QA Readonly Scanner
+
+`SEO-AGENT-RUNTIME-SEO-QA-READONLY-SCANNER-01` adds a read-only runtime QA opportunity source for the FermatMind SEO Agent L4 loop.
+
+Command:
+
+```bash
+php artisan seo-agent:runtime-seo-qa-scan \
+  --source=cms-indexable \
+  --limit=50 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+The scanner reads published, public, indexable CMS article and content-page rows, builds public URLs only in memory, and performs HTTP QA with redirects disabled. Output artifacts contain only safe paths, stable subject refs, issue codes, severity, and masked evidence.
+
+Checks:
+
+- HTTP status.
+- Redirect status.
+- Canonical tag presence and safe-path match.
+- Meta robots noindex.
+- X-Robots-Tag noindex.
+- JSON-LD presence.
+
+Boundaries:
+
+- No CMS write.
+- No DB write.
+- No queue enqueue.
+- No scheduler activation.
+- No Search Channel submit.
+- No indexing request.
+- No GSC API call.
+- No raw HTML, full URL, cookie, token, credential, or private key in artifacts.
+
+The output candidate family is `runtime_seo_qa`. Candidates are review-only and require Codex review before any later dry-run package can be considered.

--- a/backend/tests/Feature/SeoIntel/SeoAgentRuntimeSeoQaReadonlyScannerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentRuntimeSeoQaReadonlyScannerTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use App\Services\SeoAgent\RuntimeSeoQaReadonlyScanner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentRuntimeSeoQaReadonlyScannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function scanner_flags_runtime_seo_qa_issues_without_emitting_raw_runtime_payloads(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+        $healthyArticle = $this->createArticle('healthy-runtime-page');
+        $noindexPage = $this->createContentPage('runtime-noindex-page', '/zh/runtime-noindex-page');
+        $redirectPage = $this->createContentPage('runtime-redirect-page', '/zh/runtime-redirect-page');
+
+        Http::fake([
+            'https://fermatmind.com/zh/articles/healthy-runtime-page' => Http::response($this->html('/zh/articles/healthy-runtime-page', true), 200),
+            'https://fermatmind.com/zh/runtime-noindex-page' => Http::response($this->html('/zh/wrong-canonical', false, 'noindex, nofollow'), 200, [
+                'X-Robots-Tag' => 'noindex',
+            ]),
+            'https://fermatmind.com/zh/runtime-redirect-page' => Http::response('', 301, [
+                'Location' => 'https://fermatmind.com/zh/runtime-redirect-target',
+            ]),
+        ]);
+
+        $artifact = (new RuntimeSeoQaReadonlyScanner)->scan('cms-indexable', 10);
+
+        $this->assertSame('seo-agent-runtime-seo-qa-readonly-scanner.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('runtime_seo_qa', $artifact['source_family'] ?? null);
+        $this->assertSame(2, $artifact['candidate_count'] ?? null);
+
+        $candidateRefs = array_column($artifact['candidates'] ?? [], 'subject_ref');
+        $this->assertContains('content_page:'.$noindexPage->id.':zh-CN', $candidateRefs);
+        $this->assertContains('content_page:'.$redirectPage->id.':zh-CN', $candidateRefs);
+        $this->assertNotContains('article:'.$healthyArticle->id.':zh-CN', $candidateRefs);
+
+        $noindexCandidate = collect($artifact['candidates'])->firstWhere('subject_ref', 'content_page:'.$noindexPage->id.':zh-CN');
+        $this->assertContains('canonical_mismatch', $noindexCandidate['gap_types'] ?? []);
+        $this->assertContains('noindex_present', $noindexCandidate['gap_types'] ?? []);
+        $this->assertContains('x_robots_noindex', $noindexCandidate['gap_types'] ?? []);
+        $this->assertContains('missing_json_ld', $noindexCandidate['gap_types'] ?? []);
+
+        $redirectCandidate = collect($artifact['candidates'])->firstWhere('subject_ref', 'content_page:'.$redirectPage->id.':zh-CN');
+        $this->assertContains('redirect_present', $redirectCandidate['gap_types'] ?? []);
+
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ([
+            'https://fermatmind.com',
+            '<html',
+            '<p>',
+            'raw_html',
+            'raw_url',
+            'full_url',
+            'cookie',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_search_console_api_call', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_indexing_api_call', true));
+    }
+
+    #[Test]
+    public function command_writes_sanitized_runtime_qa_artifact_without_db_writes(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+        $this->createContentPage('command-runtime-page', '/zh/command-runtime-page');
+        Http::fake([
+            'https://fermatmind.com/zh/command-runtime-page' => Http::response($this->html('/zh/command-runtime-page', false), 200),
+        ]);
+
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:runtime-seo-qa-scan', [
+            '--source' => 'cms-indexable',
+            '--limit' => 5,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $files = File::files($artifactDir);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertIsArray($summary);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['candidate_count'] ?? null);
+        $this->assertCount(1, $files);
+
+        $artifact = $this->readJson(data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-agent-runtime-seo-qa-readonly-scanner.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('runtime_seo_qa', $artifact['source_family'] ?? null);
+
+        $combined = (string) file_get_contents($files[0]->getPathname());
+        foreach ([
+            'https://fermatmind.com',
+            '<html',
+            'raw_html',
+            'raw_url',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'google_indexing_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function generated_contract_documents_runtime_qa_readonly_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-runtime-seo-qa-readonly-scanner.v1.json'));
+
+        $this->assertSame('seo-agent-runtime-seo-qa-readonly-scanner.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:runtime-seo-qa-scan', $artifact['command'] ?? null);
+        $this->assertSame('runtime_seo_qa', $artifact['source_family'] ?? null);
+        $this->assertContains('cms-indexable', $artifact['supported_sources'] ?? []);
+
+        foreach ([
+            'raw_url',
+            'full_url',
+            'raw_html',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'token',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_output_fields'] ?? [], $field);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'google_indexing_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Readable title',
+            'excerpt' => 'Reader-facing excerpt.',
+            'content_md' => 'Article body must never be emitted by the scanner.',
+            'content_html' => '<p>Article body must never be emitted by the scanner.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function createContentPage(string $slug, string $path): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => $path,
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Content page',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'content_md' => 'Content page body must never be emitted.',
+            'content_html' => '<p>Content page body must never be emitted.</p>',
+            'seo_title' => 'Runtime page title',
+            'seo_description' => 'Runtime page description.',
+            'meta_description' => 'Runtime page description.',
+            'canonical_path' => $path,
+            'schema_enabled' => true,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    private function html(string $canonicalPath, bool $withJsonLd, string $robots = 'index, follow'): string
+    {
+        $jsonLd = $withJsonLd ? '<script type="application/ld+json">{"@context":"https://schema.org"}</script>' : '';
+
+        return '<html><head><link rel="canonical" href="https://fermatmind.com'.$canonicalPath.'"><meta name="robots" content="'.$robots.'">'.$jsonLd.'</head><body><p>Runtime body must not be emitted.</p></body></html>';
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-runtime-seo-qa-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $this->assertFileExists($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1116,6 +1116,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentRuntimeSeoQaScanCommand;',
+            '+        SeoAgentRuntimeSeoQaScanCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3634,6 +3649,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentRuntimeSeoQaReadonlyScannerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4222,6 +4241,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4874,6 +4894,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentRuntimeSeoQaReadonlyScannerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php',
+            'backend/app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php',
         ], true);
     }
 
@@ -6519,6 +6547,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsDraftPackageDryRunCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentRuntimeSeoQaScanCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:runtime-seo-qa-scan` for read-only runtime SEO QA on CMS indexable article/content-page safe paths.
- Added sanitized `runtime_seo_qa` artifacts with status/canonical/robots/x-robots/JSON-LD issue codes only.
- Added generated contract docs and focused tests using `Http::fake()`.
- Added BigFive runtime freeze allowlist coverage for this scoped SEO Agent scanner command.

## Why
This adds the second practical opportunity source for the L4 SEO Agent without relying on GSC volume and without opening an execution surface.

## Validation
- `php -l app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php`
- `php -l app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php`
- `php -l tests/Feature/SeoIntel/SeoAgentRuntimeSeoQaReadonlyScannerTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-runtime-seo-qa-readonly-scanner.v1.json >/dev/null`
- `git diff --check`
- `php artisan test --filter SeoAgentRuntimeSeoQaReadonlyScannerTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files`

## Intentionally deferred
- No CMS writes or draft creation.
- No DB writes, migrations, scheduler, queue worker, Search Channel, GSC API, or indexing request.
- No PR-train manifest/state changes.
