### PR TITLE
SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
@@ -243,7 +243,9 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
         foreach ($gapCodes as $code) {
             $fields[] = match ($code) {
                 'missing_title' => 'seo_title',
+                'gsc_low_ctr_title_opportunity', 'gsc_low_ctr_rank_8_20' => 'seo_title',
                 'missing_meta_description' => 'seo_description',
+                'gsc_low_ctr_description_opportunity' => 'seo_description',
                 'missing_canonical' => 'canonical_url_or_path',
                 'missing_indexability_metadata' => 'is_indexable_or_robots',
                 'missing_faq_items', 'missing_visible_faq' => 'faq_items',

--- a/backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php
@@ -1,0 +1,616 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ContentPage;
+use App\Services\SeoAgent\OpportunityAggregator;
+use App\Services\SeoIntel\GscDataQualityGate;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentGscOpportunityAutoDraftCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-gsc-opportunity-auto-draft.v1';
+
+    private const SOURCE_FAMILY = 'gsc_performance';
+
+    protected $signature = 'seo-agent:gsc-opportunity-auto-draft
+        {--limit=10 : Candidate limit, bounded 1..100}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Build Codex review and CMS draft dry-run artifacts from gated GSC opportunity rows without writing CMS or publishing.';
+
+    public function handle(GscDataQualityGate $dataQualityGate): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $limit = $this->limit();
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $rows = $this->gscRows();
+        $sourceGate = $dataQualityGate->evaluate($rows);
+        $candidates = ($sourceGate['opportunity_queue_eligible'] ?? false) === true
+            ? $this->candidateRows($rows, $limit)
+            : [];
+
+        $sourceArtifact = $this->sourceArtifact($sourceGate, $rows, $candidates, $limit);
+        $sourceRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-opportunity-source-'.$timestamp.'.json',
+            $sourceArtifact
+        );
+
+        $aggregate = (new OpportunityAggregator)->aggregate([$sourceArtifact], $limit);
+        $aggregate['input_artifacts'] = [$sourceRef];
+        $aggregateRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-opportunity-aggregate-'.$timestamp.'.json',
+            $aggregate
+        );
+
+        $handoff = $this->codexReviewHandoff($sourceRef, $aggregateRef, $aggregate);
+        $handoffRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-opportunity-codex-handoff-'.$timestamp.'.json',
+            $handoff
+        );
+
+        $verdictRef = $this->runCodexReview($handoffRef, $artifactDir);
+        if ($verdictRef === null) {
+            return $this->finish($this->failureSummary('codex_review_runner_failed', [
+                'source_artifact' => $sourceRef,
+                'aggregate_artifact' => $aggregateRef,
+                'handoff_artifact' => $handoffRef,
+            ]));
+        }
+
+        $draftRef = $this->runDraftPackageDryRun($verdictRef, $artifactDir);
+        if ($draftRef === null) {
+            return $this->finish($this->failureSummary('cms_draft_package_dry_run_failed', [
+                'source_artifact' => $sourceRef,
+                'aggregate_artifact' => $aggregateRef,
+                'handoff_artifact' => $handoffRef,
+                'verdict_artifact' => $verdictRef,
+            ]));
+        }
+
+        $evidence = $this->runEvidence($sourceGate, $rows, $sourceRef, $aggregateRef, $handoffRef, $verdictRef, $draftRef);
+        $evidenceRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-opportunity-auto-draft-evidence-'.$timestamp.'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'source_gate' => [
+                'status' => (string) ($sourceGate['status'] ?? 'unknown'),
+                'opportunity_queue_eligible' => (bool) ($sourceGate['opportunity_queue_eligible'] ?? false),
+                'rows_checked' => (int) ($sourceGate['rows_checked'] ?? 0),
+            ],
+            'candidate_count' => count($candidates),
+            'draft_brief_count' => (int) data_get($draftRef, 'sanitized_summary.draft_brief_count', 0),
+            'artifact' => $evidenceRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 10;
+        }
+
+        return max(1, min((int) $raw, 100));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function gscRows(): array
+    {
+        return DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table('seo_gsc_daily')
+            ->leftJoin('seo_urls', 'seo_gsc_daily.canonical_url_hash', '=', 'seo_urls.canonical_url_hash')
+            ->select([
+                'seo_gsc_daily.report_date',
+                'seo_gsc_daily.canonical_url_hash',
+                'seo_gsc_daily.query_hash',
+                'seo_gsc_daily.query_display_masked',
+                'seo_gsc_daily.locale',
+                'seo_gsc_daily.source_engine',
+                'seo_gsc_daily.clicks',
+                'seo_gsc_daily.impressions',
+                'seo_gsc_daily.ctr_ppm',
+                'seo_gsc_daily.average_position_milli',
+                'seo_gsc_daily.is_brand_query',
+                'seo_gsc_daily.query_type',
+                'seo_gsc_daily.metadata_json',
+                'seo_urls.canonical_url',
+                'seo_urls.page_entity_type',
+                'seo_urls.entity_id_or_slug',
+                'seo_urls.indexability_state',
+            ])
+            ->where('seo_gsc_daily.source_engine', 'google')
+            ->orderByDesc('seo_gsc_daily.report_date')
+            ->limit(500)
+            ->get()
+            ->map(fn (object $row): array => [
+                'report_date' => (string) $row->report_date,
+                'canonical_url_hash' => (string) $row->canonical_url_hash,
+                'query_hash' => (string) $row->query_hash,
+                'query_display_masked' => is_string($row->query_display_masked ?? null) ? $row->query_display_masked : null,
+                'locale' => is_string($row->locale ?? null) ? $row->locale : null,
+                'source_engine' => (string) $row->source_engine,
+                'clicks' => (int) ($row->clicks ?? 0),
+                'impressions' => (int) ($row->impressions ?? 0),
+                'ctr_ppm' => $row->ctr_ppm === null ? null : (int) $row->ctr_ppm,
+                'average_position_milli' => $row->average_position_milli === null ? null : (int) $row->average_position_milli,
+                'is_brand_query' => (bool) ($row->is_brand_query ?? false),
+                'query_type' => is_string($row->query_type ?? null) ? $row->query_type : 'unknown',
+                'metadata_json' => $this->decodeJson($row->metadata_json ?? null),
+                'safe_path' => $this->safePath(is_string($row->canonical_url ?? null) ? $row->canonical_url : null),
+                'page_entity_type' => is_string($row->page_entity_type ?? null) ? $row->page_entity_type : '',
+                'entity_id_or_slug' => is_string($row->entity_id_or_slug ?? null) ? $row->entity_id_or_slug : '',
+                'indexability_state' => is_string($row->indexability_state ?? null) ? $row->indexability_state : '',
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    private function candidateRows(array $rows, int $limit): array
+    {
+        $candidates = [];
+
+        foreach ($rows as $row) {
+            if (! $this->matchesOpportunityContract($row)) {
+                continue;
+            }
+
+            $target = $this->cmsTarget($row);
+            if ($target === null) {
+                continue;
+            }
+
+            $candidates[] = $this->candidate($row, $target);
+        }
+
+        usort($candidates, static function (array $left, array $right): int {
+            $leftMetrics = (array) ($left['metrics'] ?? []);
+            $rightMetrics = (array) ($right['metrics'] ?? []);
+            $leftScore = ((int) ($leftMetrics['impressions'] ?? 0)) - ((int) ($leftMetrics['ctr_ppm'] ?? 0) / 1000);
+            $rightScore = ((int) ($rightMetrics['impressions'] ?? 0)) - ((int) ($rightMetrics['ctr_ppm'] ?? 0) / 1000);
+
+            return $rightScore <=> $leftScore;
+        });
+
+        return array_slice($candidates, 0, $limit);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function matchesOpportunityContract(array $row): bool
+    {
+        $impressions = (int) ($row['impressions'] ?? 0);
+        $clicks = (int) ($row['clicks'] ?? 0);
+        $ctrPpm = $row['ctr_ppm'] === null ? ($impressions > 0 ? (int) floor(($clicks / $impressions) * 1_000_000) : null) : (int) $row['ctr_ppm'];
+        $positionMilli = $row['average_position_milli'] === null ? null : (int) $row['average_position_milli'];
+
+        return $impressions >= 50
+            && $ctrPpm !== null
+            && $ctrPpm <= 10000
+            && $positionMilli !== null
+            && $positionMilli >= 8000
+            && $positionMilli <= 20000
+            && ! (bool) ($row['is_brand_query'] ?? false)
+            && ($row['query_type'] ?? 'unknown') === 'non_brand'
+            && ($row['safe_path'] ?? null) !== null
+            && ($row['indexability_state'] ?? '') === 'indexable';
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array{type:string,ref:string}|null
+     */
+    private function cmsTarget(array $row): ?array
+    {
+        $entityType = (string) ($row['page_entity_type'] ?? '');
+        if (! in_array($entityType, ['article', 'content_page'], true)) {
+            return null;
+        }
+
+        $entityIdOrSlug = (string) ($row['entity_id_or_slug'] ?? '');
+        $locale = (string) ($row['locale'] ?? '');
+        $safePath = (string) ($row['safe_path'] ?? '');
+        $id = null;
+
+        if ($entityIdOrSlug !== '' && ctype_digit($entityIdOrSlug)) {
+            $id = (int) $entityIdOrSlug;
+        } elseif ($entityType === 'article') {
+            $id = Article::query()
+                ->withoutGlobalScopes()
+                ->where('slug', $entityIdOrSlug !== '' ? $entityIdOrSlug : basename(trim($safePath, '/')))
+                ->when($locale !== '', fn ($query) => $query->where('locale', $locale))
+                ->value('id');
+        } else {
+            $id = ContentPage::query()
+                ->withoutGlobalScopes()
+                ->where(static function ($query) use ($entityIdOrSlug, $safePath): void {
+                    if ($entityIdOrSlug !== '') {
+                        $query->where('slug', $entityIdOrSlug);
+                    }
+                    if ($safePath !== '') {
+                        $query->orWhere('path', $safePath);
+                    }
+                })
+                ->when($locale !== '', fn ($query) => $query->where('locale', $locale))
+                ->value('id');
+        }
+
+        if (! is_numeric($id) || (int) $id < 1) {
+            return null;
+        }
+
+        $exists = $entityType === 'article'
+            ? Article::query()->withoutGlobalScopes()->whereKey((int) $id)->exists()
+            : ContentPage::query()->withoutGlobalScopes()->whereKey((int) $id)->exists();
+        if (! $exists) {
+            return null;
+        }
+
+        return [
+            'type' => $entityType,
+            'ref' => $entityType.':'.(int) $id.':'.($locale !== '' ? $locale : 'unknown'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @param  array{type:string,ref:string}  $target
+     * @return array<string, mixed>
+     */
+    private function candidate(array $row, array $target): array
+    {
+        $metrics = [
+            'clicks' => (int) ($row['clicks'] ?? 0),
+            'impressions' => (int) ($row['impressions'] ?? 0),
+            'ctr_ppm' => $row['ctr_ppm'] === null ? null : (int) $row['ctr_ppm'],
+            'average_position_milli' => $row['average_position_milli'] === null ? null : (int) $row['average_position_milli'],
+        ];
+        $sourceId = hash('sha256', implode('|', [
+            (string) ($row['report_date'] ?? ''),
+            (string) ($row['canonical_url_hash'] ?? ''),
+            (string) ($row['query_hash'] ?? ''),
+            $target['ref'],
+        ]));
+
+        return [
+            'source_family' => self::SOURCE_FAMILY,
+            'source_id' => $sourceId,
+            'subject_type' => $target['type'],
+            'subject_ref' => $target['ref'],
+            'safe_path' => (string) ($row['safe_path'] ?? ''),
+            'locale' => (string) ($row['locale'] ?? ''),
+            'severity' => ($metrics['impressions'] >= 500 && (int) ($metrics['ctr_ppm'] ?? 0) === 0) ? 'p1' : 'p2',
+            'gap_types' => [
+                'gsc_low_ctr_title_opportunity',
+                'gsc_low_ctr_description_opportunity',
+            ],
+            'evidence_refs' => [
+                [
+                    'code' => 'gsc_low_ctr_rank_8_20',
+                    'field_status' => 'eligible_live_gsc_read_model_row',
+                ],
+            ],
+            'metrics' => $metrics,
+            'canonical_url_hash' => (string) ($row['canonical_url_hash'] ?? ''),
+            'query_hash' => (string) ($row['query_hash'] ?? ''),
+            'query_display_masked' => $row['query_display_masked'] ?? null,
+            'recommended_next_step' => 'codex_review_then_cms_draft_package_dry_run',
+            'allowed_action' => 'cms_draft_package_dry_run',
+            'blocked_actions' => [
+                'cms_write_without_separate_draft_writer',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceGate
+     * @param  list<array<string, mixed>>  $rows
+     * @param  list<array<string, mixed>>  $candidates
+     * @return array<string, mixed>
+     */
+    private function sourceArtifact(array $sourceGate, array $rows, array $candidates, int $limit): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01',
+            'run_mode' => 'readonly_gsc_opportunity_to_draft_dry_run',
+            'source_family' => self::SOURCE_FAMILY,
+            'source_gate' => $sourceGate,
+            'candidate_count' => count($candidates),
+            'rows_seen' => count($rows),
+            'limit' => $limit,
+            'scoring_contract' => [
+                'min_impressions' => 50,
+                'max_ctr_ppm' => 10000,
+                'position_milli_window' => [8000, 20000],
+                'brand_query_allowed' => false,
+                'query_type_required' => 'non_brand',
+                'cms_target_required' => true,
+            ],
+            'candidates' => $candidates,
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRef
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $aggregate
+     * @return array<string, mixed>
+     */
+    private function codexReviewHandoff(array $sourceRef, array $aggregateRef, array $aggregate): array
+    {
+        return [
+            'schema_version' => 'seo-agent-codex-review-handoff.v1',
+            'task' => 'SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01',
+            'reviewer' => 'codex',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_candidates' => $aggregateRef,
+            'input_artifacts' => [$sourceRef],
+            'candidate_count' => (int) ($aggregate['candidate_count'] ?? 0),
+            'review_output_contract' => [
+                'worth_optimizing' => 'boolean',
+                'recommended_action' => 'cms_draft_package_dry_run|defer',
+                'risk_flags' => 'list<string>',
+                'needs_human_approval' => 'boolean',
+            ],
+            'candidate_preview' => array_slice((array) ($aggregate['candidates'] ?? []), 0, 100),
+            'forbidden_actions' => [
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'scheduler_activation',
+                'queue_worker_activation',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $handoffRef
+     * @return array<string, mixed>|null
+     */
+    private function runCodexReview(array $handoffRef, string $artifactDir): ?array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('seo-agent:codex-review-runner', [
+            '--handoff' => (string) ($handoffRef['path'] ?? ''),
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ], $output);
+        $summary = json_decode(trim($output->fetch()), true);
+
+        return $exit === self::SUCCESS && is_array($summary) && is_array($summary['artifact'] ?? null)
+            ? $summary['artifact']
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $verdictRef
+     * @return array<string, mixed>|null
+     */
+    private function runDraftPackageDryRun(array $verdictRef, string $artifactDir): ?array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => (string) ($verdictRef['path'] ?? ''),
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ], $output);
+        $summary = json_decode(trim($output->fetch()), true);
+
+        return $exit === self::SUCCESS && is_array($summary) && is_array($summary['artifact'] ?? null)
+            ? $summary['artifact']
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceGate
+     * @param  list<array<string, mixed>>  $rows
+     * @param  array<string, mixed>  $sourceRef
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $handoffRef
+     * @param  array<string, mixed>  $verdictRef
+     * @param  array<string, mixed>  $draftRef
+     * @return array<string, mixed>
+     */
+    private function runEvidence(
+        array $sourceGate,
+        array $rows,
+        array $sourceRef,
+        array $aggregateRef,
+        array $handoffRef,
+        array $verdictRef,
+        array $draftRef
+    ): array {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01',
+            'status' => 'success',
+            'source_gate' => [
+                'status' => (string) ($sourceGate['status'] ?? 'unknown'),
+                'opportunity_queue_eligible' => (bool) ($sourceGate['opportunity_queue_eligible'] ?? false),
+                'rows_checked' => count($rows),
+            ],
+            'artifacts' => [
+                'gsc_opportunity_source' => $sourceRef,
+                'opportunity_aggregate' => $aggregateRef,
+                'codex_review_handoff' => $handoffRef,
+                'codex_review_verdict' => $verdictRef,
+                'cms_draft_package_dry_run' => $draftRef,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            $this->line('candidate_count='.(string) ($summary['candidate_count'] ?? 0));
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function safePath(?string $canonicalUrl): ?string
+    {
+        if ($canonicalUrl === null || trim($canonicalUrl) === '') {
+            return null;
+        }
+
+        $path = parse_url($canonicalUrl, PHP_URL_PATH);
+        $query = parse_url($canonicalUrl, PHP_URL_QUERY);
+
+        if (! is_string($path) || $path === '') {
+            return '/';
+        }
+
+        return is_string($query) && $query !== '' ? $path.'?'.$query : $path;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -172,6 +172,7 @@ use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
+use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentPostPublishSearchSubmitCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
@@ -376,6 +377,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
         SeoAgentCmsPublishCanaryCommand::class,
+        SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,

--- a/backend/docs/seo/generated/seo-agent-gsc-opportunity-auto-draft.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-opportunity-auto-draft.v1.json
@@ -1,0 +1,66 @@
+{
+  "version": "seo-agent-gsc-opportunity-auto-draft.v1",
+  "task": "SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01",
+  "repo": "fap-api",
+  "type": "readonly_gsc_opportunity_to_cms_draft_dryrun_contract",
+  "command": "php artisan seo-agent:gsc-opportunity-auto-draft",
+  "inputs": [
+    "seo_intel.seo_gsc_daily",
+    "seo_intel.seo_urls",
+    "gsc_data_quality_gate"
+  ],
+  "outputs": [
+    "seo-agent-gsc-opportunity-auto-draft.v1",
+    "seo-agent-opportunity-aggregate.v1",
+    "seo-agent-codex-review-handoff.v1",
+    "seo-agent-codex-review-verdict.v1",
+    "seo-agent-cms-draft-package-dry-run.v1"
+  ],
+  "candidate_contract": {
+    "source_family": "gsc_performance",
+    "data_origin": "live_gsc_api",
+    "min_impressions": 50,
+    "max_ctr_ppm": 10000,
+    "position_milli_window": [8000, 20000],
+    "query_type_required": "non_brand",
+    "brand_query_allowed": false,
+    "cms_target_required": true,
+    "allowed_subject_types": ["article", "content_page"],
+    "target_gap_types": [
+      "gsc_low_ctr_title_opportunity",
+      "gsc_low_ctr_description_opportunity"
+    ]
+  },
+  "forbidden_input_or_output_fields": [
+    "raw_url",
+    "raw_query",
+    "full_url",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "raw_html",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false
+  },
+  "next_step": "A separate controlled CMS draft writer may consume the dry-run package after policy approval; this command never writes or publishes CMS content."
+}

--- a/backend/docs/seo/seo-agent-gsc-opportunity-auto-draft.md
+++ b/backend/docs/seo/seo-agent-gsc-opportunity-auto-draft.md
@@ -1,0 +1,39 @@
+# SEO Agent GSC Opportunity Auto Draft
+
+`SEO-AGENT-GSC-OPPORTUNITY-AUTO-DRAFT-01` bridges gated live GSC read-model rows into the L4 SEO Agent dry-run flow.
+
+## Command
+
+```bash
+php artisan seo-agent:gsc-opportunity-auto-draft \
+  --limit=10 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+## Contract
+
+The command reads `seo_intel.seo_gsc_daily` and resolves CMS targets through `seo_intel.seo_urls`. It only creates candidates when the GSC data quality gate passes and the row matches the current opportunity contract:
+
+- `data_origin=live_gsc_api`
+- `impressions >= 50`
+- `ctr_ppm <= 10000`
+- `average_position_milli` between `8000` and `20000`
+- `query_type=non_brand`
+- `is_brand_query=false`
+- URL truth resolves to an `article` or `content_page` CMS target
+
+For eligible rows, it writes sanitized artifacts for:
+
+- GSC opportunity source
+- opportunity aggregate
+- Codex review handoff
+- Codex review verdict
+- CMS draft package dry-run
+- final run evidence
+
+## Boundaries
+
+This command does not call Google Search Console, Google Indexing, external model APIs, CMS write paths, CMS publish paths, Search Channel enqueue/submit paths, schedulers, or queue workers. It does not write `seo_gsc_daily`; it only consumes rows already imported through the approved GSC sidecar/read-model flow.
+
+Artifacts must not contain full URLs, raw queries, credentials, tokens, cookies, service-account JSON, raw HTML, or CMS body content.

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscOpportunityAutoDraftTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscOpportunityAutoDraftTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentGscOpportunityAutoDraftTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::parse('2026-06-21 08:00:00'));
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function command_builds_gsc_opportunity_review_and_draft_package_without_writes(): void
+    {
+        $page = $this->createPublishedContentPage();
+        $this->seedGscRows($page);
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:gsc-opportunity-auto-draft', [
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $countsAfter = $this->rowCounts();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $evidence = $this->readJson($this->latestArtifact($artifactDir, 'seo-agent-gsc-opportunity-auto-draft-evidence-*.json'));
+        $source = $this->readJson(data_get($evidence, 'artifacts.gsc_opportunity_source.path'));
+        $aggregate = $this->readJson(data_get($evidence, 'artifacts.opportunity_aggregate.path'));
+        $verdict = $this->readJson(data_get($evidence, 'artifacts.codex_review_verdict.path'));
+        $draftPackage = $this->readJson(data_get($evidence, 'artifacts.cms_draft_package_dry_run.path'));
+
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $evidence['status'] ?? null);
+        $this->assertSame('pass', data_get($evidence, 'source_gate.status'));
+        $this->assertTrue((bool) data_get($evidence, 'source_gate.opportunity_queue_eligible'));
+        $this->assertSame(1, data_get($source, 'candidate_count'));
+        $this->assertSame(1, data_get($draftPackage, 'draft_brief_count'));
+
+        $this->assertSame('seo-agent-gsc-opportunity-auto-draft.v1', $source['schema_version'] ?? null);
+        $this->assertSame('gsc_performance', data_get($source, 'candidates.0.source_family'));
+        $this->assertSame('content_page', data_get($source, 'candidates.0.subject_type'));
+        $this->assertSame('content_page:'.$page->id.':en', data_get($source, 'candidates.0.subject_ref'));
+        $this->assertSame('/en/gsc-opportunity-page', data_get($source, 'candidates.0.safe_path'));
+        $this->assertSame(['gsc_low_ctr_title_opportunity', 'gsc_low_ctr_description_opportunity'], data_get($source, 'candidates.0.gap_types'));
+
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', $aggregate['schema_version'] ?? null);
+        $this->assertSame(1, $aggregate['candidate_count'] ?? null);
+        $this->assertSame('seo-agent-codex-review-verdict.v1', $verdict['schema_version'] ?? null);
+        $this->assertSame('cms_draft_package_dry_run', data_get($verdict, 'candidate_verdicts.0.recommended_action'));
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $draftPackage['schema_version'] ?? null);
+        $this->assertSame(1, $draftPackage['draft_brief_count'] ?? null);
+        $targetFields = data_get($draftPackage, 'draft_briefs.0.target_fields');
+        sort($targetFields);
+        $this->assertSame(['seo_description', 'seo_title'], $targetFields);
+        $this->assertFalse((bool) data_get($draftPackage, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.cms_publish', true));
+
+        $encoded = json_encode([$source, $aggregate, $verdict, $draftPackage, $evidence], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function command_outputs_zero_candidates_when_gate_is_blocked(): void
+    {
+        $page = $this->createPublishedContentPage();
+        $this->seedGscRows($page, dataOrigin: 'fixture');
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:gsc-opportunity-auto-draft', [
+            '--limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $evidence = $this->readJson($this->latestArtifact($artifactDir, 'seo-agent-gsc-opportunity-auto-draft-evidence-*.json'));
+        $source = $this->readJson(data_get($evidence, 'artifacts.gsc_opportunity_source.path'));
+
+        $this->assertSame('success', $evidence['status'] ?? null);
+        $this->assertSame('blocked', data_get($evidence, 'source_gate.status'));
+        $this->assertFalse((bool) data_get($evidence, 'source_gate.opportunity_queue_eligible'));
+        $this->assertSame(0, $source['candidate_count'] ?? null);
+        $this->assertContains('fixture_or_mock_source', data_get($source, 'source_gate.reasons'));
+        $this->assertFalse((bool) data_get($source, 'negative_guarantees.database_write', true));
+    }
+
+    #[Test]
+    public function generated_contract_documents_gsc_auto_draft_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-gsc-opportunity-auto-draft.v1.json'));
+
+        $this->assertSame('seo-agent-gsc-opportunity-auto-draft.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:gsc-opportunity-auto-draft', $contract['command'] ?? null);
+        $this->assertSame('gsc_performance', data_get($contract, 'candidate_contract.source_family'));
+        $this->assertSame('live_gsc_api', data_get($contract, 'candidate_contract.data_origin'));
+        $this->assertSame(['article', 'content_page'], data_get($contract, 'candidate_contract.allowed_subject_types'));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.google_search_console_api_call', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.google_indexing_api_call', true));
+    }
+
+    private function createPublishedContentPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'gsc-opportunity-page',
+            'path' => '/en/gsc-opportunity-page',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'GSC Opportunity Page',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'en',
+            'seo_title' => 'GSC Opportunity Page | FermatMind',
+            'seo_description' => 'A published page used to verify GSC opportunity dry-run routing.',
+            'meta_description' => 'A published page used to verify GSC opportunity dry-run routing.',
+            'canonical_path' => '/en/gsc-opportunity-page',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+        ]);
+    }
+
+    private function seedGscRows(ContentPage $page, string $dataOrigin = 'live_gsc_api'): void
+    {
+        $hash = hash('sha256', 'https://fermatmind.com/en/gsc-opportunity-page');
+
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => $hash,
+            'canonical_url' => 'https://fermatmind.com/en/gsc-opportunity-page',
+            'locale' => 'en',
+            'page_entity_type' => 'content_page',
+            'entity_id_or_slug' => (string) $page->id,
+            'source_authority' => 'cms_content_page',
+            'indexability_state' => 'indexable',
+            'is_private_flow' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'report_date' => '2026-06-17',
+            'canonical_url_hash' => $hash,
+            'canonical_url' => null,
+            'query_hash' => hash('sha256', 'best career test'),
+            'query_display_masked' => 'b*************t',
+            'locale' => 'en',
+            'source_engine' => 'google',
+            'clicks' => 0,
+            'impressions' => 180,
+            'ctr_ppm' => 0,
+            'average_position_milli' => 11200,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'data_state' => 'final',
+            'metadata_json' => json_encode(['data_origin' => $dataOrigin], JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'report_date' => '2026-06-17',
+            'canonical_url_hash' => $hash,
+            'canonical_url' => null,
+            'query_hash' => hash('sha256', 'fermatmind branded'),
+            'query_display_masked' => 'f*********d',
+            'locale' => 'en',
+            'source_engine' => 'google',
+            'clicks' => 10,
+            'impressions' => 200,
+            'ctr_ppm' => 50000,
+            'average_position_milli' => 3000,
+            'is_brand_query' => true,
+            'query_type' => 'brand',
+            'data_state' => 'final',
+            'metadata_json' => json_encode(['data_origin' => $dataOrigin], JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        $schema = Schema::connection('seo_intel');
+        $schema->dropIfExists('seo_gsc_daily');
+        $schema->dropIfExists('seo_urls');
+
+        $schema->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->boolean('is_private_flow')->default(false);
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        $schema->create('seo_gsc_daily', function ($table): void {
+            $table->id();
+            $table->date('report_date');
+            $table->char('canonical_url_hash', 64)->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->char('query_hash', 64)->nullable();
+            $table->string('query_display_masked', 255)->nullable();
+            $table->string('locale', 16)->nullable();
+            $table->string('source_engine', 64)->default('google');
+            $table->unsignedInteger('clicks')->default(0);
+            $table->unsignedInteger('impressions')->default(0);
+            $table->unsignedInteger('ctr_ppm')->nullable();
+            $table->unsignedInteger('average_position_milli')->nullable();
+            $table->boolean('is_brand_query')->default(false);
+            $table->string('query_type', 32)->default('unknown');
+            $table->string('data_state', 32)->default('final');
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'content_pages' => ContentPage::query()->withoutGlobalScopes()->count(),
+            'seo_urls' => DB::connection('seo_intel')->table('seo_urls')->count(),
+            'seo_gsc_daily' => DB::connection('seo_intel')->table('seo_gsc_daily')->count(),
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-gsc-opportunity-auto-draft-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function latestArtifact(string $dir, string $pattern): ?string
+    {
+        $paths = File::glob(rtrim($dir, '/').'/'.$pattern) ?: [];
+        rsort($paths);
+
+        return $paths[0] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'full_url',
+            'https://fermatmind.com',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1231,6 +1231,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php',
+            'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentGscOpportunityAutoDraftCommand;',
+            '+        SeoAgentGscOpportunityAutoDraftCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3781,6 +3796,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentGscOpportunityAutoDraftFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -4377,6 +4396,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -5088,6 +5108,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentGscOpportunityAutoDraftFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php',
+            'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
         ], true);
     }
 
@@ -6909,6 +6937,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentPostPublishSearchSubmitCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentGscOpportunityAutoDraftCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:gsc-opportunity-auto-draft` to bridge gated `seo_gsc_daily` live rows into the L4 SEO Agent dry-run flow.
- The command reads `seo_gsc_daily + seo_urls`, filters low CTR / ranking 8-20 / sufficient impressions / non-brand candidates, resolves only CMS-backed `article` or `content_page` targets, and writes sanitized artifacts for source, aggregate, Codex review handoff/verdict, CMS draft package dry-run, and final evidence.
- Mapped GSC low-CTR gap codes to dry-run `seo_title` and `seo_description` proposal fields.
- Added the generated contract docs and focused tests, plus the BigFive runtime-freeze allowlist for this SEO Agent command.

## Why
This is the GSC bridge for the L4 half-automatic SEO Agent: GSC live rows can now produce Codex-reviewed CMS draft proposals without directly mutating CMS content or publishing anything.

## Validation
- `php -l app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php`
- `php -l app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php`
- `php -l tests/Feature/SeoIntel/SeoAgentGscOpportunityAutoDraftTest.php`
- `php artisan test --filter SeoAgentGscOpportunityAutoDraftTest`
- `php artisan test --filter SeoAgentCodexReviewRunnerTest`
- `php artisan test --filter SeoAgentCmsDraftPackageDryRunTest`
- `php artisan test --filter SeoAgentOpportunityAggregatorTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files`
- `python3 -m json.tool docs/seo/generated/seo-agent-gsc-opportunity-auto-draft.v1.json >/dev/null`
- `git diff --check`
- `php artisan list | rg 'seo-agent:gsc-opportunity-auto-draft'`

## Intentionally deferred
- No CMS draft write execution.
- No CMS publish.
- No Search Channel enqueue or submit.
- No Google Indexing request.
- No scheduler or queue worker activation.
- No live GSC API read; this consumes existing gated read-model rows only.
- No fap-web code PR writer; that remains the next separate PR.
