### PR TITLE
SEO-AGENT-RUN-ORCHESTRATOR-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentRunCommand.php
@@ -1,0 +1,547 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\CmsFaqGapReadonlyScanner;
+use App\Services\SeoAgent\CmsTdkGapReadonlyScanner;
+use App\Services\SeoAgent\OpportunityAggregator;
+use App\Services\SeoAgent\RuntimeSeoQaReadonlyScanner;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentRunCommand extends Command
+{
+    private const EVIDENCE_SCHEMA_VERSION = 'seo-agent-run-evidence.v1';
+
+    protected $signature = 'seo-agent:run
+        {--sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap : Comma-separated sources}
+        {--limit=100 : Candidate limit, bounded 1..250}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Run the readonly SEO Agent L4 chain: scanners, aggregator, control packet, Codex review, CMS draft dry-run, and evidence.';
+
+    public function handle(
+        CmsTdkGapReadonlyScanner $tdkScanner,
+        RuntimeSeoQaReadonlyScanner $runtimeScanner,
+        CmsFaqGapReadonlyScanner $faqScanner,
+        OpportunityAggregator $aggregator,
+    ): int {
+        $sources = $this->sources();
+        if ($sources === []) {
+            return $this->finish($this->failureSummary('invalid_sources'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $limit = $this->limit();
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $scannerArtifacts = [];
+        $scannerRefs = [];
+
+        foreach ($sources as $source) {
+            $artifact = match ($source) {
+                'cms-tdk-gap' => $tdkScanner->scan('all', $limit),
+                'runtime-seo-qa' => $runtimeScanner->scan('cms-indexable', min($limit, 100)),
+                'cms-faq-gap' => $faqScanner->scan('all', $limit),
+            };
+            $scannerArtifacts[] = $artifact;
+            $scannerRefs[$source] = $this->writeArtifact($artifactDir, 'seo-agent-run-'.$source.'-'.$timestamp.'.json', $artifact);
+        }
+
+        $aggregate = $aggregator->aggregate($scannerArtifacts, $limit);
+        $aggregate['input_artifacts'] = array_values($scannerRefs);
+        $aggregateRef = $this->writeArtifact($artifactDir, 'seo-agent-run-opportunity-aggregate-'.$timestamp.'.json', $aggregate);
+
+        $packet = $this->runControlPacket($sources, $limit, $scannerRefs, $aggregateRef);
+        $packetRef = $this->writeArtifact($artifactDir, 'seo-agent-run-control-packet-'.$timestamp.'.json', $packet);
+        $handoff = $this->codexReviewHandoff($packetRef, $aggregateRef, $aggregate);
+        $handoffRef = $this->writeArtifact($artifactDir, 'seo-agent-codex-review-handoff-'.$timestamp.'.json', $handoff);
+
+        $verdict = $this->codexReviewVerdict($handoff, (string) $handoffRef['path']);
+        $verdictRef = $this->writeArtifact($artifactDir, 'seo-agent-codex-review-verdict-'.$timestamp.'.json', $verdict);
+        $reviewSummary = [
+            'artifact' => $verdictRef,
+            'worth_optimizing_count' => count(array_filter(
+                (array) ($verdict['candidate_verdicts'] ?? []),
+                static fn (array $candidate): bool => ($candidate['worth_optimizing'] ?? false) === true
+            )),
+        ];
+
+        $draftPackage = $this->cmsDraftPackageDryRun($verdict, (string) $verdictRef['path']);
+        $draftRef = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-package-dry-run-'.$timestamp.'.json', $draftPackage);
+        $draftSummary = [
+            'artifact' => $draftRef,
+            'draft_brief_count' => (int) ($draftPackage['draft_brief_count'] ?? 0),
+        ];
+
+        $evidence = $this->runEvidence($sources, $scannerRefs, $aggregateRef, $packetRef, $handoffRef, $reviewSummary, $draftSummary);
+        $evidenceRef = $this->writeArtifact($artifactDir, 'seo-agent-run-evidence-'.$timestamp.'.json', $evidence);
+
+        return $this->finish([
+            'schema_version' => self::EVIDENCE_SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'sources' => $sources,
+            'candidate_count' => (int) ($aggregate['candidate_count'] ?? 0),
+            'worth_optimizing_count' => (int) ($reviewSummary['worth_optimizing_count'] ?? 0),
+            'draft_brief_count' => (int) ($draftSummary['draft_brief_count'] ?? 0),
+            'artifact' => $evidenceRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sources(): array
+    {
+        $allowed = ['cms-tdk-gap', 'runtime-seo-qa', 'cms-faq-gap'];
+        $sources = array_values(array_unique(array_filter(array_map(
+            static fn (string $source): string => trim($source),
+            explode(',', (string) $this->option('sources'))
+        ))));
+
+        foreach ($sources as $source) {
+            if (! in_array($source, $allowed, true)) {
+                return [];
+            }
+        }
+
+        return $sources;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, array<string, mixed>>  $scannerRefs
+     * @param  array<string, mixed>  $aggregateRef
+     * @return array<string, mixed>
+     */
+    private function runControlPacket(array $sources, int $limit, array $scannerRefs, array $aggregateRef): array
+    {
+        return [
+            'schema_version' => 'seo-agent-run-control-packet.v1',
+            'run_id' => 'seo-agent-run-'.Carbon::now('UTC')->format('YmdHis'),
+            'run_mode' => 'readonly_discovery',
+            'trigger' => 'manual_cli',
+            'scope' => [
+                'source_families' => $sources,
+                'write_scope' => 'none',
+            ],
+            'input_refs' => [
+                'command' => 'php artisan seo-agent:run',
+                'sources' => $sources,
+                'limit' => $limit,
+            ],
+            'evidence_refs' => array_values($scannerRefs),
+            'model_review' => [
+                'reviewer' => 'codex',
+                'role' => 'review_only',
+                'execution_permission' => false,
+                'required_output' => 'seo-agent-codex-review-verdict.v1',
+            ],
+            'approval' => [
+                'status' => 'not_requested',
+                'approved_actions' => [],
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'allowed_actions' => [
+                'readonly_scan',
+                'evidence_artifact_write',
+                'codex_review_handoff_artifact',
+                'cms_draft_package_dry_run',
+            ],
+            'output_artifacts' => [
+                'scanner_artifacts' => $scannerRefs,
+                'opportunity_aggregate' => $aggregateRef,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'next_step' => 'Codex review and CMS draft package remain dry-run only; controlled CMS draft write is a later separately approved PR.',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $packetRef
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $aggregate
+     * @return array<string, mixed>
+     */
+    private function codexReviewHandoff(array $packetRef, array $aggregateRef, array $aggregate): array
+    {
+        return [
+            'schema_version' => 'seo-agent-codex-review-handoff.v1',
+            'task' => 'SEO-AGENT-RUN-ORCHESTRATOR-01',
+            'reviewer' => 'codex',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_control_packet' => $packetRef,
+            'input_candidates' => $aggregateRef,
+            'candidate_count' => (int) ($aggregate['candidate_count'] ?? 0),
+            'review_output_contract' => [
+                'worth_optimizing' => 'boolean',
+                'recommended_action' => 'readonly_review|cms_draft_package_dry_run|defer',
+                'risk_flags' => 'list<string>',
+                'needs_human_approval' => 'boolean',
+            ],
+            'candidate_preview' => array_slice((array) ($aggregate['candidates'] ?? []), 0, 100),
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $handoff
+     * @return array<string, mixed>
+     */
+    private function codexReviewVerdict(array $handoff, string $handoffPath): array
+    {
+        $candidateVerdicts = array_map(
+            fn (array $candidate): array => $this->candidateVerdict($candidate),
+            array_values(array_filter(
+                (array) ($handoff['candidate_preview'] ?? []),
+                static fn ($candidate): bool => is_array($candidate)
+            ))
+        );
+
+        $worthOptimizing = array_values(array_filter(
+            $candidateVerdicts,
+            static fn (array $candidate): bool => ($candidate['worth_optimizing'] ?? false) === true
+        ));
+
+        return [
+            'schema_version' => 'seo-agent-codex-review-verdict.v1',
+            'reviewer' => 'codex',
+            'review_mode' => 'deterministic_rules',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_handoff' => [
+                'path_hash' => hash('sha256', $handoffPath),
+                'sha256' => hash_file('sha256', $handoffPath) ?: '',
+                'schema_version' => (string) ($handoff['schema_version'] ?? ''),
+            ],
+            'candidate_count' => count($candidateVerdicts),
+            'candidate_verdicts' => $candidateVerdicts,
+            'worth_optimizing' => $worthOptimizing !== [],
+            'recommended_action' => $worthOptimizing !== [] ? 'cms_draft_package_dry_run' : 'defer',
+            'risk_flags' => array_values(array_unique(array_merge(...array_map(
+                static fn (array $candidate): array => (array) ($candidate['risk_flags'] ?? []),
+                $candidateVerdicts
+            )))),
+            'needs_human_approval' => true,
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function candidateVerdict(array $candidate): array
+    {
+        $severity = (string) ($candidate['severity'] ?? '');
+        $sourceId = (string) ($candidate['source_id'] ?? '');
+        $subjectRef = (string) ($candidate['subject_ref'] ?? '');
+        $safePath = (string) ($candidate['safe_path'] ?? '');
+        $evidenceRefs = (array) ($candidate['evidence_refs'] ?? []);
+        $riskFlags = [];
+
+        if ($sourceId === '' || $subjectRef === '' || $safePath === '') {
+            $riskFlags[] = 'candidate_incomplete';
+        }
+        if ($evidenceRefs === []) {
+            $riskFlags[] = 'evidence_missing';
+        }
+        if (! in_array($severity, ['p1', 'p2', 'p3'], true)) {
+            $riskFlags[] = 'unsupported_severity';
+        }
+
+        $worthOptimizing = $riskFlags === [] && in_array($severity, ['p1', 'p2'], true);
+
+        return [
+            'source_id' => $sourceId !== '' ? $sourceId : hash('sha256', $subjectRef.$safePath.json_encode($candidate)),
+            'source_family' => (string) ($candidate['source_family'] ?? ''),
+            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_ref' => $subjectRef,
+            'safe_path' => $safePath,
+            'severity' => $severity,
+            'gap_types' => array_values(array_filter(array_map('strval', (array) ($candidate['gap_types'] ?? [])))),
+            'evidence_refs' => $evidenceRefs,
+            'worth_optimizing' => $worthOptimizing,
+            'recommended_action' => $worthOptimizing ? 'cms_draft_package_dry_run' : 'defer',
+            'risk_flags' => $riskFlags,
+            'needs_human_approval' => true,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $verdict
+     * @return array<string, mixed>
+     */
+    private function cmsDraftPackageDryRun(array $verdict, string $verdictPath): array
+    {
+        $draftBriefs = array_map(
+            fn (array $candidate): array => $this->draftBrief($candidate),
+            array_values(array_filter(
+                (array) ($verdict['candidate_verdicts'] ?? []),
+                static fn ($candidate): bool => is_array($candidate)
+                    && ($candidate['recommended_action'] ?? null) === 'cms_draft_package_dry_run'
+                    && ($candidate['worth_optimizing'] ?? false) === true
+                    && ($candidate['execution_permission'] ?? false) === false
+            ))
+        );
+
+        return [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'run_mode' => 'cms_draft_package_dry_run',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'input_verdict' => [
+                'path_hash' => hash('sha256', $verdictPath),
+                'sha256' => hash_file('sha256', $verdictPath) ?: '',
+                'schema_version' => (string) ($verdict['schema_version'] ?? ''),
+            ],
+            'draft_brief_count' => count($draftBriefs),
+            'draft_briefs' => $draftBriefs,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function draftBrief(array $candidate): array
+    {
+        $gapCodes = array_values(array_unique(array_filter(array_map('strval', (array) ($candidate['gap_types'] ?? [])))));
+
+        return [
+            'source_id' => (string) ($candidate['source_id'] ?? ''),
+            'source_family' => (string) ($candidate['source_family'] ?? ''),
+            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'severity' => (string) ($candidate['severity'] ?? ''),
+            'gap_codes' => $gapCodes,
+            'target_fields' => $this->targetFields($gapCodes),
+            'draft_instructions' => [
+                'prepare_field_level_proposal_only',
+                'do_not_generate_final_body_copy',
+                'preserve_existing_slug_and_canonical_unless_separately_approved',
+                'run_claim_gate_before_any_cms_write',
+            ],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+            'blocked_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $gapCodes
+     * @return list<string>
+     */
+    private function targetFields(array $gapCodes): array
+    {
+        $fields = [];
+        foreach ($gapCodes as $code) {
+            $fields[] = match ($code) {
+                'missing_title' => 'seo_title',
+                'missing_meta_description' => 'seo_description',
+                'missing_canonical', 'canonical_mismatch' => 'canonical_url_or_path',
+                'missing_indexability_metadata', 'noindex_present', 'x_robots_noindex' => 'is_indexable_or_robots',
+                'missing_faq_items', 'missing_visible_faq' => 'faq_items',
+                'faq_schema_enabled_without_visible_faq' => 'faq_schema_eligible',
+                default => 'manual_review_required',
+            };
+        }
+
+        return array_values(array_unique($fields));
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, array<string, mixed>>  $scannerRefs
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $packetRef
+     * @param  array<string, mixed>  $handoffRef
+     * @param  array<string, mixed>  $reviewSummary
+     * @param  array<string, mixed>  $draftSummary
+     * @return array<string, mixed>
+     */
+    private function runEvidence(array $sources, array $scannerRefs, array $aggregateRef, array $packetRef, array $handoffRef, array $reviewSummary, array $draftSummary): array
+    {
+        return [
+            'schema_version' => self::EVIDENCE_SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-RUN-ORCHESTRATOR-01',
+            'status' => 'success',
+            'run_mode' => 'readonly_discovery_to_dry_run',
+            'sources' => $sources,
+            'artifacts' => [
+                'scanners' => $scannerRefs,
+                'opportunity_aggregate' => $aggregateRef,
+                'run_control_packet' => $packetRef,
+                'codex_review_handoff' => $handoffRef,
+                'codex_review_verdict' => (array) ($reviewSummary['artifact'] ?? []),
+                'cms_draft_package_dry_run' => (array) ($draftSummary['artifact'] ?? []),
+            ],
+            'summary' => [
+                'candidate_count' => (int) ($aggregateRef['sanitized_summary']['candidate_count'] ?? 0),
+                'worth_optimizing_count' => (int) ($reviewSummary['worth_optimizing_count'] ?? 0),
+                'draft_brief_count' => (int) ($draftSummary['draft_brief_count'] ?? 0),
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::EVIDENCE_SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'production_env_update',
+            'source_code_mutation',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -175,6 +175,7 @@ use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
+use App\Console\Commands\SeoAgentRunCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
@@ -371,6 +372,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
+        SeoAgentRunCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/seo/generated/seo-agent-run-evidence.v1.json
+++ b/backend/docs/seo/generated/seo-agent-run-evidence.v1.json
@@ -1,0 +1,43 @@
+{
+  "version": "seo-agent-run-evidence.v1",
+  "task": "SEO-AGENT-RUN-ORCHESTRATOR-01",
+  "repo": "fap-api",
+  "type": "manual_readonly_l4_run_evidence_contract",
+  "command": "php artisan seo-agent:run",
+  "default_sources": [
+    "cms-tdk-gap",
+    "runtime-seo-qa",
+    "cms-faq-gap"
+  ],
+  "chain": [
+    "scanner_artifacts",
+    "seo-agent-opportunity-aggregate.v1",
+    "seo-agent-run-control-packet.v1",
+    "seo-agent-codex-review-handoff.v1",
+    "seo-agent-codex-review-verdict.v1",
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-run-evidence.v1"
+  ],
+  "manual_cli_only": true,
+  "production_scheduler_enabled": false,
+  "gsc_live_read_allowed": false,
+  "runtime_public_http_read_allowed": true,
+  "external_model_api_call": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false,
+    "pr_train_metadata_change": false
+  },
+  "next_step": "Multi-source Codex review rules are expanded in the next PR; controlled CMS draft writing remains blocked."
+}

--- a/backend/docs/seo/seo-agent-run-orchestrator.md
+++ b/backend/docs/seo/seo-agent-run-orchestrator.md
@@ -1,0 +1,31 @@
+# SEO Agent Run Orchestrator
+
+`SEO-AGENT-RUN-ORCHESTRATOR-01` adds the first manual L4 chain runner for FermatMind SEO Agent.
+
+## Command
+
+```bash
+php artisan seo-agent:run \
+  --sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap \
+  --limit=100 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+## Chain
+
+The command runs the safe local chain:
+
+1. readonly scanner artifacts
+2. opportunity aggregate artifact
+3. run control packet
+4. Codex review handoff
+5. deterministic Codex review verdict
+6. CMS draft package dry-run
+7. final run evidence
+
+## Boundaries
+
+The orchestrator is a manual CLI entrypoint. It does not enable production scheduler, start queue workers, write CMS, publish CMS, enqueue Search Channel, submit indexing requests, call GSC live APIs, or call external model APIs.
+
+Runtime SEO QA may perform read-only HTTP checks against configured public CMS paths when that source is selected. GSC data must enter through existing sidecar/readmodel/artifact boundaries.

--- a/backend/tests/Feature/SeoIntel/SeoAgentRunOrchestratorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentRunOrchestratorTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentRunOrchestratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_runs_full_readonly_chain_and_writes_final_evidence_without_db_writes(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+        $this->createArticle('orchestrator-article-gap');
+        $this->createFaqGapPage();
+
+        Http::fake([
+            'https://fermatmind.com/*' => Http::response('<html><head><link rel="canonical" href="https://fermatmind.com/wrong"></head><body></body></html>', 200),
+        ]);
+
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:run', [
+            '--sources' => 'cms-tdk-gap,runtime-seo-qa,cms-faq-gap',
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $files = File::files($artifactDir);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($summary, Artisan::output());
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $evidence = $this->readJson(data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-agent-run-evidence.v1', $summary['schema_version'] ?? null);
+        $this->assertSame('seo-agent-run-evidence.v1', $evidence['schema_version'] ?? null);
+        $this->assertGreaterThanOrEqual(1, $summary['candidate_count'] ?? 0);
+        $this->assertGreaterThanOrEqual(1, $summary['draft_brief_count'] ?? 0);
+        $this->assertCount(9, $files);
+
+        $this->assertSame([
+            'cms-tdk-gap',
+            'runtime-seo-qa',
+            'cms-faq-gap',
+        ], $evidence['sources'] ?? null);
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', data_get($evidence, 'artifacts.opportunity_aggregate.schema_version'));
+        $this->assertSame('seo-agent-run-control-packet.v1', data_get($evidence, 'artifacts.run_control_packet.schema_version'));
+        $this->assertSame('seo-agent-codex-review-handoff.v1', data_get($evidence, 'artifacts.codex_review_handoff.schema_version'));
+        $this->assertSame('seo-agent-codex-review-verdict.v1', data_get($evidence, 'artifacts.codex_review_verdict.schema_version'));
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', data_get($evidence, 'artifacts.cms_draft_package_dry_run.schema_version'));
+
+        $combined = implode("\n", array_map(
+            static fn ($file): string => (string) file_get_contents($file->getPathname()),
+            $files
+        ));
+
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'external_model_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_sources(): void
+    {
+        $exitCode = Artisan::call('seo-agent:run', [
+            '--sources' => 'cms-tdk-gap,gsc-live-read',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('invalid_sources', $summary['issues'] ?? []);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.google_search_console_api_call', true));
+    }
+
+    #[Test]
+    public function generated_contract_documents_run_orchestrator_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-run-evidence.v1.json'));
+
+        $this->assertSame('seo-agent-run-evidence.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:run', $artifact['command'] ?? null);
+        $this->assertFalse((bool) ($artifact['production_scheduler_enabled'] ?? true));
+        $this->assertFalse((bool) ($artifact['gsc_live_read_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['external_model_api_call'] ?? true));
+        $this->assertTrue((bool) ($artifact['runtime_public_http_read_allowed'] ?? false));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Orchestrator article',
+            'excerpt' => 'Orchestrator article.',
+            'content_md' => 'Article body must never be emitted.',
+            'content_html' => '<p>Article body must never be emitted.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        return $article;
+    }
+
+    private function createFaqGapPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'orchestrator-help-faq-gap',
+            'path' => '/zh/help/orchestrator-faq-gap',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Orchestrator help',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [],
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-run-orchestrator-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'https://fermatmind.com',
+            '<html',
+            '<p>',
+            'raw_url',
+            'raw_query',
+            'full_url',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'content_md',
+            'content_html',
+            'raw_html',
+            'cms_draft_body',
+            'Article body must never be emitted',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1161,6 +1161,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_run_orchestrator_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentRunCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentRunCommand;',
+            '+        SeoAgentRunCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3691,6 +3705,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentRunOrchestratorFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4282,6 +4300,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4958,6 +4977,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentOpportunityAggregateCommand.php',
             'backend/app/Services/SeoAgent/OpportunityAggregator.php',
+        ], true);
+    }
+
+    private function isSeoAgentRunOrchestratorFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentRunCommand.php',
         ], true);
     }
 
@@ -6669,6 +6695,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentOpportunityAggregateCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentRunOrchestratorOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentRunCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:run` as the recommended readonly L4 SEO Agent orchestration entrypoint.
- The command runs selected scanners, aggregates opportunities, emits a run control packet, creates a Codex review handoff, generates deterministic review verdicts, produces CMS draft dry-run packages, and writes final run evidence.
- Added generated contract docs and focused feature coverage.
- Updated the Big Five runtime freeze guard allowlist for this scoped SEO Agent CLI addition.

## Why
- This connects the existing readonly scanners, aggregator, Codex review boundary, and CMS draft dry-run package into one repeatable artifact chain without enabling execution actions.

## Validation
- `php -l app/Console/Commands/SeoAgentRunCommand.php`
- `php artisan test --filter SeoAgentRunOrchestratorTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_run_orchestrator_files`
- `python3 -m json.tool docs/seo/generated/seo-agent-run-evidence.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No CMS writes or publication.
- No search submission or indexing request.
- No scheduler or queue worker activation.
- No GSC live read from the orchestrator.
- No external model/API calls.

## Repository rule impact
- No content authority change. This PR adds a backend readonly/dry-run orchestration command and evidence contract only.