### PR TITLE
SEO-AGENT-CMS-FAQ-GAP-READONLY-SCANNER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\CmsFaqGapReadonlyScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentCmsFaqGapScanCommand extends Command
+{
+    protected $signature = 'seo-agent:cms-faq-gap-scan
+        {--surface=all : Surface to scan: articles, content-pages, or all}
+        {--limit=100 : Candidate limit, bounded 1..250}
+        {--artifact-dir= : Directory for sanitized JSON artifact}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only CMS FAQ gap scanner for explicit FAQ/schema signals.';
+
+    public function handle(CmsFaqGapReadonlyScanner $scanner): int
+    {
+        $surface = trim((string) $this->option('surface'));
+        if (! in_array($surface, ['articles', 'content-pages', 'all'], true)) {
+            return $this->finish($this->failureSummary('invalid_surface'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $artifact = $scanner->scan($surface, $this->limit());
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $artifactRef = $this->writeArtifact($artifactDir, 'seo-agent-cms-faq-gap-scan-'.$timestamp.'.json', $artifact);
+
+        return $this->finish([
+            'schema_version' => CmsFaqGapReadonlyScanner::SCHEMA_VERSION,
+            'task' => CmsFaqGapReadonlyScanner::TASK,
+            'ok' => true,
+            'status' => 'success',
+            'surface' => $surface,
+            'candidate_count' => (int) ($artifact['candidate_count'] ?? 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue): array
+    {
+        return [
+            'schema_version' => CmsFaqGapReadonlyScanner::SCHEMA_VERSION,
+            'task' => CmsFaqGapReadonlyScanner::TASK,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            'candidate_count' => 0,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            $artifact = (array) ($summary['artifact'] ?? []);
+            if ($artifact !== []) {
+                $this->line('artifact_path='.(string) ($artifact['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($artifact['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($artifact['sha256'] ?? ''));
+            }
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'faq_schema_enable' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -171,6 +171,7 @@ use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
+use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
@@ -363,6 +364,7 @@ class Kernel extends ConsoleKernel
         ArticleUpdateImageMetadata::class,
         ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
+        SeoAgentCmsFaqGapScanCommand::class,
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,

--- a/backend/app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php
+++ b/backend/app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoAgent;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+
+final class CmsFaqGapReadonlyScanner
+{
+    public const SCHEMA_VERSION = 'seo-agent-cms-faq-gap-readonly-scanner.v1';
+
+    public const TASK = 'SEO-AGENT-CMS-FAQ-GAP-READONLY-SCANNER-01';
+
+    private const BLOCKED_ACTIONS = [
+        'cms_write',
+        'cms_publish',
+        'search_channel_enqueue',
+        'search_channel_submit',
+        'indexing_request',
+        'scheduler_activation',
+        'queue_worker_activation',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function scan(string $surface = 'all', int $limit = 100): array
+    {
+        $surface = in_array($surface, ['articles', 'content-pages', 'all'], true) ? $surface : 'all';
+        $limit = max(1, min($limit, 250));
+        $candidates = [];
+
+        if ($surface === 'articles' || $surface === 'all') {
+            foreach ($this->articleCandidates($limit) as $candidate) {
+                $candidates[] = $candidate;
+                if (count($candidates) >= $limit) {
+                    break;
+                }
+            }
+        }
+
+        if (($surface === 'content-pages' || $surface === 'all') && count($candidates) < $limit) {
+            foreach ($this->contentPageCandidates($limit - count($candidates)) as $candidate) {
+                $candidates[] = $candidate;
+                if (count($candidates) >= $limit) {
+                    break;
+                }
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => 'success',
+            'source_family' => 'cms_faq_gap',
+            'run_mode' => 'readonly_discovery',
+            'surface' => $surface,
+            'limit' => $limit,
+            'candidate_count' => count($candidates),
+            'candidates' => $candidates,
+            'candidate_shape' => [
+                'required_fields' => [
+                    'source_family',
+                    'source_id',
+                    'subject_type',
+                    'subject_ref',
+                    'safe_path',
+                    'severity',
+                    'gap_types',
+                    'evidence_refs',
+                    'recommended_next_step',
+                    'allowed_action',
+                    'blocked_actions',
+                ],
+            ],
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function articleCandidates(int $limit): array
+    {
+        $rows = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['seoMeta' => static fn ($query) => $query->withoutGlobalScopes()])
+            ->published()
+            ->orderBy('id')
+            ->limit($limit * 4)
+            ->get();
+
+        $candidates = [];
+        foreach ($rows as $article) {
+            $seoMeta = $article->seoMeta instanceof ArticleSeoMeta ? $article->seoMeta : null;
+            $schema = $seoMeta instanceof ArticleSeoMeta && is_array($seoMeta->schema_json) ? $seoMeta->schema_json : [];
+            $answerSurface = data_get($schema, 'editorial_package_v1.answer_surface_v1');
+            $hasAnswerSurfaceSignal = is_array($answerSurface);
+            $hasFaqSchemaSignal = $this->containsFaqPage($schema);
+
+            if (! $hasAnswerSurfaceSignal && ! $hasFaqSchemaSignal) {
+                continue;
+            }
+
+            $faqItems = is_array(data_get($schema, 'editorial_package_v1.answer_surface_v1.faq_items'))
+                ? (array) data_get($schema, 'editorial_package_v1.answer_surface_v1.faq_items')
+                : [];
+            $hasVisibleFaq = $this->hasValidFaqItems($faqItems);
+            if ($hasVisibleFaq) {
+                continue;
+            }
+
+            $gaps = ['missing_faq_items'];
+            if ($hasFaqSchemaSignal) {
+                $gaps[] = 'faq_schema_enabled_without_visible_faq';
+            }
+
+            $candidates[] = $this->candidate(
+                subjectType: 'article',
+                subjectRef: 'article:'.(int) $article->id.':'.(string) $article->locale,
+                safePath: $this->articleSafePath($article),
+                locale: (string) $article->locale,
+                gapTypes: array_values(array_unique($gaps)),
+                evidenceRefs: [
+                    [
+                        'code' => 'article_faq_signal_present',
+                        'field_status' => 'present',
+                    ],
+                    [
+                        'code' => 'visible_faq_items',
+                        'field_status' => 'missing_or_incomplete',
+                    ],
+                ],
+            );
+
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function contentPageCandidates(int $limit): array
+    {
+        $rows = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->publishedPublic()
+            ->orderBy('id')
+            ->limit($limit * 4)
+            ->get();
+
+        $candidates = [];
+        foreach ($rows as $page) {
+            if (! $this->contentPageHasFaqSignal($page)) {
+                continue;
+            }
+
+            $hasVisibleFaq = $this->hasValidFaqItems(is_array($page->faq_items) ? $page->faq_items : []);
+            if ($hasVisibleFaq) {
+                continue;
+            }
+
+            $gaps = ['missing_faq_items'];
+            if ((bool) $page->schema_enabled) {
+                $gaps[] = 'faq_schema_enabled_without_visible_faq';
+            }
+
+            $candidates[] = $this->candidate(
+                subjectType: 'content_page',
+                subjectRef: 'content_page:'.(int) $page->id.':'.(string) $page->locale,
+                safePath: $this->contentPageSafePath($page),
+                locale: (string) $page->locale,
+                gapTypes: array_values(array_unique($gaps)),
+                evidenceRefs: [
+                    [
+                        'code' => 'content_page_faq_signal_present',
+                        'field_status' => 'present',
+                    ],
+                    [
+                        'code' => 'faq_items',
+                        'field_status' => 'missing_or_incomplete',
+                    ],
+                ],
+            );
+
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @param  list<array<string, mixed>>  $evidenceRefs
+     * @return array<string, mixed>
+     */
+    private function candidate(string $subjectType, string $subjectRef, string $safePath, string $locale, array $gapTypes, array $evidenceRefs): array
+    {
+        $sourcePayload = implode('|', [$subjectType, $subjectRef, $safePath, implode(',', $gapTypes)]);
+
+        return [
+            'source_family' => 'cms_faq_gap',
+            'source_id' => hash('sha256', $sourcePayload),
+            'subject_type' => $subjectType,
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'locale' => $locale,
+            'severity' => $this->severity($gapTypes),
+            'gap_types' => $gapTypes,
+            'evidence_refs' => $evidenceRefs,
+            'recommended_next_step' => 'codex_review_required_before_cms_draft',
+            'allowed_action' => 'readonly_review',
+            'blocked_actions' => self::BLOCKED_ACTIONS,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     */
+    private function severity(array $gapTypes): string
+    {
+        if (in_array('faq_schema_enabled_without_visible_faq', $gapTypes, true)) {
+            return 'p1';
+        }
+
+        if (in_array('missing_faq_items', $gapTypes, true)) {
+            return 'p2';
+        }
+
+        return 'p3';
+    }
+
+    private function contentPageHasFaqSignal(ContentPage $page): bool
+    {
+        if ((bool) $page->faq_schema_eligible || (bool) $page->schema_enabled) {
+            return true;
+        }
+
+        $identity = strtolower(implode(' ', [
+            (string) $page->kind,
+            (string) $page->page_type,
+            (string) $page->slug,
+            (string) $page->path,
+        ]));
+
+        return preg_match('/\b(faq|help|support)\b/u', $identity) === 1;
+    }
+
+    /**
+     * @param  mixed  $items
+     */
+    private function hasValidFaqItems(mixed $items): bool
+    {
+        if (! is_array($items) || $items === []) {
+            return false;
+        }
+
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                return false;
+            }
+
+            $question = trim((string) ($item['question'] ?? $item['q'] ?? ''));
+            $answer = trim((string) ($item['answer'] ?? $item['a'] ?? ''));
+            if ($question === '' || $answer === '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  mixed  $value
+     */
+    private function containsFaqPage(mixed $value): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        $type = $value['@type'] ?? null;
+        if ($type === 'FAQPage' || (is_array($type) && in_array('FAQPage', $type, true))) {
+            return true;
+        }
+
+        foreach ($value as $child) {
+            if ($this->containsFaqPage($child)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function articleSafePath(Article $article): string
+    {
+        $slug = $this->safeSlug((string) $article->slug);
+        if ($slug === '') {
+            $slug = 'article-'.substr(hash('sha256', (string) $article->id), 0, 12);
+        }
+
+        return str_starts_with(strtolower((string) $article->locale), 'zh')
+            ? '/zh/articles/'.$slug
+            : '/articles/'.$slug;
+    }
+
+    private function contentPageSafePath(ContentPage $page): string
+    {
+        $path = trim((string) $page->path);
+        if ($path === '') {
+            $path = '/'.$this->safeSlug((string) $page->slug);
+        }
+
+        if (preg_match('#^https?://#i', $path) === 1) {
+            $parsedPath = parse_url($path, PHP_URL_PATH);
+            $path = is_string($parsedPath) && $parsedPath !== '' ? $parsedPath : '/content-page-'.substr(hash('sha256', (string) $page->id), 0, 12);
+        }
+
+        $path = '/'.ltrim(strtok($path, '?#') ?: $path, '/');
+
+        return preg_replace('#/+#', '/', $path) ?: '/';
+    }
+
+    private function safeSlug(string $slug): string
+    {
+        $slug = trim($slug, "/ \t\n\r\0\x0B");
+        $slug = preg_replace('/[^A-Za-z0-9._~%-]+/', '-', $slug) ?: '';
+
+        return trim($slug, '-');
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'faq_schema_enable' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/seo-agent-cms-faq-gap-readonly-scanner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-faq-gap-readonly-scanner.v1.json
@@ -1,0 +1,79 @@
+{
+  "version": "seo-agent-cms-faq-gap-readonly-scanner.v1",
+  "task": "SEO-AGENT-CMS-FAQ-GAP-READONLY-SCANNER-01",
+  "command": "php artisan seo-agent:cms-faq-gap-scan",
+  "source_family": "cms_faq_gap",
+  "run_mode": "readonly_discovery",
+  "supported_surfaces": [
+    "articles",
+    "content-pages",
+    "all"
+  ],
+  "candidate_fields": [
+    "source_family",
+    "source_id",
+    "subject_type",
+    "subject_ref",
+    "safe_path",
+    "locale",
+    "severity",
+    "gap_types",
+    "evidence_refs",
+    "recommended_next_step",
+    "allowed_action",
+    "blocked_actions"
+  ],
+  "article_signal_policy": [
+    "article_seo_meta.schema_json contains FAQPage",
+    "article_seo_meta.schema_json.editorial_package_v1.answer_surface_v1 exists without valid faq_items"
+  ],
+  "content_page_signal_policy": [
+    "faq_schema_eligible=true",
+    "schema_enabled=true",
+    "kind/page_type/slug/path indicates help, support, or faq"
+  ],
+  "forbidden_output_fields": [
+    "raw_url",
+    "full_url",
+    "raw_body",
+    "content_md",
+    "content_html",
+    "schema_json",
+    "payload",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "Bearer "
+  ],
+  "allowed_actions": [
+    "readonly_scan",
+    "evidence_artifact_write",
+    "codex_review_handoff_future"
+  ],
+  "blocked_actions": [
+    "cms_write",
+    "cms_publish",
+    "faq_schema_enable",
+    "search_channel_enqueue",
+    "search_channel_submit",
+    "indexing_request",
+    "scheduler_activation",
+    "queue_worker_activation"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "faq_schema_enable": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "pr_train_metadata_change": false
+  }
+}

--- a/backend/docs/seo/seo-agent-cms-faq-gap-readonly-scanner.md
+++ b/backend/docs/seo/seo-agent-cms-faq-gap-readonly-scanner.md
@@ -1,0 +1,45 @@
+# SEO Agent CMS FAQ Gap Readonly Scanner
+
+`SEO-AGENT-CMS-FAQ-GAP-READONLY-SCANNER-01` adds a conservative CMS FAQ opportunity source for the FermatMind SEO Agent L4 loop.
+
+Command:
+
+```bash
+php artisan seo-agent:cms-faq-gap-scan \
+  --surface=all \
+  --limit=100 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+Supported surfaces:
+
+- `articles`
+- `content-pages`
+- `all`
+
+The scanner only emits candidates for records with explicit FAQ or FAQ-schema signals. It does not assume every public page needs FAQ content.
+
+Article signals:
+
+- `article_seo_meta.schema_json` contains a `FAQPage` JSON-LD signal.
+- `article_seo_meta.schema_json.editorial_package_v1.answer_surface_v1` exists but does not contain valid FAQ items.
+
+ContentPage signals:
+
+- `faq_schema_eligible=true`.
+- `schema_enabled=true`.
+- Help/support/FAQ identity from `kind`, `page_type`, `slug`, or `path`.
+
+Boundaries:
+
+- No CMS write.
+- No DB write.
+- No FAQ schema activation.
+- No queue enqueue.
+- No scheduler activation.
+- No Search Channel submit.
+- No indexing request.
+- No raw body, schema payload, full URL, token, credential, or private key in artifacts.
+
+The output candidate family is `cms_faq_gap`. Candidates are review-only and require Codex review before any later CMS draft dry-run package can be considered.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsFaqGapReadonlyScannerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsFaqGapReadonlyScannerTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+use App\Services\SeoAgent\CmsFaqGapReadonlyScanner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsFaqGapReadonlyScannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function scanner_finds_only_explicit_faq_gap_signals_without_emitting_raw_content_or_schema(): void
+    {
+        $missingArticle = $this->createArticle('article-faq-gap');
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $missingArticle->id,
+            'locale' => 'zh-CN',
+            'seo_title' => 'FAQ schema article',
+            'seo_description' => 'FAQ schema article.',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/article-faq-gap',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => [
+                '@type' => 'FAQPage',
+                'editorial_package_v1' => [
+                    'answer_surface_v1' => [
+                        'faq_items' => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $completeArticle = $this->createArticle('article-faq-complete');
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $completeArticle->id,
+            'locale' => 'zh-CN',
+            'seo_title' => 'Complete FAQ article',
+            'seo_description' => 'Complete FAQ article.',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/article-faq-complete',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => [
+                '@graph' => [
+                    ['@type' => 'FAQPage'],
+                ],
+                'editorial_package_v1' => [
+                    'answer_surface_v1' => [
+                        'faq_items' => [
+                            ['question' => 'What is this page?', 'answer' => 'A complete FAQ page.'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $noSignalArticle = $this->createArticle('article-without-faq-signal');
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $noSignalArticle->id,
+            'locale' => 'zh-CN',
+            'seo_title' => 'No FAQ article',
+            'seo_description' => 'No FAQ article.',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/article-without-faq-signal',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => ['@type' => 'Article'],
+        ]);
+
+        $missingPage = $this->createContentPage('help-faq-gap', '/zh/help/faq-gap', [
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [],
+        ]);
+        $completePage = $this->createContentPage('help-faq-complete', '/zh/help/faq-complete', [
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [
+                ['question' => 'How do I contact support?', 'answer' => 'Use the support page.'],
+            ],
+        ]);
+
+        $artifact = (new CmsFaqGapReadonlyScanner)->scan('all', 20);
+
+        $this->assertSame('seo-agent-cms-faq-gap-readonly-scanner.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('cms_faq_gap', $artifact['source_family'] ?? null);
+        $this->assertSame(2, $artifact['candidate_count'] ?? null);
+
+        $candidateRefs = array_column($artifact['candidates'] ?? [], 'subject_ref');
+        $this->assertContains('article:'.$missingArticle->id.':zh-CN', $candidateRefs);
+        $this->assertContains('content_page:'.$missingPage->id.':zh-CN', $candidateRefs);
+        $this->assertNotContains('article:'.$completeArticle->id.':zh-CN', $candidateRefs);
+        $this->assertNotContains('article:'.$noSignalArticle->id.':zh-CN', $candidateRefs);
+        $this->assertNotContains('content_page:'.$completePage->id.':zh-CN', $candidateRefs);
+
+        $articleCandidate = collect($artifact['candidates'])->firstWhere('subject_ref', 'article:'.$missingArticle->id.':zh-CN');
+        $this->assertSame('/zh/articles/article-faq-gap', $articleCandidate['safe_path'] ?? null);
+        $this->assertSame('p1', $articleCandidate['severity'] ?? null);
+        $this->assertContains('missing_faq_items', $articleCandidate['gap_types'] ?? []);
+        $this->assertContains('faq_schema_enabled_without_visible_faq', $articleCandidate['gap_types'] ?? []);
+
+        $pageCandidate = collect($artifact['candidates'])->firstWhere('subject_ref', 'content_page:'.$missingPage->id.':zh-CN');
+        $this->assertSame('/zh/help/faq-gap', $pageCandidate['safe_path'] ?? null);
+        $this->assertContains('missing_faq_items', $pageCandidate['gap_types'] ?? []);
+        $this->assertContains('faq_schema_enabled_without_visible_faq', $pageCandidate['gap_types'] ?? []);
+
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ([
+            'https://fermatmind.com',
+            'raw_url',
+            'full_url',
+            'content_md',
+            'content_html',
+            'schema_json',
+            'payload',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'Article body must never be emitted',
+            'Content page body must never be emitted',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.faq_schema_enable', true));
+    }
+
+    #[Test]
+    public function command_writes_sanitized_faq_gap_artifact_without_db_writes(): void
+    {
+        $this->createContentPage('command-help-faq-gap', '/zh/help/command-faq-gap', [
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [],
+        ]);
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-faq-gap-scan', [
+            '--surface' => 'all',
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $files = File::files($artifactDir);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertIsArray($summary);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['candidate_count'] ?? null);
+        $this->assertCount(1, $files);
+
+        $artifact = $this->readJson(data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-agent-cms-faq-gap-readonly-scanner.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('cms_faq_gap', $artifact['source_family'] ?? null);
+
+        $combined = (string) file_get_contents($files[0]->getPathname());
+        foreach ([
+            'https://fermatmind.com',
+            'raw_url',
+            'schema_json',
+            'content_md',
+            'content_html',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'faq_schema_enable',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function generated_contract_documents_faq_gap_readonly_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-faq-gap-readonly-scanner.v1.json'));
+
+        $this->assertSame('seo-agent-cms-faq-gap-readonly-scanner.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-faq-gap-scan', $artifact['command'] ?? null);
+        $this->assertSame('cms_faq_gap', $artifact['source_family'] ?? null);
+        $this->assertContains('all', $artifact['supported_surfaces'] ?? []);
+
+        foreach ([
+            'raw_url',
+            'full_url',
+            'raw_body',
+            'content_md',
+            'content_html',
+            'schema_json',
+            'payload',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'token',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_output_fields'] ?? [], $field);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'faq_schema_enable',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Readable title',
+            'excerpt' => 'Reader-facing excerpt.',
+            'content_md' => 'Article body must never be emitted by the scanner.',
+            'content_html' => '<p>Article body must never be emitted by the scanner.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createContentPage(string $slug, string $path, array $overrides = []): ContentPage
+    {
+        return ContentPage::query()->create(array_merge([
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => $path,
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Content page',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'content_md' => 'Content page body must never be emitted.',
+            'content_html' => '<p>Content page body must never be emitted.</p>',
+            'seo_title' => 'FAQ page title',
+            'seo_description' => 'FAQ page description.',
+            'meta_description' => 'FAQ page description.',
+            'canonical_path' => $path,
+            'schema_enabled' => false,
+            'faq_schema_eligible' => false,
+            'faq_items' => [],
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ], $overrides));
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-cms-faq-gap-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $this->assertFileExists($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1131,6 +1131,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_faq_gap_readonly_scanner_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsFaqGapScanCommand;',
+            '+        SeoAgentCmsFaqGapScanCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3653,6 +3668,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsFaqGapReadonlyScannerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4242,6 +4261,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4902,6 +4922,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentRuntimeSeoQaScanCommand.php',
             'backend/app/Services/SeoAgent/RuntimeSeoQaReadonlyScanner.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsFaqGapReadonlyScannerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php',
+            'backend/app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php',
         ], true);
     }
 
@@ -6569,6 +6597,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentRuntimeSeoQaScanCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsFaqGapScanCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:cms-faq-gap-scan` for conservative read-only FAQ gap discovery.
- Emits `cms_faq_gap` candidates only when article/content-page records have explicit FAQ or FAQ-schema signals.
- Added sanitized contract docs/generated JSON and focused feature tests.
- Added BigFive runtime freeze allowlist coverage for this scoped SEO Agent scanner command.

## Why
This adds the third practical opportunity source for the L4 SEO Agent while avoiding broad FAQ assumptions and preserving review-only boundaries.

## Validation
- `php -l app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php`
- `php -l app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php`
- `php -l tests/Feature/SeoIntel/SeoAgentCmsFaqGapReadonlyScannerTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-faq-gap-readonly-scanner.v1.json >/dev/null`
- `git diff --check`
- `php artisan test --filter SeoAgentCmsFaqGapReadonlyScannerTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_cms_faq_gap_readonly_scanner_files`

## Intentionally deferred
- No CMS writes, draft creation, FAQ schema activation, DB writes, scheduler, queue, Search Channel, or indexing request.
- No PR-train manifest/state changes.
