### PR TITLE
SEO-AGENT-CMS-DRAFT-WRITE-BATCH10-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
@@ -42,6 +42,7 @@ final class SeoAgentCmsDraftWriteCommand extends Command
         {--limit=1 : Maximum draft rows to create, 1..10}
         {--confirm-package-sha256= : Required package sha256 for execute mode}
         {--confirm-write= : Exact confirmation phrase for execute mode}
+        {--auto-approve-low-risk : Execute only low-risk CMS draft proposals without an exact human confirmation phrase}
         {--execute : Actually create bounded CMS draft revisions}
         {--json : Emit JSON summary}';
 
@@ -81,6 +82,7 @@ final class SeoAgentCmsDraftWriteCommand extends Command
         $requiredPhrase = $this->requiredConfirmationPhrase($limit, $packageSha);
         $proposals = array_slice($this->proposalItems($package), 0, $limit);
         $execute = (bool) $this->option('execute');
+        $autoApproveLowRisk = (bool) $this->option('auto-approve-low-risk');
 
         if (! $execute) {
             return $this->finish([
@@ -94,17 +96,22 @@ final class SeoAgentCmsDraftWriteCommand extends Command
                 'max_rows_per_execution' => 10,
                 'package_sha256' => $packageSha,
                 'required_confirmation_phrase' => $requiredPhrase,
+                'auto_approve_low_risk_available' => true,
+                'auto_approve_low_risk_eligible' => $this->lowRiskIssue($proposals) === null,
                 'writes_attempted' => false,
                 'writes_committed' => false,
                 'negative_guarantees' => $this->negativeGuarantees(),
             ]);
         }
 
