### PR TITLE
SEO-AGENT-MULTISOURCE-CODEX-REVIEW-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
@@ -135,6 +135,14 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             $candidateVerdicts,
             static fn (array $verdict): bool => ($verdict['worth_optimizing'] ?? false) === true
         ));
+        $draftReady = array_filter(
+            $candidateVerdicts,
+            static fn (array $verdict): bool => ($verdict['recommended_action'] ?? '') === 'cms_draft_package_dry_run'
+        );
+        $technicalReview = array_filter(
+            $candidateVerdicts,
+            static fn (array $verdict): bool => ($verdict['recommended_action'] ?? '') === 'technical_review_required'
+        );
 
         return [
             'schema_version' => self::SCHEMA_VERSION,
@@ -150,7 +158,9 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             'candidate_count' => count($candidateVerdicts),
             'candidate_verdicts' => $candidateVerdicts,
             'worth_optimizing' => $worthOptimizing !== [],
-            'recommended_action' => $worthOptimizing !== [] ? 'cms_draft_package_dry_run' : 'defer',
+            'recommended_action' => $draftReady !== []
+                ? 'cms_draft_package_dry_run'
+                : ($technicalReview !== [] ? 'technical_review_required' : 'defer'),
             'risk_flags' => $this->aggregateRiskFlags($candidateVerdicts),
             'needs_human_approval' => true,
             'forbidden_actions' => [
@@ -174,10 +184,16 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
     private function candidateVerdict(array $candidate): array
     {
         $severity = (string) ($candidate['severity'] ?? '');
+        $sourceFamily = (string) ($candidate['source_family'] ?? '');
         $sourceId = (string) ($candidate['source_id'] ?? '');
+        $subjectType = (string) ($candidate['subject_type'] ?? '');
         $subjectRef = (string) ($candidate['subject_ref'] ?? '');
         $safePath = (string) ($candidate['safe_path'] ?? '');
         $evidenceRefs = (array) ($candidate['evidence_refs'] ?? []);
+        $gapTypes = array_values(array_filter(
+            array_map('strval', (array) ($candidate['gap_types'] ?? [])),
+            static fn (string $gap): bool => $gap !== ''
+        ));
         $riskFlags = [];
 
         if ($sourceId === '' || $subjectRef === '' || $safePath === '') {
@@ -190,26 +206,88 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             $riskFlags[] = 'unsupported_severity';
         }
 
-        $worthOptimizing = $riskFlags === [] && in_array($severity, ['p1', 'p2'], true);
+        [$recommendedAction, $reviewReason, $sourceRiskFlags] = $this->reviewDecision(
+            $sourceFamily,
+            $subjectType,
+            $severity,
+            $gapTypes,
+            $riskFlags
+        );
+        $riskFlags = array_values(array_unique(array_merge($riskFlags, $sourceRiskFlags)));
+        $worthOptimizing = in_array($recommendedAction, ['cms_draft_package_dry_run', 'technical_review_required'], true);
 
         return [
             'source_id' => $sourceId !== '' ? $sourceId : hash('sha256', $subjectRef.$safePath.json_encode($candidate)),
-            'source_family' => (string) ($candidate['source_family'] ?? ''),
-            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'source_family' => $sourceFamily,
+            'subject_type' => $subjectType,
             'subject_ref' => $subjectRef,
             'safe_path' => $safePath,
             'severity' => $severity,
-            'gap_types' => array_values(array_filter(
-                array_map('strval', (array) ($candidate['gap_types'] ?? [])),
-                static fn (string $gap): bool => $gap !== ''
-            )),
+            'gap_types' => $gapTypes,
             'evidence_refs' => $this->sanitizedEvidenceRefs($evidenceRefs),
             'worth_optimizing' => $worthOptimizing,
-            'recommended_action' => $worthOptimizing ? 'cms_draft_package_dry_run' : 'defer',
+            'recommended_action' => $recommendedAction,
+            'review_reason' => $reviewReason,
             'risk_flags' => $riskFlags,
             'needs_human_approval' => true,
             'execution_permission' => false,
         ];
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @param  list<string>  $existingRiskFlags
+     * @return array{0: string, 1: string, 2: list<string>}
+     */
+    private function reviewDecision(
+        string $sourceFamily,
+        string $subjectType,
+        string $severity,
+        array $gapTypes,
+        array $existingRiskFlags
+    ): array {
+        if ($existingRiskFlags !== [] || ! in_array($severity, ['p1', 'p2'], true)) {
+            return ['defer', 'p3_or_incomplete_or_unsupported_candidate', []];
+        }
+
+        if ($this->isGscOnlyWithoutCmsTarget($sourceFamily, $subjectType)) {
+            return ['defer', 'gsc_candidate_without_cms_target', ['cms_target_missing']];
+        }
+
+        if ($sourceFamily === 'runtime_seo_qa' && $this->hasTechnicalRuntimeGap($gapTypes)) {
+            return ['technical_review_required', 'runtime_seo_qa_requires_technical_review', ['technical_surface_requires_human_review']];
+        }
+
+        if (in_array($sourceFamily, ['cms_tdk_gap', 'cms_faq_gap'], true)) {
+            return ['cms_draft_package_dry_run', $sourceFamily.'_ready_for_draft_dry_run', []];
+        }
+
+        return ['cms_draft_package_dry_run', 'complete_p1_p2_candidate_ready_for_draft_dry_run', []];
+    }
+
+    private function isGscOnlyWithoutCmsTarget(string $sourceFamily, string $subjectType): bool
+    {
+        return str_contains($sourceFamily, 'gsc')
+            && ! in_array($subjectType, ['article', 'content_page'], true);
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     */
+    private function hasTechnicalRuntimeGap(array $gapTypes): bool
+    {
+        foreach ($gapTypes as $gapType) {
+            if (str_contains($gapType, 'canonical')
+                || str_contains($gapType, 'noindex')
+                || str_contains($gapType, 'robots')
+                || str_contains($gapType, 'redirect')
+                || str_contains($gapType, 'status')
+            ) {
+                return true;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/backend/app/Console/Commands/SeoAgentRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentRunCommand.php
@@ -265,6 +265,14 @@ final class SeoAgentRunCommand extends Command
             $candidateVerdicts,
             static fn (array $candidate): bool => ($candidate['worth_optimizing'] ?? false) === true
         ));
+        $draftReady = array_filter(
+            $candidateVerdicts,
+            static fn (array $candidate): bool => ($candidate['recommended_action'] ?? '') === 'cms_draft_package_dry_run'
+        );
+        $technicalReview = array_filter(
+            $candidateVerdicts,
+            static fn (array $candidate): bool => ($candidate['recommended_action'] ?? '') === 'technical_review_required'
+        );
 
         return [
             'schema_version' => 'seo-agent-codex-review-verdict.v1',
@@ -280,11 +288,10 @@ final class SeoAgentRunCommand extends Command
             'candidate_count' => count($candidateVerdicts),
             'candidate_verdicts' => $candidateVerdicts,
             'worth_optimizing' => $worthOptimizing !== [],
-            'recommended_action' => $worthOptimizing !== [] ? 'cms_draft_package_dry_run' : 'defer',
-            'risk_flags' => array_values(array_unique(array_merge(...array_map(
-                static fn (array $candidate): array => (array) ($candidate['risk_flags'] ?? []),
-                $candidateVerdicts
-            )))),
+            'recommended_action' => $draftReady !== []
+                ? 'cms_draft_package_dry_run'
+                : ($technicalReview !== [] ? 'technical_review_required' : 'defer'),
+            'risk_flags' => $this->aggregateRiskFlags($candidateVerdicts),
             'needs_human_approval' => true,
             'forbidden_actions' => $this->forbiddenActions(),
             'negative_guarantees' => $this->negativeGuarantees(),
@@ -298,10 +305,16 @@ final class SeoAgentRunCommand extends Command
     private function candidateVerdict(array $candidate): array
     {
         $severity = (string) ($candidate['severity'] ?? '');
+        $sourceFamily = (string) ($candidate['source_family'] ?? '');
         $sourceId = (string) ($candidate['source_id'] ?? '');
+        $subjectType = (string) ($candidate['subject_type'] ?? '');
         $subjectRef = (string) ($candidate['subject_ref'] ?? '');
         $safePath = (string) ($candidate['safe_path'] ?? '');
         $evidenceRefs = (array) ($candidate['evidence_refs'] ?? []);
+        $gapTypes = array_values(array_filter(
+            array_map('strval', (array) ($candidate['gap_types'] ?? [])),
+            static fn (string $gap): bool => $gap !== ''
+        ));
         $riskFlags = [];
 
         if ($sourceId === '' || $subjectRef === '' || $safePath === '') {
@@ -314,23 +327,104 @@ final class SeoAgentRunCommand extends Command
             $riskFlags[] = 'unsupported_severity';
         }
 
-        $worthOptimizing = $riskFlags === [] && in_array($severity, ['p1', 'p2'], true);
+        [$recommendedAction, $reviewReason, $sourceRiskFlags] = $this->reviewDecision(
+            $sourceFamily,
+            $subjectType,
+            $severity,
+            $gapTypes,
+            $riskFlags
+        );
+        $riskFlags = array_values(array_unique(array_merge($riskFlags, $sourceRiskFlags)));
+        $worthOptimizing = in_array($recommendedAction, ['cms_draft_package_dry_run', 'technical_review_required'], true);
 
         return [
             'source_id' => $sourceId !== '' ? $sourceId : hash('sha256', $subjectRef.$safePath.json_encode($candidate)),
-            'source_family' => (string) ($candidate['source_family'] ?? ''),
-            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'source_family' => $sourceFamily,
+            'subject_type' => $subjectType,
             'subject_ref' => $subjectRef,
             'safe_path' => $safePath,
             'severity' => $severity,
-            'gap_types' => array_values(array_filter(array_map('strval', (array) ($candidate['gap_types'] ?? [])))),
+            'gap_types' => $gapTypes,
             'evidence_refs' => $evidenceRefs,
             'worth_optimizing' => $worthOptimizing,
-            'recommended_action' => $worthOptimizing ? 'cms_draft_package_dry_run' : 'defer',
+            'recommended_action' => $recommendedAction,
+            'review_reason' => $reviewReason,
             'risk_flags' => $riskFlags,
             'needs_human_approval' => true,
             'execution_permission' => false,
         ];
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     * @param  list<string>  $existingRiskFlags
+     * @return array{0: string, 1: string, 2: list<string>}
+     */
+    private function reviewDecision(
+        string $sourceFamily,
+        string $subjectType,
+        string $severity,
+        array $gapTypes,
+        array $existingRiskFlags
+    ): array {
+        if ($existingRiskFlags !== [] || ! in_array($severity, ['p1', 'p2'], true)) {
+            return ['defer', 'p3_or_incomplete_or_unsupported_candidate', []];
+        }
+
+        if ($this->isGscOnlyWithoutCmsTarget($sourceFamily, $subjectType)) {
+            return ['defer', 'gsc_candidate_without_cms_target', ['cms_target_missing']];
+        }
+
+        if ($sourceFamily === 'runtime_seo_qa' && $this->hasTechnicalRuntimeGap($gapTypes)) {
+            return ['technical_review_required', 'runtime_seo_qa_requires_technical_review', ['technical_surface_requires_human_review']];
+        }
+
+        if (in_array($sourceFamily, ['cms_tdk_gap', 'cms_faq_gap'], true)) {
+            return ['cms_draft_package_dry_run', $sourceFamily.'_ready_for_draft_dry_run', []];
+        }
+
+        return ['cms_draft_package_dry_run', 'complete_p1_p2_candidate_ready_for_draft_dry_run', []];
+    }
+
+    private function isGscOnlyWithoutCmsTarget(string $sourceFamily, string $subjectType): bool
+    {
+        return str_contains($sourceFamily, 'gsc')
+            && ! in_array($subjectType, ['article', 'content_page'], true);
+    }
+
+    /**
+     * @param  list<string>  $gapTypes
+     */
+    private function hasTechnicalRuntimeGap(array $gapTypes): bool
+    {
+        foreach ($gapTypes as $gapType) {
+            if (str_contains($gapType, 'canonical')
+                || str_contains($gapType, 'noindex')
+                || str_contains($gapType, 'robots')
+                || str_contains($gapType, 'redirect')
+                || str_contains($gapType, 'status')
+            ) {
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidateVerdicts
+     * @return list<string>
+     */
+    private function aggregateRiskFlags(array $candidateVerdicts): array
+    {
+        $flags = [];
+        foreach ($candidateVerdicts as $candidate) {
+            foreach ((array) ($candidate['risk_flags'] ?? []) as $flag) {
+                $flags[] = (string) $flag;
+            }
+        }
+
+        return array_values(array_unique($flags));
     }
 
     /**

--- a/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
@@ -10,6 +10,10 @@
   "external_model_api_call": false,
   "rules": {
     "p1_or_p2_complete_candidate": "cms_draft_package_dry_run",
+    "cms_tdk_gap": "cms_draft_package_dry_run",
+    "cms_faq_gap": "cms_draft_package_dry_run",
+    "runtime_seo_qa_canonical_noindex_robots": "technical_review_required",
+    "gsc_without_cms_target": "defer",
     "p3_or_incomplete_candidate": "defer",
     "needs_human_approval": true,
     "execution_permission": false

--- a/backend/docs/seo/seo-agent-codex-review-runner.md
+++ b/backend/docs/seo/seo-agent-codex-review-runner.md
@@ -17,8 +17,17 @@ The command writes `seo-agent-codex-review-verdict.v1` with:
 - `candidate_verdicts[]`
 - `worth_optimizing`
 - `recommended_action`
+- `source_family`
+- `review_reason`
 - `risk_flags`
 - `needs_human_approval`
 - `execution_permission=false`
 
-Candidates with complete evidence and severity `p1` or `p2` may be recommended for `cms_draft_package_dry_run`. Candidates with severity `p3`, incomplete evidence, or unsupported shape are deferred.
+Candidates with complete evidence and severity `p1` or `p2` are mapped by source family:
+
+- `cms_tdk_gap`: `cms_draft_package_dry_run`
+- `cms_faq_gap`: `cms_draft_package_dry_run`
+- `runtime_seo_qa` canonical/noindex/robots/redirect/status issues: `technical_review_required`
+- GSC-only candidates without an article/content page target: `defer`
+
+Candidates with severity `p3`, incomplete evidence, or unsupported shape are deferred. Every verdict remains review-only and requires human approval before any later draft or write step.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
@@ -25,6 +25,31 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
         $handoffPath = $this->writeHandoff([
             $this->candidate('p1', 'title gap'),
             $this->candidate('p2', 'description gap'),
+            $this->candidate('p1', 'canonical runtime', [
+                'source_family' => 'runtime_seo_qa',
+                'gap_types' => ['canonical_mismatch'],
+                'evidence_refs' => [
+                    [
+                        'code' => 'canonical_mismatch',
+                        'field_status' => 'mismatch',
+                    ],
+                ],
+            ]),
+            $this->candidate('p2', 'faq gap', [
+                'source_family' => 'cms_faq_gap',
+                'gap_types' => ['missing_faq_items'],
+                'evidence_refs' => [
+                    [
+                        'code' => 'missing_faq_items',
+                        'field_status' => 'missing',
+                    ],
+                ],
+            ]),
+            $this->candidate('p1', 'gsc no cms target', [
+                'source_family' => 'gsc_performance',
+                'subject_type' => 'query_page',
+                'gap_types' => ['low_ctr'],
+            ]),
             $this->candidate('p3', 'low priority'),
             [
                 'source_family' => 'cms_tdk_gap',
@@ -52,14 +77,27 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
         $this->assertSame('deterministic_rules', $verdict['review_mode'] ?? null);
         $this->assertFalse((bool) ($verdict['execution_permission'] ?? true));
         $this->assertFalse((bool) data_get($verdict, 'negative_guarantees.external_model_api_call', true));
-        $this->assertSame(4, $verdict['candidate_count'] ?? null);
+        $this->assertSame(7, $verdict['candidate_count'] ?? null);
         $this->assertTrue((bool) ($verdict['worth_optimizing'] ?? false));
         $this->assertSame('cms_draft_package_dry_run', $verdict['recommended_action'] ?? null);
 
         $candidateActions = array_column($verdict['candidate_verdicts'] ?? [], 'recommended_action');
-        $this->assertSame(['cms_draft_package_dry_run', 'cms_draft_package_dry_run', 'defer', 'defer'], $candidateActions);
+        $this->assertSame([
+            'cms_draft_package_dry_run',
+            'cms_draft_package_dry_run',
+            'technical_review_required',
+            'cms_draft_package_dry_run',
+            'defer',
+            'defer',
+            'defer',
+        ], $candidateActions);
         $this->assertSame(['missing_title'], data_get($verdict, 'candidate_verdicts.0.gap_types'));
         $this->assertSame('missing_title', data_get($verdict, 'candidate_verdicts.0.evidence_refs.0.code'));
+        $this->assertSame('runtime_seo_qa_requires_technical_review', data_get($verdict, 'candidate_verdicts.2.review_reason'));
+        $this->assertSame('cms_faq_gap_ready_for_draft_dry_run', data_get($verdict, 'candidate_verdicts.3.review_reason'));
+        $this->assertSame('gsc_candidate_without_cms_target', data_get($verdict, 'candidate_verdicts.4.review_reason'));
+        $this->assertContains('technical_surface_requires_human_review', $verdict['risk_flags'] ?? []);
+        $this->assertContains('cms_target_missing', $verdict['risk_flags'] ?? []);
         $this->assertContains('candidate_incomplete', $verdict['risk_flags'] ?? []);
         $this->assertContains('evidence_missing', $verdict['risk_flags'] ?? []);
 
@@ -113,6 +151,8 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
         $this->assertSame('seo-agent-codex-review-verdict.v1', $artifact['output_schema'] ?? null);
         $this->assertSame('codex', $artifact['reviewer'] ?? null);
         $this->assertFalse((bool) ($artifact['external_model_api_call'] ?? true));
+        $this->assertSame('technical_review_required', data_get($artifact, 'rules.runtime_seo_qa_canonical_noindex_robots'));
+        $this->assertSame('defer', data_get($artifact, 'rules.gsc_without_cms_target'));
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
     }
 


### PR DESCRIPTION
## What changed
- Upgraded `seo-agent:codex-review-runner` to map multi-source opportunity candidates by source family.
- Added review reasons and source-aware risk flags for TDK, FAQ, runtime SEO QA, and GSC-only candidates.
- Kept `seo-agent:run` aligned with the same deterministic review rules.
- Updated the generated review runner contract, docs, and focused tests.

## Why
- The L4 SEO Agent now has a single review boundary that can handle aggregator output from multiple readonly scanner sources without calling external models or executing actions.

## Validation
- `php -l app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php`
- `php -l app/Console/Commands/SeoAgentRunCommand.php`
- `php artisan test --filter SeoAgentCodexReviewRunnerTest`
- `php artisan test --filter SeoAgentRunOrchestratorTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_(codex_review_runner|run_orchestrator)_files`
- `python3 -m json.tool docs/seo/generated/seo-agent-codex-review-runner.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No CMS writes or publication.
- No search submission or indexing request.
- No scheduler or queue worker activation.
- No external model/API calls.
- No CMS draft proposal expansion; that is PR4.

## Repository rule impact
- No content authority change. This PR only updates backend review-only SEO Agent command behavior and contracts.