### PR TITLE
SEO-AGENT-CMS-PUBLISH-CANARY-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php
@@ -1,0 +1,678 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class SeoAgentCmsPublishCanaryCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-cms-publish-canary.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const DRAFT_WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const TASK = 'SEO-AGENT-CMS-PUBLISH-CANARY-01';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    private const FORBIDDEN_CLAIM_PATTERNS = [
+        '/\bdiagnos(e|is|tic)\b/i',
+        '/\bcure(s|d)?\b/i',
+        '/\bguarantee(d|s)?\b/i',
+        '/\bofficial\s+(partner|partnership|endorsement)\b/i',
+        '/\bclinically\s+proven\b/i',
+        '/\bhiring\s+fit\b/i',
+    ];
+
+    protected $signature = 'seo-agent:cms-publish-canary
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--draft-write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--limit=1 : Maximum CMS drafts to publish; first canary requires exactly 1}
+        {--confirm-package-sha256= : Required package sha256 for execute mode}
+        {--confirm-publish= : Exact confirmation phrase for execute mode when not using low-risk auto approval}
+        {--auto-approve-low-risk : Execute one low-risk ContentPage canary without an exact publish phrase}
+        {--execute : Actually publish one bounded CMS draft}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Controlled SEO Agent CMS publish canary; publishes at most one low-risk ContentPage draft and never submits search/indexing.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        $evidencePath = $this->readablePath((string) $this->option('draft-write-evidence'));
+        if ($packagePath === null || $evidencePath === null) {
+            return $this->finish($this->failureSummary('input_artifact_unreadable'));
+        }
+
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+        if ($limit !== 1) {
+            return $this->finish($this->failureSummary('limit_must_equal_one'));
+        }
+
+        $packageRaw = (string) file_get_contents($packagePath);
+        $evidenceRaw = (string) file_get_contents($evidencePath);
+        $forbidden = array_values(array_unique(array_merge(
+            $this->forbiddenStringsPresent($packageRaw),
+            $this->forbiddenStringsPresent($evidenceRaw),
+        )));
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($packageRaw, true);
+        $draftWrite = json_decode($evidenceRaw, true);
+        if (! is_array($package) || ! is_array($draftWrite)) {
+            return $this->finish($this->failureSummary('input_artifact_json_invalid'));
+        }
+
+        $packageIssue = $this->validatePackage($package);
+        if ($packageIssue !== null) {
+            return $this->finish($this->failureSummary($packageIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $draftIssue = $this->validateDraftWriteEvidence($draftWrite, $packageSha);
+        if ($draftIssue !== null) {
+            return $this->finish($this->failureSummary($draftIssue, [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $proposal = $this->firstProposal($package);
+        if ($proposal === null) {
+            return $this->finish($this->failureSummary('publish_candidate_missing', [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $candidateIssue = $this->validateLowRiskContentPageProposal($proposal);
+        if ($candidateIssue !== null) {
+            return $this->finish($this->failureSummary($candidateIssue, [
+                'package_sha256' => $packageSha,
+                'target_model' => (string) ($proposal['target_model'] ?? $proposal['subject_type'] ?? ''),
+            ]));
+        }
+
+        $requiredPhrase = $this->requiredConfirmationPhrase($packageSha);
+        $execute = (bool) $this->option('execute');
+        $autoApproveLowRisk = (bool) $this->option('auto-approve-low-risk');
+        $plan = $this->publishPlan($proposal, $packageSha);
+
+        if (! $execute) {
+            return $this->finish([
+                'schema_version' => self::SCHEMA_VERSION,
+                'ok' => true,
+                'status' => 'planned',
+                'dry_run' => true,
+                'execute' => false,
+                'would_publish' => (bool) ($plan['publishable'] ?? false),
+                'planned_count' => (bool) ($plan['publishable'] ?? false) ? 1 : 0,
+                'max_rows_per_execution' => 1,
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $requiredPhrase,
+                'auto_approve_low_risk_available' => true,
+                'plan' => $plan,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'boundaries' => $this->boundaries(false),
+            ]);
+        }
+
+        if ((string) $this->option('confirm-package-sha256') !== $packageSha) {
+            return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $requiredPhrase,
+            ]));
+        }
+
+        if (! $autoApproveLowRisk && (string) $this->option('confirm-publish') !== $requiredPhrase) {
+            return $this->finish($this->failureSummary('confirm_publish_phrase_mismatch', [
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $requiredPhrase,
+            ]));
+        }
+
+        if (! (bool) ($plan['publishable'] ?? false)) {
+            return $this->finish($this->failureSummary('publish_plan_not_publishable', [
+                'package_sha256' => $packageSha,
+                'plan' => $plan,
+            ]));
+        }
+
+        $result = DB::transaction(fn (): array => $this->publishContentPageCanary($proposal, $packageSha, $autoApproveLowRisk));
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => (string) ($result['status'] ?? 'success'),
+            'dry_run' => false,
+            'execute' => true,
+            'approval_mode' => $autoApproveLowRisk ? 'low_risk_auto_approved' : 'exact_human_confirmation',
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => (bool) ($result['writes_committed'] ?? false),
+            'published_count' => (int) ($result['published_count'] ?? 0),
+            'rows_skipped_existing' => (int) ($result['rows_skipped_existing'] ?? 0),
+            'affected_refs' => (array) ($result['affected_refs'] ?? []),
+            'rollback_evidence' => (array) ($result['rollback_evidence'] ?? []),
+            'boundaries' => $this->boundaries((bool) ($result['writes_committed'] ?? false)),
+        ]);
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true) {
+            return 'package_not_dry_run';
+        }
+        if ((bool) ($package['cms_write_allowed'] ?? true) !== false || (bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $draftWrite
+     */
+    private function validateDraftWriteEvidence(array $draftWrite, string $packageSha): ?string
+    {
+        if (($draftWrite['schema_version'] ?? null) !== self::DRAFT_WRITE_SCHEMA_VERSION) {
+            return 'draft_write_evidence_schema_invalid';
+        }
+        if (($draftWrite['status'] ?? null) !== 'success') {
+            return 'draft_write_evidence_not_success';
+        }
+        if ((string) ($draftWrite['package_sha256'] ?? '') !== $packageSha) {
+            return 'draft_write_package_sha_mismatch';
+        }
+        if ((bool) ($draftWrite['writes_attempted'] ?? false) !== true) {
+            return 'draft_write_not_executed';
+        }
+        if ((bool) data_get($draftWrite, 'negative_guarantees.cms_publish', true) !== false
+            || (bool) data_get($draftWrite, 'negative_guarantees.search_channel_submit', true) !== false
+            || (bool) data_get($draftWrite, 'negative_guarantees.indexing_request', true) !== false) {
+            return 'draft_write_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array<string, mixed>|null
+     */
+    private function firstProposal(array $package): ?array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return null;
+        }
+
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function validateLowRiskContentPageProposal(array $proposal): ?string
+    {
+        $targetModel = (string) ($proposal['target_model'] ?? $proposal['subject_type'] ?? '');
+        if ($targetModel === 'article') {
+            return 'article_publish_canary_not_supported_in_v1';
+        }
+        if ($targetModel !== 'content_page') {
+            return 'unsupported_target_model';
+        }
+        if (! in_array((string) ($proposal['source_family'] ?? ''), ['cms_tdk_gap', 'cms_faq_gap'], true)) {
+            return 'low_risk_source_family_not_allowed';
+        }
+        if (! in_array((string) ($proposal['severity'] ?? ''), ['p1', 'p2'], true)) {
+            return 'low_risk_severity_not_allowed';
+        }
+        if ((bool) ($proposal['claim_gate_required'] ?? false) !== true
+            || (bool) ($proposal['human_approval_required'] ?? false) !== true
+            || (bool) ($proposal['execution_permission'] ?? false) !== false) {
+            return 'proposal_boundary_invalid';
+        }
+
+        $fields = $this->targetFields($proposal);
+        if ($fields === []) {
+            return 'target_fields_missing';
+        }
+
+        foreach ($fields as $field) {
+            if (! in_array($field, [
+                'seo_title',
+                'seo_description',
+                'canonical_url_or_path',
+                'is_indexable_or_robots',
+                'faq_items',
+                'faq_schema_eligible',
+            ], true)) {
+                return 'target_field_not_allowed';
+            }
+        }
+
+        if ($this->forbiddenClaimDetected($proposal)) {
+            return 'forbidden_claim_detected';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return list<string>
+     */
+    private function targetFields(array $proposal): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', (array) ($proposal['target_fields'] ?? [])),
+            static fn (string $field): bool => $field !== ''
+        )));
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function publishPlan(array $proposal, string $packageSha): array
+    {
+        try {
+            $page = $this->contentPage($proposal);
+            $revision = $this->contentPageRevision($page, $proposal, $packageSha);
+        } catch (RuntimeException $exception) {
+            return [
+                'publishable' => false,
+                'issue' => $exception->getMessage(),
+            ];
+        }
+
+        $alreadyPublished = $page->published_revision_id !== null
+            && (int) $page->published_revision_id === (int) $revision->id
+            && (string) $revision->revision_status === CmsTranslationRevision::STATUS_PUBLISHED;
+
+        return [
+            'publishable' => true,
+            'target_model' => 'content_page',
+            'subject_ref' => (string) ($proposal['subject_ref'] ?? ''),
+            'revision_id' => (int) $revision->id,
+            'already_published' => $alreadyPublished,
+            'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+            'target_fields' => $this->targetFields($proposal),
+            'rollback_snapshot_available' => true,
+            'claim_gate' => 'pass_after_forbidden_claim_scan',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function publishContentPageCanary(array $proposal, string $packageSha, bool $autoApproveLowRisk): array
+    {
+        $page = $this->contentPage($proposal, true);
+        $revision = $this->contentPageRevision($page, $proposal, $packageSha, true);
+
+        if ($page->published_revision_id !== null
+            && (int) $page->published_revision_id === (int) $revision->id
+            && (string) $revision->revision_status === CmsTranslationRevision::STATUS_PUBLISHED) {
+            return [
+                'status' => 'success',
+                'writes_committed' => false,
+                'published_count' => 0,
+                'rows_skipped_existing' => 1,
+                'affected_refs' => [$this->affectedRef('skipped_existing', $proposal, (int) $revision->id)],
+                'rollback_evidence' => $this->rollbackEvidence($page, $revision),
+            ];
+        }
+
+        $rollback = $this->rollbackEvidence($page, $revision);
+        $fields = $this->targetFields($proposal);
+        $updates = $this->contentPageUpdates($page, $proposal, $fields);
+        $now = Carbon::now('UTC');
+
+        $page->forceFill([
+            ...$updates,
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'is_public' => true,
+            'review_state' => 'approved',
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'last_reviewed_at' => $now,
+            'reviewer' => 'seo_agent_publish_canary',
+            'publish_allowed' => true,
+            'operator_approval_required' => false,
+            'operator_approved_at' => $now,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+            'published_at' => $page->published_at ?? $now,
+            'translation_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+        ])->save();
+
+        $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+        $revision->forceFill([
+            'revision_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+            'approved_at' => $revision->approved_at ?? $now,
+            'published_at' => $revision->published_at ?? $now,
+            'payload_json' => [
+                ...$payload,
+                'seo_agent_publish_canary' => [
+                    'task' => self::TASK,
+                    'package_sha256' => $packageSha,
+                    'approval_mode' => $autoApproveLowRisk ? 'low_risk_auto_approved' : 'exact_human_confirmation',
+                    'published_at' => $now->toIso8601String(),
+                    'search_submit_allowed' => false,
+                    'indexing_request_allowed' => false,
+                ],
+            ],
+        ])->save();
+
+        return [
+            'status' => 'success',
+            'writes_committed' => true,
+            'published_count' => 1,
+            'rows_skipped_existing' => 0,
+            'affected_refs' => [$this->affectedRef('published', $proposal, (int) $revision->id)],
+            'rollback_evidence' => $rollback,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function contentPage(array $proposal, bool $lock = false): ContentPage
+    {
+        $pageId = $this->idFromSubjectRef((string) ($proposal['subject_ref'] ?? ''), 'content_page');
+        $query = ContentPage::query()->withoutGlobalScopes()->whereKey($pageId);
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        $page = $query->first();
+        if (! $page instanceof ContentPage) {
+            throw new RuntimeException('content_page_not_found');
+        }
+        if ((string) $page->status !== ContentPage::STATUS_PUBLISHED || ! (bool) $page->is_public) {
+            throw new RuntimeException('content_page_must_already_be_public_for_canary_v1');
+        }
+
+        return $page;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function contentPageRevision(ContentPage $page, array $proposal, string $packageSha, bool $lock = false): CmsTranslationRevision
+    {
+        $targetFields = $this->targetFields($proposal);
+        sort($targetFields);
+        $query = CmsTranslationRevision::query()
+            ->where('content_type', 'content_page')
+            ->where('content_id', (int) $page->id);
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        $revision = $query->get()->first(function (CmsTranslationRevision $revision) use ($packageSha, $targetFields): bool {
+            $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+            $fields = array_values(array_map('strval', (array) data_get($payload, 'seo_agent.target_fields', [])));
+            sort($fields);
+
+            return data_get($payload, 'seo_agent.task') === 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01'
+                && data_get($payload, 'seo_agent.package_sha256') === $packageSha
+                && $fields === $targetFields;
+        });
+
+        if (! $revision instanceof CmsTranslationRevision) {
+            throw new RuntimeException('seo_agent_content_page_draft_revision_not_found');
+        }
+        if (! in_array((string) $revision->revision_status, [CmsTranslationRevision::STATUS_DRAFT, CmsTranslationRevision::STATUS_APPROVED, CmsTranslationRevision::STATUS_PUBLISHED], true)) {
+            throw new RuntimeException('draft_revision_status_not_publishable');
+        }
+
+        return $revision;
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== $expectedType || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            throw new RuntimeException('subject_ref_invalid');
+        }
+
+        return (int) $parts[1];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  list<string>  $fields
+     * @return array<string, mixed>
+     */
+    private function contentPageUpdates(ContentPage $page, array $proposal, array $fields): array
+    {
+        $updates = [];
+        if (in_array('seo_title', $fields, true)) {
+            $title = trim((string) ($proposal['proposed_seo_title'] ?? ''));
+            if ($title === '') {
+                throw new RuntimeException('proposed_seo_title_missing');
+            }
+            $updates['seo_title'] = $title;
+        }
+        if (in_array('seo_description', $fields, true)) {
+            $description = trim((string) ($proposal['proposed_seo_description'] ?? ''));
+            if ($description === '') {
+                throw new RuntimeException('proposed_seo_description_missing');
+            }
+            $updates['seo_description'] = $description;
+            if (trim((string) ($page->meta_description ?? '')) === '') {
+                $updates['meta_description'] = $description;
+            }
+        }
+        if (in_array('canonical_url_or_path', $fields, true)) {
+            $canonical = trim((string) ($proposal['proposed_canonical_path'] ?? $proposal['safe_path'] ?? ''));
+            if ($canonical === '' || ! str_starts_with($canonical, '/') || str_starts_with($canonical, '//')) {
+                throw new RuntimeException('proposed_canonical_path_invalid');
+            }
+            $updates['canonical_path'] = $canonical;
+        }
+        if (in_array('is_indexable_or_robots', $fields, true)) {
+            $updates['is_indexable'] = true;
+        }
+        if (in_array('faq_items', $fields, true)) {
+            $faqItems = array_values(array_filter((array) ($proposal['proposed_faq_items'] ?? []), static fn ($item): bool => is_array($item)));
+            if ($faqItems === []) {
+                throw new RuntimeException('proposed_faq_items_missing');
+            }
+            $updates['faq_items'] = $faqItems;
+        }
+        if (in_array('faq_schema_eligible', $fields, true)) {
+            $updates['faq_schema_eligible'] = true;
+            $updates['schema_eligibility_reviewed_at'] = Carbon::now('UTC');
+        }
+
+        return $updates;
+    }
+
+    private function requiredConfirmationPhrase(string $packageSha): string
+    {
+        return 'I explicitly approve '.self::TASK.' to publish at most 1 CMS draft from package sha256 '.$packageSha.'; no queue, no search, no indexing, no scheduler.';
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function affectedRef(string $status, array $proposal, int $revisionId): array
+    {
+        return [
+            'status' => $status,
+            'target_model' => 'content_page',
+            'subject_ref' => (string) ($proposal['subject_ref'] ?? ''),
+            'revision_id' => $revisionId,
+            'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rollbackEvidence(ContentPage $page, CmsTranslationRevision $revision): array
+    {
+        return [
+            'available' => true,
+            'content_page_ref' => 'content_page:'.(int) $page->id.':'.(string) $page->locale,
+            'previous_revision_id' => $page->published_revision_id ? (int) $page->published_revision_id : null,
+            'candidate_revision_id' => (int) $revision->id,
+            'previous_state' => [
+                'status' => (string) $page->status,
+                'is_public' => (bool) $page->is_public,
+                'is_indexable' => (bool) $page->is_indexable,
+                'seo_title_hash' => hash('sha256', (string) ($page->seo_title ?? '')),
+                'seo_description_hash' => hash('sha256', (string) ($page->seo_description ?? '')),
+                'meta_description_hash' => hash('sha256', (string) ($page->meta_description ?? '')),
+                'canonical_path' => (string) ($page->canonical_path ?? ''),
+                'faq_items_count' => count((array) ($page->faq_items ?? [])),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function forbiddenClaimDetected(array $proposal): bool
+    {
+        $text = implode("\n", array_filter([
+            (string) ($proposal['proposed_seo_title'] ?? ''),
+            (string) ($proposal['proposed_seo_description'] ?? ''),
+            json_encode($proposal['proposed_faq_items'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '',
+        ]));
+
+        foreach (self::FORBIDDEN_CLAIM_PATTERNS as $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'boundaries' => $this->boundaries(false),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function boundaries(bool $published): array
+    {
+        return [
+            'cms_publish' => $published,
+            'published_revision_mutation' => $published,
+            'live_published_content_mutation' => $published,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -171,6 +171,7 @@ use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
+use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
@@ -373,6 +374,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
+        SeoAgentCmsPublishCanaryCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,

--- a/backend/docs/seo/generated/seo-agent-cms-publish-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-publish-canary.v1.json
@@ -1,0 +1,73 @@
+{
+  "version": "seo-agent-cms-publish-canary.v1",
+  "task": "SEO-AGENT-CMS-PUBLISH-CANARY-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-publish-canary",
+  "input_schemas": [
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-controlled-cms-draft-write.v1"
+  ],
+  "output_schema": "seo-agent-cms-publish-canary.v1",
+  "default_mode": "dry_run_plan",
+  "execute_requires": [
+    "--execute",
+    "--limit=1",
+    "--confirm-package-sha256=<package-sha256>",
+    "--auto-approve-low-risk or --confirm-publish=<exact phrase>"
+  ],
+  "max_rows_per_execution": 1,
+  "supported_targets_v1": [
+    "content_page"
+  ],
+  "unsupported_targets_v1": {
+    "article": "blocked because SEO Agent article drafts are isolated article_revisions while the existing article publish path uses article_translation_revisions"
+  },
+  "low_risk_auto_publish_mode": {
+    "allowed_source_families": [
+      "cms_tdk_gap",
+      "cms_faq_gap"
+    ],
+    "allowed_severities": [
+      "p1",
+      "p2"
+    ],
+    "allowed_target_fields": [
+      "seo_title",
+      "seo_description",
+      "canonical_url_or_path",
+      "is_indexable_or_robots",
+      "faq_items",
+      "faq_schema_eligible"
+    ],
+    "claim_gate_required": true,
+    "forbidden_claim_scan_required": true,
+    "rollback_evidence_required": true
+  },
+  "post_publish_boundaries": {
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "external_model_api_call": false
+  },
+  "evidence": {
+    "records_package_sha256": true,
+    "records_revision_id": true,
+    "records_rollback_snapshot_hashes": true,
+    "forbidden_fields_absent": [
+      "raw_url",
+      "raw_query",
+      "credential_path",
+      "client_email",
+      "private_key",
+      "Bearer token",
+      "cookie",
+      "content_md",
+      "content_html",
+      "cms_draft_body"
+    ]
+  },
+  "next_step": "Only after one successful canary publish should post-publish search submit be implemented in a separate PR."
+}

--- a/backend/docs/seo/seo-agent-cms-publish-canary.md
+++ b/backend/docs/seo/seo-agent-cms-publish-canary.md
@@ -1,0 +1,51 @@
+# SEO Agent CMS Publish Canary
+
+Task: `SEO-AGENT-CMS-PUBLISH-CANARY-01`
+
+This command promotes at most one low-risk SEO Agent CMS draft into the live ContentPage read path. It is the first bounded publish step after the draft writer and remains separate from search queue, Google Indexing, scheduler, and queue workers.
+
+## Command
+
+Dry-run plan:
+
+```bash
+php artisan seo-agent:cms-publish-canary \
+  --package=<seo-agent-cms-draft-package-dry-run.v1.json> \
+  --draft-write-evidence=<seo-agent-controlled-cms-draft-write.v1.json> \
+  --limit=1 \
+  --json
+```
+
+Low-risk canary execute:
+
+```bash
+php artisan seo-agent:cms-publish-canary \
+  --package=<seo-agent-cms-draft-package-dry-run.v1.json> \
+  --draft-write-evidence=<seo-agent-controlled-cms-draft-write.v1.json> \
+  --limit=1 \
+  --confirm-package-sha256=<package-sha256> \
+  --auto-approve-low-risk \
+  --execute \
+  --json
+```
+
+## Scope
+
+- Publishes at most one ContentPage SEO Agent draft revision.
+- Requires the package SHA to match the draft write evidence.
+- Requires the draft write evidence to show a successful controlled draft write.
+- Requires low-risk source families only: `cms_tdk_gap` and `cms_faq_gap`.
+- Requires allowed target fields only: SEO title, SEO description, canonical path, indexability metadata, FAQ items, and FAQ schema eligibility.
+- Creates rollback evidence before mutating the live ContentPage row.
+- Marks claim gate as passed only after a deterministic forbidden-claim scan of proposed SEO fields.
+
+## Boundaries
+
+- Article publish canary is not supported in v1 because the current draft writer stores Article proposals in isolated `article_revisions`, while the existing Article publish path uses `article_translation_revisions`.
+- Search queue enqueue remains false.
+- Search submit remains false.
+- Google Indexing request remains false.
+- Scheduler activation remains false.
+- Queue worker activation remains false.
+- No external model API is called.
+- No full URL, raw query, raw body, credential path, client email, private key, token, cookie, or service-account JSON may appear in input or output artifacts.

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsPublishCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsPublishCanaryTest.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsPublishCanaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_plans_one_content_page_canary_without_writing(): void
+    {
+        $page = $this->createContentPage();
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($page);
+        $before = $this->pageState($page);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['would_publish'] ?? false));
+        $this->assertFalse((bool) ($summary['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($summary['writes_committed'] ?? true));
+        $this->assertSame($before, $this->pageState($page->refresh()));
+        $this->assertSame(CmsTranslationRevision::STATUS_DRAFT, CmsTranslationRevision::query()->firstOrFail()->revision_status);
+    }
+
+    #[Test]
+    public function execute_low_risk_canary_publishes_one_content_page_draft_only(): void
+    {
+        $page = $this->createContentPage();
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($page);
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 1,
+            '--confirm-package-sha256' => $packageSha,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['writes_attempted'] ?? false));
+        $this->assertTrue((bool) ($summary['writes_committed'] ?? false));
+        $this->assertSame(1, $summary['published_count'] ?? null);
+        $this->assertSame(0, $summary['rows_skipped_existing'] ?? null);
+        $this->assertTrue((bool) data_get($summary, 'boundaries.cms_publish'));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.indexing_request', true));
+        $this->assertTrue((bool) data_get($summary, 'rollback_evidence.available'));
+
+        $fresh = $page->refresh();
+        $revision = CmsTranslationRevision::query()->firstOrFail();
+        $this->assertSame('Content Page Candidate | FermatMind', (string) $fresh->seo_title);
+        $this->assertSame('Review candidate with FermatMind guidance.', (string) $fresh->seo_description);
+        $this->assertSame('/zh/content-page-candidate', (string) $fresh->canonical_path);
+        $this->assertSame('passed', (string) $fresh->claim_gate_status);
+        $this->assertSame([], $fresh->forbidden_claims ?? []);
+        $this->assertSame((int) $revision->id, (int) $fresh->published_revision_id);
+        $this->assertSame(CmsTranslationRevision::STATUS_PUBLISHED, (string) $revision->revision_status);
+        $this->assertSame($packageSha, data_get($revision->payload_json, 'seo_agent.package_sha256'));
+        $this->assertSame('low_risk_auto_approved', data_get($revision->payload_json, 'seo_agent_publish_canary.approval_mode'));
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 1,
+            '--confirm-package-sha256' => $packageSha,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertFalse((bool) ($summary['writes_committed'] ?? true));
+        $this->assertSame(1, $summary['rows_skipped_existing'] ?? null);
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function execute_fails_closed_for_article_target_or_bad_package_sha(): void
+    {
+        $page = $this->createContentPage();
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 1,
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_sha256_confirmation_mismatch', $summary['issues'] ?? []);
+
+        [$articlePackagePath, $articleEvidencePath] = $this->createPackageAndDraftEvidence($page, [
+            'target_model' => 'article',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:123:zh-CN',
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-canary', [
+            '--package' => $articlePackagePath,
+            '--draft-write-evidence' => $articleEvidencePath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('article_publish_canary_not_supported_in_v1', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_publish_canary_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-publish-canary.v1.json'));
+
+        $this->assertSame('seo-agent-cms-publish-canary.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-publish-canary', $artifact['command'] ?? null);
+        $this->assertSame(1, $artifact['max_rows_per_execution'] ?? null);
+        $this->assertContains('content_page', $artifact['supported_targets_v1'] ?? []);
+        $this->assertSame(false, data_get($artifact, 'post_publish_boundaries.search_channel_enqueue'));
+        $this->assertSame(false, data_get($artifact, 'post_publish_boundaries.indexing_request'));
+    }
+
+    private function createContentPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'content-page-candidate',
+            'path' => '/zh/content-page-candidate',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Content Page Candidate',
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'draft',
+            'published_revision_id' => 88,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposalOverrides
+     * @return array{0: string, 1: string}
+     */
+    private function createPackageAndDraftEvidence(ContentPage $page, array $proposalOverrides = []): array
+    {
+        $proposal = array_merge([
+            'source_id' => hash('sha256', 'content-page'.(string) $page->id),
+            'source_family' => 'cms_tdk_gap',
+            'target_model' => 'content_page',
+            'subject_type' => 'content_page',
+            'subject_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+            'safe_path' => '/zh/content-page-candidate',
+            'severity' => 'p2',
+            'target_fields' => ['seo_title', 'seo_description', 'canonical_url_or_path'],
+            'proposed_seo_title' => 'Content Page Candidate | FermatMind',
+            'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
+            'proposed_canonical_path' => '/zh/content-page-candidate',
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+        ], $proposalOverrides);
+
+        $packagePath = $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_count' => 1,
+            'proposal_items' => [$proposal],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ]);
+
+        if (($proposal['target_model'] ?? '') === 'content_page') {
+            $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+                '--package' => $packagePath,
+                '--limit' => 1,
+                '--auto-approve-low-risk' => true,
+                '--execute' => true,
+                '--json' => true,
+            ]);
+            $this->assertSame(0, $exitCode, Artisan::output());
+            $draftEvidence = [
+                'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+                'ok' => true,
+                'status' => 'success',
+                'execute' => true,
+                'approval_mode' => 'low_risk_auto_approved',
+                'package_sha256' => hash_file('sha256', $packagePath) ?: '',
+                'writes_attempted' => true,
+                'writes_committed' => true,
+                'rows_created' => 1,
+                'negative_guarantees' => [
+                    'cms_publish' => false,
+                    'search_channel_submit' => false,
+                    'indexing_request' => false,
+                ],
+            ];
+        } else {
+            $draftEvidence = [
+                'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+                'ok' => true,
+                'status' => 'success',
+                'execute' => true,
+                'approval_mode' => 'low_risk_auto_approved',
+                'package_sha256' => hash_file('sha256', $packagePath) ?: '',
+                'writes_attempted' => true,
+                'writes_committed' => true,
+                'rows_created' => 1,
+                'negative_guarantees' => [
+                    'cms_publish' => false,
+                    'search_channel_submit' => false,
+                    'indexing_request' => false,
+                ],
+            ];
+        }
+
+        $draftEvidencePath = $this->writeJson('seo-agent-controlled-cms-draft-write-', $draftEvidence);
+
+        return [$packagePath, $draftEvidencePath];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pageState(ContentPage $page): array
+    {
+        return [
+            'seo_title' => $page->seo_title,
+            'seo_description' => $page->seo_description,
+            'canonical_path' => $page->canonical_path,
+            'published_revision_id' => $page->published_revision_id,
+            'claim_gate_status' => $page->claim_gate_status,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1203,6 +1203,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_publish_canary_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsPublishCanaryCommand;',
+            '+        SeoAgentCmsPublishCanaryCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3745,6 +3759,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsPublishCanaryFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4339,6 +4357,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -5036,6 +5055,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsPublishCanaryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php',
         ], true);
     }
 
@@ -6813,6 +6839,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentWeeklyReadonlyRunnerCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsPublishCanaryOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsPublishCanaryCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:cms-publish-canary` for a bounded L4 publish canary.
- Supports one low-risk ContentPage SEO Agent draft publish with package SHA validation, draft-write evidence validation, claim scan, and rollback evidence.
- Fails closed for Article targets in v1 because SEO Agent article drafts currently use isolated `article_revisions`, while the existing Article publish path uses `article_translation_revisions`.
- Added contract docs/generated JSON and focused tests, plus BigFive freeze guard allowlisting for the scoped command.

## Why
This is the first controlled publish step after CMS draft writing. It proves the L4 agent can publish a single low-risk canary while keeping search queue, Google Indexing, scheduler, and queue workers disabled.

## Validation
- `php artisan test --filter SeoAgentCmsPublishCanaryTest`
- `php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `php artisan test --filter 'BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_agent_cms_publish_canary_files'`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-publish-canary.v1.json >/dev/null`
- `git diff --check`

## Deferred
- Article publish canary support.
- Batch publish.
- Search queue submit.
- Google Indexing.
- Scheduler activation.
- Frontend code mutation.
