### PR TITLE
SEO-AGENT-CMS-PUBLISH-AUTO-CANARY3-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php
@@ -1,0 +1,549 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoAgent\AutoApprovalPolicy;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentCmsPublishAutoCanaryCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-cms-publish-auto-canary.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const DRAFT_WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    protected $signature = 'seo-agent:cms-publish-auto-canary
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--draft-write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--limit=3 : Maximum low-risk ContentPage canaries to publish, 1..3}
+        {--artifact-dir= : Directory for publish auto-canary evidence artifacts}
+        {--auto-approve-low-risk : Required for execute mode}
+        {--execute : Actually publish bounded low-risk ContentPage canaries}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Auto-publish up to three low-risk SEO Agent ContentPage canaries; never enqueues search or indexing.';
+
+    public function handle(AutoApprovalPolicy $policy): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        $evidencePath = $this->readablePath((string) $this->option('draft-write-evidence'));
+        if ($packagePath === null || $evidencePath === null) {
+            return $this->finish($this->failureSummary('input_artifact_unreadable'));
+        }
+
+        $limit = $this->limit();
+        if ($limit === null) {
+            return $this->finish($this->failureSummary('limit_out_of_bounds'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $packageRaw = (string) file_get_contents($packagePath);
+        $evidenceRaw = (string) file_get_contents($evidencePath);
+        $forbidden = array_values(array_unique(array_merge(
+            $this->forbiddenStringsPresent($packageRaw),
+            $this->forbiddenStringsPresent($evidenceRaw),
+        )));
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($packageRaw, true);
+        $draftWrite = json_decode($evidenceRaw, true);
+        if (! is_array($package) || ! is_array($draftWrite)) {
+            return $this->finish($this->failureSummary('input_artifact_json_invalid'));
+        }
+
+        $packageIssue = $this->validatePackage($package);
+        if ($packageIssue !== null) {
+            return $this->finish($this->failureSummary($packageIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $draftIssue = $this->validateDraftWriteEvidence($draftWrite, $packageSha);
+        if ($draftIssue !== null) {
+            return $this->finish($this->failureSummary($draftIssue, [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $proposals = $this->proposalItems($package);
+        $policyResult = $policy->evaluateCandidates($proposals, count($proposals) > 0 ? count($proposals) : 1);
+        $selected = $this->publishableContentPageProposals($proposals, $policyResult, $limit);
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+
+        if ($selected === []) {
+            $evidence = $this->evidence($packagePath, $evidencePath, $packageSha, $limit, 'success', [
+                'publish_plan' => [
+                    'status' => 'skipped_no_auto_approved_content_page_candidates',
+                    'selected_count' => 0,
+                    'planned_count' => 0,
+                ],
+                'policy_summary' => $this->policySummary($policyResult),
+            ]);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-publish-auto-canary-'.$timestamp.'.json', $evidence);
+
+            return $this->finish($this->successSummary('success', 0, 0, 0, $artifact));
+        }
+
+        $execute = (bool) $this->option('execute');
+        if ($execute && ! (bool) $this->option('auto-approve-low-risk')) {
+            return $this->finish($this->failureSummary('auto_approve_low_risk_required_for_execute', [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $results = [];
+        foreach ($selected as $proposal) {
+            $result = $this->runPublishCanary($packagePath, $evidencePath, $packageSha, (string) ($proposal['subject_ref'] ?? ''), $execute);
+            $results[] = $result;
+            if (($result['ok'] ?? false) !== true) {
+                break;
+            }
+        }
+
+        $ok = count($results) === count($selected)
+            && count(array_filter($results, static fn (array $result): bool => ($result['ok'] ?? false) !== true)) === 0;
+        $published = array_sum(array_map(static fn (array $result): int => (int) ($result['published_count'] ?? 0), $results));
+        $skipped = array_sum(array_map(static fn (array $result): int => (int) ($result['rows_skipped_existing'] ?? 0), $results));
+        $planned = array_sum(array_map(static fn (array $result): int => (int) ($result['planned_count'] ?? 0), $results));
+
+        $evidence = $this->evidence($packagePath, $evidencePath, $packageSha, $limit, $ok ? 'success' : 'blocked', [
+            'policy_summary' => $this->policySummary($policyResult),
+            'selected_subject_refs' => array_map(static fn (array $proposal): string => (string) ($proposal['subject_ref'] ?? ''), $selected),
+            'publish_results' => array_map(fn (array $result): array => $this->summaryForEvidence($result), $results),
+            'publish_summary' => [
+                'execute' => $execute,
+                'selected_count' => count($selected),
+                'planned_count' => $planned,
+                'published_count' => $published,
+                'rows_skipped_existing' => $skipped,
+                'rows_failed' => array_values(array_filter(
+                    array_map(static fn (array $result): array => [
+                        'status' => (string) ($result['status'] ?? ''),
+                        'issues' => array_values(array_map('strval', (array) ($result['issues'] ?? []))),
+                    ], $results),
+                    static fn (array $failure): bool => $failure['issues'] !== []
+                )),
+            ],
+        ]);
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-publish-auto-canary-'.$timestamp.'.json', $evidence);
+
+        if (! $ok) {
+            return $this->finish($this->failureSummary('cms_publish_auto_canary_failed', ['artifact' => $artifact]));
+        }
+
+        return $this->finish($this->successSummary(
+            'success',
+            count($selected),
+            $execute ? $published : $planned,
+            $skipped,
+            $artifact
+        ));
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function limit(): ?int
+    {
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+
+        return is_int($limit) && $limit >= 1 && $limit <= 3 ? $limit : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/cms-publish-auto-canary');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true) {
+            return 'package_not_dry_run';
+        }
+        if ((bool) ($package['cms_write_allowed'] ?? true) !== false || (bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+        if ((bool) ($package['claim_gate_required'] ?? false) !== true
+            || (bool) ($package['human_approval_required'] ?? false) !== true) {
+            return 'package_approval_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $draftWrite
+     */
+    private function validateDraftWriteEvidence(array $draftWrite, string $packageSha): ?string
+    {
+        if (($draftWrite['schema_version'] ?? null) !== self::DRAFT_WRITE_SCHEMA_VERSION) {
+            return 'draft_write_evidence_schema_invalid';
+        }
+        if (($draftWrite['status'] ?? null) !== 'success') {
+            return 'draft_write_evidence_not_success';
+        }
+        if ((string) ($draftWrite['package_sha256'] ?? '') !== $packageSha) {
+            return 'draft_write_package_sha_mismatch';
+        }
+        if ((bool) ($draftWrite['writes_attempted'] ?? false) !== true) {
+            return 'draft_write_not_executed';
+        }
+        if ((bool) data_get($draftWrite, 'negative_guarantees.cms_publish', true) !== false
+            || (bool) data_get($draftWrite, 'negative_guarantees.search_channel_submit', true) !== false
+            || (bool) data_get($draftWrite, 'negative_guarantees.indexing_request', true) !== false) {
+            return 'draft_write_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return list<array<string, mixed>>
+     */
+    private function proposalItems(array $package): array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return [];
+        }
+
+        return array_values(array_filter($items, static fn ($item): bool => is_array($item)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     * @param  array<string, mixed>  $policyResult
+     * @return list<array<string, mixed>>
+     */
+    private function publishableContentPageProposals(array $proposals, array $policyResult, int $limit): array
+    {
+        $decisions = array_values(array_filter(
+            (array) ($policyResult['candidate_decisions'] ?? []),
+            static fn ($decision): bool => is_array($decision)
+        ));
+
+        $selected = [];
+        foreach ($proposals as $index => $proposal) {
+            $decision = $decisions[$index] ?? [];
+            if (($decision['approval_decision'] ?? '') !== 'auto_approved') {
+                continue;
+            }
+            if (($decision['target_model'] ?? '') !== 'content_page') {
+                continue;
+            }
+            if (! in_array('cms_publish_auto_canary', (array) ($decision['allowed_next_actions'] ?? []), true)) {
+                continue;
+            }
+
+            $selected[] = $proposal;
+            if (count($selected) >= $limit) {
+                break;
+            }
+        }
+
+        return $selected;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runPublishCanary(string $packagePath, string $evidencePath, string $packageSha, string $subjectRef, bool $execute): array
+    {
+        $command = $this->getApplication()?->find('seo-agent:cms-publish-canary');
+        if ($command === null) {
+            return $this->failureSummary('cms_publish_canary_command_missing');
+        }
+
+        $input = [
+            'command' => 'seo-agent:cms-publish-canary',
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $evidencePath,
+            '--limit' => 1,
+            '--subject-ref' => $subjectRef,
+            '--json' => true,
+        ];
+
+        if ($execute) {
+            $input['--confirm-package-sha256'] = $packageSha;
+            $input['--auto-approve-low-risk'] = true;
+            $input['--execute'] = true;
+        }
+
+        $buffer = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput($input), $buffer);
+        $summary = json_decode(trim($buffer->fetch()), true);
+        if (! is_array($summary)) {
+            return $this->failureSummary('cms_publish_canary_summary_json_invalid', [
+                'publish_canary_exit_code' => $exitCode,
+                'subject_ref' => $subjectRef,
+            ]);
+        }
+
+        $summary['publish_canary_exit_code'] = $exitCode;
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return $this->artifactRef($path, (string) ($payload['schema_version'] ?? self::SCHEMA_VERSION));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $policyResult
+     * @return array<string, mixed>
+     */
+    private function policySummary(array $policyResult): array
+    {
+        return [
+            'schema_version' => (string) ($policyResult['schema_version'] ?? AutoApprovalPolicy::SCHEMA_VERSION),
+            'candidate_count' => (int) ($policyResult['candidate_count'] ?? 0),
+            'auto_approved_count' => (int) ($policyResult['auto_approved_count'] ?? 0),
+            'blocked_count' => (int) ($policyResult['blocked_count'] ?? 0),
+            'candidate_decisions' => array_values((array) ($policyResult['candidate_decisions'] ?? [])),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function summaryForEvidence(array $summary): array
+    {
+        return [
+            'schema_version' => (string) ($summary['schema_version'] ?? ''),
+            'ok' => (bool) ($summary['ok'] ?? false),
+            'status' => (string) ($summary['status'] ?? ''),
+            'dry_run' => (bool) ($summary['dry_run'] ?? false),
+            'execute' => (bool) ($summary['execute'] ?? false),
+            'planned_count' => (int) ($summary['planned_count'] ?? 0),
+            'published_count' => (int) ($summary['published_count'] ?? 0),
+            'rows_skipped_existing' => (int) ($summary['rows_skipped_existing'] ?? 0),
+            'writes_attempted' => (bool) ($summary['writes_attempted'] ?? false),
+            'writes_committed' => (bool) ($summary['writes_committed'] ?? false),
+            'affected_refs' => array_values((array) ($summary['affected_refs'] ?? [])),
+            'issues' => array_values(array_map('strval', (array) ($summary['issues'] ?? []))),
+            'boundaries' => is_array($summary['boundaries'] ?? null) ? (array) $summary['boundaries'] : [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function evidence(string $packagePath, string $evidencePath, string $packageSha, int $limit, string $status, array $extra): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-CMS-PUBLISH-AUTO-CANARY3-01',
+            'status' => $status,
+            'run_mode' => 'low_risk_content_page_publish_canary3',
+            'trigger' => 'manual_cli_or_l5_low_risk_scheduler',
+            'command' => 'php artisan seo-agent:cms-publish-auto-canary',
+            'delegated_command' => 'php artisan seo-agent:cms-publish-canary',
+            'package_artifact' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'draft_write_evidence' => $this->artifactRef($evidencePath, self::DRAFT_WRITE_SCHEMA_VERSION),
+            'package_sha256' => $packageSha,
+            'max_rows_per_execution' => 3,
+            'requested_limit' => $limit,
+            ...$extra,
+            'allowed_actions' => [
+                'auto_approval_policy_evaluation',
+                'content_page_publish_canary',
+                'evidence_artifact_write',
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function successSummary(string $status, int $selectedCount, int $publishedOrPlannedCount, int $rowsSkipped, array $artifact): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $status,
+            'selected_count' => $selectedCount,
+            'published_or_planned_count' => $publishedOrPlannedCount,
+            'rows_skipped_existing' => $rowsSkipped,
+            'artifact' => $artifact,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach ([
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'session',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ] as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'article_auto_publish',
+            'cms_bulk_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'sitemap_submission',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'production_env_update',
+            'source_code_mutation',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'article_publish' => false,
+            'cms_bulk_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+            'frontend_code_mutation' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php
@@ -50,6 +50,7 @@ final class SeoAgentCmsPublishCanaryCommand extends Command
         {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
         {--draft-write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
         {--limit=1 : Maximum CMS drafts to publish; first canary requires exactly 1}
+        {--subject-ref= : Optional exact package proposal subject_ref to publish}
         {--confirm-package-sha256= : Required package sha256 for execute mode}
         {--confirm-publish= : Exact confirmation phrase for execute mode when not using low-risk auto approval}
         {--auto-approve-low-risk : Execute one low-risk ContentPage canary without an exact publish phrase}
@@ -102,7 +103,7 @@ final class SeoAgentCmsPublishCanaryCommand extends Command
             ]));
         }
 
-        $proposal = $this->firstProposal($package);
+        $proposal = $this->selectedProposal($package, trim((string) $this->option('subject-ref')));
         if ($proposal === null) {
             return $this->finish($this->failureSummary('publish_candidate_missing', [
                 'package_sha256' => $packageSha,
@@ -243,7 +244,7 @@ final class SeoAgentCmsPublishCanaryCommand extends Command
      * @param  array<string, mixed>  $package
      * @return array<string, mixed>|null
      */
-    private function firstProposal(array $package): ?array
+    private function selectedProposal(array $package, string $subjectRef = ''): ?array
     {
         $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
         if (! is_array($items)) {
@@ -251,7 +252,7 @@ final class SeoAgentCmsPublishCanaryCommand extends Command
         }
 
         foreach ($items as $item) {
-            if (is_array($item)) {
+            if (is_array($item) && ($subjectRef === '' || (string) ($item['subject_ref'] ?? '') === $subjectRef)) {
                 return $item;
             }
         }

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -171,6 +171,7 @@ use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
+use App\Console\Commands\SeoAgentCmsPublishAutoCanaryCommand;
 use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentPostPublishSearchSubmitCommand;
@@ -377,6 +378,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
+        SeoAgentCmsPublishAutoCanaryCommand::class,
         SeoAgentCmsPublishCanaryCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,

--- a/backend/docs/seo/generated/seo-agent-cms-publish-auto-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-publish-auto-canary.v1.json
@@ -1,0 +1,77 @@
+{
+  "version": "seo-agent-cms-publish-auto-canary.v1",
+  "task": "SEO-AGENT-CMS-PUBLISH-AUTO-CANARY3-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-publish-auto-canary",
+  "input_schemas": [
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-controlled-cms-draft-write.v1",
+    "seo-agent-auto-approval-policy.v1"
+  ],
+  "output_schema": "seo-agent-cms-publish-auto-canary.v1",
+  "default_mode": "dry_run_plan",
+  "delegates_to": "php artisan seo-agent:cms-publish-canary",
+  "execute_requires": [
+    "--execute",
+    "--limit=1..3",
+    "--auto-approve-low-risk",
+    "package sha256 must match draft-write evidence"
+  ],
+  "max_rows_per_execution": 3,
+  "supported_targets_v1": [
+    "content_page"
+  ],
+  "unsupported_targets_v1": {
+    "article": "blocked in L5-A publish automation; article drafts may be written but not auto-published"
+  },
+  "low_risk_auto_publish_mode": {
+    "allowed_source_families": [
+      "cms_tdk_gap",
+      "cms_faq_gap"
+    ],
+    "allowed_severities": [
+      "p1",
+      "p2"
+    ],
+    "allowed_target_fields": [
+      "seo_title",
+      "seo_description",
+      "canonical_path",
+      "is_indexable",
+      "faq_items",
+      "schema_enabled"
+    ],
+    "claim_gate_required": true,
+    "forbidden_claim_scan_required": true,
+    "rollback_evidence_required": true
+  },
+  "post_publish_boundaries": {
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "external_model_api_call": false,
+    "frontend_code_mutation": false
+  },
+  "evidence": {
+    "records_package_sha256": true,
+    "records_draft_write_evidence_sha256": true,
+    "records_selected_subject_refs": true,
+    "records_delegated_publish_results": true,
+    "forbidden_fields_absent": [
+      "raw_url",
+      "raw_query",
+      "credential_path",
+      "client_email",
+      "private_key",
+      "Bearer token",
+      "cookie",
+      "content_md",
+      "content_html",
+      "cms_draft_body"
+    ]
+  },
+  "next_step": "Post-publish IndexNow automation remains a separate PR."
+}

--- a/backend/docs/seo/seo-agent-cms-publish-auto-canary.md
+++ b/backend/docs/seo/seo-agent-cms-publish-auto-canary.md
@@ -1,0 +1,53 @@
+# SEO Agent CMS Publish Auto Canary
+
+Task: `SEO-AGENT-CMS-PUBLISH-AUTO-CANARY3-01`
+
+This command upgrades the one-item publish canary into a low-risk ContentPage auto-canary wrapper. It delegates each selected item to `seo-agent:cms-publish-canary`, uses the original package SHA and draft-write evidence, and publishes at most three ContentPage drafts per execution.
+
+## Command
+
+Dry-run plan:
+
+```bash
+php artisan seo-agent:cms-publish-auto-canary \
+  --package=<seo-agent-cms-draft-package-dry-run.v1.json> \
+  --draft-write-evidence=<seo-agent-controlled-cms-draft-write.v1.json> \
+  --limit=3 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+Low-risk canary execute:
+
+```bash
+php artisan seo-agent:cms-publish-auto-canary \
+  --package=<seo-agent-cms-draft-package-dry-run.v1.json> \
+  --draft-write-evidence=<seo-agent-controlled-cms-draft-write.v1.json> \
+  --limit=3 \
+  --artifact-dir=/path/to/artifacts \
+  --auto-approve-low-risk \
+  --execute \
+  --json
+```
+
+## Scope
+
+- Selects only candidates auto-approved by `seo-agent-auto-approval-policy.v1`.
+- Supports only `target_model=content_page` in this phase.
+- Allows only low-risk `cms_tdk_gap` and `cms_faq_gap` candidates.
+- Publishes at most three ContentPage draft revisions.
+- Requires the package SHA to match the draft-write evidence.
+- Writes a standalone `seo-agent-cms-publish-auto-canary.v1` evidence artifact.
+
+## Boundaries
+
+- Article publish remains blocked.
+- Bulk publish remains blocked.
+- Search queue enqueue remains false.
+- Search submit remains false.
+- Google Indexing request remains false.
+- Scheduler activation remains false.
+- Queue worker activation remains false.
+- No external model API is called.
+- No full URL, raw query, raw body, credential path, client email, private key, token, cookie, or service-account JSON may appear in input or output artifacts.
+

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsPublishAutoCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsPublishAutoCanaryTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsPublishAutoCanaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_plans_low_risk_content_page_canaries_without_publishing(): void
+    {
+        $pages = [
+            $this->createContentPage('auto-canary-one'),
+            $this->createContentPage('auto-canary-two'),
+            $this->createContentPage('auto-canary-three'),
+        ];
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($pages);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-publish-auto'),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(3, $summary['selected_count'] ?? null);
+        $this->assertSame(3, $summary['published_or_planned_count'] ?? null);
+        $this->assertSame(0, $summary['rows_skipped_existing'] ?? null);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.indexing_request', true));
+
+        foreach ($pages as $page) {
+            $fresh = $page->refresh();
+            $this->assertSame(88, (int) $fresh->published_revision_id);
+            $this->assertSame('not_reviewed', (string) $fresh->claim_gate_status);
+        }
+
+        $artifactPath = (string) data_get($summary, 'artifact.path');
+        $this->assertFileExists($artifactPath);
+        $artifact = $this->readJson($artifactPath);
+        $this->assertSame('seo-agent-cms-publish-auto-canary.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame(3, data_get($artifact, 'publish_summary.selected_count'));
+        $this->assertSame(false, data_get($artifact, 'negative_guarantees.search_channel_submit'));
+    }
+
+    #[Test]
+    public function execute_auto_publishes_at_most_three_content_page_canaries(): void
+    {
+        $pages = [
+            $this->createContentPage('auto-canary-one'),
+            $this->createContentPage('auto-canary-two'),
+            $this->createContentPage('auto-canary-three'),
+        ];
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($pages);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-publish-auto'),
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(3, $summary['selected_count'] ?? null);
+        $this->assertSame(3, $summary['published_or_planned_count'] ?? null);
+        $this->assertSame(0, $summary['rows_skipped_existing'] ?? null);
+
+        foreach ($pages as $page) {
+            $fresh = $page->refresh();
+            $this->assertSame('passed', (string) $fresh->claim_gate_status);
+            $this->assertSame('approved', (string) $fresh->review_state);
+            $this->assertNotSame(88, (int) $fresh->published_revision_id);
+            $revision = CmsTranslationRevision::query()->findOrFail((int) $fresh->published_revision_id);
+            $this->assertSame(CmsTranslationRevision::STATUS_PUBLISHED, (string) $revision->revision_status);
+            $this->assertSame(hash_file('sha256', $packagePath), data_get($revision->payload_json, 'seo_agent_publish_canary.package_sha256'));
+        }
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-publish-auto'),
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(0, $summary['published_or_planned_count'] ?? null);
+        $this->assertSame(3, $summary['rows_skipped_existing'] ?? null);
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function execute_fails_closed_without_auto_approval_or_with_limit_above_three(): void
+    {
+        $pages = [$this->createContentPage('auto-canary-one')];
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence($pages);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 4,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('limit_out_of_bounds', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 1,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('auto_approve_low_risk_required_for_execute', $summary['issues'] ?? []);
+        $this->assertSame(88, (int) $pages[0]->refresh()->published_revision_id);
+    }
+
+    #[Test]
+    public function article_candidates_are_not_selected_for_auto_publish(): void
+    {
+        $page = $this->createContentPage('auto-canary-one');
+        [$packagePath, $draftEvidencePath] = $this->createPackageAndDraftEvidence([$page], [[
+            'target_model' => 'article',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:123:zh-CN',
+        ]], runDraftWriter: false);
+
+        $exitCode = Artisan::call('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftEvidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-publish-auto'),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(0, $summary['selected_count'] ?? null);
+        $this->assertSame(0, $summary['published_or_planned_count'] ?? null);
+        $this->assertSame(88, (int) $page->refresh()->published_revision_id);
+    }
+
+    #[Test]
+    public function generated_contract_documents_publish_auto_canary_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-publish-auto-canary.v1.json'));
+
+        $this->assertSame('seo-agent-cms-publish-auto-canary.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-publish-auto-canary', $artifact['command'] ?? null);
+        $this->assertSame(3, $artifact['max_rows_per_execution'] ?? null);
+        $this->assertContains('content_page', $artifact['supported_targets_v1'] ?? []);
+        $this->assertSame(false, data_get($artifact, 'post_publish_boundaries.search_channel_enqueue'));
+        $this->assertSame(false, data_get($artifact, 'post_publish_boundaries.indexing_request'));
+    }
+
+    private function createContentPage(string $slug): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => '/zh/'.$slug,
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => Str::headline($slug),
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'draft',
+            'published_revision_id' => 88,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @param  list<ContentPage>  $pages
+     * @param  list<array<string, mixed>>  $overrides
+     * @return array{0: string, 1: string}
+     */
+    private function createPackageAndDraftEvidence(array $pages, array $overrides = [], bool $runDraftWriter = true): array
+    {
+        $proposals = [];
+        foreach ($pages as $index => $page) {
+            $proposals[] = array_merge([
+                'source_id' => hash('sha256', 'content-page'.(string) $page->id),
+                'source_family' => 'cms_tdk_gap',
+                'target_model' => 'content_page',
+                'subject_type' => 'content_page',
+                'subject_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+                'safe_path' => '/zh/'.(string) $page->slug,
+                'severity' => 'p2',
+                'target_fields' => ['seo_title', 'seo_description', 'canonical_url_or_path'],
+                'proposed_seo_title' => Str::headline((string) $page->slug).' | FermatMind',
+                'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
+                'proposed_canonical_path' => '/zh/'.(string) $page->slug,
+                'claim_gate_required' => true,
+                'human_approval_required' => true,
+                'execution_permission' => false,
+            ], $overrides[$index] ?? []);
+        }
+
+        $packagePath = $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_count' => count($proposals),
+            'proposal_items' => $proposals,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ]);
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        if ($runDraftWriter) {
+            $exitCode = Artisan::call('seo-agent:cms-draft-write', [
+                '--package' => $packagePath,
+                '--limit' => count($proposals),
+                '--auto-approve-low-risk' => true,
+                '--execute' => true,
+                '--json' => true,
+            ]);
+            $this->assertSame(0, $exitCode, Artisan::output());
+            $draftEvidence = [
+                'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+                'ok' => true,
+                'status' => 'success',
+                'execute' => true,
+                'approval_mode' => 'low_risk_auto_approved',
+                'package_sha256' => $packageSha,
+                'writes_attempted' => true,
+                'writes_committed' => true,
+                'rows_created' => count($proposals),
+                'negative_guarantees' => [
+                    'cms_publish' => false,
+                    'search_channel_submit' => false,
+                    'indexing_request' => false,
+                ],
+            ];
+        } else {
+            $draftEvidence = [
+                'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+                'ok' => true,
+                'status' => 'success',
+                'execute' => true,
+                'approval_mode' => 'low_risk_auto_approved',
+                'package_sha256' => $packageSha,
+                'writes_attempted' => true,
+                'writes_committed' => true,
+                'rows_created' => 1,
+                'negative_guarantees' => [
+                    'cms_publish' => false,
+                    'search_channel_submit' => false,
+                    'indexing_request' => false,
+                ],
+            ];
+        }
+
+        $draftEvidencePath = $this->writeJson('seo-agent-controlled-cms-draft-write-', $draftEvidence);
+
+        return [$packagePath, $draftEvidencePath];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1231,6 +1231,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_publish_auto_canary_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsPublishAutoCanaryCommand;',
+            '+        SeoAgentCmsPublishAutoCanaryCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_post_publish_search_submit_files(): void
     {
         $changed = [
@@ -3819,6 +3833,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsPublishAutoCanaryFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentPostPublishSearchSubmitFile($file)) {
                 continue;
             }
@@ -4427,6 +4445,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentWeeklyReadonlyRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentWeeklyDraftWriteAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsPublishAutoCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
@@ -5140,6 +5159,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsPublishCanaryCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsPublishAutoCanaryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php',
         ], true);
     }
 
@@ -6983,6 +7009,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsPublishCanaryCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsPublishAutoCanaryOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsPublishAutoCanaryCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:cms-publish-auto-canary`, a low-risk ContentPage publish wrapper that delegates each item to the existing bounded `seo-agent:cms-publish-canary` command.
- Extended `seo-agent:cms-publish-canary` with `--subject-ref` so the wrapper can publish a specific proposal from the original package without changing the package SHA.
- Added the publish auto-canary contract docs/generated JSON and focused feature coverage.
- Updated the Big Five runtime freeze allowlist for the new SEO Agent command registration.

## Why
This is the L5-A publish step after weekly auto draft write: publish up to 3 low-risk ContentPage canaries while keeping Article publish, search queue, Search Channel submit, Google Indexing, scheduler, queue workers, and frontend mutation blocked.

## Validation
```bash
cd backend
php artisan test --filter SeoAgentCmsPublishAutoCanaryTest
php artisan test --filter SeoAgentCmsPublishCanaryTest
php artisan test --filter SeoAgentWeeklyDraftWriteAutoTest
php artisan test --filter SeoAgentAutoApprovalPolicyTest
php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest
python3 -m json.tool docs/seo/generated/seo-agent-cms-publish-auto-canary.v1.json >/dev/null
php artisan list --raw | grep 'seo-agent:cms-publish-auto-canary'
git diff --check
```

## Intentionally deferred
- No Article auto-publish.
- No Search Channel enqueue/submit.
- No Google Indexing live API call.
- No scheduler or queue worker activation.
- No frontend code mutation or deploy.
