### PR TITLE
SEO-AGENT-WEEKLY-READONLY-RUNNER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentWeeklyReadonlyRunnerCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-weekly-readonly-runner.v1';
+
+    protected $signature = 'seo-agent:weekly-readonly-runner
+        {--sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap : Comma-separated readonly sources}
+        {--limit=100 : Candidate limit, bounded 1..250}
+        {--artifact-dir= : Directory for weekly evidence artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Run the SEO Agent weekly readonly chain and write a standard evidence artifact without scheduler or writes.';
+
+    public function handle(): int
+    {
+        $sources = $this->sources();
+        if ($sources === []) {
+            return $this->finish($this->failureSummary('invalid_sources'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $limit = $this->limit();
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $runDir = rtrim($artifactDir, '/').'/weekly-readonly-run-'.$timestamp;
+
+        $runCommand = $this->getApplication()?->find('seo-agent:run');
+        if ($runCommand === null) {
+            return $this->finish($this->failureSummary('delegated_command_missing'));
+        }
+
+        $runOutputBuffer = new BufferedOutput();
+        $exitCode = $runCommand->run(new ArrayInput([
+            'command' => 'seo-agent:run',
+            '--sources' => implode(',', $sources),
+            '--limit' => $limit,
+            '--artifact-dir' => $runDir,
+            '--json' => true,
+        ]), $runOutputBuffer);
+
+        $runOutput = trim($runOutputBuffer->fetch());
+        $runSummary = json_decode($runOutput, true);
+
+        if (! is_array($runSummary)) {
+            $evidence = $this->weeklyEvidence($sources, $limit, 'blocked', [
+                'issues' => ['run_summary_json_invalid'],
+                'run_exit_code' => $exitCode,
+            ]);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-readonly-runner-'.$timestamp.'.json', $evidence);
+
+            return $this->finish($this->failureSummary('run_summary_json_invalid', [
+                'artifact' => $artifact,
+            ]));
+        }
+
+        $status = $exitCode === self::SUCCESS && ($runSummary['ok'] ?? false) === true ? 'success' : 'blocked';
+        $evidence = $this->weeklyEvidence($sources, $limit, $status, [
+            'run_exit_code' => $exitCode,
+            'run_artifact' => (array) ($runSummary['artifact'] ?? []),
+            'candidate_count' => (int) ($runSummary['candidate_count'] ?? 0),
+            'worth_optimizing_count' => (int) ($runSummary['worth_optimizing_count'] ?? 0),
+            'draft_brief_count' => (int) ($runSummary['draft_brief_count'] ?? 0),
+            'issues' => array_values(array_map('strval', (array) ($runSummary['issues'] ?? []))),
+        ]);
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-readonly-runner-'.$timestamp.'.json', $evidence);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $status === 'success',
+            'status' => $status,
+            'sources' => $sources,
+            'candidate_count' => (int) ($runSummary['candidate_count'] ?? 0),
+            'worth_optimizing_count' => (int) ($runSummary['worth_optimizing_count'] ?? 0),
+            'draft_brief_count' => (int) ($runSummary['draft_brief_count'] ?? 0),
+            'artifact' => $artifact,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sources(): array
+    {
+        $allowed = ['cms-tdk-gap', 'runtime-seo-qa', 'cms-faq-gap'];
+        $sources = array_values(array_unique(array_filter(array_map(
+            static fn (string $source): string => trim($source),
+            explode(',', (string) $this->option('sources'))
+        ))));
+
+        foreach ($sources as $source) {
+            if (! in_array($source, $allowed, true)) {
+                return [];
+            }
+        }
+
+        return $sources;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/weekly');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function weeklyEvidence(array $sources, int $limit, string $status, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-WEEKLY-READONLY-RUNNER-01',
+            'status' => $status,
+            'run_mode' => 'weekly_readonly_discovery_to_dry_run',
+            'trigger' => 'manual_cli_or_external_weekly_automation',
+            'command' => 'php artisan seo-agent:weekly-readonly-runner',
+            'delegated_command' => 'php artisan seo-agent:run',
+            'sources' => $sources,
+            'limit' => $limit,
+            'schedule_contract' => [
+                'laravel_production_scheduler_enabled_by_pr' => false,
+                'queue_worker_started_by_pr' => false,
+                'recommended_frequency' => 'weekly',
+                'activation_requires_separate_approval' => true,
+            ],
+            'chain' => [
+                'scanner_artifacts',
+                'seo-agent-opportunity-aggregate.v1',
+                'seo-agent-run-control-packet.v1',
+                'seo-agent-codex-review-handoff.v1',
+                'seo-agent-codex-review-verdict.v1',
+                'seo-agent-cms-draft-package-dry-run.v1',
+                'seo-agent-run-evidence.v1',
+            ],
+            ...$extra,
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'production_env_update',
+            'source_code_mutation',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'pr_train_metadata_change' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -177,6 +177,7 @@ use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
 use App\Console\Commands\SeoAgentRunCommand;
+use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
 use App\Console\Commands\StorageInventory;
@@ -375,6 +376,7 @@ class Kernel extends ConsoleKernel
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,
+        SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/seo/generated/seo-agent-weekly-readonly-runner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-weekly-readonly-runner.v1.json
@@ -1,0 +1,46 @@
+{
+  "version": "seo-agent-weekly-readonly-runner.v1",
+  "task": "SEO-AGENT-WEEKLY-READONLY-RUNNER-01",
+  "repo": "fap-api",
+  "type": "weekly_readonly_l4_runner_contract",
+  "command": "php artisan seo-agent:weekly-readonly-runner",
+  "delegated_command": "php artisan seo-agent:run",
+  "default_sources": [
+    "cms-tdk-gap",
+    "runtime-seo-qa",
+    "cms-faq-gap"
+  ],
+  "chain": [
+    "scanner_artifacts",
+    "seo-agent-opportunity-aggregate.v1",
+    "seo-agent-run-control-packet.v1",
+    "seo-agent-codex-review-handoff.v1",
+    "seo-agent-codex-review-verdict.v1",
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-run-evidence.v1",
+    "seo-agent-weekly-readonly-runner.v1"
+  ],
+  "manual_or_external_automation_entrypoint": true,
+  "production_scheduler_enabled_by_pr": false,
+  "scheduler_activation_requires_separate_approval": true,
+  "runtime_public_http_read_allowed": true,
+  "gsc_live_read_allowed": false,
+  "external_model_api_call": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false,
+    "pr_train_metadata_change": false
+  },
+  "next_step": "Controlled CMS draft writes remain a separate PR and are not enabled by this runner."
+}

--- a/backend/docs/seo/seo-agent-weekly-readonly-runner.md
+++ b/backend/docs/seo/seo-agent-weekly-readonly-runner.md
@@ -1,0 +1,32 @@
+# SEO Agent Weekly Readonly Runner
+
+`SEO-AGENT-WEEKLY-READONLY-RUNNER-01` adds a weekly-safe entrypoint for the FermatMind SEO Agent L4 chain.
+
+## Command
+
+```bash
+php artisan seo-agent:weekly-readonly-runner \
+  --sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap \
+  --limit=100 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+## Chain
+
+The command delegates to `php artisan seo-agent:run` and writes a wrapper evidence artifact:
+
+1. readonly scanner artifacts
+2. opportunity aggregate artifact
+3. run control packet
+4. Codex review handoff
+5. deterministic Codex review verdict
+6. CMS draft package dry-run
+7. final run evidence
+8. weekly readonly runner evidence
+
+## Boundaries
+
+This is a manual or external automation entrypoint. The PR does not enable Laravel production scheduler, start queue workers, write CMS drafts, publish CMS, enqueue Search Channel, submit Google Indexing requests, call GSC live APIs, or call external model APIs.
+
+Activation through a real production scheduler remains a separate approval.

--- a/backend/tests/Feature/SeoIntel/SeoAgentWeeklyReadonlyRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentWeeklyReadonlyRunnerTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentWeeklyReadonlyRunnerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_runs_weekly_readonly_chain_and_writes_wrapper_evidence_without_writes(): void
+    {
+        config(['seo_intel.public_canonical_host' => 'https://fermatmind.com']);
+        $this->createArticle('weekly-runner-article-gap');
+        $this->createFaqGapPage();
+
+        Http::fake([
+            'https://fermatmind.com/*' => Http::response('<html><head><link rel="canonical" href="https://fermatmind.com/wrong"></head><body></body></html>', 200),
+        ]);
+
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:weekly-readonly-runner', [
+            '--sources' => 'cms-tdk-gap,runtime-seo-qa,cms-faq-gap',
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $countsAfter = $this->rowCounts();
+        $files = File::allFiles($artifactDir);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($summary, Artisan::output());
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('seo-agent-weekly-readonly-runner.v1', $summary['schema_version'] ?? null);
+        $this->assertGreaterThanOrEqual(1, $summary['candidate_count'] ?? 0);
+        $this->assertGreaterThanOrEqual(1, $summary['draft_brief_count'] ?? 0);
+        $this->assertCount(10, $files);
+
+        $evidence = $this->readJson(data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-agent-weekly-readonly-runner.v1', $evidence['schema_version'] ?? null);
+        $this->assertSame('SEO-AGENT-WEEKLY-READONLY-RUNNER-01', $evidence['task'] ?? null);
+        $this->assertSame('php artisan seo-agent:run', $evidence['delegated_command'] ?? null);
+        $this->assertSame('manual_cli_or_external_weekly_automation', $evidence['trigger'] ?? null);
+        $this->assertFalse((bool) data_get($evidence, 'schedule_contract.laravel_production_scheduler_enabled_by_pr', true));
+        $this->assertFalse((bool) data_get($evidence, 'schedule_contract.queue_worker_started_by_pr', true));
+        $this->assertTrue((bool) data_get($evidence, 'schedule_contract.activation_requires_separate_approval', false));
+        $this->assertSame('seo-agent-run-evidence.v1', data_get($evidence, 'run_artifact.schema_version'));
+
+        $combined = implode("\n", array_map(
+            static fn ($file): string => (string) file_get_contents($file->getPathname()),
+            $files
+        ));
+
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'google_indexing_api_call',
+            'external_model_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+            $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_sources(): void
+    {
+        $exitCode = Artisan::call('seo-agent:weekly-readonly-runner', [
+            '--sources' => 'cms-tdk-gap,gsc-live-read',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('invalid_sources', $summary['issues'] ?? []);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.scheduler_activation', true));
+    }
+
+    #[Test]
+    public function generated_contract_documents_weekly_readonly_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-weekly-readonly-runner.v1.json'));
+
+        $this->assertSame('seo-agent-weekly-readonly-runner.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:weekly-readonly-runner', $artifact['command'] ?? null);
+        $this->assertSame('php artisan seo-agent:run', $artifact['delegated_command'] ?? null);
+        $this->assertFalse((bool) ($artifact['production_scheduler_enabled_by_pr'] ?? true));
+        $this->assertTrue((bool) ($artifact['scheduler_activation_requires_separate_approval'] ?? false));
+        $this->assertFalse((bool) ($artifact['gsc_live_read_allowed'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_indexing_api_call', true));
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Weekly runner article',
+            'excerpt' => 'Weekly runner article.',
+            'content_md' => 'Article body must never be emitted.',
+            'content_html' => '<p>Article body must never be emitted.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        return $article;
+    }
+
+    private function createFaqGapPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'weekly-runner-help-faq-gap',
+            'path' => '/zh/help/weekly-runner-faq-gap',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Weekly runner help',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [],
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-weekly-readonly-runner-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'https://fermatmind.com',
+            '<html',
+            '<p>',
+            'raw_url',
+            'raw_query',
+            'full_url',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'content_md',
+            'content_html',
+            'raw_html',
+            'cms_draft_body',
+            'Article body must never be emitted',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1189,6 +1189,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_weekly_readonly_runner_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentWeeklyReadonlyRunnerCommand;',
+            '+        SeoAgentWeeklyReadonlyRunnerCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3727,6 +3741,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentWeeklyReadonlyRunnerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4320,6 +4338,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -5010,6 +5029,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentWeeklyReadonlyRunnerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php',
         ], true);
     }
 
@@ -6765,6 +6791,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentRunCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentWeeklyReadonlyRunnerCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:weekly-readonly-runner` as the weekly-safe L4 entrypoint.
- The command delegates to existing `seo-agent:run`, writes a wrapper evidence artifact, and preserves readonly boundaries.
- Added the weekly runner contract docs, generated JSON, and focused feature coverage.

## Why
This creates the long-term weekly review entrypoint for FermatMind SEO Agent without enabling scheduler, CMS writes, publishing, Search Channel, Google Indexing, GSC live API, or external model calls.

## Validation
- `php artisan test --filter SeoAgentWeeklyReadonlyRunnerTest`
- `php artisan test --filter SeoAgentRunOrchestratorTest`
- `python3 -m json.tool docs/seo/generated/seo-agent-weekly-readonly-runner.v1.json >/dev/null`
- `git diff --check`

## Runtime note
The requested real local L4 dry-run was attempted first, but this local environment has no usable CMS MySQL credentials and failed with `Access denied for user 'root'@'localhost'`. This PR does not claim that runtime validation succeeded locally; it adds the safe runner so the same chain can be executed in a configured CMS runtime.

## Intentionally deferred
- No Laravel production scheduler activation.
- No CMS draft write automation.
- No publish canary.
- No Search Channel or Google Indexing submission.
- No GSC opportunity auto-draft.
- No fap-web code PR writer.
