### PR TITLE
SEO-AGENT-WEEKLY-DRAFT-WRITE-AUTO-BATCH10-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentWeeklyDraftWriteAutoCommand.php
+++ b/backend/app/Console/Commands/SeoAgentWeeklyDraftWriteAutoCommand.php
@@ -1,0 +1,542 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\AutoApprovalPolicy;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentWeeklyDraftWriteAutoCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-weekly-draft-write-auto.v1';
+
+    protected $signature = 'seo-agent:weekly-draft-write-auto
+        {--sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap : Comma-separated readonly sources}
+        {--limit=100 : Discovery candidate limit, bounded 1..250}
+        {--draft-limit=10 : Maximum low-risk CMS draft revisions to write, 1..10}
+        {--artifact-dir= : Directory for weekly draft-write evidence artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Run weekly SEO Agent discovery, auto-approve low-risk proposals, and write bounded CMS draft revisions without publish or search.';
+
+    public function handle(AutoApprovalPolicy $policy): int
+    {
+        $sources = $this->sources();
+        if ($sources === []) {
+            return $this->finish($this->failureSummary('invalid_sources'));
+        }
+
+        $limit = $this->limit();
+        $draftLimit = $this->draftLimit();
+        if ($draftLimit === null) {
+            return $this->finish($this->failureSummary('draft_limit_out_of_bounds'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $runDir = rtrim($artifactDir, '/').'/weekly-draft-write-auto-run-'.$timestamp;
+
+        $weeklySummary = $this->runWeeklyReadonly($sources, $limit, $runDir);
+        if (($weeklySummary['ok'] ?? false) !== true) {
+            $evidence = $this->evidence($sources, $limit, $draftLimit, 'blocked', [
+                'issues' => ['weekly_readonly_run_failed'],
+                'weekly_summary' => $this->summaryForEvidence($weeklySummary),
+            ]);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-draft-write-auto-'.$timestamp.'.json', $evidence);
+
+            return $this->finish($this->failureSummary('weekly_readonly_run_failed', ['artifact' => $artifact]));
+        }
+
+        $packagePath = $this->draftPackagePath($weeklySummary);
+        if ($packagePath === null) {
+            $evidence = $this->evidence($sources, $limit, $draftLimit, 'blocked', [
+                'issues' => ['draft_package_artifact_missing'],
+                'weekly_summary' => $this->summaryForEvidence($weeklySummary),
+            ]);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-draft-write-auto-'.$timestamp.'.json', $evidence);
+
+            return $this->finish($this->failureSummary('draft_package_artifact_missing', ['artifact' => $artifact]));
+        }
+
+        $package = $this->readJson($packagePath);
+        if (($package['schema_version'] ?? null) !== 'seo-agent-cms-draft-package-dry-run.v1') {
+            return $this->finish($this->failureSummary('draft_package_schema_invalid'));
+        }
+
+        $proposals = $this->proposalItems($package);
+        $policyResult = $policy->evaluateCandidates($proposals, $limit);
+        $approvedProposals = $this->approvedProposals($proposals, $policyResult, $draftLimit);
+        $filteredPackage = $this->filteredPackage($package, $approvedProposals, $policyResult);
+        $filteredPackageRef = $this->writeArtifact($artifactDir, 'seo-agent-weekly-draft-write-auto-package-'.$timestamp.'.json', $filteredPackage);
+
+        if ($approvedProposals === []) {
+            $evidence = $this->evidence($sources, $limit, $draftLimit, 'success', [
+                'weekly_summary' => $this->summaryForEvidence($weeklySummary),
+                'source_package' => $this->artifactRef($packagePath, 'seo-agent-cms-draft-package-dry-run.v1'),
+                'filtered_package' => $filteredPackageRef,
+                'policy_summary' => $this->policySummary($policyResult),
+                'draft_write' => [
+                    'status' => 'skipped_no_auto_approved_proposals',
+                    'writes_attempted' => false,
+                    'rows_created' => 0,
+                    'rows_skipped_existing' => 0,
+                ],
+            ]);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-draft-write-auto-'.$timestamp.'.json', $evidence);
+
+            return $this->finish($this->successSummary('success', $sources, 0, 0, 0, $artifact));
+        }
+
+        $writeSummary = $this->runDraftWriter((string) $filteredPackageRef['path'], $draftLimit);
+        $writeOk = ($writeSummary['ok'] ?? false) === true && ($writeSummary['status'] ?? '') === 'success';
+        $evidence = $this->evidence($sources, $limit, $draftLimit, $writeOk ? 'success' : 'blocked', [
+            'weekly_summary' => $this->summaryForEvidence($weeklySummary),
+            'source_package' => $this->artifactRef($packagePath, 'seo-agent-cms-draft-package-dry-run.v1'),
+            'filtered_package' => $filteredPackageRef,
+            'policy_summary' => $this->policySummary($policyResult),
+            'draft_write' => $this->summaryForEvidence($writeSummary),
+        ]);
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-weekly-draft-write-auto-'.$timestamp.'.json', $evidence);
+
+        if (! $writeOk) {
+            return $this->finish($this->failureSummary('cms_draft_write_failed', ['artifact' => $artifact]));
+        }
+
+        return $this->finish($this->successSummary(
+            'success',
+            $sources,
+            count($approvedProposals),
+            (int) ($writeSummary['rows_created'] ?? 0),
+            (int) ($writeSummary['rows_skipped_existing'] ?? 0),
+            $artifact
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sources(): array
+    {
+        $allowed = ['cms-tdk-gap', 'runtime-seo-qa', 'cms-faq-gap'];
+        $sources = array_values(array_unique(array_filter(array_map(
+            static fn (string $source): string => trim($source),
+            explode(',', (string) $this->option('sources'))
+        ))));
+
+        foreach ($sources as $source) {
+            if (! in_array($source, $allowed, true)) {
+                return [];
+            }
+        }
+
+        return $sources;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function draftLimit(): ?int
+    {
+        $limit = filter_var($this->option('draft-limit'), FILTER_VALIDATE_INT);
+
+        return is_int($limit) && $limit >= 1 && $limit <= 10 ? $limit : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/weekly-draft-write-auto');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @return array<string, mixed>
+     */
+    private function runWeeklyReadonly(array $sources, int $limit, string $runDir): array
+    {
+        $command = $this->getApplication()?->find('seo-agent:weekly-readonly-runner');
+        if ($command === null) {
+            return $this->failureSummary('weekly_readonly_command_missing');
+        }
+
+        $buffer = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput([
+            'command' => 'seo-agent:weekly-readonly-runner',
+            '--sources' => implode(',', $sources),
+            '--limit' => $limit,
+            '--artifact-dir' => $runDir,
+            '--json' => true,
+        ]), $buffer);
+
+        $summary = json_decode(trim($buffer->fetch()), true);
+        if (! is_array($summary)) {
+            return $this->failureSummary('weekly_readonly_summary_json_invalid', [
+                'weekly_exit_code' => $exitCode,
+            ]);
+        }
+
+        $summary['weekly_exit_code'] = $exitCode;
+
+        return $summary;
+    }
+
+    private function draftPackagePath(array $weeklySummary): ?string
+    {
+        $weeklyArtifactPath = (string) data_get($weeklySummary, 'artifact.path', '');
+        if ($weeklyArtifactPath === '' || ! is_file($weeklyArtifactPath)) {
+            return null;
+        }
+
+        $weeklyArtifact = $this->readJson($weeklyArtifactPath);
+        $runEvidencePath = (string) data_get($weeklyArtifact, 'run_artifact.path', '');
+        if ($runEvidencePath === '' || ! is_file($runEvidencePath)) {
+            return null;
+        }
+
+        $runEvidence = $this->readJson($runEvidencePath);
+        $packagePath = (string) data_get($runEvidence, 'artifacts.cms_draft_package_dry_run.path', '');
+
+        return $packagePath !== '' && is_file($packagePath) ? $packagePath : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('artifact_json_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return list<array<string, mixed>>
+     */
+    private function proposalItems(array $package): array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return [];
+        }
+
+        return array_values(array_filter($items, static fn ($item): bool => is_array($item)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     * @param  array<string, mixed>  $policyResult
+     * @return list<array<string, mixed>>
+     */
+    private function approvedProposals(array $proposals, array $policyResult, int $draftLimit): array
+    {
+        $decisions = array_values(array_filter(
+            (array) ($policyResult['candidate_decisions'] ?? []),
+            static fn ($decision): bool => is_array($decision)
+        ));
+
+        $approved = [];
+        foreach ($proposals as $index => $proposal) {
+            $decision = $decisions[$index] ?? [];
+            if (($decision['approval_decision'] ?? '') !== 'auto_approved') {
+                continue;
+            }
+            if (! in_array('cms_draft_write_auto', (array) ($decision['allowed_next_actions'] ?? []), true)) {
+                continue;
+            }
+
+            $approved[] = $proposal;
+            if (count($approved) >= $draftLimit) {
+                break;
+            }
+        }
+
+        return $approved;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  list<array<string, mixed>>  $approvedProposals
+     * @param  array<string, mixed>  $policyResult
+     * @return array<string, mixed>
+     */
+    private function filteredPackage(array $package, array $approvedProposals, array $policyResult): array
+    {
+        $filtered = $package;
+        $filtered['draft_brief_count'] = count($approvedProposals);
+        $filtered['draft_briefs'] = $approvedProposals;
+        $filtered['proposal_count'] = count($approvedProposals);
+        $filtered['proposal_items'] = $approvedProposals;
+        $filtered['auto_approval_policy'] = [
+            'schema_version' => AutoApprovalPolicy::SCHEMA_VERSION,
+            'approval_mode' => 'low_risk_auto_approved',
+            'auto_approved_count' => (int) ($policyResult['auto_approved_count'] ?? 0),
+            'blocked_count' => (int) ($policyResult['blocked_count'] ?? 0),
+            'selected_for_draft_write_count' => count($approvedProposals),
+        ];
+
+        return $filtered;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runDraftWriter(string $packagePath, int $draftLimit): array
+    {
+        $command = $this->getApplication()?->find('seo-agent:cms-draft-write');
+        if ($command === null) {
+            return $this->failureSummary('cms_draft_write_command_missing');
+        }
+
+        $buffer = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput([
+            'command' => 'seo-agent:cms-draft-write',
+            '--package' => $packagePath,
+            '--limit' => $draftLimit,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]), $buffer);
+
+        $summary = json_decode(trim($buffer->fetch()), true);
+        if (! is_array($summary)) {
+            return $this->failureSummary('cms_draft_write_summary_json_invalid', [
+                'draft_write_exit_code' => $exitCode,
+            ]);
+        }
+
+        $summary['draft_write_exit_code'] = $exitCode;
+
+        return $summary;
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function evidence(array $sources, int $limit, int $draftLimit, string $status, array $extra): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-WEEKLY-DRAFT-WRITE-AUTO-BATCH10-01',
+            'status' => $status,
+            'run_mode' => 'weekly_discovery_to_low_risk_cms_draft_write',
+            'trigger' => 'manual_cli_or_external_weekly_automation',
+            'command' => 'php artisan seo-agent:weekly-draft-write-auto',
+            'delegated_commands' => [
+                'php artisan seo-agent:weekly-readonly-runner',
+                'php artisan seo-agent:cms-draft-write --auto-approve-low-risk --execute',
+            ],
+            'sources' => $sources,
+            'limit' => $limit,
+            'draft_limit' => $draftLimit,
+            ...$extra,
+            'allowed_actions' => [
+                'readonly_scan',
+                'evidence_artifact_write',
+                'auto_approval_policy_evaluation',
+                'cms_draft_revision_write',
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return $this->artifactRef($path, (string) ($payload['schema_version'] ?? 'unknown'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function summaryForEvidence(array $summary): array
+    {
+        return [
+            'schema_version' => (string) ($summary['schema_version'] ?? ''),
+            'ok' => (bool) ($summary['ok'] ?? false),
+            'status' => (string) ($summary['status'] ?? ''),
+            'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+            'draft_brief_count' => (int) ($summary['draft_brief_count'] ?? 0),
+            'planned_count' => (int) ($summary['planned_count'] ?? 0),
+            'rows_created' => (int) ($summary['rows_created'] ?? 0),
+            'rows_skipped_existing' => (int) ($summary['rows_skipped_existing'] ?? 0),
+            'rows_failed' => array_values((array) ($summary['rows_failed'] ?? [])),
+            'writes_attempted' => (bool) ($summary['writes_attempted'] ?? false),
+            'writes_committed' => (bool) ($summary['writes_committed'] ?? false),
+            'artifact' => is_array($summary['artifact'] ?? null) ? (array) $summary['artifact'] : [],
+            'issues' => array_values(array_map('strval', (array) ($summary['issues'] ?? []))),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $policyResult
+     * @return array<string, mixed>
+     */
+    private function policySummary(array $policyResult): array
+    {
+        return [
+            'schema_version' => (string) ($policyResult['schema_version'] ?? AutoApprovalPolicy::SCHEMA_VERSION),
+            'candidate_count' => (int) ($policyResult['candidate_count'] ?? 0),
+            'auto_approved_count' => (int) ($policyResult['auto_approved_count'] ?? 0),
+            'blocked_count' => (int) ($policyResult['blocked_count'] ?? 0),
+            'candidate_decisions' => array_values((array) ($policyResult['candidate_decisions'] ?? [])),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    private function successSummary(string $status, array $sources, int $approvedCount, int $rowsCreated, int $rowsSkipped, array $artifact): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $status,
+            'sources' => $sources,
+            'auto_approved_count' => $approvedCount,
+            'rows_created' => $rowsCreated,
+            'rows_skipped_existing' => $rowsSkipped,
+            'artifact' => $artifact,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'cms_publish',
+            'live_published_content_mutation',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'production_env_update',
+            'source_code_mutation',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'frontend_code_mutation' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -180,6 +180,7 @@ use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
 use App\Console\Commands\SeoAgentRunCommand;
+use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
@@ -382,6 +383,7 @@ class Kernel extends ConsoleKernel
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,
+        SeoAgentWeeklyDraftWriteAutoCommand::class,
         SeoAgentWeeklyReadonlyRunnerCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,

--- a/backend/docs/seo/generated/seo-agent-weekly-draft-write-auto.v1.json
+++ b/backend/docs/seo/generated/seo-agent-weekly-draft-write-auto.v1.json
@@ -1,0 +1,62 @@
+{
+  "version": "seo-agent-weekly-draft-write-auto.v1",
+  "task": "SEO-AGENT-WEEKLY-DRAFT-WRITE-AUTO-BATCH10-01",
+  "repo": "fap-api",
+  "type": "weekly_l5_low_risk_draft_write_contract",
+  "command": "php artisan seo-agent:weekly-draft-write-auto",
+  "delegated_commands": [
+    "php artisan seo-agent:weekly-readonly-runner",
+    "php artisan seo-agent:cms-draft-write --auto-approve-low-risk --execute"
+  ],
+  "input_contracts": [
+    "seo-agent-weekly-readonly-runner.v1",
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-auto-approval-policy.v1"
+  ],
+  "output_schema": "seo-agent-weekly-draft-write-auto.v1",
+  "max_draft_rows_per_execution": 10,
+  "allowed_auto_approval_sources": [
+    "cms_tdk_gap",
+    "cms_faq_gap"
+  ],
+  "allowed_targets": [
+    "article",
+    "content_page"
+  ],
+  "allowed_target_fields": [
+    "seo_title",
+    "seo_description",
+    "canonical_path",
+    "is_indexable",
+    "faq_items",
+    "schema_enabled"
+  ],
+  "writes": {
+    "article": "article_revisions payload_json draft proposal",
+    "content_page": "cms_translation_revisions payload_json draft proposal"
+  },
+  "no_op_when_no_low_risk_candidates": true,
+  "publish_allowed": false,
+  "search_channel_enqueue_allowed": false,
+  "search_channel_submit_allowed": false,
+  "google_indexing_live_api_allowed": false,
+  "laravel_scheduler_enabled_by_pr": false,
+  "queue_worker_started_by_pr": false,
+  "negative_guarantees": {
+    "cms_publish": false,
+    "published_revision_mutation": false,
+    "live_published_content_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false,
+    "frontend_code_mutation": false
+  },
+  "next_step": "Automatic publish canary remains a separate PR."
+}

--- a/backend/docs/seo/seo-agent-weekly-draft-write-auto.md
+++ b/backend/docs/seo/seo-agent-weekly-draft-write-auto.md
@@ -1,0 +1,39 @@
+# SEO Agent Weekly Draft Write Auto
+
+Task: `SEO-AGENT-WEEKLY-DRAFT-WRITE-AUTO-BATCH10-01`
+
+This command runs the existing weekly readonly SEO Agent chain, evaluates the generated CMS draft proposals with `seo-agent-auto-approval-policy.v1`, filters to low-risk proposals, and writes at most 10 CMS draft/revision rows.
+
+## Command
+
+```bash
+php artisan seo-agent:weekly-draft-write-auto \
+  --sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap \
+  --limit=100 \
+  --draft-limit=10 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+## Chain
+
+1. `seo-agent:weekly-readonly-runner`
+2. Read the generated `seo-agent-cms-draft-package-dry-run.v1`
+3. Evaluate proposals with `seo-agent-auto-approval-policy.v1`
+4. Write a filtered low-risk package artifact
+5. `seo-agent:cms-draft-write --auto-approve-low-risk --execute`
+6. Write `seo-agent-weekly-draft-write-auto.v1` evidence
+
+## Boundaries
+
+- Writes only bounded CMS draft/revision rows.
+- Does not publish CMS content.
+- Does not mutate published revision pointers.
+- Does not enqueue Search Channel items.
+- Does not submit Search Channel or Google Indexing requests.
+- Does not start queue workers.
+- Does not enable Laravel scheduler.
+- Does not call external model APIs.
+- Does not mutate frontend code.
+
+No-op weeks are allowed: if there are no auto-approved low-risk proposals, the command writes evidence and exits successfully without CMS writes.

--- a/backend/tests/Feature/SeoIntel/SeoAgentWeeklyDraftWriteAutoTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentWeeklyDraftWriteAutoTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use App\Models\ArticleSeoMeta;
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentWeeklyDraftWriteAutoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_runs_weekly_chain_filters_policy_and_writes_low_risk_drafts_only(): void
+    {
+        $this->createArticle('weekly-auto-draft-article-gap');
+        $this->createFaqGapPage();
+
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:weekly-draft-write-auto', [
+            '--sources' => 'cms-tdk-gap,cms-faq-gap',
+            '--limit' => 10,
+            '--draft-limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $files = File::allFiles($artifactDir);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertIsArray($summary, Artisan::output());
+        $this->assertSame('seo-agent-weekly-draft-write-auto.v1', $summary['schema_version'] ?? null);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertGreaterThanOrEqual(2, $summary['auto_approved_count'] ?? 0);
+        $this->assertSame(2, ($summary['rows_created'] ?? 0) + ($summary['rows_skipped_existing'] ?? 0));
+        $this->assertSame(1, ArticleRevision::query()->count());
+        $this->assertSame(1, CmsTranslationRevision::query()->count());
+
+        $evidence = $this->readJson(data_get($summary, 'artifact.path'));
+        $this->assertSame('SEO-AGENT-WEEKLY-DRAFT-WRITE-AUTO-BATCH10-01', $evidence['task'] ?? null);
+        $this->assertSame('php artisan seo-agent:weekly-draft-write-auto', $evidence['command'] ?? null);
+        $this->assertSame('success', $evidence['status'] ?? null);
+        $this->assertSame(10, $evidence['draft_limit'] ?? null);
+        $this->assertGreaterThanOrEqual(2, data_get($evidence, 'policy_summary.auto_approved_count'));
+        $this->assertSame('success', data_get($evidence, 'draft_write.status'));
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', data_get($evidence, 'filtered_package.schema_version'));
+        $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.google_indexing_api_call', true));
+        $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.frontend_code_mutation', true));
+
+        $articleRevision = ArticleRevision::query()->firstOrFail();
+        $this->assertSame('SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01', data_get($articleRevision->payload_json, 'seo_agent.task'));
+        $this->assertFalse((bool) data_get($articleRevision->payload_json, 'seo_agent.publish_allowed', true));
+
+        $combined = implode("\n", array_map(
+            static fn ($file): string => (string) file_get_contents($file->getPathname()),
+            $files
+        ));
+
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function command_succeeds_as_noop_when_no_low_risk_candidates_exist(): void
+    {
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:weekly-draft-write-auto', [
+            '--sources' => 'cms-tdk-gap,cms-faq-gap',
+            '--limit' => 10,
+            '--draft-limit' => 10,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $evidence = $this->readJson(data_get($summary, 'artifact.path'));
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(0, $summary['auto_approved_count'] ?? null);
+        $this->assertSame(0, $summary['rows_created'] ?? null);
+        $this->assertSame(0, ArticleRevision::query()->count());
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+        $this->assertSame('skipped_no_auto_approved_proposals', data_get($evidence, 'draft_write.status'));
+        $this->assertFalse((bool) data_get($evidence, 'draft_write.writes_attempted', true));
+    }
+
+    #[Test]
+    public function command_fails_closed_for_bad_draft_limit_or_invalid_source(): void
+    {
+        $exitCode = Artisan::call('seo-agent:weekly-draft-write-auto', [
+            '--sources' => 'cms-tdk-gap',
+            '--draft-limit' => 11,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('draft_limit_out_of_bounds', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:weekly-draft-write-auto', [
+            '--sources' => 'cms-tdk-gap,gsc-live-read',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('invalid_sources', $summary['issues'] ?? []);
+        $this->assertSame(0, ArticleRevision::query()->count());
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+    }
+
+    #[Test]
+    public function generated_contract_documents_weekly_draft_write_auto_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-weekly-draft-write-auto.v1.json'));
+
+        $this->assertSame('seo-agent-weekly-draft-write-auto.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:weekly-draft-write-auto', $artifact['command'] ?? null);
+        $this->assertSame(10, $artifact['max_draft_rows_per_execution'] ?? null);
+        $this->assertContains('seo-agent-auto-approval-policy.v1', $artifact['input_contracts'] ?? []);
+        $this->assertFalse((bool) ($artifact['publish_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['search_channel_enqueue_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['google_indexing_live_api_allowed'] ?? true));
+        $this->assertFalse((bool) ($artifact['laravel_scheduler_enabled_by_pr'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.external_model_api_call', true));
+    }
+
+    private function createArticle(string $slug): Article
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => 'Weekly auto draft article',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Article body must never be emitted.',
+            'content_html' => '<p>Article body must never be emitted.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_revision_id' => 99,
+            'published_at' => now()->subDay(),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        return $article;
+    }
+
+    private function createFaqGapPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'weekly-auto-draft-faq-gap',
+            'path' => '/zh/help/weekly-auto-draft-faq-gap',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Weekly auto draft help',
+            'summary' => 'Existing summary.',
+            'seo_title' => 'Weekly auto draft help',
+            'seo_description' => 'Existing SEO description.',
+            'meta_description' => 'Existing SEO description.',
+            'canonical_path' => '/zh/help/weekly-auto-draft-faq-gap',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => true,
+            'faq_schema_eligible' => true,
+            'faq_items' => [],
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'published_revision_id' => 88,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-weekly-draft-write-auto-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'https://fermatmind.com',
+            '<html',
+            '<p>',
+            'raw_url',
+            'raw_query',
+            'full_url',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'content_md',
+            'content_html',
+            'raw_html',
+            'cms_draft_body',
+            'Article body must never be emitted',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1203,6 +1203,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_weekly_draft_write_auto_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentWeeklyDraftWriteAutoCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentWeeklyDraftWriteAutoCommand;',
+            '+        SeoAgentWeeklyDraftWriteAutoCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_cms_publish_canary_files(): void
     {
         $changed = [
@@ -3797,6 +3811,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentWeeklyDraftWriteAutoFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentCmsPublishCanaryFile($file)) {
                 continue;
             }
@@ -4407,6 +4425,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRunOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentWeeklyDraftWriteAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5107,6 +5126,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentWeeklyReadonlyRunnerCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentWeeklyDraftWriteAutoFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentWeeklyDraftWriteAutoCommand.php',
         ], true);
     }
 
@@ -6913,6 +6939,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentWeeklyReadonlyRunnerCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentWeeklyDraftWriteAutoOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentWeeklyDraftWriteAutoCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `php artisan seo-agent:weekly-draft-write-auto`.
- The command runs the existing weekly readonly chain, reads the generated CMS draft package, applies `seo-agent-auto-approval-policy.v1`, writes a filtered low-risk package, and delegates to `seo-agent:cms-draft-write --auto-approve-low-risk --execute`.
- Added docs and generated contract for `seo-agent-weekly-draft-write-auto.v1`.
- Added focused feature coverage plus BigFive runtime-freeze classifier allowlist coverage for the new SEO Agent command registration.

## Why
This is the first L5-A automation step after the policy PR: low-risk CMS draft/revision creation can now run weekly with a hard batch10 limit while keeping publish, search queue, IndexNow, Google Indexing, scheduler, queue worker, and frontend mutation closed.

## Validation
- `cd backend && php artisan test --filter SeoAgentWeeklyDraftWriteAutoTest`
- `cd backend && php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `cd backend && php artisan test --filter SeoAgentAutoApprovalPolicyTest`
- `cd backend && php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest`
- `cd backend && python3 -m json.tool docs/seo/generated/seo-agent-weekly-draft-write-auto.v1.json >/dev/null`
- `cd backend && php artisan list --raw | grep 'seo-agent:weekly-draft-write-auto'`
- `cd backend && git diff --check`

## Intentionally deferred
- CMS auto publish canary3.
- Post-publish IndexNow automation.
- GSC post-publish feedback.
- Rollback guard.
- Priority queue scheduler / external cron orchestration.
- Google Indexing live API.
- fap-web code PR writer.
