### PR TITLE
SEO-AGENT-POST-PUBLISH-INDEXNOW-AUTO-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentPostPublishIndexnowAutoCommand.php
+++ b/backend/app/Console/Commands/SeoAgentPostPublishIndexnowAutoCommand.php
@@ -1,0 +1,710 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\ContentPage;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueApprovalExecutor;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueBoundedLiveExecutor;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueuePlanner;
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueWriteService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class SeoAgentPostPublishIndexnowAutoCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-post-publish-indexnow-auto.v1';
+
+    private const SINGLE_PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-canary.v1';
+
+    private const AUTO_PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-auto-canary.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:post-publish-indexnow-auto
+        {--publish-evidence= : Path to seo-agent CMS publish evidence JSON}
+        {--limit=3 : Maximum published ContentPage URLs to submit to IndexNow, 1..3}
+        {--base-url= : Public site base URL used to resolve safe paths; defaults to app.url}
+        {--artifact-dir= : Directory for IndexNow auto evidence artifacts}
+        {--execute : Enqueue, approve, and live-submit IndexNow queue items}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Auto-submit low-risk published ContentPage canaries to IndexNow only; no Google Indexing or scheduler.';
+
+    public function handle(
+        SearchChannelQueuePlanner $planner,
+        SearchChannelQueueWriteService $writer,
+        SearchChannelQueueApprovalExecutor $approval,
+        SearchChannelQueueBoundedLiveExecutor $live,
+    ): int {
+        $evidencePath = $this->readablePath((string) $this->option('publish-evidence'));
+        if ($evidencePath === null) {
+            return $this->finish($this->failureSummary('publish_evidence_unreadable'));
+        }
+
+        $limit = $this->limit();
+        if ($limit === null) {
+            return $this->finish($this->failureSummary('limit_out_of_bounds'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $raw = (string) file_get_contents($evidencePath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $evidence = json_decode($raw, true);
+        if (! is_array($evidence)) {
+            return $this->finish($this->failureSummary('publish_evidence_json_invalid'));
+        }
+
+        $evidenceIssue = $this->validatePublishEvidence($evidence);
+        if ($evidenceIssue !== null) {
+            return $this->finish($this->failureSummary($evidenceIssue));
+        }
+
+        $publishedRefs = array_slice($this->publishedRefs($evidence), 0, $limit);
+        if ($publishedRefs === []) {
+            return $this->finish($this->failureSummary('published_content_page_refs_missing'));
+        }
+
+        $targets = [];
+        $issues = [];
+        foreach ($publishedRefs as $ref) {
+            $target = $this->publishedTarget($ref);
+            if (($target['ok'] ?? false) !== true) {
+                $issues[] = (string) ($target['issue'] ?? 'published_target_invalid');
+                continue;
+            }
+            $targets[] = $target;
+        }
+
+        if ($issues !== []) {
+            return $this->finish($this->failureSummary('published_target_validation_failed', [
+                'target_issues' => array_values(array_unique($issues)),
+            ]));
+        }
+
+        $execute = (bool) $this->option('execute');
+        $evidenceSha = hash_file('sha256', $evidencePath) ?: '';
+        $plans = [];
+        $plannedItems = [];
+        $duplicateSubmitted = [];
+        $duplicateReadyIds = [];
+        $planIssues = [];
+
+        foreach ($targets as $target) {
+            $canonicalUrl = (string) $target['canonical_url'];
+            $plan = $planner->plan('indexnow', 'content_page', 1, $canonicalUrl);
+            $plans[] = $this->safePlanSummary($plan, $target);
+            foreach ((array) ($plan['planned_items'] ?? []) as $item) {
+                if (is_array($item)) {
+                    $plannedItems[] = $item;
+                }
+            }
+
+            if ((int) ($plan['planned_queue_count'] ?? 0) < 1) {
+                $existing = $this->existingIndexnowQueueItem($canonicalUrl);
+                if ($existing !== null && ($existing['execution_state'] ?? '') === 'submitted') {
+                    $duplicateSubmitted[] = $existing;
+                    continue;
+                }
+                if ($existing !== null && in_array(($existing['execution_state'] ?? ''), ['dry_run_ready'], true)) {
+                    $duplicateReadyIds[] = (int) $existing['id'];
+                    continue;
+                }
+
+                $planIssues[] = (string) (($plan['source_unavailable_reason'] ?? null) ?: 'indexnow_queue_plan_unavailable');
+            }
+        }
+
+        $plannedItems = array_slice($plannedItems, 0, $limit);
+        if (! $execute) {
+            $artifact = $this->writeEvidence($artifactDir, $evidencePath, $evidenceSha, 'planned', [
+                'execute' => false,
+                'target_count' => count($targets),
+                'planned_queue_count' => count($plannedItems),
+                'duplicate_ready_count' => count($duplicateReadyIds),
+                'duplicate_submitted_count' => count($duplicateSubmitted),
+                'plans' => $plans,
+                'issues' => array_values(array_unique($planIssues)),
+            ]);
+
+            return $this->finish($this->successSummary('planned', false, $artifact, [
+                'target_count' => count($targets),
+                'planned_queue_count' => count($plannedItems),
+                'duplicate_submitted_count' => count($duplicateSubmitted),
+                'external_calls_attempted' => false,
+                'search_submission_attempted' => false,
+            ]));
+        }
+
+        if ($plannedItems === [] && $duplicateReadyIds === [] && $duplicateSubmitted === []) {
+            return $this->finish($this->failureSummary('no_indexnow_queue_items_available', [
+                'plans' => $plans,
+                'plan_issues' => array_values(array_unique($planIssues)),
+            ]));
+        }
+
+        $writeResult = $plannedItems === [] ? ['batch_ids' => [], 'written_items' => 0] : $writer->write($plannedItems);
+        $queueItemIds = array_values(array_unique(array_merge(
+            $this->queueItemIdsForPlannedItems($plannedItems),
+            $duplicateReadyIds,
+        )));
+
+        [$pendingIds, $approvedIds, $submittedIds, $blockedStates] = $this->partitionQueueItems($queueItemIds);
+        $approveResult = ['status' => 'skipped', 'queue_item_ids' => [], 'issues' => []];
+        if ($pendingIds !== []) {
+            $approvePhrase = $approval->approvalPhrase($pendingIds, ['indexnow']);
+            $approveResult = $approval->approve(
+                queueItemIds: $pendingIds,
+                channels: ['indexnow'],
+                approvalPhrase: null,
+                approvalToken: hash('sha256', $approvePhrase),
+                actorId: 'seo-agent-indexnow-auto',
+                dryRun: false,
+            );
+        }
+
+        if (! in_array(($approveResult['status'] ?? 'success'), ['success', 'skipped'], true)) {
+            $artifact = $this->writeEvidence($artifactDir, $evidencePath, $evidenceSha, 'blocked', [
+                'execute' => true,
+                'write_result' => $writeResult,
+                'approve_result' => $this->safeExecutorSummary($approveResult),
+                'blocked_states' => $blockedStates,
+            ]);
+
+            return $this->finish($this->failureSummary('indexnow_queue_approval_failed', ['artifact' => $artifact]));
+        }
+
+        $submitIds = array_values(array_unique(array_merge($approvedIds, $pendingIds)));
+        $submitResult = ['status' => 'skipped', 'queue_item_ids' => [], 'issues' => []];
+        if ($submitIds !== []) {
+            $submitPhrase = $live->approvalPhrase($submitIds, ['indexnow']);
+            $submitResult = $live->submit(
+                queueItemIds: $submitIds,
+                channels: ['indexnow'],
+                approvalPhrase: null,
+                approvalToken: hash('sha256', $submitPhrase),
+                actorId: 'seo-agent-indexnow-auto',
+                dryRun: false,
+            );
+        }
+
+        $ok = in_array(($submitResult['status'] ?? 'success'), ['success', 'skipped'], true) && $blockedStates === [];
+        $artifact = $this->writeEvidence($artifactDir, $evidencePath, $evidenceSha, $ok ? 'success' : 'blocked', [
+            'execute' => true,
+            'target_count' => count($targets),
+            'write_result' => $writeResult,
+            'queue_item_ids' => $queueItemIds,
+            'submitted_queue_item_ids' => $submitIds,
+            'already_submitted_queue_item_ids' => array_values(array_unique(array_merge(
+                $submittedIds,
+                array_map(static fn (array $item): int => (int) $item['id'], $duplicateSubmitted),
+            ))),
+            'approve_result' => $this->safeExecutorSummary($approveResult),
+            'submit_result' => $this->safeExecutorSummary($submitResult),
+            'blocked_states' => $blockedStates,
+            'plans' => $plans,
+        ]);
+
+        if (! $ok) {
+            return $this->finish($this->failureSummary('indexnow_live_submission_failed', ['artifact' => $artifact]));
+        }
+
+        return $this->finish($this->successSummary('success', true, $artifact, [
+            'target_count' => count($targets),
+            'written_items' => (int) ($writeResult['written_items'] ?? 0),
+            'approved_count' => count($pendingIds),
+            'submitted_count' => count($submitIds),
+            'duplicate_submitted_count' => count($duplicateSubmitted) + count($submittedIds),
+            'external_calls_attempted' => count($submitIds) > 0,
+            'search_submission_attempted' => count($submitIds) > 0,
+        ]));
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function limit(): ?int
+    {
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+
+        return is_int($limit) && $limit >= 1 && $limit <= 3 ? $limit : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/post-publish-indexnow-auto');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function validatePublishEvidence(array $evidence): ?string
+    {
+        $schema = (string) ($evidence['schema_version'] ?? '');
+        if (! in_array($schema, [self::SINGLE_PUBLISH_SCHEMA_VERSION, self::AUTO_PUBLISH_SCHEMA_VERSION], true)) {
+            return 'publish_evidence_schema_invalid';
+        }
+        if (($evidence['status'] ?? null) !== 'success') {
+            return 'publish_evidence_not_success';
+        }
+
+        if ($schema === self::SINGLE_PUBLISH_SCHEMA_VERSION) {
+            if ((bool) ($evidence['execute'] ?? false) !== true
+                || (bool) ($evidence['writes_committed'] ?? false) !== true
+                || (int) ($evidence['published_count'] ?? 0) !== 1) {
+                return 'single_publish_evidence_missing_committed_publish';
+            }
+            if ((bool) data_get($evidence, 'rollback_evidence.available') !== true) {
+                return 'rollback_evidence_missing';
+            }
+            if ((bool) data_get($evidence, 'boundaries.search_channel_enqueue') !== false
+                || (bool) data_get($evidence, 'boundaries.indexing_request') !== false) {
+                return 'publish_evidence_boundary_invalid';
+            }
+
+            return null;
+        }
+
+        if ((bool) data_get($evidence, 'publish_summary.execute') !== true
+            || (int) data_get($evidence, 'publish_summary.published_count', 0) < 1) {
+            return 'auto_publish_evidence_missing_committed_publish';
+        }
+        if ((bool) data_get($evidence, 'negative_guarantees.search_channel_enqueue') !== false
+            || (bool) data_get($evidence, 'negative_guarantees.indexing_request') !== false) {
+            return 'auto_publish_evidence_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return list<array<string, mixed>>
+     */
+    private function publishedRefs(array $evidence): array
+    {
+        if (($evidence['schema_version'] ?? null) === self::SINGLE_PUBLISH_SCHEMA_VERSION) {
+            return array_values(array_filter(
+                (array) ($evidence['affected_refs'] ?? []),
+                static fn ($ref): bool => is_array($ref) && ($ref['status'] ?? null) === 'published'
+            ));
+        }
+
+        $refs = [];
+        foreach ((array) ($evidence['publish_results'] ?? []) as $result) {
+            if (! is_array($result) || (int) ($result['published_count'] ?? 0) < 1) {
+                continue;
+            }
+            foreach ((array) ($result['affected_refs'] ?? []) as $ref) {
+                if (is_array($ref) && ($ref['status'] ?? null) === 'published') {
+                    $refs[] = $ref;
+                }
+            }
+        }
+
+        return $refs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $ref
+     * @return array<string, mixed>
+     */
+    private function publishedTarget(array $ref): array
+    {
+        if (($ref['target_model'] ?? null) !== 'content_page') {
+            return ['ok' => false, 'issue' => 'target_model_not_supported'];
+        }
+
+        $pageId = $this->idFromSubjectRef((string) ($ref['subject_ref'] ?? ''), 'content_page');
+        if ($pageId < 1) {
+            return ['ok' => false, 'issue' => 'subject_ref_invalid'];
+        }
+
+        $page = ContentPage::query()->withoutGlobalScopes()->find($pageId);
+        if (! $page instanceof ContentPage) {
+            return ['ok' => false, 'issue' => 'content_page_not_found'];
+        }
+        if ((string) $page->status !== ContentPage::STATUS_PUBLISHED || ! (bool) $page->is_public || ! (bool) $page->is_indexable) {
+            return ['ok' => false, 'issue' => 'content_page_not_public_indexable'];
+        }
+
+        $safePath = (string) ($ref['safe_path'] ?? $page->canonical_path ?? $page->path ?? '');
+        $canonicalUrl = $this->canonicalUrl($safePath);
+        if ($canonicalUrl === null) {
+            return ['ok' => false, 'issue' => 'canonical_url_resolution_failed'];
+        }
+
+        return [
+            'ok' => true,
+            'subject_ref' => (string) ($ref['subject_ref'] ?? ''),
+            'safe_path' => $safePath,
+            'canonical_url' => $canonicalUrl,
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+        ];
+    }
+
+    private function canonicalUrl(string $safePath): ?string
+    {
+        if ($safePath === '' || ! str_starts_with($safePath, '/') || str_starts_with($safePath, '//')) {
+            return null;
+        }
+
+        $base = trim((string) ($this->option('base-url') ?: config('app.url')));
+        if ($base === '') {
+            return null;
+        }
+
+        $url = rtrim($base, '/').$safePath;
+
+        return filter_var($url, FILTER_VALIDATE_URL) === false ? null : $url;
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== $expectedType || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            return 0;
+        }
+
+        return (int) $parts[1];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $plannedItems
+     * @return list<int>
+     */
+    private function queueItemIdsForPlannedItems(array $plannedItems): array
+    {
+        if ($plannedItems === []) {
+            return [];
+        }
+
+        return DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table('seo_search_channel_queue_items')
+            ->whereIn('idempotency_key', array_values(array_map(static fn (array $item): string => (string) ($item['idempotency_key'] ?? ''), $plannedItems)))
+            ->where('channel', 'indexnow')
+            ->orderBy('id')
+            ->pluck('id')
+            ->map(static fn (mixed $id): int => (int) $id)
+            ->all();
+    }
+
+    /**
+     * @return array{id:int, approval_state:string, execution_state:string}|null
+     */
+    private function existingIndexnowQueueItem(string $canonicalUrl): ?array
+    {
+        $row = DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table('seo_search_channel_queue_items')
+            ->where('url_hash', hash('sha256', $canonicalUrl))
+            ->where('channel', 'indexnow')
+            ->orderByDesc('id')
+            ->first(['id', 'approval_state', 'execution_state']);
+
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row->id,
+            'approval_state' => (string) $row->approval_state,
+            'execution_state' => (string) $row->execution_state,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @return array{0:list<int>,1:list<int>,2:list<int>,3:list<array<string, mixed>>}
+     */
+    private function partitionQueueItems(array $queueItemIds): array
+    {
+        $pending = [];
+        $approved = [];
+        $submitted = [];
+        $blocked = [];
+        if ($queueItemIds === []) {
+            return [$pending, $approved, $submitted, $blocked];
+        }
+
+        $items = DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table('seo_search_channel_queue_items')
+            ->whereIn('id', $queueItemIds)
+            ->orderBy('id')
+            ->get(['id', 'approval_state', 'execution_state', 'channel']);
+
+        foreach ($items as $item) {
+            $id = (int) $item->id;
+            if ((string) $item->channel !== 'indexnow') {
+                $blocked[] = ['queue_item_id' => $id, 'issue' => 'non_indexnow_channel_blocked'];
+                continue;
+            }
+
+            $approval = (string) $item->approval_state;
+            $execution = (string) $item->execution_state;
+            if ($approval === 'pending' && $execution === 'dry_run_ready') {
+                $pending[] = $id;
+            } elseif ($approval === 'approved' && $execution === 'dry_run_ready') {
+                $approved[] = $id;
+            } elseif ($execution === 'submitted') {
+                $submitted[] = $id;
+            } else {
+                $blocked[] = [
+                    'queue_item_id' => $id,
+                    'approval_state' => $approval,
+                    'execution_state' => $execution,
+                    'issue' => 'queue_item_state_not_auto_submittable',
+                ];
+            }
+        }
+
+        return [$pending, $approved, $submitted, $blocked];
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     * @param  array<string, mixed>  $target
+     * @return array<string, mixed>
+     */
+    private function safePlanSummary(array $plan, array $target): array
+    {
+        return [
+            'safe_path' => (string) ($target['safe_path'] ?? ''),
+            'canonical_url_hash' => (string) ($target['canonical_url_hash'] ?? ''),
+            'candidate_count' => (int) ($plan['candidate_count'] ?? 0),
+            'eligible_count' => (int) ($plan['eligible_count'] ?? 0),
+            'planned_queue_count' => (int) ($plan['planned_queue_count'] ?? 0),
+            'duplicate_detected' => (bool) ($plan['duplicate_detected'] ?? false),
+            'reason_code_breakdown' => (array) ($plan['reason_code_breakdown'] ?? []),
+            'selected_channels' => array_values(array_map('strval', (array) ($plan['selected_channels'] ?? []))),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function safeExecutorSummary(array $result): array
+    {
+        return [
+            'status' => (string) ($result['status'] ?? ''),
+            'dry_run' => (bool) ($result['dry_run'] ?? false),
+            'queue_item_ids' => array_values(array_map('intval', (array) ($result['queue_item_ids'] ?? []))),
+            'queue_item_count' => (int) ($result['queue_item_count'] ?? 0),
+            'channels' => array_values(array_map('strval', (array) ($result['channels'] ?? []))),
+            'issues' => array_values(array_map('strval', (array) ($result['issues'] ?? []))),
+            'external_calls_attempted' => (bool) ($result['external_calls_attempted'] ?? false),
+            'search_submission_attempted' => (bool) ($result['search_submission_attempted'] ?? false),
+            'writes_attempted' => (bool) ($result['writes_attempted'] ?? false),
+            'writes_committed' => (bool) ($result['writes_committed'] ?? false),
+            'items' => array_values(array_map(static fn ($item): array => [
+                'queue_item_id' => (int) data_get(is_array($item) ? $item : [], 'queue_item_id', 0),
+                'channel' => (string) data_get(is_array($item) ? $item : [], 'channel', ''),
+                'url_hash' => (string) data_get(is_array($item) ? $item : [], 'url_hash', ''),
+                'status' => (string) data_get(is_array($item) ? $item : [], 'status', ''),
+                'submission_status' => (string) data_get(is_array($item) ? $item : [], 'submission_status', ''),
+                'execution_state' => (string) data_get(is_array($item) ? $item : [], 'execution_state', ''),
+                'http_status' => data_get(is_array($item) ? $item : [], 'http_status'),
+                'issues' => array_values(array_map('strval', (array) data_get(is_array($item) ? $item : [], 'issues', []))),
+            ], (array) ($result['items'] ?? []))),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function writeEvidence(string $artifactDir, string $publishEvidencePath, string $publishEvidenceSha, string $status, array $extra): array
+    {
+        $path = rtrim($artifactDir, '/').'/seo-agent-post-publish-indexnow-auto-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-POST-PUBLISH-INDEXNOW-AUTO-01',
+            'status' => $status,
+            'run_mode' => 'post_publish_indexnow_auto',
+            'command' => 'php artisan seo-agent:post-publish-indexnow-auto',
+            'publish_evidence' => [
+                'path' => $publishEvidencePath,
+                'size' => filesize($publishEvidencePath) ?: 0,
+                'sha256' => $publishEvidenceSha,
+            ],
+            ...$extra,
+            'allowed_actions' => [
+                'url_truth_read',
+                'search_channel_queue_write',
+                'search_channel_queue_approve',
+                'indexnow_live_submit',
+                'evidence_artifact_write',
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => self::SCHEMA_VERSION,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function successSummary(string $status, bool $execute, array $artifact, array $extra): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $status,
+            'execute' => $execute,
+            ...$extra,
+            'artifact' => $artifact,
+            'google_indexing_live_api_called' => false,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'google_indexing_live_api_called' => false,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'google_sitemap_live_submit',
+            'google_indexing_live_api_call',
+            'baidu_push_live_submit',
+            'cms_write',
+            'cms_publish',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'frontend_code_mutation',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'cms_write' => false,
+            'cms_publish' => false,
+            'google_sitemap_live_submit' => false,
+            'google_indexing_api_call' => false,
+            'baidu_push_live_submit' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+            'frontend_code_mutation' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -174,6 +174,7 @@ use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsPublishAutoCanaryCommand;
 use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
+use App\Console\Commands\SeoAgentPostPublishIndexnowAutoCommand;
 use App\Console\Commands\SeoAgentPostPublishSearchSubmitCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
@@ -381,6 +382,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsPublishAutoCanaryCommand::class,
         SeoAgentCmsPublishCanaryCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
+        SeoAgentPostPublishIndexnowAutoCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,

--- a/backend/docs/seo/generated/seo-agent-post-publish-indexnow-auto.v1.json
+++ b/backend/docs/seo/generated/seo-agent-post-publish-indexnow-auto.v1.json
@@ -1,0 +1,72 @@
+{
+  "version": "seo-agent-post-publish-indexnow-auto.v1",
+  "task": "SEO-AGENT-POST-PUBLISH-INDEXNOW-AUTO-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:post-publish-indexnow-auto",
+  "input_schemas": [
+    "seo-agent-cms-publish-canary.v1",
+    "seo-agent-cms-publish-auto-canary.v1"
+  ],
+  "output_schema": "seo-agent-post-publish-indexnow-auto.v1",
+  "default_mode": "dry_run_plan",
+  "execute_requires": [
+    "--execute",
+    "--limit=1..3",
+    "successful CMS publish evidence",
+    "URL Truth row for each published ContentPage"
+  ],
+  "max_published_urls_per_execution": 3,
+  "live_submit_channels_v1": [
+    "indexnow"
+  ],
+  "blocked_live_submit_channels_v1": [
+    "google_sitemap",
+    "google_indexing",
+    "baidu_push",
+    "so360_submit",
+    "sogou_submit",
+    "shenma_submit"
+  ],
+  "supported_targets_v1": [
+    "content_page"
+  ],
+  "pipeline": [
+    "validate_publish_evidence",
+    "resolve_published_content_page_safe_path",
+    "read_url_truth",
+    "enqueue_indexnow",
+    "approve_bounded_queue_item",
+    "submit_indexnow_bounded_live",
+    "write_sanitized_evidence"
+  ],
+  "negative_guarantees": {
+    "cms_write": false,
+    "cms_publish": false,
+    "google_sitemap_live_submit": false,
+    "google_indexing_api_call": false,
+    "baidu_push_live_submit": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "external_model_api_call": false,
+    "frontend_code_mutation": false
+  },
+  "evidence": {
+    "records_publish_evidence_sha256": true,
+    "records_queue_item_ids": true,
+    "records_url_hashes": true,
+    "records_http_status": true,
+    "forbidden_fields_absent": [
+      "raw_url",
+      "raw_query",
+      "credential_path",
+      "client_email",
+      "private_key",
+      "Bearer token",
+      "cookie",
+      "content_md",
+      "content_html",
+      "cms_draft_body"
+    ]
+  },
+  "next_step": "GSC post-publish feedback remains a separate PR."
+}

--- a/backend/docs/seo/seo-agent-post-publish-indexnow-auto.md
+++ b/backend/docs/seo/seo-agent-post-publish-indexnow-auto.md
@@ -1,0 +1,50 @@
+# SEO Agent Post Publish IndexNow Auto
+
+Task: `SEO-AGENT-POST-PUBLISH-INDEXNOW-AUTO-01`
+
+This command is the L5-A post-publish submission step. It accepts successful SEO Agent CMS publish evidence, verifies the published ContentPage through URL Truth, writes an `indexnow` Search Channel queue item when needed, approves the bounded queue item, and submits it through the existing bounded live executor.
+
+## Command
+
+Dry-run plan:
+
+```bash
+php artisan seo-agent:post-publish-indexnow-auto \
+  --publish-evidence=<seo-agent-cms-publish-canary-or-auto-canary.json> \
+  --limit=3 \
+  --artifact-dir=/path/to/artifacts \
+  --json
+```
+
+Execute:
+
+```bash
+php artisan seo-agent:post-publish-indexnow-auto \
+  --publish-evidence=<seo-agent-cms-publish-canary-or-auto-canary.json> \
+  --limit=3 \
+  --artifact-dir=/path/to/artifacts \
+  --execute \
+  --json
+```
+
+## Scope
+
+- Accepts `seo-agent-cms-publish-canary.v1` and `seo-agent-cms-publish-auto-canary.v1`.
+- Supports only published `content_page` refs.
+- Uses URL Truth (`seo_urls`) as the canonical eligibility source.
+- Writes/approves/submits only `indexnow` queue items.
+- Submits at most three published URLs per run.
+- Records queue item ids, provider status, HTTP status, URL hashes, and sanitized evidence.
+
+## Boundaries
+
+- No CMS write or publish.
+- No Google Sitemap live submit.
+- No Google Indexing live API call.
+- No Baidu live submit.
+- No scheduler activation.
+- No queue worker activation.
+- No frontend mutation.
+- No external model API call.
+- No full URL, raw query, raw body, credential path, client email, private key, token, cookie, or service-account JSON may appear in command output or evidence.
+

--- a/backend/tests/Feature/SeoIntel/SeoAgentPostPublishIndexnowAutoTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentPostPublishIndexnowAutoTest.php
@@ -1,0 +1,427 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentPostPublishIndexnowAutoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.url' => 'https://fermatmind.com',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
+            'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => 'secret-indexnow-key',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => 'https://fermatmind.com/indexnow.txt',
+            'seo_intel.search_channel_queue.approved_source_authorities' => [
+                'backend_cms',
+                'backend_public_surface',
+                'scale_catalog',
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function dry_run_plans_indexnow_only_without_queue_write_or_external_call(): void
+    {
+        Http::fake();
+        $page = $this->createPublishedPage();
+        $this->seedSeoUrl('https://fermatmind.com/zh/content-page-candidate', (string) $page->id);
+        $evidencePath = $this->writeAutoPublishEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-indexnow-auto', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-indexnow-auto'),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, json_encode($summary));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['target_count'] ?? null);
+        $this->assertSame(1, $summary['planned_queue_count'] ?? null);
+        $this->assertFalse((bool) ($summary['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($summary['google_indexing_live_api_called'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        Http::assertNothingSent();
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('seo-agent-post-publish-indexnow-auto.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame(['indexnow'], data_get($artifact, 'plans.0.selected_channels'));
+        $this->assertSame(false, data_get($artifact, 'negative_guarantees.google_indexing_api_call'));
+    }
+
+    #[Test]
+    public function execute_enqueues_approves_and_submits_indexnow_only(): void
+    {
+        Http::fake([
+            'api.indexnow.test/*' => Http::response('', 202),
+        ]);
+        $page = $this->createPublishedPage();
+        $this->seedSeoUrl('https://fermatmind.com/zh/content-page-candidate', (string) $page->id);
+        $evidencePath = $this->writeSinglePublishEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-indexnow-auto', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-indexnow-auto'),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, json_encode($summary));
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['written_items'] ?? null);
+        $this->assertSame(1, $summary['approved_count'] ?? null);
+        $this->assertSame(1, $summary['submitted_count'] ?? null);
+        $this->assertTrue((bool) ($summary['external_calls_attempted'] ?? false));
+        $this->assertTrue((bool) ($summary['search_submission_attempted'] ?? false));
+        $this->assertFalse((bool) ($summary['google_indexing_live_api_called'] ?? true));
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->first();
+        $this->assertNotNull($item);
+        $this->assertSame('indexnow', (string) $item->channel);
+        $this->assertSame('approved', (string) $item->approval_state);
+        $this->assertSame('submitted', (string) $item->execution_state);
+
+        $events = DB::connection('seo_intel')->table('seo_search_channel_queue_events')->orderBy('id')->pluck('event_type')->all();
+        $this->assertContains('queue_item_planned', $events);
+        $this->assertContains('search_channel_queue_approved', $events);
+        $this->assertContains('bounded_live_submission_started', $events);
+        $this->assertContains('bounded_live_submission_response', $events);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://api.indexnow.test/indexnow'
+                && $request['key'] === 'secret-indexnow-key'
+                && $request['urlList'] === ['https://fermatmind.com/zh/content-page-candidate'];
+        });
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/content-page-candidate', $encoded);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $artifactEncoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($artifactEncoded);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/content-page-candidate', $artifactEncoded);
+        $this->assertStringNotContainsString('secret-indexnow-key', $artifactEncoded);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-indexnow-auto', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 3,
+            '--artifact-dir' => storage_path('framework/testing/seo-agent-indexnow-auto'),
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, json_encode($summary));
+        $this->assertSame(0, $summary['submitted_count'] ?? null);
+        $this->assertSame(1, $summary['duplicate_submitted_count'] ?? null);
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function execute_fails_closed_without_url_truth_or_for_limit_above_three(): void
+    {
+        Http::fake();
+        $page = $this->createPublishedPage();
+        $evidencePath = $this->writeSinglePublishEvidence($page);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-indexnow-auto', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 4,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('limit_out_of_bounds', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-indexnow-auto', [
+            '--publish-evidence' => $evidencePath,
+            '--limit' => 1,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('no_indexnow_queue_items_available', $summary['issues'] ?? []);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function generated_contract_documents_indexnow_auto_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-post-publish-indexnow-auto.v1.json'));
+
+        $this->assertSame('seo-agent-post-publish-indexnow-auto.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:post-publish-indexnow-auto', $artifact['command'] ?? null);
+        $this->assertSame(3, $artifact['max_published_urls_per_execution'] ?? null);
+        $this->assertSame(['indexnow'], $artifact['live_submit_channels_v1'] ?? null);
+        $this->assertContains('google_indexing', $artifact['blocked_live_submit_channels_v1'] ?? []);
+        $this->assertSame(false, data_get($artifact, 'negative_guarantees.google_indexing_api_call'));
+        $this->assertSame(false, data_get($artifact, 'negative_guarantees.scheduler_activation'));
+    }
+
+    private function createPublishedPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'content-page-candidate',
+            'path' => '/zh/content-page-candidate',
+            'canonical_path' => '/zh/content-page-candidate',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Content Page Candidate',
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => true,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'approved',
+            'published_revision_id' => 88,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function writeSinglePublishEvidence(ContentPage $page): string
+    {
+        return $this->writeJson('seo-agent-cms-publish-canary-', [
+            'schema_version' => 'seo-agent-cms-publish-canary.v1',
+            'ok' => true,
+            'status' => 'success',
+            'execute' => true,
+            'writes_committed' => true,
+            'published_count' => 1,
+            'affected_refs' => [[
+                'status' => 'published',
+                'target_model' => 'content_page',
+                'subject_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+                'revision_id' => 101,
+                'safe_path' => '/zh/content-page-candidate',
+            ]],
+            'rollback_evidence' => [
+                'available' => true,
+                'content_page_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+            ],
+            'boundaries' => [
+                'cms_publish' => true,
+                'search_channel_enqueue' => false,
+                'indexing_request' => false,
+            ],
+        ]);
+    }
+
+    private function writeAutoPublishEvidence(ContentPage $page): string
+    {
+        return $this->writeJson('seo-agent-cms-publish-auto-canary-', [
+            'schema_version' => 'seo-agent-cms-publish-auto-canary.v1',
+            'ok' => true,
+            'status' => 'success',
+            'publish_summary' => [
+                'execute' => true,
+                'published_count' => 1,
+            ],
+            'publish_results' => [[
+                'schema_version' => 'seo-agent-cms-publish-canary.v1',
+                'ok' => true,
+                'status' => 'success',
+                'execute' => true,
+                'published_count' => 1,
+                'affected_refs' => [[
+                    'status' => 'published',
+                    'target_model' => 'content_page',
+                    'subject_ref' => 'content_page:'.(int) $page->id.':zh-CN',
+                    'revision_id' => 101,
+                    'safe_path' => '/zh/content-page-candidate',
+                ]],
+            ]],
+            'negative_guarantees' => [
+                'search_channel_enqueue' => false,
+                'indexing_request' => false,
+            ],
+        ]);
+    }
+
+    private function seedSeoUrl(string $canonicalUrl, string $entityId): void
+    {
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'content_page',
+            'entity_id_or_slug' => $entityId,
+            'cluster' => 'content_page',
+            'source_authority' => 'backend_cms',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => now()->subMinute(),
+            'lastmod_source' => 'content_pages.updated_at',
+            'is_private_flow' => false,
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode([
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'content_pages',
+            ], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_batches', function ($table): void {
+            $table->id();
+            $table->string('channel', 64);
+            $table->string('status', 64)->default('draft');
+            $table->unsignedInteger('item_count')->default(0);
+            $table->json('dry_run_report')->nullable();
+            $table->text('approval_note')->nullable();
+            $table->string('created_by', 128)->nullable();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'secret-indexnow-key',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1259,6 +1259,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_post_publish_indexnow_auto_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentPostPublishIndexnowAutoCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentPostPublishIndexnowAutoCommand;',
+            '+        SeoAgentPostPublishIndexnowAutoCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files(): void
     {
         $changed = [
@@ -3841,6 +3855,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentPostPublishIndexnowAutoFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentGscOpportunityAutoDraftFile($file)) {
                 continue;
             }
@@ -4447,6 +4465,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsPublishCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsPublishAutoCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -5173,6 +5192,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentPostPublishIndexnowAutoFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentPostPublishIndexnowAutoCommand.php',
         ], true);
     }
 
@@ -7053,6 +7079,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentPostPublishSearchSubmitCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentPostPublishIndexnowAutoCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:post-publish-indexnow-auto`, a bounded L5-A post-publish wrapper that validates SEO Agent publish evidence, reads URL Truth, writes IndexNow queue items, approves them, and submits through the existing bounded live executor.
- Supports both single publish canary and auto-canary evidence, while keeping only `content_page` targets eligible.
- Added contract docs/generated JSON and focused feature tests.
- Updated the Big Five runtime freeze allowlist for the new SEO Agent command registration.

## Why
This is the post-publish IndexNow automation step after low-risk ContentPage canary publish. It automates only IndexNow for already-published ContentPage URLs and keeps Google Indexing, Google sitemap live submit, Baidu, scheduler, queue worker, CMS mutation, and frontend mutation blocked.

## Validation
```bash
cd backend
php artisan test --filter SeoAgentPostPublishIndexnowAutoTest
php artisan test --filter SeoAgentPostPublishSearchSubmitTest
php artisan test --filter SeoIntelSearchChannelApproveCommandTest
php artisan test --filter SeoIntelSearchChannelBoundedLiveExecutorTest
php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest
python3 -m json.tool docs/seo/generated/seo-agent-post-publish-indexnow-auto.v1.json >/dev/null
php artisan list --raw | grep 'seo-agent:post-publish-indexnow-auto'
git diff --check
```

## Intentionally deferred
- No Google Indexing live API call.
- No Google sitemap live submit.
- No Baidu/other search channel live submit.
- No scheduler or queue worker activation.
- No CMS write/publish or frontend mutation.
