### PR TITLE
BIG5-RESULT-ASSET-AGENT-RUNBOOK-01: docs(big5):固化 result asset agent runbook

### DIFF
--- a/backend/docs/big5/result-asset-agent-gates.md
+++ b/backend/docs/big5/result-asset-agent-gates.md
@@ -1,0 +1,119 @@
+# Big Five Result Page V2 Asset Agent Stage Gates
+
+Status: `BIG5-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+These gates define how Big Five Result Page V2 asset-agent work moves from documentation to preview handoff. They do not open runtime, CMS, pilot, or production access.
+
+## Gate 1: Runbook
+
+Entry: explicit PR-train authorization.
+
+Pass criteria:
+
+- docs define agent responsibilities, inputs, outputs, forbidden actions, and stop conditions;
+- no runtime, CMS, asset-generation, or production files are changed;
+- `git diff --check` passes.
+
+Exit state: runbook documented, generation still forbidden.
+
+## Gate 2: Source Ledger
+
+Entry: runbook merged.
+
+Pass criteria:
+
+- ledger template exists;
+- first evidence ledger covers IPIP, BFI-2 structure-only use, University of Oregon method framing, internal V2.0 source, internal long-form source, and existing asset packs;
+- every claim row has source, reference, permitted use, limitation, and disallowed use;
+- JSON validates;
+- no generated selector assets are created.
+
+Exit state: sources traceable, generation still forbidden.
+
+## Gate 3: Validator Harness
+
+Entry: source ledger merged.
+
+Pass criteria:
+
+- agent run validator can inspect a run directory without mutating runtime state;
+- harness reuses `BigFiveResultPageV2SelectorAssetValidator`;
+- inventory, checksum, forbidden public field, share leak, and gate report checks exist;
+- strict mode fails closed on invalid inventory, P0 blockers, or leaks;
+- focused harness and selector validator tests pass.
+
+Exit state: validation executable, generation still forbidden.
+
+## Gate 4: Existing Asset Gap Audit
+
+Entry: validator harness merged.
+
+Pass criteria:
+
+- current 13 packages are inventoried;
+- current 325 selector assets are counted and grouped;
+- current 3125 route matrix rows are counted across five shards;
+- current 31 golden cases are counted and O59 canonical case is identified;
+- gaps are grouped by registry, scope, scenario, share-safe coverage, norm-unavailable coverage, and route/golden-case readiness;
+- output is a gap register, not a repair or generated asset batch.
+
+Exit state: gap register ready for targeted repair.
+
+## Gate 5: Selector QA Repair
+
+Entry: existing asset gap audit merged.
+
+Pass criteria:
+
+- known selector QA policy issues are repaired: coverage warnings, golden group normalization, slot/module naming, banned terms, O59 canonical regression;
+- assets remain `staging_only`;
+- no runtime wrapper, CMS import, pilot flag, or production flag changes;
+- selector import, validator, and golden case tests pass.
+
+Exit state: selector QA can act as a staging gate.
+
+## Gate 6: Share-Safety Pilot Batch
+
+Entry: selector QA repair merged.
+
+Pass criteria:
+
+- pilot batch scope is limited to `share_safety_registry`;
+- raw draft, repair draft, final asset, validation report, safety report, and go/no-go report are preserved;
+- every generated asset remains `staging_only` and `production_use_allowed=false`;
+- shareable public payloads contain no raw scores, vectors, percentiles, type codes, or private fields;
+- strict harness and selector validator pass.
+
+Exit state: share-safe draft can be reviewed as staging-only content.
+
+## Gate 7: Route Matrix And Golden Case QA
+
+Entry: share-safety pilot batch merged.
+
+Pass criteria:
+
+- 3125 route rows validate across O1 through O5 shards;
+- eight canonical profiles are covered;
+- O59 row and O59 golden case pass;
+- selector references resolve;
+- conflict-resolution rules are deterministic;
+- output is a staging selector input readiness report, not runtime wiring.
+
+Exit state: route matrix can be considered staging selector input.
+
+## Gate 8: Render Preview Handoff
+
+Entry: route matrix and golden case QA merged.
+
+Pass criteria:
+
+- backend fixtures and expected assertions cover result page, PDF, share, history, compare, locked/free redaction, low quality, and norm unavailable behavior;
+- fixtures validate through backend payload and public-surface policies;
+- no frontend content, CMS write, runtime flag, or production gate is changed;
+- fap-web handoff document names the fixture files, expected assertions, and explicit deferred items.
+
+Exit state: fap-web can run rendered preview QA against backend-owned fixtures.
+
+## Production Boundary
+
+None of these gates authorize production. Production requires a separate release package, backend dry-run, staging import, rendered preview pass, API smoke, pilot allowlist, production import gate, and production rollout approval.

--- a/backend/docs/big5/result-asset-agent-runbook.md
+++ b/backend/docs/big5/result-asset-agent-runbook.md
@@ -1,0 +1,104 @@
+# Big Five Result Page V2 Asset Agent Runbook
+
+Status: `BIG5-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+This runbook defines the backend-only operating contract for the Big Five Result Page V2 content asset agent. It does not authorize asset generation, CMS import, runtime wiring, pilot access, or production rollout.
+
+## Authority Model
+
+The agent must reuse the RIASEC projection, deep-slot, and fail-closed pattern:
+
+- backend projection and selector contracts are the only content authority;
+- frontend inference and frontend-authored interpretation fallback are forbidden;
+- missing, invalid, pending, or unsafe slots are hidden or degraded by backend policy;
+- public payloads are allowlisted and must not expose private scoring, route, QA, or editor metadata;
+- stage promotion requires explicit evidence artifacts, not the presence of generated copy.
+
+The agent is dedicated to Big Five Result Page V2 private result surfaces. It must not be replaced by or merged with a public personality profile SEO agent because private result pages include score vectors, norm availability, paid/free redaction, share/PDF/history/compare payloads, and route selector risks that public profile pages do not carry.
+
+## Agent Responsibilities
+
+The full program is split into eight PR-train tasks:
+
+1. `BIG5-RESULT-ASSET-AGENT-RUNBOOK-01`: document runbook, protocol, forbidden actions, and gates.
+2. `BIG5-RESULT-SOURCE-LEDGER-01`: create source ledger templates and first evidence ledger.
+3. `BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01`: build the agent run validator harness.
+4. `BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01`: audit existing package, selector, route, and golden-case gaps.
+5. `BIG5-RESULT-SELECTOR-QA-REPAIR-01`: repair selector QA policy issues while keeping assets staging-only.
+6. `BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01`: dry-run a narrow `share_safety_registry` pilot batch.
+7. `BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01`: validate route matrix and golden-case selector readiness.
+8. `BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01`: hand off backend fixtures and expected assertions to fap-web rendered preview QA.
+
+Each task is one PR scope. A later task must not be implemented in an earlier PR.
+
+## Subagent Roles
+
+The orchestrator may call bounded subagents, but the output boundary remains this backend artifact protocol:
+
+- Source Ledger Agent: tracks every claim to source, reference, limitation, permitted use, and disallowed use.
+- Asset Factory Agent: emits only `fap.big5.result_page_v2.selector_asset.v0.1` candidate assets when a generation PR explicitly allows it.
+- Selector Contract QA Agent: validates selector contract, slot, trigger, priority, mutual exclusion, reading mode, fallback, and public payload allowlist.
+- Safety and Claim QA Agent: blocks deterministic type, diagnosis, therapy, hiring, success prediction, ability measurement, unsupported percentile, raw score, vector, and share leak claims.
+- Route Matrix and Golden Case Agent: checks 3125 route rows, canonical profiles, O59, selector references, and conflict resolution.
+- Render Preview and Surface QA Agent: creates backend fixtures and expected assertions for result page, PDF, share, history, compare, and locked/free redaction previews.
+- Release Guard Agent: separates draft, validation, staging import candidate, rendered preview, pilot allowlist, production import gate, and production rollout.
+
+## Required Inputs
+
+Every run must declare:
+
+- `run_id`;
+- task id and branch id;
+- target gate: `scan`, `ledger`, `validate`, `gap_audit`, `qa_repair`, `draft`, `route_qa`, or `preview_handoff`;
+- locale set, if content is in scope;
+- input inventory snapshot paths;
+- source ledger path, when claim evaluation is in scope;
+- allowed output paths;
+- forbidden actions;
+- validator and QA commands to run.
+
+When an input is missing or invalid, the agent must fail closed and write a blocked report. It must not synthesize missing source authority or use frontend fallback copy.
+
+## Required Outputs
+
+Runs that create artifacts must follow the protocol in `result-asset-agent-schema.md`. Docs-only tasks may omit run artifacts, but they must keep the same negative guarantees:
+
+- `runtime_use=staging_only`;
+- `production_use_allowed=false`;
+- `ready_for_runtime=false`;
+- `ready_for_production=false`;
+- no CMS writes;
+- no runtime wrapper enablement;
+- no frontend fallback;
+- no private score, raw score, vector, percentile, or share leak.
+
+## Forbidden Actions
+
+All Big Five Result Page V2 asset-agent tasks forbid:
+
+- modifying public runtime APIs unless the active PR explicitly declares a runtime contract scope;
+- importing or mutating CMS data;
+- setting `production_use_allowed=true`;
+- enabling pilot or production flags;
+- changing `BigFiveResultPageV2RuntimeWrapper` rollout behavior;
+- generating frontend fallback interpretation copy;
+- adding sitemap, llms, search queue, public SEO page, or public personality profile output;
+- exporting private user identifiers, attempt ids, raw scores, domain vectors, facet vectors, percentiles, editor notes, QA notes, import policy, or internal metadata into public payloads;
+- using BFI-2 item text, proprietary report copy, competitor result copy, or internal drafts as copy-paste sources.
+
+## Stop Conditions
+
+Stop immediately when:
+
+- the working tree contains unrelated changes that cannot be isolated from the current PR scope;
+- a dependency PR is not merged into `main`;
+- changed files drift outside the manifest allowlist;
+- local manifest checks fail;
+- selector validator reports critical errors;
+- safety QA reports a forbidden public payload or share payload leak;
+- route matrix or golden case QA cannot prove current-count invariants;
+- any artifact implies runtime, pilot, CMS import, or production readiness before the matching gate.
+
+## First Pilot Default
+
+The first generation-capable dry run is limited to `share_safety_registry`. O59, low-quality, and norm-unavailable combined generation remains deferred until share-safe public payload boundaries pass in isolation.

