### PR TITLE
SEO-AGENT-AUTO-APPROVAL-POLICY-01

### DIFF
--- a/backend/app/Services/SeoAgent/AutoApprovalPolicy.php
+++ b/backend/app/Services/SeoAgent/AutoApprovalPolicy.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoAgent;
+
+final class AutoApprovalPolicy
+{
+    public const SCHEMA_VERSION = 'seo-agent-auto-approval-policy.v1';
+
+    private const ALLOWED_SOURCE_FAMILIES = ['cms_tdk_gap', 'cms_faq_gap'];
+
+    private const ALLOWED_TARGET_MODELS = ['article', 'content_page'];
+
+    private const ALLOWED_SEVERITIES = ['p1', 'p2'];
+
+    private const FIELD_ALIASES = [
+        'canonical_url_or_path' => 'canonical_path',
+        'is_indexable_or_robots' => 'is_indexable',
+        'faq_schema_eligible' => 'schema_enabled',
+    ];
+
+    private const ALLOWED_TARGET_FIELDS = [
+        'seo_title',
+        'seo_description',
+        'canonical_path',
+        'is_indexable',
+        'faq_items',
+        'schema_enabled',
+    ];
+
+    private const FORBIDDEN_KEYS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+        'payload',
+        'metadata_json',
+    ];
+
+    private const FORBIDDEN_CLAIM_PATTERNS = [
+        '/\bdiagnos(e|is|tic)\b/i',
+        '/\bcure(s|d)?\b/i',
+        '/\bguarantee(d|s)?\b/i',
+        '/\bofficial\s+(partner|partnership|endorsement)\b/i',
+        '/\bclinically\s+proven\b/i',
+        '/\bhiring\s+fit\b/i',
+        '/\bmedical\s+advice\b/i',
+        '/\btreatment\b/i',
+    ];
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return array<string, mixed>
+     */
+    public function evaluateCandidates(array $candidates, int $limit = 100): array
+    {
+        $limit = max(1, min($limit, 250));
+        $evaluations = array_map(
+            fn (array $candidate): array => $this->evaluateCandidate($candidate),
+            array_slice($candidates, 0, $limit)
+        );
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'success',
+            'policy_mode' => 'l5_low_risk_auto_approval',
+            'candidate_count' => count($evaluations),
+            'auto_approved_count' => count(array_filter(
+                $evaluations,
+                static fn (array $evaluation): bool => ($evaluation['approval_decision'] ?? '') === 'auto_approved'
+            )),
+            'blocked_count' => count(array_filter(
+                $evaluations,
+                static fn (array $evaluation): bool => ($evaluation['approval_decision'] ?? '') === 'blocked'
+            )),
+            'candidate_decisions' => $evaluations,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    public function evaluateCandidate(array $candidate): array
+    {
+        $sourceFamily = (string) ($candidate['source_family'] ?? '');
+        $targetModel = (string) ($candidate['target_model'] ?? $candidate['subject_type'] ?? '');
+        $severity = (string) ($candidate['severity'] ?? '');
+        $targetFields = $this->targetFields($candidate);
+        $reasonCodes = [];
+
+        if (! in_array($sourceFamily, self::ALLOWED_SOURCE_FAMILIES, true)) {
+            $reasonCodes[] = match ($sourceFamily) {
+                'runtime_seo_qa' => 'runtime_seo_qa_requires_technical_review',
+                'gsc_performance' => 'gsc_performance_requires_manual_review_for_l5_auto_approval',
+                default => 'source_family_not_allowed',
+            };
+        }
+
+        if (! in_array($targetModel, self::ALLOWED_TARGET_MODELS, true)) {
+            $reasonCodes[] = 'target_model_not_allowed';
+        }
+
+        if (! in_array($severity, self::ALLOWED_SEVERITIES, true)) {
+            $reasonCodes[] = 'severity_not_allowed';
+        }
+
+        if ($targetFields === []) {
+            $reasonCodes[] = 'target_fields_missing';
+        }
+
+        foreach ($targetFields as $field) {
+            if (! in_array($field, self::ALLOWED_TARGET_FIELDS, true)) {
+                $reasonCodes[] = 'target_field_not_allowed';
+                break;
+            }
+        }
+
+        if ((bool) ($candidate['claim_gate_required'] ?? false) !== true
+            || (bool) ($candidate['human_approval_required'] ?? false) !== true
+            || (bool) ($candidate['execution_permission'] ?? true) !== false) {
+            $reasonCodes[] = 'approval_boundary_invalid';
+        }
+
+        if (($forbidden = $this->forbiddenKeysPresent($candidate)) !== []) {
+            foreach ($forbidden as $key) {
+                $reasonCodes[] = 'forbidden_field_present:'.$key;
+            }
+        }
+
+        if ($this->containsFullUrl($candidate)) {
+            $reasonCodes[] = 'full_url_present';
+        }
+
+        if ($this->forbiddenClaimDetected($candidate)) {
+            $reasonCodes[] = 'forbidden_claim_detected';
+        }
+
+        $blockedActions = [
+            'cms_body_generation',
+            'article_auto_publish',
+            'google_indexing_live_api_call',
+            'frontend_direct_push',
+            'frontend_auto_deploy',
+        ];
+        $allowedActions = [];
+
+        if ($reasonCodes === []) {
+            $allowedActions[] = 'cms_draft_write_auto';
+
+            if ($targetModel === 'content_page') {
+                $allowedActions[] = 'cms_publish_auto_canary';
+                $allowedActions[] = 'post_publish_indexnow_auto';
+            } else {
+                $blockedActions[] = 'cms_publish_auto_canary';
+                $blockedActions[] = 'post_publish_indexnow_auto';
+            }
+        } else {
+            $blockedActions[] = 'cms_draft_write_auto';
+            $blockedActions[] = 'cms_publish_auto_canary';
+            $blockedActions[] = 'post_publish_indexnow_auto';
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'candidate_ref' => (string) ($candidate['subject_ref'] ?? $candidate['source_id'] ?? ''),
+            'source_family' => $sourceFamily,
+            'target_model' => $targetModel,
+            'severity' => $severity,
+            'normalized_target_fields' => $targetFields,
+            'approval_decision' => $reasonCodes === [] ? 'auto_approved' : 'blocked',
+            'risk_tier' => $reasonCodes === [] ? 'low' : 'blocked',
+            'allowed_next_actions' => $allowedActions,
+            'blocked_actions' => array_values(array_unique($blockedActions)),
+            'reason_codes' => array_values(array_unique($reasonCodes)),
+            'policy_notes' => [
+                'article_publish_auto_allowed' => false,
+                'content_page_publish_auto_limit' => 3,
+                'draft_write_auto_limit' => 10,
+                'scheduler_activation_allowed' => false,
+                'queue_worker_allowed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function targetFields(array $candidate): array
+    {
+        $fields = array_map('strval', (array) ($candidate['target_fields'] ?? []));
+        $normalized = array_map(
+            static fn (string $field): string => self::FIELD_ALIASES[$field] ?? $field,
+            $fields
+        );
+
+        return array_values(array_unique(array_filter(
+            $normalized,
+            static fn (string $field): bool => $field !== ''
+        )));
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return list<string>
+     */
+    private function forbiddenKeysPresent(mixed $value): array
+    {
+        $matches = [];
+
+        if (! is_array($value)) {
+            return $matches;
+        }
+
+        foreach ($value as $key => $child) {
+            $normalizedKey = strtolower((string) $key);
+            foreach (self::FORBIDDEN_KEYS as $forbiddenKey) {
+                if ($normalizedKey === $forbiddenKey || str_contains($normalizedKey, $forbiddenKey)) {
+                    $matches[] = $forbiddenKey;
+                }
+            }
+
+            foreach ($this->forbiddenKeysPresent($child) as $match) {
+                $matches[] = $match;
+            }
+        }
+
+        return array_values(array_unique($matches));
+    }
+
+    private function containsFullUrl(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return preg_match('/https?:\/\//i', $value) === 1;
+        }
+
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $child) {
+            if ($this->containsFullUrl($child)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function forbiddenClaimDetected(array $candidate): bool
+    {
+        $haystack = json_encode($candidate, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($haystack)) {
+            return true;
+        }
+
+        foreach (self::FORBIDDEN_CLAIM_PATTERNS as $pattern) {
+            if (preg_match($pattern, $haystack) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'google_indexing_live_api_call' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'frontend_direct_push' => false,
+            'frontend_auto_deploy' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/seo-agent-auto-approval-policy.v1.json
+++ b/backend/docs/seo/generated/seo-agent-auto-approval-policy.v1.json
@@ -1,0 +1,91 @@
+{
+  "version": "seo-agent-auto-approval-policy.v1",
+  "task": "SEO-AGENT-AUTO-APPROVAL-POLICY-01",
+  "repo": "fap-api",
+  "default_policy_mode": "l5_low_risk_auto_approval",
+  "decision_output_fields": [
+    "approval_decision",
+    "risk_tier",
+    "allowed_next_actions",
+    "blocked_actions",
+    "reason_codes",
+    "normalized_target_fields"
+  ],
+  "allowed_source_families": [
+    "cms_tdk_gap",
+    "cms_faq_gap"
+  ],
+  "allowed_target_models_for_draft_write": [
+    "article",
+    "content_page"
+  ],
+  "allowed_target_models_for_auto_publish": [
+    "content_page"
+  ],
+  "allowed_severities": [
+    "p1",
+    "p2"
+  ],
+  "allowed_target_fields": [
+    "seo_title",
+    "seo_description",
+    "canonical_path",
+    "is_indexable",
+    "faq_items",
+    "schema_enabled"
+  ],
+  "accepted_field_aliases": {
+    "canonical_url_or_path": "canonical_path",
+    "is_indexable_or_robots": "is_indexable",
+    "faq_schema_eligible": "schema_enabled"
+  },
+  "blocked_source_families": {
+    "runtime_seo_qa": "technical_review_required",
+    "gsc_performance": "manual_review_required_for_l5_auto_approval"
+  },
+  "claim_risk_blockers": [
+    "diagnostic",
+    "cure",
+    "guarantee",
+    "official endorsement",
+    "clinically proven",
+    "hiring fit",
+    "medical advice",
+    "treatment"
+  ],
+  "forbidden_input_fields": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "cms_draft_body",
+    "payload",
+    "metadata_json"
+  ],
+  "limits": {
+    "draft_write_auto_limit": 10,
+    "content_page_publish_auto_limit": 3,
+    "article_publish_auto_allowed": false
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "google_indexing_live_api_call": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "frontend_direct_push": false,
+    "frontend_auto_deploy": false,
+    "external_model_api_call": false
+  },
+  "next_step": "Consume this service in weekly draft write automation before enabling automatic ContentPage publish and IndexNow submit."
+}

--- a/backend/docs/seo/seo-agent-auto-approval-policy.md
+++ b/backend/docs/seo/seo-agent-auto-approval-policy.md
@@ -1,0 +1,35 @@
+# SEO Agent Auto Approval Policy
+
+`seo-agent-auto-approval-policy.v1` defines the shared low-risk approval contract for the FermatMind SEO Agent L5-A path.
+
+The policy does not write CMS rows, publish pages, enqueue Search Channel rows, submit IndexNow, call Google Indexing, start schedulers, or run queue workers. It only classifies sanitized opportunity candidates into `auto_approved` or `blocked`.
+
+## Low-Risk Allow List
+
+- Source families: `cms_tdk_gap`, `cms_faq_gap`.
+- Target models: `article` and `content_page` for CMS draft write.
+- Publish target: `content_page` only.
+- Severities: `p1`, `p2`.
+- Target fields: `seo_title`, `seo_description`, `canonical_path`, `is_indexable`, `faq_items`, `schema_enabled`.
+- Compatibility aliases accepted by the policy: `canonical_url_or_path`, `is_indexable_or_robots`, `faq_schema_eligible`.
+
+## Blocking Rules
+
+- Runtime SEO QA candidates require technical review.
+- GSC performance candidates require manual review in the L5-A auto-approval path.
+- Article candidates can be auto-approved for draft write only; article auto-publish is blocked.
+- Full URLs, raw query/url fields, raw body fields, credential fields, tokens, cookies, metadata payloads, and service-account material block approval.
+- Diagnostic, cure, guarantee, official endorsement, clinically proven, hiring-fit, medical-advice, or treatment claims block approval.
+
+## Output Contract
+
+Every candidate decision includes:
+
+- `approval_decision`
+- `risk_tier`
+- `allowed_next_actions`
+- `blocked_actions`
+- `reason_codes`
+- `normalized_target_fields`
+
+The first L5-A orchestration PRs must consume this contract before automatic draft write, automatic ContentPage canary publish, or automatic IndexNow submission.

--- a/backend/tests/Feature/SeoIntel/SeoAgentAutoApprovalPolicyTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentAutoApprovalPolicyTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoAgent\AutoApprovalPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentAutoApprovalPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function content_page_tdk_candidate_is_auto_approved_for_draft_publish_and_indexnow(): void
+    {
+        $decision = (new AutoApprovalPolicy)->evaluateCandidate($this->candidate([
+            'target_model' => 'content_page',
+            'subject_type' => 'content_page',
+            'subject_ref' => 'content_page:5:zh-CN',
+            'target_fields' => ['seo_title', 'seo_description', 'canonical_url_or_path', 'is_indexable_or_robots'],
+        ]));
+
+        $this->assertSame('auto_approved', $decision['approval_decision'] ?? null);
+        $this->assertSame('low', $decision['risk_tier'] ?? null);
+        $this->assertSame([
+            'seo_title',
+            'seo_description',
+            'canonical_path',
+            'is_indexable',
+        ], $decision['normalized_target_fields'] ?? null);
+        $this->assertContains('cms_draft_write_auto', $decision['allowed_next_actions'] ?? []);
+        $this->assertContains('cms_publish_auto_canary', $decision['allowed_next_actions'] ?? []);
+        $this->assertContains('post_publish_indexnow_auto', $decision['allowed_next_actions'] ?? []);
+        $this->assertSame([], $decision['reason_codes'] ?? null);
+    }
+
+    #[Test]
+    public function article_candidate_is_auto_approved_for_draft_only(): void
+    {
+        $decision = (new AutoApprovalPolicy)->evaluateCandidate($this->candidate([
+            'target_model' => 'article',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:9:zh-CN',
+            'target_fields' => ['seo_title', 'seo_description'],
+        ]));
+
+        $this->assertSame('auto_approved', $decision['approval_decision'] ?? null);
+        $this->assertContains('cms_draft_write_auto', $decision['allowed_next_actions'] ?? []);
+        $this->assertNotContains('cms_publish_auto_canary', $decision['allowed_next_actions'] ?? []);
+        $this->assertContains('cms_publish_auto_canary', $decision['blocked_actions'] ?? []);
+        $this->assertContains('article_auto_publish', $decision['blocked_actions'] ?? []);
+    }
+
+    #[Test]
+    public function non_low_risk_sources_are_blocked_with_specific_reasons(): void
+    {
+        $policy = new AutoApprovalPolicy;
+
+        $runtime = $policy->evaluateCandidate($this->candidate([
+            'source_family' => 'runtime_seo_qa',
+            'target_fields' => ['manual_review_required'],
+        ]));
+        $gsc = $policy->evaluateCandidate($this->candidate([
+            'source_family' => 'gsc_performance',
+            'target_fields' => ['seo_title'],
+        ]));
+
+        $this->assertSame('blocked', $runtime['approval_decision'] ?? null);
+        $this->assertContains('runtime_seo_qa_requires_technical_review', $runtime['reason_codes'] ?? []);
+        $this->assertContains('target_field_not_allowed', $runtime['reason_codes'] ?? []);
+        $this->assertSame('blocked', $gsc['approval_decision'] ?? null);
+        $this->assertContains('gsc_performance_requires_manual_review_for_l5_auto_approval', $gsc['reason_codes'] ?? []);
+    }
+
+    #[Test]
+    public function forbidden_fields_full_urls_and_claim_risks_fail_closed(): void
+    {
+        $policy = new AutoApprovalPolicy;
+
+        $raw = $policy->evaluateCandidate($this->candidate([
+            'raw_url' => 'https://fermatmind.com/zh/unsafe',
+        ]));
+        $claim = $policy->evaluateCandidate($this->candidate([
+            'proposed_seo_description' => 'Clinically proven diagnostic guidance for hiring fit.',
+        ]));
+
+        $this->assertSame('blocked', $raw['approval_decision'] ?? null);
+        $this->assertContains('forbidden_field_present:raw_url', $raw['reason_codes'] ?? []);
+        $this->assertContains('full_url_present', $raw['reason_codes'] ?? []);
+        $this->assertSame('blocked', $claim['approval_decision'] ?? null);
+        $this->assertContains('forbidden_claim_detected', $claim['reason_codes'] ?? []);
+    }
+
+    #[Test]
+    public function batch_evaluation_reports_counts_and_never_claims_side_effects(): void
+    {
+        $summary = (new AutoApprovalPolicy)->evaluateCandidates([
+            $this->candidate(),
+            $this->candidate(['severity' => 'p3']),
+        ]);
+
+        $this->assertSame('seo-agent-auto-approval-policy.v1', $summary['schema_version'] ?? null);
+        $this->assertSame(2, $summary['candidate_count'] ?? null);
+        $this->assertSame(1, $summary['auto_approved_count'] ?? null);
+        $this->assertSame(1, $summary['blocked_count'] ?? null);
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'google_indexing_live_api_call',
+            'scheduler_activation',
+            'queue_worker_started',
+            'frontend_direct_push',
+            'frontend_auto_deploy',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($summary, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function generated_contract_documents_policy_boundaries(): void
+    {
+        $artifact = json_decode((string) file_get_contents(base_path('docs/seo/generated/seo-agent-auto-approval-policy.v1.json')), true);
+
+        $this->assertSame('seo-agent-auto-approval-policy.v1', $artifact['version'] ?? null);
+        $this->assertContains('cms_tdk_gap', $artifact['allowed_source_families'] ?? []);
+        $this->assertContains('cms_faq_gap', $artifact['allowed_source_families'] ?? []);
+        $this->assertContains('content_page', $artifact['allowed_target_models_for_auto_publish'] ?? []);
+        $this->assertFalse((bool) data_get($artifact, 'limits.article_publish_auto_allowed', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_indexing_live_api_call', true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function candidate(array $overrides = []): array
+    {
+        return array_merge([
+            'source_family' => 'cms_tdk_gap',
+            'source_id' => hash('sha256', 'candidate'),
+            'target_model' => 'content_page',
+            'subject_type' => 'content_page',
+            'subject_ref' => 'content_page:1:zh-CN',
+            'safe_path' => '/zh/content-page',
+            'severity' => 'p2',
+            'target_fields' => ['seo_title', 'seo_description'],
+            'proposed_seo_title' => 'Content Page | FermatMind',
+            'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1246,6 +1246,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_auto_approval_policy_file(): void
+    {
+        $changed = [
+            'backend/app/Services/SeoAgent/AutoApprovalPolicy.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
@@ -3800,6 +3809,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentAutoApprovalPolicyFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelSearchChannelQueueRuntimeFile($file)) {
                 continue;
             }
@@ -5116,6 +5129,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php',
             'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentAutoApprovalPolicyFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/SeoAgent/AutoApprovalPolicy.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added a reusable SEO Agent auto approval policy service for the L5-A low-risk path.
- Added the `seo-agent-auto-approval-policy.v1` docs and generated contract.
- Added focused tests for allowed low-risk candidates, blocked sources, forbidden fields, full URLs, claim-risk blockers, and no-side-effect guarantees.

## Why
This establishes the shared decision layer required before weekly automatic draft writes, ContentPage canary publish, and IndexNow automation. It does not connect the policy to production execution commands yet.

## Validation
- `cd backend && php artisan test --filter SeoAgentAutoApprovalPolicyTest`
- `cd backend && php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `cd backend && php artisan test --filter SeoAgentCmsPublishCanaryTest`
- `cd backend && python3 -m json.tool docs/seo/generated/seo-agent-auto-approval-policy.v1.json >/dev/null`
- `cd backend && git diff --check`

## Intentionally deferred
- Weekly automatic draft write orchestration.
- Automatic ContentPage publish canary3.
- Automatic IndexNow submission.
- GSC post-publish feedback and rollback guard.
- Laravel scheduler / queue worker activation.
- fap-web code PR writer.
