### PR TITLE
SEO-AGENT-POST-PUBLISH-SEARCH-SUBMIT-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
+++ b/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\ContentPage;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueuePlanner;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueWriteService;
+use Illuminate\Console\Command;
+
+final class SeoAgentPostPublishSearchSubmitCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-post-publish-search-submit.v1';
+
+    private const PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-canary.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:post-publish-search-submit
+        {--publish-evidence= : Path to seo-agent-cms-publish-canary.v1 JSON evidence}
+        {--channels=indexnow,google_sitemap : Comma-separated Search Channel queue channels}
+        {--limit=1 : First post-publish bridge requires exactly 1 published URL}
+        {--base-url= : Public site base URL used to resolve safe paths; defaults to app.url}
+        {--confirm-evidence-sha256= : Required publish evidence sha256 for execute mode}
+        {--execute : Actually enqueue Search Channel rows; no live external submission}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Bridge one SEO Agent publish canary into Search Channel queue evidence without live external submission.';
+
+    public function handle(SearchChannelQueuePlanner $planner, SearchChannelQueueWriteService $writer): int
+    {
+        $evidencePath = $this->readablePath((string) $this->option('publish-evidence'));
+        if ($evidencePath === null) {
+            return $this->finish($this->failureSummary('publish_evidence_unreadable'));
+        }
+
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+        if ($limit !== 1) {
+            return $this->finish($this->failureSummary('limit_must_equal_one'));
+        }
+
+        $raw = (string) file_get_contents($evidencePath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $evidence = json_decode($raw, true);
+        if (! is_array($evidence)) {
+            return $this->finish($this->failureSummary('publish_evidence_json_invalid'));
+        }
+
+        $evidenceIssue = $this->validatePublishEvidence($evidence);
+        if ($evidenceIssue !== null) {
+            return $this->finish($this->failureSummary($evidenceIssue));
+        }
+
+        $affected = $this->firstAffectedRef($evidence);
+        if ($affected === null) {
+            return $this->finish($this->failureSummary('published_ref_missing'));
+        }
+
+        $targetIssue = $this->validatePublishedContentPage($affected);
+        if ($targetIssue !== null) {
+            return $this->finish($this->failureSummary($targetIssue));
+        }
+
+        $safePath = (string) ($affected['safe_path'] ?? '');
+        $canonicalUrl = $this->canonicalUrl($safePath);
+        if ($canonicalUrl === null) {
+            return $this->finish($this->failureSummary('canonical_url_resolution_failed'));
+        }
+
+        $channels = $this->channels();
+        if ($channels === []) {
+            return $this->finish($this->failureSummary('channels_missing'));
+        }
+
+        $evidenceSha = hash_file('sha256', $evidencePath) ?: '';
+        $execute = (bool) $this->option('execute');
+        if ($execute && (string) $this->option('confirm-evidence-sha256') !== $evidenceSha) {
+            return $this->finish($this->failureSummary('evidence_sha256_confirmation_mismatch', [
+                'publish_evidence_sha256' => $evidenceSha,
+            ]));
+        }
+
+        $plans = [];
+        $plannedItems = [];
+        $issues = [];
+        $duplicates = 0;
+
+        foreach ($channels as $channel) {
+            $plan = $planner->plan($channel, 'content_page', 20, $canonicalUrl);
+            $plans[$channel] = $this->safePlanSummary($plan);
+            if ((int) ($plan['planned_queue_count'] ?? 0) > 0) {
+                $plannedItems = array_merge($plannedItems, (array) ($plan['planned_items'] ?? []));
+            } elseif ((bool) ($plan['duplicate_detected'] ?? false)) {
+                $duplicates++;
+            } else {
+                $issues[] = $channel.':'.(string) (($plan['source_unavailable_reason'] ?? null) ?: 'no_eligible_queue_item');
+            }
+        }
+
+        $plannedItems = array_slice($plannedItems, 0, count($channels));
+
+        if (! $execute) {
+            return $this->finish([
+                'schema_version' => self::SCHEMA_VERSION,
+                'ok' => true,
+                'status' => 'planned',
+                'dry_run' => true,
+                'execute' => false,
+                'publish_evidence_sha256' => $evidenceSha,
+                'canonical_url_hash' => hash('sha256', $canonicalUrl),
+                'safe_path' => $safePath,
+                'channels' => $channels,
+                'planned_queue_count' => count($plannedItems),
+                'duplicate_count' => $duplicates,
+                'plans' => $plans,
+                'issues' => array_values(array_unique($issues)),
+                'search_channel_enqueue_attempted' => false,
+                'search_channel_enqueue_committed' => false,
+                'google_indexing_request_planned' => in_array('google_sitemap', $channels, true),
+                'google_indexing_live_api_called' => false,
+                'boundaries' => $this->boundaries(false),
+            ]);
+        }
+
+        if ($plannedItems === [] && $duplicates < count($channels)) {
+            return $this->finish($this->failureSummary('no_eligible_queue_items', [
+                'publish_evidence_sha256' => $evidenceSha,
+                'canonical_url_hash' => hash('sha256', $canonicalUrl),
+                'plans' => $plans,
+                'issues' => array_values(array_unique($issues)),
+            ]));
+        }
+
+        $writeResult = $plannedItems === [] ? ['batch_ids' => [], 'written_items' => 0] : $writer->write($plannedItems);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'publish_evidence_sha256' => $evidenceSha,
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'safe_path' => $safePath,
+            'channels' => $channels,
+            'batch_ids' => $writeResult['batch_ids'],
+            'written_items' => (int) $writeResult['written_items'],
+            'duplicate_count' => $duplicates,
+            'search_channel_enqueue_attempted' => true,
+            'search_channel_enqueue_committed' => ((int) $writeResult['written_items']) > 0,
+            'search_submission_attempted' => false,
+            'google_indexing_request_planned' => in_array('google_sitemap', $channels, true),
+            'google_indexing_live_api_called' => false,
+            'plans' => $plans,
+            'boundaries' => $this->boundaries(((int) $writeResult['written_items']) > 0),
+        ]);
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function validatePublishEvidence(array $evidence): ?string
+    {
+        if (($evidence['schema_version'] ?? null) !== self::PUBLISH_SCHEMA_VERSION) {
+            return 'publish_evidence_schema_invalid';
+        }
+        if (($evidence['status'] ?? null) !== 'success' || (bool) ($evidence['execute'] ?? false) !== true) {
+            return 'publish_evidence_not_success_execute';
+        }
+        if ((bool) ($evidence['writes_committed'] ?? false) !== true || (int) ($evidence['published_count'] ?? 0) !== 1) {
+            return 'publish_evidence_missing_one_committed_publish';
+        }
+        if ((bool) data_get($evidence, 'rollback_evidence.available') !== true) {
+            return 'rollback_evidence_missing';
+        }
+        if ((bool) data_get($evidence, 'boundaries.cms_publish') !== true
+            || (bool) data_get($evidence, 'boundaries.search_channel_enqueue') !== false
+            || (bool) data_get($evidence, 'boundaries.indexing_request') !== false) {
+            return 'publish_evidence_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>|null
+     */
+    private function firstAffectedRef(array $evidence): ?array
+    {
+        foreach ((array) ($evidence['affected_refs'] ?? []) as $ref) {
+            if (is_array($ref) && ($ref['status'] ?? null) === 'published') {
+                return $ref;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $affected
+     */
+    private function validatePublishedContentPage(array $affected): ?string
+    {
+        if (($affected['target_model'] ?? null) !== 'content_page') {
+            return 'target_model_not_supported';
+        }
+
+        $pageId = $this->idFromSubjectRef((string) ($affected['subject_ref'] ?? ''), 'content_page');
+        if ($pageId < 1) {
+            return 'subject_ref_invalid';
+        }
+
+        $page = ContentPage::query()->withoutGlobalScopes()->find($pageId);
+        if (! $page instanceof ContentPage) {
+            return 'content_page_not_found';
+        }
+        if ((string) $page->status !== ContentPage::STATUS_PUBLISHED || ! (bool) $page->is_public || ! (bool) $page->is_indexable) {
+            return 'content_page_not_public_indexable';
+        }
+
+        return null;
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== $expectedType || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            return 0;
+        }
+
+        return (int) $parts[1];
+    }
+
+    private function canonicalUrl(string $safePath): ?string
+    {
+        if ($safePath === '' || ! str_starts_with($safePath, '/') || str_starts_with($safePath, '//')) {
+            return null;
+        }
+
+        $base = trim((string) ($this->option('base-url') ?: config('app.url')));
+        if ($base === '') {
+            return null;
+        }
+
+        $url = rtrim($base, '/').$safePath;
+
+        return filter_var($url, FILTER_VALIDATE_URL) ? $url : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function channels(): array
+    {
+        $channels = array_values(array_unique(array_filter(array_map(
+            static fn (string $part): string => strtolower(trim($part)),
+            explode(',', (string) $this->option('channels')),
+        ), static fn (string $channel): bool => $channel !== '')));
+
+        return array_values(array_filter($channels, static fn (string $channel): bool => in_array($channel, ['indexnow', 'google_sitemap'], true)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @return array<string, mixed>
+     */
+    private function safePlanSummary(array $plan): array
+    {
+        return [
+            'source_unavailable_reason' => $plan['source_unavailable_reason'] ?? null,
+            'candidate_count' => (int) ($plan['candidate_count'] ?? 0),
+            'eligible_count' => (int) ($plan['eligible_count'] ?? 0),
+            'blocked_count' => (int) ($plan['blocked_count'] ?? 0),
+            'planned_queue_count' => (int) ($plan['planned_queue_count'] ?? 0),
+            'duplicate_detected' => (bool) ($plan['duplicate_detected'] ?? false),
+            'reason_code_breakdown' => (array) ($plan['reason_code_breakdown'] ?? []),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'search_channel_enqueue_attempted' => false,
+            'search_channel_enqueue_committed' => false,
+            'search_submission_attempted' => false,
+            'google_indexing_live_api_called' => false,
+            'boundaries' => $this->boundaries(false),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function boundaries(bool $queueWritten): array
+    {
+        return [
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => $queueWritten,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'google_indexing_live_api_call' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -172,6 +172,7 @@ use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
+use App\Console\Commands\SeoAgentPostPublishSearchSubmitCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
@@ -375,6 +376,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
         SeoAgentCmsPublishCanaryCommand::class,
+        SeoAgentPostPublishSearchSubmitCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -298,6 +298,7 @@ return [
         'allowed_page_entity_types' => [
             'article',
             'research_report',
+            'content_page',
             'home',
             'test_hub',
             'test_detail',

--- a/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
+++ b/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
@@ -1,0 +1,59 @@
+{
+  "version": "seo-agent-post-publish-search-submit.v1",
+  "task": "SEO-AGENT-POST-PUBLISH-SEARCH-SUBMIT-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:post-publish-search-submit",
+  "input_schema": "seo-agent-cms-publish-canary.v1",
+  "output_schema": "seo-agent-post-publish-search-submit.v1",
+  "default_mode": "dry_run_plan",
+  "execute_requires": [
+    "--execute",
+    "--limit=1",
+    "--confirm-evidence-sha256=<publish-evidence-sha256>"
+  ],
+  "supported_targets_v1": [
+    "content_page"
+  ],
+  "channels_v1": [
+    "indexnow",
+    "google_sitemap"
+  ],
+  "max_published_urls_per_execution": 1,
+  "requires_url_truth_row": true,
+  "requires_publish_evidence": {
+    "schema_version": "seo-agent-cms-publish-canary.v1",
+    "status": "success",
+    "execute": true,
+    "writes_committed": true,
+    "published_count": 1,
+    "rollback_evidence_available": true
+  },
+  "write_targets": [
+    "seo_search_channel_queue_items",
+    "seo_search_channel_queue_batches",
+    "seo_search_channel_queue_events"
+  ],
+  "protected_targets_not_written": [
+    "seo_baidu_push_logs",
+    "seo_indexnow_submissions",
+    "seo_domestic_submission_logs"
+  ],
+  "live_submission": {
+    "search_channel_submit": false,
+    "google_indexing_live_api_call": false,
+    "sitemap_submission": false,
+    "external_api_calls": false
+  },
+  "negative_guarantees": {
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "google_indexing_live_api_call": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "external_model_api_call": false
+  },
+  "next_step": "Implement live submission or Google Indexing executor only in a separate explicitly approved PR."
+}

--- a/backend/docs/seo/seo-agent-post-publish-search-submit.md
+++ b/backend/docs/seo/seo-agent-post-publish-search-submit.md
@@ -1,0 +1,45 @@
+# SEO Agent Post-Publish Search Submit
+
+Task: `SEO-AGENT-POST-PUBLISH-SEARCH-SUBMIT-01`
+
+This command bridges one successful SEO Agent CMS publish canary into Search Channel queue evidence. It accepts only `seo-agent-cms-publish-canary.v1` success evidence and only enqueues a URL that is already published, public, indexable, and present in URL Truth (`seo_urls`).
+
+## Command
+
+Dry-run plan:
+
+```bash
+php artisan seo-agent:post-publish-search-submit \
+  --publish-evidence=<seo-agent-cms-publish-canary.v1.json> \
+  --channels=indexnow,google_sitemap \
+  --limit=1 \
+  --json
+```
+
+Execute enqueue:
+
+```bash
+php artisan seo-agent:post-publish-search-submit \
+  --publish-evidence=<seo-agent-cms-publish-canary.v1.json> \
+  --channels=indexnow,google_sitemap \
+  --limit=1 \
+  --confirm-evidence-sha256=<publish-evidence-sha256> \
+  --execute \
+  --json
+```
+
+## Boundaries
+
+- Writes only existing Search Channel queue tables through the existing queue writer.
+- Does not mutate CMS.
+- Does not publish CMS.
+- Does not perform live Search Channel submission.
+- Does not call Google Indexing API directly.
+- Does not submit sitemap directly.
+- Does not start scheduler or queue workers.
+- Does not call external model APIs.
+- Does not accept draft or uncommitted publish evidence.
+
+## Google Indexing Boundary
+
+The first implementation records the Google side as the existing `google_sitemap` Search Channel queue/readiness path. It does not call a live Google Indexing API from this command. A future live Google Indexing executor must be implemented and approved separately.

--- a/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentPostPublishSearchSubmitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.url' => 'https://www.fermatmind.com',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function dry_run_plans_post_publish_queue_without_writing(): void
+    {
+        $page = $this->createPublishedPage();
+        $canonicalUrl = 'https://www.fermatmind.com/zh/content-page-candidate';
+        $this->seedSeoUrl($canonicalUrl, (string) $page->id);
+        $evidencePath = $this->writePublishEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--channels' => 'indexnow,google_sitemap',
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(2, $summary['planned_queue_count'] ?? null);
+        $this->assertTrue((bool) ($summary['google_indexing_request_planned'] ?? false));
+        $this->assertFalse((bool) ($summary['search_channel_enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_enqueue', true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
+    public function execute_enqueues_only_published_url_without_live_submission(): void
+    {
+        $page = $this->createPublishedPage();
+        $canonicalUrl = 'https://www.fermatmind.com/zh/content-page-candidate';
+        $this->seedSeoUrl($canonicalUrl, (string) $page->id);
+        $evidencePath = $this->writePublishEvidence($page);
+        $evidenceSha = hash_file('sha256', $evidencePath) ?: '';
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--channels' => 'indexnow,google_sitemap',
+            '--limit' => 1,
+            '--confirm-evidence-sha256' => $evidenceSha,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['search_channel_enqueue_attempted'] ?? false));
+        $this->assertTrue((bool) ($summary['search_channel_enqueue_committed'] ?? false));
+        $this->assertFalse((bool) ($summary['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($summary['google_indexing_live_api_called'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.indexing_request', true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.scheduler_activation', true));
+        $this->assertSame(2, $summary['written_items'] ?? null);
+        $this->assertSame(2, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(2, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+
+        $channels = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_items')
+            ->orderBy('channel')
+            ->pluck('channel')
+            ->all();
+        $this->assertSame(['google_sitemap', 'indexnow'], $channels);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_baidu_push_logs')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_indexnow_submissions')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_domestic_submission_logs')->count());
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function execute_fails_closed_for_bad_sha_or_unpublished_evidence(): void
+    {
+        $page = $this->createPublishedPage();
+        $this->seedSeoUrl('https://www.fermatmind.com/zh/content-page-candidate', (string) $page->id);
+        $evidencePath = $this->writePublishEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 1,
+            '--confirm-evidence-sha256' => str_repeat('0', 64),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('evidence_sha256_confirmation_mismatch', $summary['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+
+        $blockedPath = $this->writePublishEvidence($page, ['writes_committed' => false, 'published_count' => 0]);
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $blockedPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('publish_evidence_missing_one_committed_publish', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_post_publish_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-post-publish-search-submit.v1.json'));
+
+        $this->assertSame('seo-agent-post-publish-search-submit.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:post-publish-search-submit', $artifact['command'] ?? null);
+        $this->assertSame(1, $artifact['max_published_urls_per_execution'] ?? null);
+        $this->assertContains('content_page', $artifact['supported_targets_v1'] ?? []);
+        $this->assertFalse((bool) data_get($artifact, 'live_submission.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($artifact, 'live_submission.google_indexing_live_api_call', true));
+    }
+
+    private function createPublishedPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'content-page-candidate',
+            'path' => '/zh/content-page-candidate',
+            'canonical_path' => '/zh/content-page-candidate',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Content Page Candidate',
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => true,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'approved',
+            'published_revision_id' => 88,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function writePublishEvidence(ContentPage $page, array $overrides = []): string
+    {
+        return $this->writeJson('seo-agent-cms-publish-canary-', array_replace_recursive([
+            'schema_version' => 'seo-agent-cms-publish-canary.v1',
+            'ok' => true,
+            'status' => 'success',
+            'execute' => true,
+            'writes_committed' => true,
+            'published_count' => 1,
+            'affected_refs' => [[
+                'status' => 'published',
+                'target_model' => 'content_page',
+                'subject_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+                'revision_id' => 101,
+                'safe_path' => '/zh/content-page-candidate',
+            ]],
+            'rollback_evidence' => [
+                'available' => true,
+                'content_page_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+            ],
+            'boundaries' => [
+                'cms_publish' => true,
+                'search_channel_enqueue' => false,
+                'indexing_request' => false,
+            ],
+        ], $overrides));
+    }
+
+    private function seedSeoUrl(string $canonicalUrl, string $entityId): void
+    {
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'content_page',
+            'entity_id_or_slug' => $entityId,
+            'cluster' => 'content_page',
+            'source_authority' => 'backend_cms',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => now()->subMinute(),
+            'lastmod_source' => 'content_pages.updated_at',
+            'is_private_flow' => false,
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode([
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'content_pages',
+            ], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_batches', function ($table): void {
+            $table->id();
+            $table->string('channel', 64);
+            $table->string('status', 64)->default('draft');
+            $table->unsignedInteger('item_count')->default(0);
+            $table->json('dry_run_report')->nullable();
+            $table->text('approval_note')->nullable();
+            $table->string('created_by', 128)->nullable();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+
+        foreach (['seo_baidu_push_logs', 'seo_indexnow_submissions', 'seo_domestic_submission_logs'] as $table) {
+            Schema::connection('seo_intel')->create($table, function ($schema): void {
+                $schema->id();
+            });
+        }
+    }
+
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1217,6 +1217,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_post_publish_search_submit_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentPostPublishSearchSubmitCommand;',
+            '+        SeoAgentPostPublishSearchSubmitCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3763,6 +3777,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentPostPublishSearchSubmitFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4358,6 +4376,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -5062,6 +5081,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentPostPublishSearchSubmitFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php',
         ], true);
     }
 
@@ -6861,6 +6887,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsPublishCanaryCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentPostPublishSearchSubmitOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentPostPublishSearchSubmitCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:post-publish-search-submit` to bridge one successful SEO Agent publish canary into Search Channel queue evidence.
- Requires `seo-agent-cms-publish-canary.v1` success evidence, SHA confirmation in execute mode, a public/indexable ContentPage, and an existing `seo_urls` URL Truth row.
- Allows `content_page` in Search Channel queue eligibility.
- Queues only bounded channels `indexnow` and `google_sitemap`; it does not perform live external submission or call Google Indexing directly.
- Added contract docs/generated JSON, focused tests, and BigFive freeze guard allowlisting.

## Why
This creates the post-publish handoff step: after a low-risk CMS canary is published, the URL can enter a traceable Search Channel queue path while remaining separate from live submission and scheduler activation.

## Validation
- `php artisan test --filter SeoAgentPostPublishSearchSubmitTest`
- `php artisan test --filter SeoIntelSearchChannelQueueRuntimeTest`
- `php artisan test --filter 'BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_agent_post_publish_search_submit_files'`
- `python3 -m json.tool docs/seo/generated/seo-agent-post-publish-search-submit.v1.json >/dev/null`
- `git diff --check`

## Deferred
- Live Search Channel submission.
- Live Google Indexing API calls.
- Scheduler activation.
- Queue worker activation.
- Draft or unpublished URL submission.
