### PR TITLE
SEO-AGENT-CMS-DRAFT-PACKAGE-PROPOSAL-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
@@ -143,6 +143,8 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
             ],
             'draft_brief_count' => count($draftBriefs),
             'draft_briefs' => $draftBriefs,
+            'proposal_count' => count($draftBriefs),
+            'proposal_items' => $draftBriefs,
             'claim_gate_required' => true,
             'human_approval_required' => true,
             'forbidden_actions' => [
@@ -165,16 +167,37 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
     private function draftBrief(array $candidate): array
     {
         $gapCodes = $this->gapCodes($candidate);
+        $targetFields = $this->targetFields($gapCodes);
+        $safePath = (string) ($candidate['safe_path'] ?? '');
+        $subjectType = (string) ($candidate['subject_type'] ?? '');
+        $targetModel = $subjectType === 'content_page' ? 'content_page' : 'article';
+        $label = $this->labelFromSafePath($safePath);
 
         return [
             'source_id' => (string) ($candidate['source_id'] ?? ''),
             'source_family' => (string) ($candidate['source_family'] ?? ''),
-            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_type' => $subjectType,
             'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
-            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'safe_path' => $safePath,
             'severity' => (string) ($candidate['severity'] ?? ''),
             'gap_codes' => $gapCodes,
-            'target_fields' => $this->targetFields($gapCodes),
+            'target_model' => $targetModel,
+            'target_fields' => $targetFields,
+            'proposed_seo_title' => in_array('seo_title', $targetFields, true)
+                ? $this->proposedSeoTitle($label)
+                : null,
+            'proposed_seo_description' => in_array('seo_description', $targetFields, true)
+                ? $this->proposedSeoDescription($label)
+                : null,
+            'proposed_faq_items' => in_array('faq_items', $targetFields, true)
+                ? $this->proposedFaqItems($label)
+                : [],
+            'proposed_canonical_path' => in_array('canonical_url_or_path', $targetFields, true)
+                ? $safePath
+                : null,
+            'proposed_indexability' => in_array('is_indexable_or_robots', $targetFields, true)
+                ? 'indexable_after_manual_review'
+                : null,
             'draft_instructions' => [
                 'prepare_field_level_proposal_only',
                 'do_not_generate_final_body_copy',
@@ -232,6 +255,41 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
         return array_values(array_unique($fields));
     }
 
+    private function labelFromSafePath(string $safePath): string
+    {
+        $lastSegment = basename(trim($safePath, '/'));
+        $label = trim(str_replace(['-', '_'], ' ', $lastSegment));
+
+        return $label !== '' ? ucwords($label) : 'FermatMind page';
+    }
+
+    private function proposedSeoTitle(string $label): string
+    {
+        return mb_substr($label.' | FermatMind', 0, 70);
+    }
+
+    private function proposedSeoDescription(string $label): string
+    {
+        return mb_substr('Review '.$label.' with FermatMind guidance, evidence, and next steps after claim-gate approval.', 0, 155);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function proposedFaqItems(string $label): array
+    {
+        return [
+            [
+                'question' => 'What should readers know about '.$label.'?',
+                'answer' => 'Draft answer pending claim gate and human approval.',
+            ],
+            [
+                'question' => 'What is the next step for '.$label.'?',
+                'answer' => 'Draft answer pending claim gate and human approval.',
+            ],
+        ];
+    }
+
     /**
      * @return list<string>
      */
@@ -267,6 +325,7 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
             'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
             'sanitized_summary' => [
                 'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'proposal_count' => (int) ($payload['proposal_count'] ?? 0),
                 'cms_write_allowed' => false,
             ],
         ];

--- a/backend/app/Console/Commands/SeoAgentRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentRunCommand.php
@@ -457,6 +457,8 @@ final class SeoAgentRunCommand extends Command
             ],
             'draft_brief_count' => count($draftBriefs),
             'draft_briefs' => $draftBriefs,
+            'proposal_count' => count($draftBriefs),
+            'proposal_items' => $draftBriefs,
             'claim_gate_required' => true,
             'human_approval_required' => true,
             'forbidden_actions' => $this->forbiddenActions(),
@@ -471,16 +473,37 @@ final class SeoAgentRunCommand extends Command
     private function draftBrief(array $candidate): array
     {
         $gapCodes = array_values(array_unique(array_filter(array_map('strval', (array) ($candidate['gap_types'] ?? [])))));
+        $targetFields = $this->targetFields($gapCodes);
+        $safePath = (string) ($candidate['safe_path'] ?? '');
+        $subjectType = (string) ($candidate['subject_type'] ?? '');
+        $targetModel = $subjectType === 'content_page' ? 'content_page' : 'article';
+        $label = $this->labelFromSafePath($safePath);
 
         return [
             'source_id' => (string) ($candidate['source_id'] ?? ''),
             'source_family' => (string) ($candidate['source_family'] ?? ''),
-            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_type' => $subjectType,
             'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
-            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'safe_path' => $safePath,
             'severity' => (string) ($candidate['severity'] ?? ''),
             'gap_codes' => $gapCodes,
-            'target_fields' => $this->targetFields($gapCodes),
+            'target_model' => $targetModel,
+            'target_fields' => $targetFields,
+            'proposed_seo_title' => in_array('seo_title', $targetFields, true)
+                ? $this->proposedSeoTitle($label)
+                : null,
+            'proposed_seo_description' => in_array('seo_description', $targetFields, true)
+                ? $this->proposedSeoDescription($label)
+                : null,
+            'proposed_faq_items' => in_array('faq_items', $targetFields, true)
+                ? $this->proposedFaqItems($label)
+                : [],
+            'proposed_canonical_path' => in_array('canonical_url_or_path', $targetFields, true)
+                ? $safePath
+                : null,
+            'proposed_indexability' => in_array('is_indexable_or_robots', $targetFields, true)
+                ? 'indexable_after_manual_review'
+                : null,
             'draft_instructions' => [
                 'prepare_field_level_proposal_only',
                 'do_not_generate_final_body_copy',
@@ -520,6 +543,41 @@ final class SeoAgentRunCommand extends Command
         }
 
         return array_values(array_unique($fields));
+    }
+
+    private function labelFromSafePath(string $safePath): string
+    {
+        $lastSegment = basename(trim($safePath, '/'));
+        $label = trim(str_replace(['-', '_'], ' ', $lastSegment));
+
+        return $label !== '' ? ucwords($label) : 'FermatMind page';
+    }
+
+    private function proposedSeoTitle(string $label): string
+    {
+        return mb_substr($label.' | FermatMind', 0, 70);
+    }
+
+    private function proposedSeoDescription(string $label): string
+    {
+        return mb_substr('Review '.$label.' with FermatMind guidance, evidence, and next steps after claim-gate approval.', 0, 155);
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    private function proposedFaqItems(string $label): array
+    {
+        return [
+            [
+                'question' => 'What should readers know about '.$label.'?',
+                'answer' => 'Draft answer pending claim gate and human approval.',
+            ],
+            [
+                'question' => 'What is the next step for '.$label.'?',
+                'answer' => 'Draft answer pending claim gate and human approval.',
+            ],
+        ];
     }
 
     /**

--- a/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
@@ -1,6 +1,6 @@
 {
   "version": "seo-agent-cms-draft-package-dry-run.v1",
-  "task": "SEO-AGENT-CMS-DRAFT-PACKAGE-DRYRUN-01",
+  "task": "SEO-AGENT-CMS-DRAFT-PACKAGE-PROPOSAL-01",
   "repo": "fap-api",
   "command": "php artisan seo-agent:cms-draft-package-dry-run",
   "input_schema": "seo-agent-codex-review-verdict.v1",
@@ -8,6 +8,7 @@
   "dry_run": true,
   "cms_write_allowed": false,
   "generates_final_copy": false,
+  "proposal_artifact": true,
   "draft_brief_fields": [
     "source_id",
     "source_family",
@@ -15,10 +16,23 @@
     "subject_ref",
     "safe_path",
     "gap_codes",
+    "target_model",
     "target_fields",
+    "proposed_seo_title",
+    "proposed_seo_description",
+    "proposed_faq_items",
+    "proposed_canonical_path",
+    "proposed_indexability",
     "draft_instructions",
     "claim_gate_required",
     "human_approval_required"
+  ],
+  "proposal_fields": [
+    "proposed_seo_title",
+    "proposed_seo_description",
+    "proposed_faq_items",
+    "proposed_canonical_path",
+    "proposed_indexability"
   ],
   "negative_guarantees": {
     "database_write": false,

--- a/backend/docs/seo/seo-agent-cms-draft-package-dryrun.md
+++ b/backend/docs/seo/seo-agent-cms-draft-package-dryrun.md
@@ -1,8 +1,8 @@
 # SEO Agent CMS Draft Package Dry-run
 
-Task: `SEO-AGENT-CMS-DRAFT-PACKAGE-DRYRUN-01`
+Task: `SEO-AGENT-CMS-DRAFT-PACKAGE-PROPOSAL-01`
 
-This command converts a `seo-agent-codex-review-verdict.v1` artifact into a CMS draft package dry-run artifact. It generates field-level draft briefs only. It does not write CMS records, create revisions, generate final copy, enqueue search actions, request indexing, or activate schedulers.
+This command converts a `seo-agent-codex-review-verdict.v1` artifact into a CMS draft package dry-run artifact. It generates field-level proposal items only. It does not write CMS records, create revisions, generate final body copy, enqueue search actions, request indexing, or activate schedulers.
 
 ## Command
 
@@ -12,4 +12,14 @@ php artisan seo-agent:cms-draft-package-dry-run --verdict=<path> --artifact-dir=
 
 ## Output
 
-The command writes `seo-agent-cms-draft-package-dry-run.v1` with `draft_briefs[]`. Each brief contains the target subject, safe path, gap codes, target fields, draft instructions, claim-gate requirement, and human-approval requirement.
+The command writes `seo-agent-cms-draft-package-dry-run.v1` with `draft_briefs[]` and compatible `proposal_items[]`. Each proposal contains the target subject, safe path, gap codes, target model, target fields, deterministic proposed SEO fields, draft instructions, claim-gate requirement, and human-approval requirement.
+
+Proposal fields may include:
+
+- `proposed_seo_title`
+- `proposed_seo_description`
+- `proposed_faq_items`
+- `proposed_canonical_path`
+- `proposed_indexability`
+
+The proposal text is deterministic and template-based. It is not final editorial body copy, and any later CMS draft write remains separately gated by package SHA, exact confirmation phrase, and human approval.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
@@ -23,7 +23,13 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
         $this->createRows();
         $artifactDir = $this->artifactDir();
         $verdictPath = $this->writeVerdict([
-            $this->candidateVerdict('cms_draft_package_dry_run', true, ['missing_title', 'missing_meta_description']),
+            $this->candidateVerdict('cms_draft_package_dry_run', true, [
+                'missing_title',
+                'missing_meta_description',
+                'missing_canonical',
+                'missing_indexability_metadata',
+                'missing_faq_items',
+            ]),
             $this->candidateVerdict('defer', false, ['missing_canonical']),
         ]);
         $countsBefore = $this->rowCounts();
@@ -46,12 +52,35 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
         $this->assertFalse((bool) ($package['cms_write_allowed'] ?? true));
         $this->assertFalse((bool) ($package['execution_permission'] ?? true));
         $this->assertSame(1, $package['draft_brief_count'] ?? null);
+        $this->assertSame(1, $package['proposal_count'] ?? null);
 
         $brief = $package['draft_briefs'][0] ?? [];
         $this->assertSame('article:1:zh-CN', $brief['subject_ref'] ?? null);
         $this->assertSame('/zh/articles/draft-package-candidate', $brief['safe_path'] ?? null);
-        $this->assertSame(['missing_title', 'missing_meta_description'], $brief['gap_codes'] ?? null);
-        $this->assertSame(['seo_title', 'seo_description'], $brief['target_fields'] ?? null);
+        $this->assertSame([
+            'missing_title',
+            'missing_meta_description',
+            'missing_canonical',
+            'missing_indexability_metadata',
+            'missing_faq_items',
+        ], $brief['gap_codes'] ?? null);
+        $this->assertSame([
+            'seo_title',
+            'seo_description',
+            'canonical_url_or_path',
+            'is_indexable_or_robots',
+            'faq_items',
+        ], $brief['target_fields'] ?? null);
+        $this->assertSame('article', $brief['target_model'] ?? null);
+        $this->assertSame('Draft Package Candidate | FermatMind', $brief['proposed_seo_title'] ?? null);
+        $this->assertSame(
+            'Review Draft Package Candidate with FermatMind guidance, evidence, and next steps after claim-gate approval.',
+            $brief['proposed_seo_description'] ?? null
+        );
+        $this->assertSame('/zh/articles/draft-package-candidate', $brief['proposed_canonical_path'] ?? null);
+        $this->assertSame('indexable_after_manual_review', $brief['proposed_indexability'] ?? null);
+        $this->assertCount(2, $brief['proposed_faq_items'] ?? []);
+        $this->assertSame($brief, data_get($package, 'proposal_items.0'));
         $this->assertTrue((bool) ($brief['claim_gate_required'] ?? false));
         $this->assertTrue((bool) ($brief['human_approval_required'] ?? false));
 
@@ -117,6 +146,13 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
         $this->assertTrue((bool) ($artifact['dry_run'] ?? false));
         $this->assertFalse((bool) ($artifact['cms_write_allowed'] ?? true));
         $this->assertFalse((bool) ($artifact['generates_final_copy'] ?? true));
+        $this->assertSame([
+            'proposed_seo_title',
+            'proposed_seo_description',
+            'proposed_faq_items',
+            'proposed_canonical_path',
+            'proposed_indexability',
+        ], $artifact['proposal_fields'] ?? null);
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
     }
 


### PR DESCRIPTION
## What changed
- Upgraded the CMS draft package dry-run artifact to include deterministic proposal fields while preserving the existing v1 schema compatibility.
- Added proposal fields for SEO title, SEO description, FAQ items, canonical path, and indexability.
- Kept `seo-agent:run` aligned with the same proposal output.
- Updated generated contract docs and focused tests.

## Why
- This makes Codex-approved SEO Agent candidates reviewable as concrete dry-run CMS proposals before any future controlled writer exists.

## Validation
- `php -l app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php`
- `php -l app/Console/Commands/SeoAgentRunCommand.php`
- `php artisan test --filter SeoAgentCmsDraftPackageDryRunTest`
- `php artisan test --filter SeoAgentRunOrchestratorTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_(cms_draft_package_dry_run|run_orchestrator)_files`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No CMS writes or revisions.
- No CMS publication.
- No search submission or indexing request.
- No scheduler or queue worker activation.
- No external model/API calls.
- Controlled CMS draft writer remains PR5.

## Repository rule impact
- No content authority change. This PR only expands backend dry-run proposal artifacts; CMS remains authoritative and unwritten.