### PR TITLE
SEO-AGENT-OPPORTUNITY-AGGREGATOR-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentOpportunityAggregateCommand.php
+++ b/backend/app/Console/Commands/SeoAgentOpportunityAggregateCommand.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\OpportunityAggregator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentOpportunityAggregateCommand extends Command
+{
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'full_url',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'raw_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:opportunity-aggregate
+        {--inputs= : Comma-separated sanitized scanner artifact paths}
+        {--limit=100 : Candidate limit, bounded 1..250}
+        {--artifact-dir= : Directory for sanitized JSON artifact}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Aggregate sanitized SEO Agent opportunity source artifacts into one ranked read-only opportunity pool.';
+
+    public function handle(OpportunityAggregator $aggregator): int
+    {
+        $inputPaths = $this->inputPaths();
+        if ($inputPaths === []) {
+            return $this->finish($this->failureSummary('inputs_missing_or_unreadable'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $artifacts = [];
+        $inputRefs = [];
+        foreach ($inputPaths as $path) {
+            $raw = (string) file_get_contents($path);
+            $forbidden = $this->forbiddenStringsPresent($raw);
+            if ($forbidden !== []) {
+                return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                    'input_path_hash' => hash('sha256', $path),
+                    'forbidden_matches' => $forbidden,
+                ]));
+            }
+
+            $decoded = json_decode($raw, true);
+            if (! is_array($decoded)) {
+                return $this->finish($this->failureSummary('input_json_invalid', [
+                    'input_path_hash' => hash('sha256', $path),
+                ]));
+            }
+
+            $artifacts[] = $decoded;
+            $inputRefs[] = [
+                'path_hash' => hash('sha256', $path),
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'schema_version' => (string) ($decoded['schema_version'] ?? $decoded['version'] ?? 'unknown'),
+                'candidate_count' => (int) ($decoded['candidate_count'] ?? 0),
+            ];
+        }
+
+        $artifact = $aggregator->aggregate($artifacts, $this->limit());
+        $artifact['input_artifacts'] = $inputRefs;
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-opportunity-aggregate-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $artifact
+        );
+
+        return $this->finish([
+            'schema_version' => OpportunityAggregator::SCHEMA_VERSION,
+            'task' => OpportunityAggregator::TASK,
+            'ok' => true,
+            'status' => 'success',
+            'input_artifact_count' => count($inputRefs),
+            'candidate_count' => (int) ($artifact['candidate_count'] ?? 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function inputPaths(): array
+    {
+        $raw = trim((string) $this->option('inputs'));
+        if ($raw === '' || str_contains($raw, "\0")) {
+            return [];
+        }
+
+        $paths = [];
+        foreach (explode(',', $raw) as $path) {
+            $path = trim($path);
+            if ($path === '') {
+                continue;
+            }
+            $path = str_starts_with($path, '/') ? $path : base_path($path);
+            if (! is_file($path) || ! is_readable($path)) {
+                return [];
+            }
+            $paths[] = $path;
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => OpportunityAggregator::SCHEMA_VERSION,
+            'task' => OpportunityAggregator::TASK,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -174,6 +174,7 @@ use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
+use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
@@ -369,6 +370,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
+        SeoAgentOpportunityAggregateCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/app/Services/SeoAgent/OpportunityAggregator.php
+++ b/backend/app/Services/SeoAgent/OpportunityAggregator.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoAgent;
+
+final class OpportunityAggregator
+{
+    public const SCHEMA_VERSION = 'seo-agent-opportunity-aggregate.v1';
+
+    public const TASK = 'SEO-AGENT-OPPORTUNITY-AGGREGATOR-01';
+
+    private const SOURCE_WEIGHTS = [
+        'runtime_seo_qa' => 40,
+        'cms_tdk_gap' => 30,
+        'cms_faq_gap' => 20,
+        'gsc_performance' => 10,
+    ];
+
+    private const SEVERITY_WEIGHTS = [
+        'p0' => 400,
+        'p1' => 300,
+        'p2' => 200,
+        'p3' => 100,
+    ];
+
+    /**
+     * @param  list<array<string, mixed>>  $artifacts
+     * @return array<string, mixed>
+     */
+    public function aggregate(array $artifacts, int $limit = 100): array
+    {
+        $limit = max(1, min($limit, 250));
+        $merged = [];
+
+        foreach ($artifacts as $artifact) {
+            foreach ($this->extractCandidates($artifact) as $candidate) {
+                $normalized = $this->normalizeCandidate($candidate);
+                if ($normalized === null) {
+                    continue;
+                }
+
+                $dedupeKey = $this->dedupeKey($normalized);
+                if (! isset($merged[$dedupeKey])) {
+                    $merged[$dedupeKey] = $normalized;
+                    continue;
+                }
+
+                $merged[$dedupeKey] = $this->mergeCandidate($merged[$dedupeKey], $normalized);
+            }
+        }
+
+        $candidates = array_values($merged);
+        foreach ($candidates as &$candidate) {
+            $candidate['score'] = $this->score($candidate);
+        }
+        unset($candidate);
+
+        usort($candidates, fn (array $left, array $right): int => $this->sortCandidates($left, $right));
+        $candidates = array_slice($candidates, 0, $limit);
+
+        foreach ($candidates as $index => &$candidate) {
+            $candidate['priority_rank'] = $index + 1;
+        }
+        unset($candidate);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => 'success',
+            'run_mode' => 'readonly_discovery',
+            'input_artifact_count' => count($artifacts),
+            'candidate_count' => count($candidates),
+            'limit' => $limit,
+            'candidates' => $candidates,
+            'dedupe_policy' => 'subject_type + subject_ref + source_family + sorted_gap_types',
+            'ranking_policy' => 'severity desc, source weight desc, evidence count desc, dedupe key asc',
+            'source_weights' => self::SOURCE_WEIGHTS,
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return list<array<string, mixed>>
+     */
+    private function extractCandidates(array $artifact): array
+    {
+        $candidates = $artifact['candidates'] ?? data_get($artifact, 'data.recent_rows', []);
+        if (! is_array($candidates)) {
+            return [];
+        }
+
+        return array_values(array_filter($candidates, static fn ($candidate): bool => is_array($candidate)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>|null
+     */
+    private function normalizeCandidate(array $candidate): ?array
+    {
+        $sourceFamily = (string) ($candidate['source_family'] ?? $candidate['source'] ?? '');
+        $subjectType = (string) ($candidate['subject_type'] ?? '');
+        $subjectRef = (string) ($candidate['subject_ref'] ?? '');
+        $safePath = (string) ($candidate['safe_path'] ?? $candidate['canonical_path'] ?? '');
+        $severity = (string) ($candidate['severity'] ?? 'p3');
+
+        if ($sourceFamily === '' || $subjectType === '' || $subjectRef === '' || $safePath === '') {
+            return null;
+        }
+
+        if (! in_array($severity, ['p0', 'p1', 'p2', 'p3'], true)) {
+            $severity = 'p3';
+        }
+
+        $gapTypes = $this->strings((array) ($candidate['gap_types'] ?? $candidate['gap_codes'] ?? []));
+        if ($gapTypes === []) {
+            $gapTypes = $this->gapTypesFromEvidence((array) ($candidate['evidence_refs'] ?? []));
+        }
+
+        return [
+            'source_family' => $sourceFamily,
+            'source_id' => (string) ($candidate['source_id'] ?? hash('sha256', json_encode($candidate) ?: 'candidate')),
+            'subject_type' => $subjectType,
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'locale' => (string) ($candidate['locale'] ?? ''),
+            'severity' => $severity,
+            'gap_types' => $gapTypes,
+            'dedupe_key' => '',
+            'evidence_refs' => $this->sanitizeEvidenceRefs((array) ($candidate['evidence_refs'] ?? [])),
+            'recommended_next_step' => (string) ($candidate['recommended_next_step'] ?? 'codex_review_required'),
+            'allowed_action' => (string) ($candidate['allowed_action'] ?? 'readonly_review'),
+            'blocked_actions' => $this->strings((array) ($candidate['blocked_actions'] ?? [])),
+            'source_ids' => [(string) ($candidate['source_id'] ?? '')],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function dedupeKey(array &$candidate): string
+    {
+        $gapTypes = $this->strings((array) ($candidate['gap_types'] ?? []));
+        sort($gapTypes);
+        $candidate['gap_types'] = $gapTypes;
+
+        $key = implode('|', [
+            (string) ($candidate['subject_type'] ?? ''),
+            (string) ($candidate['subject_ref'] ?? ''),
+            (string) ($candidate['source_family'] ?? ''),
+            implode(',', $gapTypes),
+        ]);
+        $candidate['dedupe_key'] = hash('sha256', $key);
+
+        return (string) $candidate['dedupe_key'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $existing
+     * @param  array<string, mixed>  $incoming
+     * @return array<string, mixed>
+     */
+    private function mergeCandidate(array $existing, array $incoming): array
+    {
+        $existing['evidence_refs'] = array_values(array_slice(array_merge(
+            (array) ($existing['evidence_refs'] ?? []),
+            (array) ($incoming['evidence_refs'] ?? [])
+        ), 0, 20));
+
+        $existing['source_ids'] = array_values(array_unique(array_filter(array_merge(
+            (array) ($existing['source_ids'] ?? []),
+            (array) ($incoming['source_ids'] ?? [])
+        ))));
+
+        if ($this->severityWeight((string) ($incoming['severity'] ?? 'p3')) > $this->severityWeight((string) ($existing['severity'] ?? 'p3'))) {
+            $existing['severity'] = $incoming['severity'];
+        }
+
+        return $existing;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function score(array $candidate): int
+    {
+        return $this->severityWeight((string) ($candidate['severity'] ?? 'p3'))
+            + (self::SOURCE_WEIGHTS[(string) ($candidate['source_family'] ?? '')] ?? 0)
+            + min(count((array) ($candidate['evidence_refs'] ?? [])), 20);
+    }
+
+    /**
+     * @param  array<string, mixed>  $left
+     * @param  array<string, mixed>  $right
+     */
+    private function sortCandidates(array $left, array $right): int
+    {
+        return ((int) ($right['score'] ?? 0) <=> (int) ($left['score'] ?? 0))
+            ?: strcmp((string) ($left['dedupe_key'] ?? ''), (string) ($right['dedupe_key'] ?? ''));
+    }
+
+    private function severityWeight(string $severity): int
+    {
+        return self::SEVERITY_WEIGHTS[$severity] ?? self::SEVERITY_WEIGHTS['p3'];
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function strings(array $values): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', $values),
+            static fn (string $value): bool => $value !== ''
+        )));
+    }
+
+    /**
+     * @param  array<int, mixed>  $evidenceRefs
+     * @return list<string>
+     */
+    private function gapTypesFromEvidence(array $evidenceRefs): array
+    {
+        $codes = [];
+        foreach ($evidenceRefs as $ref) {
+            if (is_array($ref) && ($ref['code'] ?? '') !== '') {
+                $codes[] = (string) $ref['code'];
+            }
+        }
+
+        return $this->strings($codes);
+    }
+
+    /**
+     * @param  array<int, mixed>  $evidenceRefs
+     * @return list<array<string, mixed>>
+     */
+    private function sanitizeEvidenceRefs(array $evidenceRefs): array
+    {
+        $refs = [];
+        foreach ($evidenceRefs as $ref) {
+            if (! is_array($ref)) {
+                continue;
+            }
+
+            $clean = [];
+            foreach (['code', 'field_status', 'status_code', 'expected_safe_path_hash', 'observed_safe_path_hash'] as $field) {
+                if (array_key_exists($field, $ref)) {
+                    $clean[$field] = is_scalar($ref[$field]) ? $ref[$field] : (string) json_encode($ref[$field]);
+                }
+            }
+            if ($clean !== []) {
+                $refs[] = $clean;
+            }
+        }
+
+        return $refs;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/seo-agent-opportunity-aggregate.v1.json
+++ b/backend/docs/seo/generated/seo-agent-opportunity-aggregate.v1.json
@@ -1,0 +1,69 @@
+{
+  "version": "seo-agent-opportunity-aggregate.v1",
+  "task": "SEO-AGENT-OPPORTUNITY-AGGREGATOR-01",
+  "repo": "fap-api",
+  "type": "readonly_opportunity_aggregate_contract",
+  "command": "php artisan seo-agent:opportunity-aggregate",
+  "input_schemas": [
+    "seo-agent-cms-tdk-gap-readonly-scanner.v1",
+    "seo-agent-runtime-seo-qa-readonly-scanner.v1",
+    "seo-agent-cms-faq-gap-readonly-scanner.v1",
+    "future_gsc_or_opportunity_queue_export_artifact"
+  ],
+  "output_schema": "seo-agent-opportunity-aggregate.v1",
+  "candidate_required_fields": [
+    "source_family",
+    "source_id",
+    "subject_type",
+    "subject_ref",
+    "safe_path",
+    "severity",
+    "score",
+    "dedupe_key",
+    "priority_rank",
+    "gap_types",
+    "evidence_refs"
+  ],
+  "dedupe_policy": "subject_type + subject_ref + source_family + sorted_gap_types",
+  "cross_source_same_subject_merge_allowed": false,
+  "ranking_policy": "severity desc, source weight desc, evidence count desc, dedupe key asc",
+  "source_weights": {
+    "runtime_seo_qa": 40,
+    "cms_tdk_gap": 30,
+    "cms_faq_gap": 20,
+    "gsc_performance": 10
+  },
+  "forbidden_input_or_output_fields": [
+    "raw_url",
+    "raw_query",
+    "full_url",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "raw_html",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false,
+    "pr_train_metadata_change": false
+  },
+  "next_step": "Feed this aggregate artifact into a run orchestrator or Codex review handoff in a later PR; this PR does not execute downstream actions."
+}

--- a/backend/docs/seo/seo-agent-opportunity-aggregator.md
+++ b/backend/docs/seo/seo-agent-opportunity-aggregator.md
@@ -1,0 +1,25 @@
+# SEO Agent Opportunity Aggregator
+
+`SEO-AGENT-OPPORTUNITY-AGGREGATOR-01` adds the first unified opportunity pool for the FermatMind SEO Agent L4 loop.
+
+## Command
+
+```bash
+php artisan seo-agent:opportunity-aggregate \
+  --inputs=/path/to/scanner-a.json,/path/to/scanner-b.json \
+  --limit=100 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+## Contract
+
+The command accepts sanitized readonly opportunity artifacts from existing scanner sources such as `cms_tdk_gap`, `runtime_seo_qa`, and `cms_faq_gap`. It emits `seo-agent-opportunity-aggregate.v1` with ranked, deduplicated candidates.
+
+Deduplication is limited to `subject_type + subject_ref + source_family + sorted gap_types`. Cross-source candidates for the same subject remain separate so Codex review can see distinct reasons.
+
+Ranking is deterministic: severity first, then source weight (`runtime_seo_qa`, `cms_tdk_gap`, `cms_faq_gap`, `gsc_performance`), then evidence count.
+
+## Boundaries
+
+This command writes only a sanitized JSON artifact. It does not write databases, mutate CMS content, enqueue Search Channel records, submit indexing requests, call Google APIs, activate schedulers, start queue workers, or change production environment variables.

--- a/backend/tests/Feature/SeoIntel/SeoAgentOpportunityAggregatorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentOpportunityAggregatorTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentOpportunityAggregatorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_aggregates_dedupes_and_ranks_multisource_candidates_without_db_writes(): void
+    {
+        $this->createRows();
+        $artifactDir = $this->artifactDir();
+        $tdkPath = $this->writeArtifact('tdk', [
+            $this->candidate('cms_tdk_gap', 'article:1:zh-CN', '/zh/articles/shared', 'p1', ['missing_title'], evidenceCount: 1),
+            $this->candidate('cms_tdk_gap', 'article:1:zh-CN', '/zh/articles/shared', 'p1', ['missing_title'], evidenceCount: 2),
+        ]);
+        $runtimePath = $this->writeArtifact('runtime', [
+            $this->candidate('runtime_seo_qa', 'article:1:zh-CN', '/zh/articles/shared', 'p1', ['canonical_mismatch'], evidenceCount: 2),
+        ]);
+        $faqPath = $this->writeArtifact('faq', [
+            $this->candidate('cms_faq_gap', 'content_page:2:zh-CN', '/zh/help/faq-gap', 'p2', ['missing_faq_items'], evidenceCount: 1),
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:opportunity-aggregate', [
+            '--inputs' => implode(',', [$tdkPath, $runtimePath, $faqPath]),
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $aggregate = $this->readJson(data_get($summary, 'artifact.path'));
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($countsBefore, $this->rowCounts());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', $aggregate['schema_version'] ?? null);
+        $this->assertSame(3, $aggregate['candidate_count'] ?? null);
+        $this->assertSame(3, $aggregate['input_artifact_count'] ?? null);
+
+        $this->assertSame('runtime_seo_qa', data_get($aggregate, 'candidates.0.source_family'));
+        $this->assertSame(1, data_get($aggregate, 'candidates.0.priority_rank'));
+        $this->assertSame('cms_tdk_gap', data_get($aggregate, 'candidates.1.source_family'));
+        $this->assertSame('cms_faq_gap', data_get($aggregate, 'candidates.2.source_family'));
+
+        $tdkCandidate = collect($aggregate['candidates'])->firstWhere('source_family', 'cms_tdk_gap');
+        $this->assertIsArray($tdkCandidate);
+        $this->assertSame(['missing_title'], $tdkCandidate['gap_types'] ?? null);
+        $this->assertCount(3, $tdkCandidate['evidence_refs'] ?? []);
+
+        $encoded = json_encode([$summary, $aggregate], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'external_model_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($aggregate, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_forbidden_input_fields(): void
+    {
+        $forbiddenPath = $this->writeJson([
+            'schema_version' => 'seo-agent-cms-tdk-gap-readonly-scanner.v1',
+            'candidate_count' => 1,
+            'candidates' => [
+                [
+                    'source_family' => 'cms_tdk_gap',
+                    'subject_type' => 'article',
+                    'subject_ref' => 'article:1:zh-CN',
+                    'safe_path' => '/zh/articles/unsafe',
+                    'raw_url' => 'https://fermatmind.com/zh/articles/unsafe',
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:opportunity-aggregate', [
+            '--inputs' => $forbiddenPath,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+    }
+
+    #[Test]
+    public function generated_contract_documents_aggregator_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-opportunity-aggregate.v1.json'));
+
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:opportunity-aggregate', $artifact['command'] ?? null);
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', $artifact['output_schema'] ?? null);
+        $this->assertFalse((bool) ($artifact['cross_source_same_subject_merge_allowed'] ?? true));
+        $this->assertSame(40, data_get($artifact, 'source_weights.runtime_seo_qa'));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.external_model_api_call', true));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     */
+    private function writeArtifact(string $family, array $candidates): string
+    {
+        return $this->writeJson([
+            'schema_version' => 'seo-agent-'.$family.'.v1',
+            'status' => 'success',
+            'source_family' => $family,
+            'candidate_count' => count($candidates),
+            'candidates' => $candidates,
+            'negative_guarantees' => [
+                'database_write' => false,
+                'cms_write' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @return array<string, mixed>
+     */
+    private function candidate(string $sourceFamily, string $subjectRef, string $safePath, string $severity, array $gapTypes, int $evidenceCount): array
+    {
+        return [
+            'source_family' => $sourceFamily,
+            'source_id' => hash('sha256', $sourceFamily.$subjectRef.$severity.implode(',', $gapTypes).$evidenceCount),
+            'subject_type' => str_starts_with($subjectRef, 'content_page:') ? 'content_page' : 'article',
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'locale' => 'zh-CN',
+            'severity' => $severity,
+            'gap_types' => $gapTypes,
+            'evidence_refs' => array_map(
+                static fn (int $index): array => [
+                    'code' => $gapTypes[0] ?? 'gap',
+                    'field_status' => 'missing',
+                    'status_code' => 200 + $index,
+                ],
+                range(1, $evidenceCount)
+            ),
+            'recommended_next_step' => 'codex_review_required',
+            'allowed_action' => 'readonly_review',
+            'blocked_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_submit',
+                'indexing_request',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(array $payload): string
+    {
+        $path = storage_path('framework/testing/seo-agent-opportunity-aggregate-input-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-opportunity-aggregate-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function createRows(): void
+    {
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'aggregator-db-sentinel',
+            'locale' => 'zh-CN',
+            'title' => 'Sentinel',
+            'excerpt' => 'Sentinel.',
+            'content_md' => 'Sentinel markdown body is not read or emitted by this command.',
+            'content_html' => '<p>Sentinel HTML body is not read or emitted by this command.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'aggregator-page-sentinel',
+            'path' => '/zh/aggregator-page-sentinel',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Sentinel',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'https://fermatmind.com',
+            'raw_url',
+            'raw_query',
+            'full_url',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'content_md',
+            'content_html',
+            'raw_html',
+            'cms_draft_body',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1146,6 +1146,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_opportunity_aggregator_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentOpportunityAggregateCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoAgent/OpportunityAggregator.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentOpportunityAggregateCommand;',
+            '+        SeoAgentOpportunityAggregateCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3672,6 +3687,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentOpportunityAggregatorFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4262,6 +4281,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4930,6 +4950,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsFaqGapScanCommand.php',
             'backend/app/Services/SeoAgent/CmsFaqGapReadonlyScanner.php',
+        ], true);
+    }
+
+    private function isSeoAgentOpportunityAggregatorFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentOpportunityAggregateCommand.php',
+            'backend/app/Services/SeoAgent/OpportunityAggregator.php',
         ], true);
     }
 
@@ -6619,6 +6647,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsFaqGapScanCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentOpportunityAggregatorOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentOpportunityAggregateCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:opportunity-aggregate` to combine sanitized SEO Agent scanner artifacts into one ranked opportunity pool.
- Added `OpportunityAggregator` for normalization, dedupe, scoring, and deterministic priority ranking.
- Added generated contract/docs plus focused tests and BigFive runtime freeze guard allowlist for this scoped command/service.

## Why
This is PR 1 of the L4 SEO Agent completion plan. It creates the shared read-only opportunity pool required before orchestrator, multi-source Codex review, draft proposal generation, or controlled CMS draft writing.

## Validation
```bash
cd backend
php artisan test --filter SeoAgentOpportunityAggregatorTest
php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_opportunity_aggregator_files
python3 -m json.tool docs/seo/generated/seo-agent-opportunity-aggregate.v1.json >/dev/null
git diff --check
php artisan list | rg "seo-agent:opportunity-aggregate"
```

## Intentionally deferred
- `SEO-AGENT-RUN-ORCHESTRATOR-01`
- `SEO-AGENT-MULTISOURCE-CODEX-REVIEW-01`
- `SEO-AGENT-CMS-DRAFT-PACKAGE-PROPOSAL-01`
- `SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01`
- No DB writes, CMS writes, publish, scheduler, queue worker, Search Channel, indexing, GSC live read, or external model API call.

## Repository rule impact
This PR adds a backend-authoritative SEO Agent read-only artifact command. It does not create or modify publishable CMS content, publishing state, frontend content authority, or search/indexing execution.