### PR TITLE
SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class SeoAgentCmsDraftWriteCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const TASK = 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:cms-draft-write
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--limit=1 : Maximum draft rows to create, 1..10}
+        {--confirm-package-sha256= : Required package sha256 for execute mode}
+        {--confirm-write= : Exact confirmation phrase for execute mode}
+        {--execute : Actually create bounded CMS draft revisions}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Controlled SEO Agent CMS draft writer; defaults to dry-run and never publishes or submits search/indexing.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->packagePath();
+        if ($packagePath === null) {
+            return $this->finish($this->failureSummary('package_unreadable'));
+        }
+
+        $limit = $this->limit();
+        if ($limit === null) {
+            return $this->finish($this->failureSummary('limit_out_of_bounds'));
+        }
+
+        $raw = (string) file_get_contents($packagePath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($raw, true);
+        if (! is_array($package)) {
+            return $this->finish($this->failureSummary('package_json_invalid'));
+        }
+
+        $validationIssue = $this->validatePackage($package);
+        if ($validationIssue !== null) {
+            return $this->finish($this->failureSummary($validationIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $requiredPhrase = $this->requiredConfirmationPhrase($limit, $packageSha);
+        $proposals = array_slice($this->proposalItems($package), 0, $limit);
+        $execute = (bool) $this->option('execute');
+
+        if (! $execute) {
+            return $this->finish([
+                'schema_version' => self::SCHEMA_VERSION,
+                'ok' => true,
+                'status' => 'planned',
+                'dry_run' => true,
+                'execute' => false,
+                'would_write' => $proposals !== [],
+                'planned_count' => count($proposals),
+                'max_rows_per_execution' => 10,
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $requiredPhrase,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'negative_guarantees' => $this->negativeGuarantees(),
+            ]);
+        }
+
+        $confirmationIssue = $this->validateConfirmation($packageSha, $requiredPhrase);
+        if ($confirmationIssue !== null) {
+            return $this->finish($this->failureSummary($confirmationIssue, [
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $requiredPhrase,
+            ]));
+        }
+
+        $created = [];
+        $skipped = [];
+        $failed = [];
+
+        foreach ($proposals as $proposal) {
+            try {
+                $result = DB::transaction(fn (): array => $this->writeProposal($proposal, $packageSha));
+                if (($result['status'] ?? '') === 'skipped_existing') {
+                    $skipped[] = $result;
+                } else {
+                    $created[] = $result;
+                }
+            } catch (RuntimeException $exception) {
+                $failed[] = [
+                    'subject_ref' => (string) ($proposal['subject_ref'] ?? ''),
+                    'issue' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $failed === [],
+            'status' => $failed === [] ? 'success' : 'partial_failure',
+            'dry_run' => false,
+            'execute' => true,
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => $created !== [],
+            'planned_count' => count($proposals),
+            'rows_created' => count($created),
+            'rows_skipped_existing' => count($skipped),
+            'rows_failed' => $failed,
+            'affected_refs' => array_values(array_merge($created, $skipped)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function packagePath(): ?string
+    {
+        $path = trim((string) $this->option('package'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function limit(): ?int
+    {
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+
+        return is_int($limit) && $limit >= 1 && $limit <= 10 ? $limit : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true) {
+            return 'package_not_dry_run';
+        }
+        if ((bool) ($package['cms_write_allowed'] ?? true) !== false) {
+            return 'package_cms_write_boundary_invalid';
+        }
+        if ((bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+        if ((bool) ($package['claim_gate_required'] ?? false) !== true
+            || (bool) ($package['human_approval_required'] ?? false) !== true) {
+            return 'package_approval_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return list<array<string, mixed>>
+     */
+    private function proposalItems(array $package): array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return [];
+        }
+
+        return array_values(array_filter($items, static fn ($item): bool => is_array($item)));
+    }
+
+    private function validateConfirmation(string $packageSha, string $requiredPhrase): ?string
+    {
+        if ((string) $this->option('confirm-package-sha256') !== $packageSha) {
+            return 'package_sha256_confirmation_mismatch';
+        }
+        if ((string) $this->option('confirm-write') !== $requiredPhrase) {
+            return 'confirm_write_phrase_mismatch';
+        }
+
+        return null;
+    }
+
+    private function requiredConfirmationPhrase(int $limit, string $packageSha): string
+    {
+        return 'I explicitly approve '.self::TASK.' to write at most '.$limit.' CMS draft rows from package sha256 '.$packageSha.'; no publish, no queue, no search, no indexing, no scheduler.';
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function writeProposal(array $proposal, string $packageSha): array
+    {
+        $targetModel = (string) ($proposal['target_model'] ?? $proposal['subject_type'] ?? '');
+
+        return match ($targetModel) {
+            'article' => $this->writeArticleRevision($proposal, $packageSha),
+            'content_page' => $this->writeContentPageRevision($proposal, $packageSha),
+            default => throw new RuntimeException('unsupported_target_model'),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function writeArticleRevision(array $proposal, string $packageSha): array
+    {
+        $articleId = $this->idFromSubjectRef((string) ($proposal['subject_ref'] ?? ''), 'article');
+        $article = Article::query()->withoutGlobalScopes()->find($articleId);
+        if (! $article instanceof Article) {
+            throw new RuntimeException('article_not_found');
+        }
+
+        $targetFields = $this->targetFields($proposal);
+        if ($this->articleRevisionExists((int) $article->id, $packageSha, $targetFields)) {
+            return $this->affectedRef('skipped_existing', 'article', (string) ($proposal['subject_ref'] ?? ''), null);
+        }
+
+        $revisionNo = ((int) ArticleRevision::query()->withoutGlobalScopes()
+            ->where('org_id', (int) $article->org_id)
+            ->where('article_id', (int) $article->id)
+            ->max('revision_no')) + 1;
+
+        $revision = ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => $revisionNo,
+            'editor_admin_user_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => $article->content_html,
+            'change_note' => 'SEO Agent controlled draft proposal',
+            'payload_json' => $this->revisionPayload($proposal, $packageSha, $targetFields),
+            'created_at' => Carbon::now('UTC'),
+        ]);
+
+        return $this->affectedRef('created', 'article', (string) ($proposal['subject_ref'] ?? ''), (int) $revision->id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function writeContentPageRevision(array $proposal, string $packageSha): array
+    {
+        $pageId = $this->idFromSubjectRef((string) ($proposal['subject_ref'] ?? ''), 'content_page');
+        $page = ContentPage::query()->withoutGlobalScopes()->find($pageId);
+        if (! $page instanceof ContentPage) {
+            throw new RuntimeException('content_page_not_found');
+        }
+
+        $targetFields = $this->targetFields($proposal);
+        if ($this->contentPageRevisionExists((int) $page->id, $packageSha, $targetFields)) {
+            return $this->affectedRef('skipped_existing', 'content_page', (string) ($proposal['subject_ref'] ?? ''), null);
+        }
+
+        $revisionNo = ((int) CmsTranslationRevision::query()
+            ->where('content_type', 'content_page')
+            ->where('content_id', (int) $page->id)
+            ->max('revision_number')) + 1;
+
+        $revision = CmsTranslationRevision::query()->create([
+            'org_id' => (int) $page->org_id,
+            'content_type' => 'content_page',
+            'content_id' => (int) $page->id,
+            'source_content_id' => $page->source_content_id ? (int) $page->source_content_id : null,
+            'translation_group_id' => (string) $page->translation_group_id,
+            'locale' => (string) $page->locale,
+            'source_locale' => (string) ($page->source_locale ?: $page->locale),
+            'revision_number' => $revisionNo,
+            'revision_status' => CmsTranslationRevision::STATUS_DRAFT,
+            'source_version_hash' => $page->source_version_hash,
+            'translated_from_version_hash' => $page->translated_from_version_hash,
+            'payload_json' => $this->revisionPayload($proposal, $packageSha, $targetFields),
+            'supersedes_revision_id' => $page->working_revision_id ? (int) $page->working_revision_id : null,
+            'created_by_admin_id' => null,
+            'reviewed_at' => null,
+            'approved_at' => null,
+            'archived_at' => null,
+            'published_at' => null,
+        ]);
+
+        return $this->affectedRef('created', 'content_page', (string) ($proposal['subject_ref'] ?? ''), (int) $revision->id);
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== $expectedType || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            throw new RuntimeException('subject_ref_invalid');
+        }
+
+        return (int) $parts[1];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return list<string>
+     */
+    private function targetFields(array $proposal): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', (array) ($proposal['target_fields'] ?? [])),
+            static fn (string $field): bool => $field !== ''
+        )));
+    }
+
+    /**
+     * @param  list<string>  $targetFields
+     * @return array<string, mixed>
+     */
+    private function revisionPayload(array $proposal, string $packageSha, array $targetFields): array
+    {
+        return [
+            'seo_agent' => [
+                'task' => self::TASK,
+                'package_sha256' => $packageSha,
+                'subject_ref' => (string) ($proposal['subject_ref'] ?? ''),
+                'target_fields' => $targetFields,
+                'claim_gate_required' => true,
+                'human_approval_required' => true,
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'indexing_request_allowed' => false,
+            ],
+            'proposal' => [
+                'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+                'proposed_seo_title' => $proposal['proposed_seo_title'] ?? null,
+                'proposed_seo_description' => $proposal['proposed_seo_description'] ?? null,
+                'proposed_faq_items' => $proposal['proposed_faq_items'] ?? [],
+                'proposed_canonical_path' => $proposal['proposed_canonical_path'] ?? null,
+                'proposed_indexability' => $proposal['proposed_indexability'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $targetFields
+     */
+    private function articleRevisionExists(int $articleId, string $packageSha, array $targetFields): bool
+    {
+        return ArticleRevision::query()->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->get(['payload_json'])
+            ->contains(fn (ArticleRevision $revision): bool => $this->payloadMatches($revision->payload_json, $packageSha, $targetFields));
+    }
+
+    /**
+     * @param  list<string>  $targetFields
+     */
+    private function contentPageRevisionExists(int $contentId, string $packageSha, array $targetFields): bool
+    {
+        return CmsTranslationRevision::query()
+            ->where('content_type', 'content_page')
+            ->where('content_id', $contentId)
+            ->get(['payload_json'])
+            ->contains(fn (CmsTranslationRevision $revision): bool => $this->payloadMatches($revision->payload_json, $packageSha, $targetFields));
+    }
+
+    /**
+     * @param  mixed  $payload
+     * @param  list<string>  $targetFields
+     */
+    private function payloadMatches($payload, string $packageSha, array $targetFields): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        $fields = array_values(array_map('strval', (array) data_get($payload, 'seo_agent.target_fields', [])));
+        sort($fields);
+        $expected = $targetFields;
+        sort($expected);
+
+        return data_get($payload, 'seo_agent.task') === self::TASK
+            && data_get($payload, 'seo_agent.package_sha256') === $packageSha
+            && $fields === $expected;
+    }
+
+    private function affectedRef(string $status, string $targetModel, string $subjectRef, ?int $revisionId): array
+    {
+        return [
+            'status' => $status,
+            'target_model' => $targetModel,
+            'subject_ref' => $subjectRef,
+            'revision_id' => $revisionId,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -170,6 +170,7 @@ use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
+use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
@@ -370,6 +371,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
+        SeoAgentCmsDraftWriteCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,

--- a/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
+++ b/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
@@ -1,0 +1,41 @@
+{
+  "version": "seo-agent-controlled-cms-draft-write.v1",
+  "task": "SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-draft-write",
+  "input_schema": "seo-agent-cms-draft-package-dry-run.v1",
+  "output_schema": "seo-agent-controlled-cms-draft-write.v1",
+  "default_mode": "dry_run_plan",
+  "execute_requires": [
+    "--execute",
+    "--confirm-package-sha256=<sha256>",
+    "--confirm-write=<exact phrase>",
+    "--limit=1..10"
+  ],
+  "supported_targets": [
+    "article",
+    "content_page"
+  ],
+  "write_targets": {
+    "article": "article_revisions.payload_json isolated SEO Agent revision",
+    "content_page": "cms_translation_revisions.payload_json draft revision"
+  },
+  "idempotency_policy": "subject_ref + package_sha256 + sorted target_fields",
+  "max_rows_per_execution": 10,
+  "publishes_content": false,
+  "mutates_published_revision": false,
+  "negative_guarantees": {
+    "cms_publish": false,
+    "published_revision_mutation": false,
+    "live_published_content_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "external_model_api_call": false
+  },
+  "next_step": "Run dry-run plan first, then execute only with package sha and exact human approval phrase."
+}

--- a/backend/docs/seo/seo-agent-controlled-cms-draft-writer.md
+++ b/backend/docs/seo/seo-agent-controlled-cms-draft-writer.md
@@ -1,0 +1,30 @@
+# SEO Agent Controlled CMS Draft Writer
+
+Task: `SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01`
+
+This command converts an approved `seo-agent-cms-draft-package-dry-run.v1` package into bounded CMS draft revisions. It defaults to a dry-run write plan. Execute mode requires the package SHA, an exact confirmation phrase, and `--limit=1..10`.
+
+## Command
+
+```bash
+php artisan seo-agent:cms-draft-write --package=<path> --limit=1 --json
+```
+
+Execute mode:
+
+```bash
+php artisan seo-agent:cms-draft-write \
+  --package=<path> \
+  --limit=1 \
+  --confirm-package-sha256=<sha256> \
+  --confirm-write="<exact phrase from dry-run output>" \
+  --execute \
+  --json
+```
+
+## Boundaries
+
+- Article proposals create isolated `article_revisions.payload_json` revisions.
+- ContentPage proposals create `cms_translation_revisions.payload_json` draft revisions.
+- The writer does not publish, mutate published revision pointers, enqueue search, submit indexing, start scheduler jobs, start queue workers, or call external model APIs.
+- Idempotency is `subject_ref + package_sha256 + sorted target_fields`.

--- a/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentControlledCmsDraftWriterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_outputs_required_confirmation_without_writing(): void
+    {
+        [$article, $page] = $this->createTargets();
+        $packagePath = $this->writePackage([
+            $this->proposal('article', (int) $article->id),
+            $this->proposal('content_page', (int) $page->id),
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 2,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['would_write'] ?? false));
+        $this->assertSame(2, $summary['planned_count'] ?? null);
+        $this->assertStringContainsString(hash_file('sha256', $packagePath), (string) ($summary['required_confirmation_phrase'] ?? ''));
+        $this->assertFalse((bool) ($summary['writes_attempted'] ?? true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function execute_fails_closed_without_exact_approval_or_with_bad_limit(): void
+    {
+        [$article] = $this->createTargets();
+        $packagePath = $this->writePackage([$this->proposal('article', (int) $article->id)]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 11,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('limit_out_of_bounds', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 1,
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--confirm-write' => 'wrong',
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('package_sha256_confirmation_mismatch', $summary['issues'] ?? []);
+        $this->assertSame(0, ArticleRevision::query()->count());
+    }
+
+    #[Test]
+    public function execute_writes_bounded_article_and_content_page_draft_revisions_then_skips_duplicates(): void
+    {
+        [$article, $page] = $this->createTargets();
+        $packagePath = $this->writePackage([
+            $this->proposal('article', (int) $article->id),
+            $this->proposal('content_page', (int) $page->id),
+        ]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $phrase = $this->approvalPhrase(2, $sha);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 2,
+            '--confirm-package-sha256' => $sha,
+            '--confirm-write' => $phrase,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['writes_attempted'] ?? false));
+        $this->assertTrue((bool) ($summary['writes_committed'] ?? false));
+        $this->assertSame(2, $summary['rows_created'] ?? null);
+        $this->assertSame(0, $summary['rows_skipped_existing'] ?? null);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_submit', true));
+
+        $articleRevision = ArticleRevision::query()->firstOrFail();
+        $this->assertSame('SEO Agent controlled draft proposal', $articleRevision->change_note);
+        $this->assertSame($sha, data_get($articleRevision->payload_json, 'seo_agent.package_sha256'));
+        $this->assertSame('Article Candidate | FermatMind', data_get($articleRevision->payload_json, 'proposal.proposed_seo_title'));
+
+        $pageRevision = CmsTranslationRevision::query()->firstOrFail();
+        $this->assertSame(CmsTranslationRevision::STATUS_DRAFT, $pageRevision->revision_status);
+        $this->assertNull($pageRevision->published_at);
+        $this->assertSame($sha, data_get($pageRevision->payload_json, 'seo_agent.package_sha256'));
+
+        $freshArticle = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+        $freshPage = ContentPage::query()->withoutGlobalScopes()->findOrFail((int) $page->id);
+        $this->assertSame($article->published_revision_id, $freshArticle->published_revision_id);
+        $this->assertSame($page->published_revision_id, $freshPage->published_revision_id);
+        $this->assertSame(ContentPage::STATUS_PUBLISHED, $freshPage->status);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 2,
+            '--confirm-package-sha256' => $sha,
+            '--confirm-write' => $phrase,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(0, $summary['rows_created'] ?? null);
+        $this->assertSame(2, $summary['rows_skipped_existing'] ?? null);
+        $this->assertSame(1, ArticleRevision::query()->count());
+        $this->assertSame(1, CmsTranslationRevision::query()->count());
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function generated_contract_documents_writer_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json'));
+
+        $this->assertSame('seo-agent-controlled-cms-draft-write.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-draft-write', $artifact['command'] ?? null);
+        $this->assertSame(10, $artifact['max_rows_per_execution'] ?? null);
+        $this->assertFalse((bool) ($artifact['publishes_content'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.indexing_request', true));
+    }
+
+    /**
+     * @return array{0: Article, 1: ContentPage}
+     */
+    private function createTargets(): array
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'article-candidate',
+            'locale' => 'zh-CN',
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_revision_id' => 99,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $page = ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'content-page-candidate',
+            'path' => '/zh/content-page-candidate',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Content Page Candidate',
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'draft',
+            'published_revision_id' => 88,
+        ]);
+
+        return [$article, $page];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function writePackage(array $proposals): string
+    {
+        $payload = [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_count' => count($proposals),
+            'proposal_items' => $proposals,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ];
+        $path = storage_path('framework/testing/seo-agent-cms-draft-package-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function proposal(string $targetModel, int $id): array
+    {
+        $safeLabel = $targetModel === 'article' ? 'article-candidate' : 'content-page-candidate';
+
+        return [
+            'source_id' => hash('sha256', $targetModel.(string) $id),
+            'target_model' => $targetModel,
+            'subject_type' => $targetModel,
+            'subject_ref' => $targetModel.':'.$id.':zh-CN',
+            'safe_path' => '/zh/'.$safeLabel,
+            'target_fields' => ['seo_title', 'seo_description'],
+            'proposed_seo_title' => ($targetModel === 'article' ? 'Article Candidate' : 'Content Page Candidate').' | FermatMind',
+            'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ];
+    }
+
+    private function approvalPhrase(int $limit, string $sha): string
+    {
+        return 'I explicitly approve SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01 to write at most '.$limit.' CMS draft rows from package sha256 '.$sha.'; no publish, no queue, no search, no indexing, no scheduler.';
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'article_revisions' => ArticleRevision::query()->count(),
+            'cms_translation_revisions' => CmsTranslationRevision::query()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1116,6 +1116,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_controlled_cms_draft_writer_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsDraftWriteCommand;',
+            '+        SeoAgentCmsDraftWriteCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -3693,6 +3707,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentControlledCmsDraftWriterFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentRuntimeSeoQaReadonlyScannerFile($file)) {
                 continue;
             }
@@ -4297,6 +4315,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentControlledCmsDraftWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -4953,6 +4972,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentControlledCmsDraftWriterFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php',
         ], true);
     }
 
@@ -6629,6 +6655,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsDraftPackageDryRunCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentControlledCmsDraftWriterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsDraftWriteCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:cms-draft-write`, a controlled CMS draft writer that defaults to dry-run planning.
- Execute mode requires package SHA, exact confirmation phrase, `--execute`, and `--limit=1..10`.
- Article proposals create isolated `article_revisions.payload_json` revisions.
- ContentPage proposals create `cms_translation_revisions.payload_json` draft revisions.
- Added idempotency by `subject_ref + package_sha256 + sorted target_fields`.
- Added generated contract docs and focused feature tests.
- Updated runtime freeze guard allowlist for this scoped SEO Agent CLI.

## Why
- This completes the first L4 semi-automated loop: readonly discovery, deterministic Codex review, dry-run proposal package, and human-approved bounded CMS draft write without publication or search/indexing side effects.

## Validation
- `php -l app/Console/Commands/SeoAgentCmsDraftWriteCommand.php`
- `php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `php artisan test --filter SeoAgentCmsDraftPackageDryRunTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_controlled_cms_draft_writer_files`
- `python3 -m json.tool docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json >/dev/null`
- `php artisan list --raw | rg ^seo-agent:cms-draft-write`
- `git diff --check`

## Intentionally deferred
- No CMS publication.
- No mutation of published revision pointers.
- No search submission or indexing request.
- No scheduler or queue worker activation.
- No external model/API calls.
- Production execution still requires an explicit package-specific approval phrase.

## Repository rule impact
- CMS remains backend-authoritative. This PR introduces a controlled backend-only draft/revision writer; it does not publish content or move authority to frontend/static files.