--- a/backend/docs/big5/result-asset-agent-schema.md
+++ b/backend/docs/big5/result-asset-agent-schema.md
@@ -1,0 +1,121 @@
+# Big Five Result Page V2 Asset Agent Artifact Protocol
+
+Status: `BIG5-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+This protocol defines the artifact shape that later Big Five Result Page V2 asset-agent PRs must use. This document is a contract only; it does not generate assets.
+
+## Directory Contract
+
+Generated or audited run artifacts must live under a run-scoped directory:
+
+```text
+backend/content_assets/big5/result_page_v2/agent_runs/<run_id>/
+```
+
+The directory is allowed only in PRs whose scope explicitly includes agent run artifacts. Docs-only PRs must not create it.
+
+## Required Artifact Names
+
+When a run reaches the matching stage, it must use these stable filenames:
+
+```text
+input_inventory.json
+source_ledger.json
+raw_draft_assets.jsonl
+repaired_draft_assets.jsonl
+final_assets.jsonl
+validation_report.json
+safety_report.json
+route_matrix_report.json
+golden_case_report.json
+render_preview_fixture_manifest.json
+go_no_go.md
+```
+
+The file may be omitted only when the declared gate is earlier than that artifact. Omitted artifacts must be listed in `go_no_go.md` with the reason.
+
+## Shared Metadata
+
+Every JSON artifact must include:
+
+- `schema_version`;
+- `task_id`;
+- `run_id`;
+- `created_at`;
+- `runtime_use: "staging_only"`;
+- `production_use_allowed: false`;
+- `ready_for_runtime: false`;
+- `ready_for_production: false`;
+- `content_authority: "backend"`;
+- `cms_write_performed: false`;
+- `runtime_change_performed: false`;
+- `frontend_fallback_allowed: false`;
+- `private_payload_exported: false`.
+
+Artifacts that reference source files must use repository-relative paths and sha256 checksums. They must not expose machine-local private paths in public reports.
+
+## Selector Asset Contract
+
+The only candidate asset schema for generation-capable tasks is:
+
+```text
+fap.big5.result_page_v2.selector_asset.v0.1
+```
+
+Candidate assets must validate against `BigFiveResultPageV2SelectorAssetValidator` before promotion from raw draft to repaired draft or final staging candidate.
+
+Required governance fields include:
+
+- `content_source`;
+- `provenance`;
+- `replacement_policy`;
+- `forbidden_public_fields`;
+- `review_status`;
+- `required_evidence_level`;
+- `evidence_level`;
+- `safety_level`;
+- `shareable`;
+- `shareable_policy`;
+- `fallback_policy`;
+- `public_payload`;
+- `internal_metadata`.
+
+## Public Payload Boundary
+
+`public_payload` is an allowlisted reader payload. It must not contain:
+
+- raw scores or raw score labels;
+- domain vectors or facet vectors;
+- percentile, normal-curve, or norm claims when norm state is unavailable;
+- `attempt_id`, user id, private URL, private path, editor notes, QA notes, import policy, selection guidance, or internal metadata;
+- fixed type codes, official 32-type claims, user-confirmed type claims, or deterministic personality labels;
+- diagnosis, treatment, therapy, hiring-screen, employment suitability, success prediction, ability measurement, admission, salary, or performance claims.
+
+`internal_metadata` may contain backend QA details only when downstream reports keep it private and checksums prove it did not leak into public payloads.
+
+## Run Reports
+
+`validation_report.json` must include selector validator status, per-asset errors, per-registry counts, reading-mode counts, slot coverage, trigger coverage, mutual exclusion conflicts, fallback policy findings, and checksums for raw, repaired, and final files.
+
+`safety_report.json` must include forbidden term scans, share-safe payload scans, claim-boundary findings, norm-unavailable checks, low-quality checks, and pass/block status.
+
+`route_matrix_report.json` must include row count, shard count, O/C/E/A/N band coverage, selector reference resolution, O59 canonical row status, and conflict-resolution status.
+
+`golden_case_report.json` must include golden case count, canonical profile coverage, O59 case status, group distribution, expected selector refs, and mismatch list.
+
+`render_preview_fixture_manifest.json` must include only backend fixture references and expected assertions. It must not contain frontend fallback body copy.
+
+## State Transitions
+
+Allowed artifact states are:
+
+- `draft_package`;
+- `backend_dry_run`;
+- `validated`;
+- `approved_for_staging_review`;
+- `staging_import_candidate`;
+- `render_preview_ready`;
+- `pilot_allowlist_candidate`;
+- `production_import_gate_candidate`.
+
+No state implies the next state. `production_import_gate_candidate` is still not production authorization.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-20T07:22:00+08:00",
+  "updated_at": "2026-06-21T16:03:28+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55084,6 +55084,299 @@
         "at": "2026-06-20T07:35:00+08:00",
         "status": "merged",
         "note": "PR #2139 was squash-merged as f2ba00ba4c7b85c62988c43f7f88ab499ad72d24; remote branch is deleted, local task branch is absent, local main is synced to origin/main, and post-merge focused validation passed."
+      }
+    ]
+  },
+  "BIG5-RESULT-ASSET-AGENT-RUNBOOK-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-asset-agent-runbook-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-ASSET-AGENT-RUNBOOK-01: docs(big5):固化 result asset agent runbook",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the Big Five Result Page V2 asset-agent plan, including authorization to add the eight manifest/state entries and execute the first docs-only runbook PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "This is the first item in the Big Five Result Page V2 asset-agent sequence."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/big5/result-asset-agent-runbook.md, backend/docs/big5/result-asset-agent-schema.md, backend/docs/big5/result-asset-agent-gates.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git status --porcelain=v1",
+          "! rg -n \"production_use_allowed: true|ready_for_runtime: true|ready_for_production: true|cms_write_performed: true|runtime_change_performed: true|frontend_fallback_allowed: true\" backend/docs/big5 docs/codex/pr-train.yaml"
+        ],
+        "notes": "Docs-only checks passed. The forbidden positive gate scan returned no matches in the new docs and manifest. Runtime commands are not applicable because this PR changes no routes, migrations, services, CMS importers, or runtime wrappers."
+      }
+    },
+    "result": {
+      "go_no_go": "GO for docs-only runbook and PR-train authorization metadata; NO-GO for asset generation, CMS import, runtime wiring, pilot access, or production rollout.",
+      "highest_blocker": null
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit user authorization. Scope is docs-only runbook/protocol/gates plus PR train metadata; no assets, CMS import, runtime, pilot, or production gate changes are allowed."
+      },
+      {
+        "at": "2026-06-21T16:02:01+08:00",
+        "status": "local_checks_passed",
+        "note": "Added runbook, artifact protocol, and stage gates; manifest/state parse, diff check, changed-file scope validation, and forbidden positive gate scan passed."
+      }
+    ]
+  },
+  "BIG5-RESULT-SOURCE-LEDGER-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-source-ledger-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-SOURCE-LEDGER-01: docs(big5):建 result source ledger",
+    "depends_on": [
+      "BIG5-RESULT-ASSET-AGENT-RUNBOOK-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-ASSET-AGENT-RUNBOOK-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the runbook PR."
+      }
+    ]
+  },
+  "BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-asset-validator-harness-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01: test(big5):建 result asset validator harness",
+    "depends_on": [
+      "BIG5-RESULT-SOURCE-LEDGER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-SOURCE-LEDGER-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the source ledger PR."
+      }
+    ]
+  },
+  "BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-existing-asset-gap-audit-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(big5):审计现有 result assets gaps",
+    "depends_on": [
+      "BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the validator harness PR."
+      }
+    ]
+  },
+  "BIG5-RESULT-SELECTOR-QA-REPAIR-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-selector-qa-repair-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-SELECTOR-QA-REPAIR-01: fix(big5):修 result selector QA policy",
+    "depends_on": [
+      "BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the gap audit PR."
+      }
+    ]
+  },
+  "BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-asset-factory-pilot-batch-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01: feat(big5):dry-run share safety selector batch",
+    "depends_on": [
+      "BIG5-RESULT-SELECTOR-QA-REPAIR-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-SELECTOR-QA-REPAIR-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the selector QA repair PR. First pilot scope remains share_safety_registry only."
+      }
+    ]
+  },
+  "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-route-matrix-golden-case-qa-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases",
+    "depends_on": [
+      "BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the share safety pilot PR."
+      }
+    ]
+  },
+  "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-result-render-preview-handoff-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent",
+    "title": "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures",
+    "depends_on": [
+      "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T15:57:09+08:00",
+        "status": "pending_dependency",
+        "note": "Manifest/state entry authorized; implementation waits for the route matrix and golden case QA PR."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T16:03:28+08:00",
+  "updated_at": "2026-06-21T16:05:20+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55091,7 +55091,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-asset-agent-runbook-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-ASSET-AGENT-RUNBOOK-01: docs(big5):固化 result asset agent runbook",
     "checks": {
@@ -55124,8 +55124,8 @@
       "highest_blocker": null
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "215cfaccc01d3a54c1578377f8c6f7d72478cb06",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2184",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55139,6 +55139,11 @@
         "at": "2026-06-21T16:02:01+08:00",
         "status": "local_checks_passed",
         "note": "Added runbook, artifact protocol, and stage gates; manifest/state parse, diff check, changed-file scope validation, and forbidden positive gate scan passed."
+      },
+      {
+        "at": "2026-06-21T16:05:20+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2184 from scoped implementation commit 215cfaccc01d3a54c1578377f8c6f7d72478cb06."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24017,6 +24017,286 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: BIG5-RESULT-ASSET-AGENT-RUNBOOK-01
+    repo: fap-api
+    branch: codex/big5-result-asset-agent-runbook-01
+    title: "BIG5-RESULT-ASSET-AGENT-RUNBOOK-01: docs(big5):固化 result asset agent runbook"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Document the Big Five Result Page V2 backend content-asset agent runbook, input/output protocol, forbidden actions, and stage gates.
+      - Reuse the RIASEC backend projection, deep-slot, and fail-closed pattern as the authority model.
+      - Do not generate assets, import CMS content, change runtime, or open pilot/production gates.
+    allowed_paths:
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate `agent_runs` artifacts or selector assets.
+      - Modify `backend/app/**`, `backend/routes/**`, `backend/database/**`, runtime wrappers, CMS importers, or production gates.
+      - Set `production_use_allowed=true`, enable pilot access, add frontend fallback, or export private result payload fields.
+    validation:
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-SOURCE-LEDGER-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-ASSET-AGENT-RUNBOOK-01
+    branch: codex/big5-result-source-ledger-01
+    title: "BIG5-RESULT-SOURCE-LEDGER-01: docs(big5):建 result source ledger"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Add source ledger template and first evidence ledger for IPIP, BFI-2 structure-only use, University of Oregon method framing, internal V2.0 source, internal long-form source, and existing asset packs.
+      - Require each claim row to include source, reference, permitted use, limitation, and disallowed use.
+      - Do not generate selector assets or CMS imports.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/source_ledger/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Copy BFI-2 item text, proprietary report copy, competitor result copy, or internal drafts into generated user-facing selector prose.
+      - Generate official assets, import CMS data, modify runtime, or open production gates.
+    validation:
+      - find backend/content_assets/big5/result_page_v2/source_ledger -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-SOURCE-LEDGER-01
+    branch: codex/big5-result-asset-validator-harness-01
+    title: "BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01: test(big5):建 result asset validator harness"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Add agent run directory validator/test wrapper for Big Five Result Page V2 asset-agent runs.
+      - Reuse `BigFiveResultPageV2SelectorAssetValidator`, asset inventory, checksums, forbidden public field scans, and share leak scans.
+      - Keep the harness read-only against runtime and production state.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate formal selector assets or `production_use_allowed=true` artifacts.
+      - Modify runtime wrapper behavior, CMS importers, public API contracts, or frontend fixtures.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-ASSET-VALIDATOR-HARNESS-01
+    branch: codex/big5-result-existing-asset-gap-audit-01
+    title: "BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(big5):审计现有 result assets gaps"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Produce a gap register for the existing 13 packages, 325 selector assets, 3125 route matrix rows, 31 golden cases, and O59 canonical case.
+      - Group gaps by registry, scope, scenario, share-safe coverage, norm-unavailable coverage, and route/golden-case readiness.
+      - Keep output as audit evidence only.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/qa/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Repair selector policy, generate official assets, import CMS data, modify runtime, or open gates.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - find backend/content_assets/big5/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-SELECTOR-QA-REPAIR-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-EXISTING-ASSET-GAP-AUDIT-01
+    branch: codex/big5-result-selector-qa-repair-01
+    title: "BIG5-RESULT-SELECTOR-QA-REPAIR-01: fix(big5):修 result selector QA policy"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Repair selector QA policy coverage warnings, golden case grouping, slot/module naming, banned terms, and O59 canonical case regression.
+      - Keep every asset and policy artifact staging-only and non-runtime.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/selector_qa_policy/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate new official content batches, modify runtime wrapper behavior, import CMS data, or open pilot/production gates.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetImportV03Test --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteDrivenGoldenCasesTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-SELECTOR-QA-REPAIR-01
+    branch: codex/big5-result-asset-factory-pilot-batch-01
+    title: "BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01: feat(big5):dry-run share safety selector batch"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Dry-run a narrow `share_safety_registry` selector asset pilot batch.
+      - Preserve raw draft, repair draft, final asset, validation report, safety report, and go/no-go report.
+      - Keep every output staging-only and production-disallowed.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/agent_runs/**
+      - backend/content_assets/big5/result_page_v2/selector_ready_assets/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate O59 plus low-quality plus norm-unavailable combined assets in this PR.
+      - Import CMS data, wire runtime selectors, enable pilot access, or open production gates.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01
+    branch: codex/big5-result-route-matrix-golden-case-qa-01
+    title: "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Validate 3125 route rows, eight canonical profiles, O59, selector reference resolution, and conflict resolution.
+      - Produce route matrix and golden case staging-input QA reports.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/route_matrix/**
+      - backend/content_assets/big5/result_page_v2/selector_qa_policy/**
+      - backend/content_assets/big5/result_page_v2/qa/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Wire route matrix to production runtime, import CMS data, or enable pilot/production flags.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveV2RouteMatrixParserTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteDrivenGoldenCasesTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01
+    repo: fap-api
+    depends_on:
+      - BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01
+    branch: codex/big5-result-render-preview-handoff-01
+    title: "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures"
+    train_scope: big5_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Generate backend fixture manifest and expected assertions for fap-web rendered preview QA.
+      - Cover result page, PDF, share, history, compare, locked/free redaction, low-quality, and norm-unavailable surfaces.
+      - Keep handoff backend-owned and production-disallowed.
+    allowed_paths:
+      - backend/content_assets/big5/result_page_v2/rendered_preview/**
+      - backend/content_assets/big5/result_page_v2/qa/**
+      - backend/docs/big5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, add frontend fallback content, import CMS data, wire runtime selectors, or open production gates.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ValidatorTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PublicSurfacePolicyTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PdfSurfacePolicyTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
     next_task: SEO-CONV-OPS-05 in fap-api after this PR is merged
 
   - id: PERSONALITY-DETAIL-FAQ-SEO-01


### PR DESCRIPTION
## What changed
- Added the Big Five Result Page V2 asset-agent runbook, artifact protocol, and stage gate docs under backend/docs/big5.
- Added eight authorized Big5 result asset-agent PR train entries with linear dependencies.
- Initialized PR-train state for the first docs-only item and the seven dependent follow-up items.

## Why
- Establishes the backend-only agent operating contract before any source ledger, harness, gap audit, repair, pilot batch, route QA, or rendered preview handoff work starts.
- Preserves RIASEC-style backend projection/deep-slot/fail-closed boundaries for Big Five private result surfaces.

## Validation
- git diff --check
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- ! rg -n "production_use_allowed: true|ready_for_runtime: true|ready_for_production: true|cms_write_performed: true|runtime_change_performed: true|frontend_fallback_allowed: true" backend/docs/big5 docs/codex/pr-train.yaml

## Intentionally deferred
- No source ledger rows are added in this PR.
- No validator harness, command, service, or tests are added in this PR.
- No selector assets, agent_runs artifacts, CMS import, runtime wiring, pilot gate, production import gate, or production rollout gate are added.

## Repository rule impact
- New content surface remains backend-authoritative and docs-only in this PR.
- No frontend fallback content is introduced.