-        $confirmationIssue = $this->validateConfirmation($packageSha, $requiredPhrase);
-        if ($confirmationIssue !== null) {
-            return $this->finish($this->failureSummary($confirmationIssue, [
+        $approvalIssue = $autoApproveLowRisk
+            ? $this->lowRiskIssue($proposals)
+            : $this->validateConfirmation($packageSha, $requiredPhrase);
+        if ($approvalIssue !== null) {
+            return $this->finish($this->failureSummary($approvalIssue, [
                 'package_sha256' => $packageSha,
                 'required_confirmation_phrase' => $requiredPhrase,
+                'auto_approve_low_risk' => $autoApproveLowRisk,
             ]));
         }
 
@@ -134,6 +141,8 @@ final class SeoAgentCmsDraftWriteCommand extends Command
             'status' => $failed === [] ? 'success' : 'partial_failure',
             'dry_run' => false,
             'execute' => true,
+            'approval_mode' => $autoApproveLowRisk ? 'low_risk_auto_approved' : 'exact_human_confirmation',
+            'auto_approve_low_risk' => $autoApproveLowRisk,
             'package_sha256' => $packageSha,
             'writes_attempted' => true,
             'writes_committed' => $created !== [],
@@ -211,6 +220,59 @@ final class SeoAgentCmsDraftWriteCommand extends Command
         }
         if ((string) $this->option('confirm-write') !== $requiredPhrase) {
             return 'confirm_write_phrase_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function lowRiskIssue(array $proposals): ?string
+    {
+        if ($proposals === []) {
+            return 'low_risk_auto_approval_empty_package';
+        }
+
+        foreach ($proposals as $proposal) {
+            $sourceFamily = (string) ($proposal['source_family'] ?? '');
+            if (! in_array($sourceFamily, ['cms_tdk_gap', 'cms_faq_gap'], true)) {
+                return 'low_risk_auto_approval_source_family_not_allowed';
+            }
+
+            $targetModel = (string) ($proposal['target_model'] ?? $proposal['subject_type'] ?? '');
+            if (! in_array($targetModel, ['article', 'content_page'], true)) {
+                return 'low_risk_auto_approval_target_model_not_allowed';
+            }
+
+            $severity = (string) ($proposal['severity'] ?? '');
+            if (! in_array($severity, ['p1', 'p2'], true)) {
+                return 'low_risk_auto_approval_severity_not_allowed';
+            }
+
+            $fields = $this->targetFields($proposal);
+            if ($fields === []) {
+                return 'low_risk_auto_approval_target_fields_missing';
+            }
+
+            foreach ($fields as $field) {
+                if (! in_array($field, [
+                    'seo_title',
+                    'seo_description',
+                    'canonical_url_or_path',
+                    'is_indexable_or_robots',
+                    'faq_items',
+                    'faq_schema_eligible',
+                ], true)) {
+                    return 'low_risk_auto_approval_target_field_not_allowed';
+                }
+            }
+
+            if ((bool) ($proposal['claim_gate_required'] ?? false) !== true
+                || (bool) ($proposal['human_approval_required'] ?? false) !== true
+                || (bool) ($proposal['execution_permission'] ?? false) !== false) {
+                return 'low_risk_auto_approval_boundaries_invalid';
+            }
         }
 
         return null;

--- a/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
+++ b/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
@@ -12,6 +12,29 @@
     "--confirm-write=<exact phrase>",
     "--limit=1..10"
   ],
+  "low_risk_auto_approve_mode": {
+    "command_shape": "php artisan seo-agent:cms-draft-write --package=<path> --limit=10 --auto-approve-low-risk --execute --json",
+    "max_rows_per_execution": 10,
+    "allowed_source_families": [
+      "cms_tdk_gap",
+      "cms_faq_gap"
+    ],
+    "allowed_severities": [
+      "p1",
+      "p2"
+    ],
+    "allowed_target_fields": [
+      "seo_title",
+      "seo_description",
+      "canonical_url_or_path",
+      "is_indexable_or_robots",
+      "faq_items",
+      "faq_schema_eligible"
+    ],
+    "publishes_content": false,
+    "search_submit_allowed": false,
+    "indexing_request_allowed": false
+  },
   "supported_targets": [
     "article",
     "content_page"

--- a/backend/docs/seo/seo-agent-controlled-cms-draft-writer.md
+++ b/backend/docs/seo/seo-agent-controlled-cms-draft-writer.md
@@ -22,9 +22,21 @@ php artisan seo-agent:cms-draft-write \
   --json
 ```
 
+Low-risk auto-approved batch mode:
+
+```bash
+php artisan seo-agent:cms-draft-write \
+  --package=<path> \
+  --limit=10 \
+  --auto-approve-low-risk \
+  --execute \
+  --json
+```
+
 ## Boundaries
 
 - Article proposals create isolated `article_revisions.payload_json` revisions.
 - ContentPage proposals create `cms_translation_revisions.payload_json` draft revisions.
+- Low-risk auto approval is limited to CMS TDK/FAQ/canonical/indexability proposals with `source_family=cms_tdk_gap|cms_faq_gap`, `severity=p1|p2`, and allowed target fields.
 - The writer does not publish, mutate published revision pointers, enqueue search, submit indexing, start scheduler jobs, start queue workers, or call external model APIs.
 - Idempotency is `subject_ref + package_sha256 + sorted target_fields`.

--- a/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
@@ -147,6 +147,72 @@ final class SeoAgentControlledCmsDraftWriterTest extends TestCase
     }
 
     #[Test]
+    public function low_risk_auto_approved_execute_writes_up_to_batch10_without_exact_phrase(): void
+    {
+        [$article, $page] = $this->createTargets();
+        $packagePath = $this->writePackage([
+            $this->proposal('article', (int) $article->id),
+            $this->proposal('content_page', (int) $page->id, [
+                'source_family' => 'cms_faq_gap',
+                'target_fields' => ['faq_items'],
+                'proposed_faq_items' => [
+                    [
+                        'question' => 'What should readers know?',
+                        'answer' => 'Draft answer pending claim gate and human approval.',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 10,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('low_risk_auto_approved', $summary['approval_mode'] ?? null);
+        $this->assertTrue((bool) ($summary['auto_approve_low_risk'] ?? false));
+        $this->assertSame(2, $summary['rows_created'] ?? null);
+        $this->assertSame(1, ArticleRevision::query()->count());
+        $this->assertSame(1, CmsTranslationRevision::query()->count());
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.indexing_request', true));
+    }
+
+    #[Test]
+    public function low_risk_auto_approved_execute_fails_closed_for_non_low_risk_source(): void
+    {
+        [$article] = $this->createTargets();
+        $packagePath = $this->writePackage([
+            $this->proposal('article', (int) $article->id, [
+                'source_family' => 'runtime_seo_qa',
+                'target_fields' => ['manual_review_required'],
+            ]),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+            '--package' => $packagePath,
+            '--limit' => 10,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('low_risk_auto_approval_source_family_not_allowed', $summary['issues'] ?? []);
+        $this->assertSame(0, ArticleRevision::query()->count());
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+    }
+
+    #[Test]
     public function generated_contract_documents_writer_boundaries(): void
     {
         $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json'));
@@ -154,6 +220,8 @@ final class SeoAgentControlledCmsDraftWriterTest extends TestCase
         $this->assertSame('seo-agent-controlled-cms-draft-write.v1', $artifact['version'] ?? null);
         $this->assertSame('php artisan seo-agent:cms-draft-write', $artifact['command'] ?? null);
         $this->assertSame(10, $artifact['max_rows_per_execution'] ?? null);
+        $this->assertSame(10, data_get($artifact, 'low_risk_auto_approve_mode.max_rows_per_execution'));
+        $this->assertContains('cms_tdk_gap', data_get($artifact, 'low_risk_auto_approve_mode.allowed_source_families', []));
         $this->assertFalse((bool) ($artifact['publishes_content'] ?? true));
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.indexing_request', true));
     }
@@ -231,22 +299,25 @@ final class SeoAgentControlledCmsDraftWriterTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function proposal(string $targetModel, int $id): array
+    private function proposal(string $targetModel, int $id, array $overrides = []): array
     {
         $safeLabel = $targetModel === 'article' ? 'article-candidate' : 'content-page-candidate';
 
-        return [
+        return array_merge([
             'source_id' => hash('sha256', $targetModel.(string) $id),
+            'source_family' => 'cms_tdk_gap',
             'target_model' => $targetModel,
             'subject_type' => $targetModel,
             'subject_ref' => $targetModel.':'.$id.':zh-CN',
             'safe_path' => '/zh/'.$safeLabel,
+            'severity' => 'p2',
             'target_fields' => ['seo_title', 'seo_description'],
             'proposed_seo_title' => ($targetModel === 'article' ? 'Article Candidate' : 'Content Page Candidate').' | FermatMind',
             'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
             'claim_gate_required' => true,
             'human_approval_required' => true,
-        ];
+            'execution_permission' => false,
+        ], $overrides);
     }
 
     private function approvalPhrase(int $limit, string $sha): string


### PR DESCRIPTION
## What changed
- Added `--auto-approve-low-risk` to `php artisan seo-agent:cms-draft-write`.
- Low-risk auto approval is limited to `cms_tdk_gap` and `cms_faq_gap` proposals with `p1|p2` severity and allowed SEO/FAQ/canonical/indexability target fields.
- Updated the draft writer contract docs, generated JSON, and focused tests.

## Why
This enables the weekly SEO Agent run to automatically create bounded CMS draft/revision proposals for low-risk candidates, up to 10 rows, without publishing or search submission.

## Validation
- `php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `php artisan test --filter 'BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff'`
- `python3 -m json.tool docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No CMS publish.
- No mutation of published revision pointers.
- No Search Channel enqueue/submit.
- No Google Indexing request.
- No scheduler activation or queue worker startup.
- No GSC opportunity auto-draft.
