### PR TITLE
BigFive: add result page candidate export and inactive import scaffold

### DIFF
--- a/backend/app/Console/Commands/BigFiveExportProductionEquivalentCandidatePayloads.php
+++ b/backend/app/Console/Commands/BigFiveExportProductionEquivalentCandidatePayloads.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveProductionEquivalentCandidatePayloadExporter;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class BigFiveExportProductionEquivalentCandidatePayloads extends Command
+{
+    protected $signature = 'bigfive:export-production-equivalent-candidate-payloads
+        {--candidate-dir= : Existing or new Big Five result page V2 candidate directory}
+        {--output-dir= : Big Five candidate export report output directory}
+        {--json : Emit machine-readable JSON summary}';
+
+    protected $description = 'Generate BIG5 result page V2 production-equivalent candidate payload fixtures without production import.';
+
+    public function handle(BigFiveProductionEquivalentCandidatePayloadExporter $exporter): int
+    {
+        try {
+            $candidateDir = trim((string) ($this->option('candidate-dir') ?: (getenv('BIG5_PHASE_CANDIDATE_DIR') ?: '')));
+            $outputDir = trim((string) ($this->option('output-dir') ?: (getenv('BIG5_PHASE_OUTPUT_DIR') ?: '')));
+
+            if ($candidateDir === '') {
+                throw new \RuntimeException('--candidate-dir or BIG5_PHASE_CANDIDATE_DIR is required.');
+            }
+            if ($outputDir === '') {
+                throw new \RuntimeException('--output-dir or BIG5_PHASE_OUTPUT_DIR is required.');
+            }
+
+            $summary = $exporter->export($candidateDir, $outputDir);
+
+            if ((bool) $this->option('json')) {
+                $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            } else {
+                $this->line('candidate_source_directory='.$summary['candidate_source_directory']);
+                $this->line('candidate_payload_output_directory='.$summary['candidate_payload_output_directory']);
+                $this->line('payload_count='.$summary['payload_count']);
+                $this->line('source_mapping_result='.json_encode($summary['source_mapping_result'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+                $this->line('metadata_leakage_result='.json_encode($summary['metadata_leakage_result'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+                $this->line('forbidden_claim_result='.json_encode($summary['forbidden_claim_result'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+                $this->line('verdict='.$summary['verdict']);
+            }
+
+            return str_starts_with((string) $summary['verdict'], 'PASS_') ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Console/Commands/BigFiveImportInactiveCandidateRelease.php
+++ b/backend/app/Console/Commands/BigFiveImportInactiveCandidateRelease.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveInactiveCandidateReleaseImporter;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class BigFiveImportInactiveCandidateRelease extends Command
+{
+    protected $signature = 'bigfive:import-inactive-candidate-release
+        {--candidate-dir= : Existing Big Five result page V2 candidate directory}
+        {--output-dir= : Big Five inactive import report output directory}
+        {--json : Emit machine-readable JSON summary}';
+
+    protected $description = 'Materialize an inactive BIG5 result page V2 candidate release artifact without activation.';
+
+    public function handle(BigFiveInactiveCandidateReleaseImporter $importer): int
+    {
+        try {
+            $candidateDir = trim((string) ($this->option('candidate-dir') ?: (getenv('BIG5_PHASE_CANDIDATE_DIR') ?: '')));
+            $outputDir = trim((string) ($this->option('output-dir') ?: (getenv('BIG5_PHASE_OUTPUT_DIR') ?: '')));
+
+            if ($candidateDir === '') {
+                throw new \RuntimeException('--candidate-dir or BIG5_PHASE_CANDIDATE_DIR is required.');
+            }
+            if ($outputDir === '') {
+                throw new \RuntimeException('--output-dir or BIG5_PHASE_OUTPUT_DIR is required.');
+            }
+
+            $contracts = array_filter([
+                'candidate_manifest_sha256' => trim((string) (getenv('BIG5_EXPECTED_CANDIDATE_MANIFEST_SHA256') ?: '')),
+                'source_assets_sha256' => trim((string) (getenv('BIG5_EXPECTED_SOURCE_ASSETS_SHA256') ?: '')),
+            ], static fn (string $value): bool => $value !== '');
+
+            $summary = $importer->import($candidateDir, $outputDir, $contracts);
+
+            if ((bool) $this->option('json')) {
+                $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            } else {
+                $this->line('candidate_source_directory='.$summary['candidate_source_directory']);
+                $this->line('inactive_release_id='.$summary['inactive_release_id']);
+                $this->line('inactive_release_storage_path='.$summary['inactive_release_storage_path']);
+                $this->line('candidate_payload_count='.$summary['candidate_payload_count']);
+                $this->line('verdict='.$summary['verdict']);
+            }
+
+            return str_starts_with((string) $summary['verdict'], 'PASS_') ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -22,6 +22,8 @@ use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
+use App\Console\Commands\BigFiveExportProductionEquivalentCandidatePayloads;
+use App\Console\Commands\BigFiveImportInactiveCandidateRelease;
 use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
 use App\Console\Commands\CareerAlignCareerAuthorityBatch;
 use App\Console\Commands\CareerAlignD8AuthorityCrosswalks;
@@ -232,6 +234,8 @@ class Kernel extends ConsoleKernel
         EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,
+        BigFiveExportProductionEquivalentCandidatePayloads::class,
+        BigFiveImportInactiveCandidateRelease::class,
         NormsImport::class,
         NormsIqImport::class,
         NormsBig5Roll::class,

--- a/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveCandidatePackageContract.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveCandidatePackageContract.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Candidate;
+
+final class BigFiveCandidatePackageContract
+{
+    public const MANIFEST_SCHEMA_VERSION = 'big5.result_page_v2.production_equivalent_candidate.v1';
+
+    public const PAYLOAD_SCHEMA_VERSION = 'big5.result_page_v2.candidate_payload.v1';
+
+    public const PAYLOADS_MANIFEST_SCHEMA_VERSION = 'big5.result_page_v2.candidate_payloads_manifest.v1';
+
+    public const INACTIVE_RELEASE_SCHEMA_VERSION = 'big5.result_page_v2.inactive_candidate_release_manifest.v1';
+
+    public const EXPECTED_SOURCE_ASSET_COUNT = 325;
+
+    public const PACK_ID = 'BIG5_OCEAN';
+
+    public const PACK_VERSION = 'result_page_v2';
+
+    public const SOURCE_ASSETS_RELATIVE_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/assets.json';
+
+    public const SOURCE_MANIFEST_RELATIVE_PATH = 'content_assets/big5/result_page_v2/selector_ready_assets/v0_3_p0_full/manifest.json';
+
+    public const RELEASE_ACTION = 'bigfive_result_page_v2_import_inactive_candidate';
+
+    public const REQUIRED_CANDIDATE_FILES = [
+        'candidate_manifest.json',
+        'candidate_hashes.json',
+        'candidate_payloads_manifest.json',
+        'candidate_payload_hashes.json',
+        'candidate_payload_source_mapping.json',
+        'source_mapping_report.json',
+        'metadata_leakage_report.json',
+        'forbidden_claim_report.json',
+        'rollback_plan.md',
+    ];
+
+    public const PUBLIC_PAYLOAD_FORBIDDEN_KEYS = [
+        'asset_key',
+        'asset_layer',
+        'asset_type',
+        'avoid_when',
+        'body_quality',
+        'can_combine_with',
+        'cannot_combine_with',
+        'copy_role',
+        'dedupe_group',
+        'editor_note',
+        'editor_notes',
+        'fallback_allowed',
+        'fixed_type',
+        'frontend_fallback',
+        'governance_metadata',
+        'import_policy',
+        'internal_combination_key',
+        'internal_metadata',
+        'internal_notes',
+        'must_include_assets',
+        'must_suppress_assets',
+        'private_metadata',
+        'production_use_allowed',
+        'qa_note',
+        'qa_notes',
+        'qa_status',
+        'raw_mean',
+        'raw_score',
+        'raw_scores',
+        'ready_for_pilot',
+        'ready_for_production',
+        'ready_for_runtime',
+        'recommended_coupling_assets',
+        'recommended_facet_assets',
+        'recommended_trait_band_assets',
+        'review_status',
+        'runtime_use',
+        'score_vector',
+        'selection_guidance',
+        'selection_priority',
+        'selector_basis',
+        'source_reference',
+        'source_trace',
+        'type_code',
+        'type_name',
+        'user_confirmed_type',
+    ];
+
+    public const FORBIDDEN_CLAIM_PATTERNS = [
+        '/临床诊断/u',
+        '/医学诊断/u',
+        '/诊断为/u',
+        '/固定人格类型/u',
+        '/你就是某一型/u',
+        '/你就是这类/u',
+        '/最终类型/u',
+        '/确定就是/u',
+        '/准确率/u',
+        '/保证/u',
+        '/clinical diagnosis/i',
+        '/medical diagnosis/i',
+        '/diagnosed as/i',
+        '/fixed type/i',
+        '/confirmed type/i',
+        '/you are this type/i',
+        '/you are a type/i',
+        '/final type/i',
+        '/accuracy rate/i',
+        '/guarantee/i',
+        '/employment screening/i',
+        '/hiring decision/i',
+        '/recruiting screen/i',
+    ];
+
+    public const ALLOWED_BOUNDARY_FRAGMENTS = [
+        '不应用于招聘',
+        '不用于招聘',
+        'not for hiring',
+        'not for employment screening',
+        'not be used for hiring',
+    ];
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporter.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Candidate;
+
+use App\Models\ContentPackRelease;
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class BigFiveInactiveCandidateReleaseImporter
+{
+    public function __construct(
+        private readonly ContentReleaseManifestCatalogService $manifestCatalogService,
+    ) {}
+
+    /**
+     * @param  array<string,string>  $contracts
+     * @return array<string,mixed>
+     */
+    public function import(string $candidateDir, string $outputDir, array $contracts = []): array
+    {
+        $candidateDir = rtrim(trim($candidateDir), DIRECTORY_SEPARATOR);
+        $outputDir = rtrim(trim($outputDir), DIRECTORY_SEPARATOR);
+        if ($candidateDir === '' || ! is_dir($candidateDir)) {
+            throw new RuntimeException('Candidate directory does not exist: '.$candidateDir);
+        }
+        if ($outputDir === '') {
+            throw new RuntimeException('Output directory is required.');
+        }
+
+        $this->ensureDirectory($outputDir);
+        $this->assertRequiredCandidateArtifacts($candidateDir);
+
+        $candidateManifestPath = $candidateDir.DIRECTORY_SEPARATOR.'candidate_manifest.json';
+        $candidateHashesPath = $candidateDir.DIRECTORY_SEPARATOR.'candidate_hashes.json';
+        $payloadDir = $candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads';
+
+        $candidateManifest = $this->decodeJsonFile($candidateManifestPath);
+        $candidateHashes = $this->decodeJsonFile($candidateHashesPath);
+        $payloadsManifest = $this->decodeJsonFile($candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads_manifest.json');
+        $payloadHashes = $this->decodeJsonFile($candidateDir.DIRECTORY_SEPARATOR.'candidate_payload_hashes.json');
+        $sourceMappingReport = $this->decodeJsonFile($candidateDir.DIRECTORY_SEPARATOR.'source_mapping_report.json');
+        $metadataLeakageReport = $this->decodeJsonFile($candidateDir.DIRECTORY_SEPARATOR.'metadata_leakage_report.json');
+        $forbiddenClaimReport = $this->decodeJsonFile($candidateDir.DIRECTORY_SEPARATOR.'forbidden_claim_report.json');
+
+        $candidateManifestHashActual = hash_file('sha256', $candidateManifestPath) ?: '';
+        $expectedCandidateManifestHash = trim((string) ($contracts['candidate_manifest_sha256'] ?? $candidateHashes['candidate_manifest_sha256'] ?? ''));
+        if ($expectedCandidateManifestHash !== '' && $candidateManifestHashActual !== $expectedCandidateManifestHash) {
+            throw new RuntimeException('Candidate manifest hash mismatch: '.$candidateManifestHashActual);
+        }
+        if ((string) ($candidateHashes['candidate_manifest_sha256'] ?? '') !== $candidateManifestHashActual) {
+            throw new RuntimeException('candidate_hashes.json candidate_manifest_sha256 mismatch.');
+        }
+
+        $sourceAssetsPath = base_path(BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH);
+        $sourceAssetsShaActual = hash_file('sha256', $sourceAssetsPath) ?: '';
+        $expectedSourceAssetsSha = trim((string) ($contracts['source_assets_sha256'] ?? $candidateHashes['source_assets_sha256'] ?? ''));
+        if ($expectedSourceAssetsSha !== '' && $sourceAssetsShaActual !== $expectedSourceAssetsSha) {
+            throw new RuntimeException('Source assets hash mismatch: '.$sourceAssetsShaActual);
+        }
+        if ((string) ($candidateHashes['source_assets_sha256'] ?? '') !== $sourceAssetsShaActual) {
+            throw new RuntimeException('candidate_hashes.json source_assets_sha256 mismatch.');
+        }
+
+        $payloadFiles = File::glob($payloadDir.DIRECTORY_SEPARATOR.'*.json') ?: [];
+        sort($payloadFiles, SORT_STRING);
+        if (count($payloadFiles) !== BigFiveCandidatePackageContract::EXPECTED_SOURCE_ASSET_COUNT) {
+            throw new RuntimeException('candidate_payloads count mismatch: expected 325 got '.count($payloadFiles));
+        }
+        if ((int) ($candidateManifest['payload_count'] ?? -1) !== BigFiveCandidatePackageContract::EXPECTED_SOURCE_ASSET_COUNT
+            || (int) ($payloadsManifest['payload_count'] ?? -1) !== BigFiveCandidatePackageContract::EXPECTED_SOURCE_ASSET_COUNT) {
+            throw new RuntimeException('Candidate payload count metadata mismatch.');
+        }
+
+        $recordedPayloadHashes = (array) ($payloadHashes['payload_file_sha256'] ?? []);
+        foreach ($payloadFiles as $payloadFile) {
+            $fileName = basename($payloadFile);
+            if (($recordedPayloadHashes[$fileName] ?? null) !== (hash_file('sha256', $payloadFile) ?: '')) {
+                throw new RuntimeException('candidate_payload_hashes.json mismatch for '.$fileName);
+            }
+        }
+
+        $this->assertGovernance($candidateManifest, $sourceMappingReport, $metadataLeakageReport, $forbiddenClaimReport);
+
+        $runtimeSourceHashBefore = hash_file('sha256', $sourceAssetsPath) ?: '';
+        $releaseId = $this->deterministicReleaseId($candidateManifestHashActual);
+        $storagePath = 'private/content_releases/BIG5_OCEAN/result_page_v2/'.$releaseId;
+        $storageRoot = storage_path('app/'.$storagePath);
+        $this->resetDirectory($storageRoot);
+        $this->copyCandidateArtifacts($candidateDir, $storageRoot);
+
+        $releaseManifestHash = 'sha256:'.$candidateManifestHashActual;
+        $releasePayload = [
+            'schema_version' => BigFiveCandidatePackageContract::INACTIVE_RELEASE_SCHEMA_VERSION,
+            'release_kind' => 'inactive_candidate',
+            'release_id' => $releaseId,
+            'activation_state' => 'inactive',
+            'candidate_source_directory' => $candidateDir,
+            'candidate_manifest_sha256' => $candidateManifestHashActual,
+            'source_assets_sha256' => $sourceAssetsShaActual,
+            'candidate_payload_count' => count($payloadFiles),
+            'storage_layout' => [
+                'candidate_root' => $storagePath.'/candidate',
+            ],
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+        ];
+
+        $now = now();
+        $release = ContentPackRelease::query()->updateOrCreate(
+            ['id' => $releaseId],
+            [
+                'action' => BigFiveCandidatePackageContract::RELEASE_ACTION,
+                'region' => 'GLOBAL',
+                'locale' => 'global',
+                'dir_alias' => BigFiveCandidatePackageContract::PACK_VERSION,
+                'from_version_id' => null,
+                'to_version_id' => null,
+                'from_pack_id' => null,
+                'to_pack_id' => BigFiveCandidatePackageContract::PACK_ID,
+                'status' => 'success',
+                'message' => 'Inactive BIG5 result page V2 candidate materialized without activation',
+                'created_by' => 'ops',
+                'manifest_hash' => $releaseManifestHash,
+                'compiled_hash' => 'sha256:'.$sourceAssetsShaActual,
+                'content_hash' => $releaseManifestHash,
+                'pack_version' => BigFiveCandidatePackageContract::PACK_VERSION,
+                'manifest_json' => $releasePayload,
+                'storage_path' => $storagePath,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+
+        $this->manifestCatalogService->upsertManifest([
+            'content_pack_release_id' => (string) $release->getKey(),
+            'manifest_hash' => $releaseManifestHash,
+            'schema_version' => BigFiveCandidatePackageContract::INACTIVE_RELEASE_SCHEMA_VERSION,
+            'storage_disk' => 'local',
+            'storage_path' => $storagePath,
+            'pack_id' => BigFiveCandidatePackageContract::PACK_ID,
+            'pack_version' => BigFiveCandidatePackageContract::PACK_VERSION,
+            'compiled_hash' => 'sha256:'.$sourceAssetsShaActual,
+            'content_hash' => $releaseManifestHash,
+            'payload_json' => $releasePayload,
+        ]);
+
+        if (DB::table('content_pack_activations')
+            ->where('pack_id', BigFiveCandidatePackageContract::PACK_ID)
+            ->where('pack_version', BigFiveCandidatePackageContract::PACK_VERSION)
+            ->where('release_id', $releaseId)
+            ->exists()) {
+            throw new RuntimeException('Inactive import unexpectedly created activation row.');
+        }
+
+        $runtimeSourceHashAfter = hash_file('sha256', $sourceAssetsPath) ?: '';
+        if ($runtimeSourceHashAfter !== $runtimeSourceHashBefore) {
+            throw new RuntimeException('Inactive import changed Big Five selector source assets.');
+        }
+
+        $summary = [
+            'verdict' => 'PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_GATE',
+            'candidate_source_directory' => $candidateDir,
+            'inactive_release_id' => $releaseId,
+            'inactive_release_storage_path' => $storagePath,
+            'candidate_manifest_hash_expected' => $expectedCandidateManifestHash ?: $candidateManifestHashActual,
+            'candidate_manifest_hash_actual' => $candidateManifestHashActual,
+            'source_assets_hash_expected' => $expectedSourceAssetsSha ?: $sourceAssetsShaActual,
+            'source_assets_hash_actual' => $sourceAssetsShaActual,
+            'candidate_payload_count' => count($payloadFiles),
+            'release_metadata_result' => [
+                'content_pack_release_id' => (string) $release->getKey(),
+                'content_pack_release_action' => BigFiveCandidatePackageContract::RELEASE_ACTION,
+                'content_release_manifest_hash' => $releaseManifestHash,
+                'inactive' => true,
+            ],
+            'runtime_default_source_result' => [
+                'preserved' => true,
+                'source_assets_hash_before' => $runtimeSourceHashBefore,
+                'source_assets_hash_after' => $runtimeSourceHashAfter,
+            ],
+            'activation_happened' => false,
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+        ];
+
+        File::put($outputDir.DIRECTORY_SEPARATOR.'big5_inactive_import_summary.json', $this->encodeJson($summary));
+        File::put($outputDir.DIRECTORY_SEPARATOR.'BigFiveInactiveImport.md', implode("\n", [
+            '# Big Five Result Page V2 Inactive Import',
+            '- verdict: '.$summary['verdict'],
+            '- inactive_release_id: '.$releaseId,
+            '- inactive_release_storage_path: `'.$storagePath.'`',
+            '- activation_happened: false',
+            '- production_import_happened: false',
+        ])."\n");
+
+        return $summary;
+    }
+
+    private function assertRequiredCandidateArtifacts(string $candidateDir): void
+    {
+        foreach (BigFiveCandidatePackageContract::REQUIRED_CANDIDATE_FILES as $file) {
+            if (! is_file($candidateDir.DIRECTORY_SEPARATOR.$file)) {
+                throw new RuntimeException('Missing required candidate artifact: '.$file);
+            }
+        }
+
+        if (! is_dir($candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads')) {
+            throw new RuntimeException('Missing candidate_payloads directory.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidateManifest
+     * @param  array<string,mixed>  $sourceMappingReport
+     * @param  array<string,mixed>  $metadataLeakageReport
+     * @param  array<string,mixed>  $forbiddenClaimReport
+     */
+    private function assertGovernance(
+        array $candidateManifest,
+        array $sourceMappingReport,
+        array $metadataLeakageReport,
+        array $forbiddenClaimReport,
+    ): void {
+        if ((string) ($candidateManifest['schema_version'] ?? '') !== BigFiveCandidatePackageContract::MANIFEST_SCHEMA_VERSION) {
+            throw new RuntimeException('Candidate manifest schema_version mismatch.');
+        }
+        foreach (['production_use_allowed', 'ready_for_runtime', 'ready_for_production', 'activation_happened', 'production_import_happened', 'full_replacement_happened'] as $flag) {
+            if ((bool) ($candidateManifest[$flag] ?? true)) {
+                throw new RuntimeException('Candidate manifest flag must be false: '.$flag);
+            }
+        }
+        if ((string) ($candidateManifest['runtime_use'] ?? '') !== 'staging_only') {
+            throw new RuntimeException('Candidate manifest runtime_use must be staging_only.');
+        }
+        if ((int) ($sourceMappingReport['source_mapping_failure_count'] ?? -1) !== 0
+            || (int) ($sourceMappingReport['missing_count'] ?? -1) !== 0
+            || (int) ($sourceMappingReport['fallback_count'] ?? -1) !== 0
+            || (int) ($sourceMappingReport['blocked_count'] ?? -1) !== 0
+            || (int) ($sourceMappingReport['duplicate_selection_count'] ?? -1) !== 0) {
+            throw new RuntimeException('Source mapping report contains failures.');
+        }
+        if ((int) ($metadataLeakageReport['metadata_leak_count'] ?? -1) !== 0) {
+            throw new RuntimeException('Metadata leakage report is not clean.');
+        }
+        if ((int) ($forbiddenClaimReport['forbidden_claim_count'] ?? -1) !== 0) {
+            throw new RuntimeException('Forbidden claim report is not clean.');
+        }
+    }
+
+    private function deterministicReleaseId(string $candidateManifestHashActual): string
+    {
+        return 'big5_result_page_v2_candidate_'.Str::lower(substr($candidateManifestHashActual, 0, 16));
+    }
+
+    private function copyCandidateArtifacts(string $candidateDir, string $storageRoot): void
+    {
+        $candidateRoot = $storageRoot.DIRECTORY_SEPARATOR.'candidate';
+        $this->resetDirectory($candidateRoot);
+
+        foreach (BigFiveCandidatePackageContract::REQUIRED_CANDIDATE_FILES as $file) {
+            File::copy($candidateDir.DIRECTORY_SEPARATOR.$file, $candidateRoot.DIRECTORY_SEPARATOR.$file);
+        }
+
+        if (! File::copyDirectory($candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads', $candidateRoot.DIRECTORY_SEPARATOR.'candidate_payloads')) {
+            throw new RuntimeException('Failed to copy candidate_payloads into inactive release artifact.');
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        $decoded = json_decode((string) File::get($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON file: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        File::ensureDirectoryExists($path);
+    }
+
+    private function resetDirectory(string $path): void
+    {
+        File::deleteDirectory($path);
+        File::ensureDirectoryExists($path);
+    }
+
+    /**
+     * @param  array<string,mixed>|list<mixed>  $value
+     */
+    private function encodeJson(array $value): string
+    {
+        return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n";
+    }
+}

--- a/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporter.php
+++ b/backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporter.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\BigFive\ResultPageV2\Candidate;
+
+use App\Services\BigFive\ResultPageV2\BigFiveResultPageV2SelectorAssetContract;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class BigFiveProductionEquivalentCandidatePayloadExporter
+{
+    /**
+     * @return array<string,mixed>
+     */
+    public function export(string $candidateDir, string $outputDir): array
+    {
+        $candidateDir = rtrim(trim($candidateDir), DIRECTORY_SEPARATOR);
+        $outputDir = rtrim(trim($outputDir), DIRECTORY_SEPARATOR);
+        if ($candidateDir === '') {
+            throw new RuntimeException('Candidate directory is required.');
+        }
+        if ($outputDir === '') {
+            throw new RuntimeException('Output directory is required.');
+        }
+
+        $sourceAssetsPath = base_path(BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH);
+        $sourceManifestPath = base_path(BigFiveCandidatePackageContract::SOURCE_MANIFEST_RELATIVE_PATH);
+        $sourceAssetsSha = hash_file('sha256', $sourceAssetsPath) ?: '';
+        $sourceManifest = $this->decodeJsonFile($sourceManifestPath);
+        if ((int) ($sourceManifest['asset_count'] ?? -1) !== BigFiveCandidatePackageContract::EXPECTED_SOURCE_ASSET_COUNT) {
+            throw new RuntimeException('Big Five selector asset manifest count mismatch.');
+        }
+        if ((string) ($sourceManifest['sha256_json'] ?? '') !== $sourceAssetsSha) {
+            throw new RuntimeException('Big Five selector asset manifest sha256_json mismatch.');
+        }
+
+        $assets = $this->decodeJsonFile($sourceAssetsPath);
+        if (! array_is_list($assets) || count($assets) !== BigFiveCandidatePackageContract::EXPECTED_SOURCE_ASSET_COUNT) {
+            throw new RuntimeException('Big Five selector asset count mismatch.');
+        }
+
+        $this->resetDirectory($candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads');
+        $this->ensureDirectory($outputDir);
+
+        $seenAssetKeys = [];
+        $payloadFiles = [];
+        $sourceMappingRows = [];
+        $metadataLeakHits = [];
+        $forbiddenClaimHits = [];
+        $coverage = [
+            'registry_counts' => [],
+            'module_counts' => [],
+            'safety_level_counts' => [],
+            'shareable_counts' => ['true' => 0, 'false' => 0],
+            'scope_counts' => [],
+        ];
+
+        foreach ($assets as $index => $asset) {
+            if (! is_array($asset)) {
+                throw new RuntimeException("Selector asset {$index} must be an object.");
+            }
+
+            $this->assertSelectorAssetShape($asset, $index);
+
+            $assetKey = (string) $asset['asset_key'];
+            if (isset($seenAssetKeys[$assetKey])) {
+                throw new RuntimeException('Duplicate selector asset key: '.$assetKey);
+            }
+            $seenAssetKeys[$assetKey] = true;
+
+            $publicPayload = $asset['public_payload'];
+            if (! is_array($publicPayload)) {
+                throw new RuntimeException('Selector asset public_payload must be an object: '.$assetKey);
+            }
+
+            $metadataLeakHits = array_merge($metadataLeakHits, $this->metadataLeakHits($publicPayload, $assetKey));
+            $forbiddenClaimHits = array_merge($forbiddenClaimHits, $this->forbiddenClaimHits($publicPayload, $assetKey));
+
+            $payload = [
+                'schema_version' => BigFiveCandidatePackageContract::PAYLOAD_SCHEMA_VERSION,
+                'scale_code' => BigFiveCandidatePackageContract::PACK_ID,
+                'source_asset_key' => $assetKey,
+                'source_assets_sha256' => $sourceAssetsSha,
+                'registry_key' => (string) $asset['registry_key'],
+                'module_key' => (string) $asset['module_key'],
+                'block_key' => (string) $asset['block_key'],
+                'block_kind' => (string) $asset['block_kind'],
+                'slot_key' => (string) $asset['slot_key'],
+                'scope' => (string) $asset['scope'],
+                'safety_level' => (string) $asset['safety_level'],
+                'evidence_level' => (string) $asset['evidence_level'],
+                'shareable' => (bool) $asset['shareable'],
+                'fallback_policy' => (string) $asset['fallback_policy'],
+                'content_source' => 'selector_ready_asset',
+                'runtime_use' => 'staging_only',
+                'production_use_allowed' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+                'public_payload' => $publicPayload,
+            ];
+
+            $fileName = str_pad((string) ($index + 1), 3, '0', STR_PAD_LEFT).'_'.$this->safeFileName($assetKey).'.json';
+            $filePath = $candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads'.DIRECTORY_SEPARATOR.$fileName;
+            File::put($filePath, $this->encodeJson($payload));
+            $payloadFiles[$fileName] = $filePath;
+
+            $sourceMappingRows[$assetKey] = [
+                'payload_file' => $fileName,
+                'source_asset_key' => $assetKey,
+                'source_assets_sha256' => $sourceAssetsSha,
+                'mapped' => true,
+            ];
+
+            $this->increment($coverage['registry_counts'], (string) $asset['registry_key']);
+            $this->increment($coverage['module_counts'], (string) $asset['module_key']);
+            $this->increment($coverage['safety_level_counts'], (string) $asset['safety_level']);
+            $this->increment($coverage['scope_counts'], (string) $asset['scope']);
+            $coverage['shareable_counts'][(bool) $asset['shareable'] ? 'true' : 'false']++;
+        }
+
+        if ($metadataLeakHits !== []) {
+            throw new RuntimeException('Big Five candidate metadata leakage detected: '.count($metadataLeakHits));
+        }
+        if ($forbiddenClaimHits !== []) {
+            throw new RuntimeException('Big Five candidate forbidden claim detected: '.count($forbiddenClaimHits));
+        }
+
+        ksort($payloadFiles);
+        ksort($sourceMappingRows);
+        $payloadFileHashes = [];
+        foreach ($payloadFiles as $fileName => $path) {
+            $payloadFileHashes[$fileName] = hash_file('sha256', $path) ?: '';
+        }
+
+        $candidateManifest = [
+            'schema_version' => BigFiveCandidatePackageContract::MANIFEST_SCHEMA_VERSION,
+            'mode' => 'dry_run_candidate_only',
+            'scale_code' => BigFiveCandidatePackageContract::PACK_ID,
+            'pack_version' => BigFiveCandidatePackageContract::PACK_VERSION,
+            'source_assets' => [
+                'selector_ready_assets' => BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH,
+                'selector_ready_assets_sha256' => $sourceAssetsSha,
+                'selector_ready_assets_count' => count($assets),
+                'selector_ready_manifest' => BigFiveCandidatePackageContract::SOURCE_MANIFEST_RELATIVE_PATH,
+            ],
+            'payload_count' => count($payloadFiles),
+            'coverage' => $coverage,
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'activation_happened' => false,
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+        ];
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'candidate_manifest.json', $this->encodeJson($candidateManifest));
+        $candidateManifestSha = hash_file('sha256', $candidateDir.DIRECTORY_SEPARATOR.'candidate_manifest.json') ?: '';
+
+        $candidateHashes = [
+            'candidate_manifest_sha256' => $candidateManifestSha,
+            'source_assets_sha256' => $sourceAssetsSha,
+            'payload_file_sha256' => $payloadFileHashes,
+        ];
+        $payloadsManifest = [
+            'schema_version' => BigFiveCandidatePackageContract::PAYLOADS_MANIFEST_SCHEMA_VERSION,
+            'payload_dir' => $candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads',
+            'payload_count' => count($payloadFiles),
+            'source_assets_sha256' => $sourceAssetsSha,
+            'payload_files' => array_keys($payloadFiles),
+        ];
+        $sourceMappingReport = [
+            'source_mapping_failure_count' => 0,
+            'missing_count' => 0,
+            'fallback_count' => 0,
+            'blocked_count' => 0,
+            'duplicate_selection_count' => 0,
+            'mapped_count' => count($sourceMappingRows),
+            'source_assets_sha256' => $sourceAssetsSha,
+        ];
+        $payloadSourceMapping = [
+            'source_mapping_failure_count' => 0,
+            'rows' => array_values($sourceMappingRows),
+        ];
+        $metadataLeakageReport = [
+            'metadata_leak_count' => 0,
+            'hits' => [],
+        ];
+        $forbiddenClaimReport = [
+            'forbidden_claim_count' => 0,
+            'hits' => [],
+        ];
+
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'candidate_hashes.json', $this->encodeJson($candidateHashes));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads_manifest.json', $this->encodeJson($payloadsManifest));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'candidate_payload_hashes.json', $this->encodeJson([
+            'candidate_payloads_manifest_sha256' => hash('sha256', $this->encodeJson($payloadsManifest)),
+            'payload_file_sha256' => $payloadFileHashes,
+        ]));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'candidate_payload_source_mapping.json', $this->encodeJson($payloadSourceMapping));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'source_mapping_report.json', $this->encodeJson($sourceMappingReport));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'metadata_leakage_report.json', $this->encodeJson($metadataLeakageReport));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'forbidden_claim_report.json', $this->encodeJson($forbiddenClaimReport));
+        File::put($candidateDir.DIRECTORY_SEPARATOR.'rollback_plan.md', "# Big Five Result Page V2 Candidate Rollback\n\nNo activation is performed. Delete or supersede the inactive candidate release before runtime activation.\n");
+
+        $summary = [
+            'verdict' => 'PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_DRY_RUN',
+            'candidate_source_directory' => $candidateDir,
+            'candidate_payload_output_directory' => $candidateDir.DIRECTORY_SEPARATOR.'candidate_payloads',
+            'candidate_manifest_sha256' => $candidateManifestSha,
+            'source_assets_sha256' => $sourceAssetsSha,
+            'payload_count' => count($payloadFiles),
+            'coverage' => $coverage,
+            'source_mapping_result' => $sourceMappingReport,
+            'metadata_leakage_result' => $metadataLeakageReport,
+            'forbidden_claim_result' => $forbiddenClaimReport,
+            'activation_happened' => false,
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+        ];
+
+        File::put($outputDir.DIRECTORY_SEPARATOR.'big5_candidate_export_summary.json', $this->encodeJson($summary));
+        File::put($outputDir.DIRECTORY_SEPARATOR.'BigFiveCandidatePayloadCoverage.md', $this->markdown([
+            '# Big Five Result Page V2 Candidate Payload Coverage',
+            '- verdict: '.$summary['verdict'],
+            '- payload_count: '.count($payloadFiles),
+            '- source_assets_sha256: `'.$sourceAssetsSha.'`',
+            '- candidate_manifest_sha256: `'.$candidateManifestSha.'`',
+            '- activation_happened: false',
+            '- production_import_happened: false',
+        ]));
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     */
+    private function assertSelectorAssetShape(array $asset, int $index): void
+    {
+        foreach (BigFiveResultPageV2SelectorAssetContract::REQUIRED_FIELDS as $field) {
+            if (! array_key_exists($field, $asset)) {
+                throw new RuntimeException("Selector asset {$index} missing required field {$field}.");
+            }
+        }
+
+        if ((string) ($asset['version'] ?? '') !== BigFiveResultPageV2SelectorAssetContract::SCHEMA_VERSION) {
+            throw new RuntimeException("Selector asset {$index} has invalid version.");
+        }
+
+        foreach (['asset_key', 'registry_key', 'module_key', 'block_key', 'block_kind', 'slot_key'] as $field) {
+            if (trim((string) ($asset[$field] ?? '')) === '') {
+                throw new RuntimeException("Selector asset {$index} field {$field} must not be empty.");
+            }
+        }
+
+        if (! is_array($asset['public_payload'] ?? null)) {
+            throw new RuntimeException("Selector asset {$index} public_payload must be an object.");
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<array{asset_key:string,path:string,key:string}>
+     */
+    private function metadataLeakHits(array $payload, string $assetKey, string $path = 'public_payload'): array
+    {
+        $hits = [];
+        foreach ($payload as $key => $value) {
+            $currentPath = $path.'.'.(string) $key;
+            if (is_string($key) && in_array($key, BigFiveCandidatePackageContract::PUBLIC_PAYLOAD_FORBIDDEN_KEYS, true)) {
+                $hits[] = ['asset_key' => $assetKey, 'path' => $currentPath, 'key' => $key];
+            }
+            if (is_array($value)) {
+                $hits = array_merge($hits, $this->metadataLeakHits($value, $assetKey, $currentPath));
+            }
+        }
+
+        return $hits;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<array{asset_key:string,pattern:string}>
+     */
+    private function forbiddenClaimHits(array $payload, string $assetKey): array
+    {
+        $text = $this->encodeJson($payload);
+        $hits = [];
+        foreach (BigFiveCandidatePackageContract::FORBIDDEN_CLAIM_PATTERNS as $pattern) {
+            if (preg_match($pattern, $text) !== 1) {
+                continue;
+            }
+            if ($this->containsAllowedBoundaryFragment($text)) {
+                continue;
+            }
+            $hits[] = ['asset_key' => $assetKey, 'pattern' => $pattern];
+        }
+
+        return $hits;
+    }
+
+    private function containsAllowedBoundaryFragment(string $text): bool
+    {
+        foreach (BigFiveCandidatePackageContract::ALLOWED_BOUNDARY_FRAGMENTS as $fragment) {
+            if (stripos($text, $fragment) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonFile(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('JSON file does not exist: '.$path);
+        }
+
+        $decoded = json_decode((string) File::get($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON file: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        File::ensureDirectoryExists($path);
+    }
+
+    private function resetDirectory(string $path): void
+    {
+        File::deleteDirectory($path);
+        File::ensureDirectoryExists($path);
+    }
+
+    /**
+     * @param  array<string,int>  $counts
+     */
+    private function increment(array &$counts, string $key): void
+    {
+        $counts[$key] = ($counts[$key] ?? 0) + 1;
+        ksort($counts);
+    }
+
+    private function safeFileName(string $assetKey): string
+    {
+        $safe = strtolower((string) preg_replace('/[^A-Za-z0-9_.-]+/', '_', $assetKey));
+
+        return substr(trim($safe, '_'), 0, 160);
+    }
+
+    /**
+     * @param  array<string,mixed>|list<mixed>  $value
+     */
+    private function encodeJson(array $value): string
+    {
+        return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n";
+    }
+
+    /**
+     * @param  list<string>  $lines
+     */
+    private function markdown(array $lines): string
+    {
+        return implode("\n", $lines)."\n";
+    }
+}

--- a/backend/tests/Feature/Console/BigFiveCandidateReleaseCommandTest.php
+++ b/backend/tests/Feature/Console/BigFiveCandidateReleaseCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveCandidatePackageContract;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class BigFiveCandidateReleaseCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_export_command_materializes_candidate_payloads_as_json(): void
+    {
+        $candidateDir = $this->freshDir('command_export_candidate');
+        $outputDir = $this->freshDir('command_export_output');
+
+        $this->artisan('bigfive:export-production-equivalent-candidate-payloads', [
+            '--candidate-dir' => $candidateDir,
+            '--output-dir' => $outputDir,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = $this->readJsonFile($outputDir.'/big5_candidate_export_summary.json');
+        $this->assertSame('PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_DRY_RUN', $summary['verdict'] ?? null);
+        $this->assertSame(325, $summary['payload_count'] ?? null);
+        $this->assertCount(325, File::glob($candidateDir.'/candidate_payloads/*.json') ?: []);
+    }
+
+    public function test_import_command_materializes_inactive_release_as_json(): void
+    {
+        $candidateDir = $this->freshDir('command_import_candidate');
+        $exportOutputDir = $this->freshDir('command_import_export_output');
+        $importOutputDir = $this->freshDir('command_import_output');
+
+        $this->artisan('bigfive:export-production-equivalent-candidate-payloads', [
+            '--candidate-dir' => $candidateDir,
+            '--output-dir' => $exportOutputDir,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $hashes = $this->readJsonFile($candidateDir.'/candidate_hashes.json');
+        putenv('BIG5_EXPECTED_CANDIDATE_MANIFEST_SHA256='.$hashes['candidate_manifest_sha256']);
+        putenv('BIG5_EXPECTED_SOURCE_ASSETS_SHA256='.$hashes['source_assets_sha256']);
+
+        try {
+            $this->artisan('bigfive:import-inactive-candidate-release', [
+                '--candidate-dir' => $candidateDir,
+                '--output-dir' => $importOutputDir,
+                '--json' => true,
+            ])->assertExitCode(0);
+        } finally {
+            putenv('BIG5_EXPECTED_CANDIDATE_MANIFEST_SHA256');
+            putenv('BIG5_EXPECTED_SOURCE_ASSETS_SHA256');
+        }
+
+        $summary = $this->readJsonFile($importOutputDir.'/big5_inactive_import_summary.json');
+        $this->assertSame('PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_GATE', $summary['verdict'] ?? null);
+        $this->assertSame(325, $summary['candidate_payload_count'] ?? null);
+        $this->assertFalse(DB::table('content_pack_activations')
+            ->where('pack_id', BigFiveCandidatePackageContract::PACK_ID)
+            ->where('pack_version', BigFiveCandidatePackageContract::PACK_VERSION)
+            ->exists());
+    }
+
+    public function test_import_command_fails_closed_on_hash_mismatch(): void
+    {
+        $candidateDir = $this->freshDir('command_hash_candidate');
+        $exportOutputDir = $this->freshDir('command_hash_export_output');
+        $importOutputDir = $this->freshDir('command_hash_import_output');
+
+        $this->artisan('bigfive:export-production-equivalent-candidate-payloads', [
+            '--candidate-dir' => $candidateDir,
+            '--output-dir' => $exportOutputDir,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        putenv('BIG5_EXPECTED_CANDIDATE_MANIFEST_SHA256='.str_repeat('0', 64));
+        try {
+            $this->artisan('bigfive:import-inactive-candidate-release', [
+                '--candidate-dir' => $candidateDir,
+                '--output-dir' => $importOutputDir,
+                '--json' => true,
+            ])->assertExitCode(1);
+        } finally {
+            putenv('BIG5_EXPECTED_CANDIDATE_MANIFEST_SHA256');
+        }
+    }
+
+    private function freshDir(string $suffix): string
+    {
+        $dir = storage_path('framework/testing/bigfive_candidate_command/'.$suffix);
+        File::deleteDirectory($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJsonFile(string $path): array
+    {
+        return json_decode((string) File::get($path), true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3357,6 +3357,35 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_allows_bigfive_v2_inactive_candidate_scaffold_scope_only(): void
+    {
+        $allowed = [
+            'backend/app/Console/Commands/BigFiveExportProductionEquivalentCandidatePayloads.php',
+            'backend/app/Console/Commands/BigFiveImportInactiveCandidateRelease.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveCandidatePackageContract.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporter.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\BigFiveExportProductionEquivalentCandidatePayloads;',
+            '+use App\\Console\\Commands\\BigFiveImportInactiveCandidateRelease;',
+            '+        BigFiveExportProductionEquivalentCandidatePayloads::class,',
+            '+        BigFiveImportInactiveCandidateRelease::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveCandidateRuntimeActivator.php',
+            'backend/database/migrations/2026_06_21_000000_activate_bigfive_result_page_v2_candidate.php',
+            'backend/routes/api.php',
+            'frontend/src/big5/result-page-v2.ts',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($allowed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_keeps_mbti_and_bigfive_runtime_changes_blocked(): void
     {
         $changed = [
@@ -4182,6 +4211,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFiveV2InactiveCandidateScaffoldFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFiveV2EnParityDraftCatalogFile($file)) {
                 continue;
             }
@@ -4467,6 +4500,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -6223,6 +6257,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isBigFiveV2InactiveCandidateScaffoldFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/BigFiveExportProductionEquivalentCandidatePayloads.php',
+            'backend/app/Console/Commands/BigFiveImportInactiveCandidateRelease.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveCandidatePackageContract.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporter.php',
+            'backend/app/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporter.php',
+        ], true);
+    }
+
     private function isBigFiveV2EnParityDraftCatalogFile(string $file): bool
     {
         return $file === 'backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json';
@@ -7128,6 +7173,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\BigFiveExportProductionEquivalentCandidatePayloads;',
+            'use App\\Console\\Commands\\BigFiveImportInactiveCandidateRelease;',
+            '        BigFiveExportProductionEquivalentCandidatePayloads::class,',
+            '        BigFiveImportInactiveCandidateRelease::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
     }
 
     /**

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2\Candidate;
+
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveCandidatePackageContract;
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveInactiveCandidateReleaseImporter;
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveProductionEquivalentCandidatePayloadExporter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class BigFiveInactiveCandidateReleaseImporterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_importer_materializes_inactive_release_without_activation_or_runtime_source_change(): void
+    {
+        $fixture = $this->candidateFixture('importer_main');
+        $sourceHashBefore = hash_file('sha256', base_path(BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH));
+
+        $summary = app(BigFiveInactiveCandidateReleaseImporter::class)->import(
+            $fixture['candidate_dir'],
+            $fixture['import_output_dir'],
+            [
+                'candidate_manifest_sha256' => $fixture['candidate_manifest_sha256'],
+                'source_assets_sha256' => $fixture['source_assets_sha256'],
+            ],
+        );
+
+        $this->assertSame('PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_GATE', $summary['verdict']);
+        $this->assertSame(325, $summary['candidate_payload_count']);
+        $this->assertSame($sourceHashBefore, hash_file('sha256', base_path(BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH)));
+        $this->assertFalse(DB::table('content_pack_activations')
+            ->where('pack_id', BigFiveCandidatePackageContract::PACK_ID)
+            ->where('pack_version', BigFiveCandidatePackageContract::PACK_VERSION)
+            ->exists());
+        $this->assertDatabaseHas('content_pack_releases', [
+            'id' => $summary['inactive_release_id'],
+            'to_pack_id' => BigFiveCandidatePackageContract::PACK_ID,
+            'pack_version' => BigFiveCandidatePackageContract::PACK_VERSION,
+            'action' => BigFiveCandidatePackageContract::RELEASE_ACTION,
+        ]);
+        $this->assertDatabaseHas('content_release_manifests', [
+            'content_pack_release_id' => $summary['inactive_release_id'],
+            'pack_id' => BigFiveCandidatePackageContract::PACK_ID,
+            'pack_version' => BigFiveCandidatePackageContract::PACK_VERSION,
+            'manifest_hash' => 'sha256:'.$fixture['candidate_manifest_sha256'],
+        ]);
+        $this->assertDirectoryExists(storage_path('app/'.$summary['inactive_release_storage_path'].'/candidate/candidate_payloads'));
+        $this->assertCount(
+            325,
+            File::glob(storage_path('app/'.$summary['inactive_release_storage_path'].'/candidate/candidate_payloads/*.json')) ?: []
+        );
+    }
+
+    public function test_importer_fails_closed_on_candidate_manifest_hash_mismatch(): void
+    {
+        $fixture = $this->candidateFixture('importer_hash_mismatch');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Candidate manifest hash mismatch');
+
+        app(BigFiveInactiveCandidateReleaseImporter::class)->import(
+            $fixture['candidate_dir'],
+            $fixture['import_output_dir'],
+            [
+                'candidate_manifest_sha256' => str_repeat('0', 64),
+                'source_assets_sha256' => $fixture['source_assets_sha256'],
+            ],
+        );
+    }
+
+    public function test_importer_fails_closed_on_payload_count_mismatch(): void
+    {
+        $fixture = $this->candidateFixture('importer_count_mismatch');
+        $payloadFiles = File::glob($fixture['candidate_dir'].'/candidate_payloads/*.json') ?: [];
+        $this->assertNotEmpty($payloadFiles);
+        File::delete($payloadFiles[0]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('candidate_payloads count mismatch');
+
+        app(BigFiveInactiveCandidateReleaseImporter::class)->import(
+            $fixture['candidate_dir'],
+            $fixture['import_output_dir'],
+            [
+                'candidate_manifest_sha256' => $fixture['candidate_manifest_sha256'],
+                'source_assets_sha256' => $fixture['source_assets_sha256'],
+            ],
+        );
+    }
+
+    /**
+     * @return array{candidate_dir:string,import_output_dir:string,candidate_manifest_sha256:string,source_assets_sha256:string}
+     */
+    private function candidateFixture(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/bigfive_candidate_import/'.$suffix);
+        $exportOutputDir = storage_path('framework/testing/bigfive_candidate_import_export_output/'.$suffix);
+        $importOutputDir = storage_path('framework/testing/bigfive_candidate_import_output/'.$suffix);
+        File::deleteDirectory($candidateDir);
+        File::deleteDirectory($exportOutputDir);
+        File::deleteDirectory($importOutputDir);
+
+        $summary = app(BigFiveProductionEquivalentCandidatePayloadExporter::class)->export($candidateDir, $exportOutputDir);
+
+        return [
+            'candidate_dir' => $candidateDir,
+            'import_output_dir' => $importOutputDir,
+            'candidate_manifest_sha256' => (string) $summary['candidate_manifest_sha256'],
+            'source_assets_sha256' => (string) $summary['source_assets_sha256'],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporterTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2\Candidate;
+
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveCandidatePackageContract;
+use App\Services\BigFive\ResultPageV2\Candidate\BigFiveProductionEquivalentCandidatePayloadExporter;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class BigFiveProductionEquivalentCandidatePayloadExporterTest extends TestCase
+{
+    public function test_exporter_materializes_325_selector_ready_payloads_with_clean_governance_reports(): void
+    {
+        $dirs = $this->freshDirs('exporter_main');
+
+        $summary = app(BigFiveProductionEquivalentCandidatePayloadExporter::class)->export(
+            $dirs['candidate_dir'],
+            $dirs['output_dir'],
+        );
+
+        $this->assertSame('PASS_FOR_BIG5_RESULT_PAGE_V2_INACTIVE_IMPORT_DRY_RUN', $summary['verdict']);
+        $this->assertSame(325, $summary['payload_count']);
+        $this->assertFalse($summary['activation_happened']);
+        $this->assertFalse($summary['production_import_happened']);
+        $this->assertFalse($summary['full_replacement_happened']);
+        $this->assertCount(325, File::glob($dirs['candidate_dir'].'/candidate_payloads/*.json') ?: []);
+
+        $manifest = $this->readJsonFile($dirs['candidate_dir'].'/candidate_manifest.json');
+        $hashes = $this->readJsonFile($dirs['candidate_dir'].'/candidate_hashes.json');
+        $sourceMapping = $this->readJsonFile($dirs['candidate_dir'].'/source_mapping_report.json');
+        $metadataLeakage = $this->readJsonFile($dirs['candidate_dir'].'/metadata_leakage_report.json');
+        $forbiddenClaim = $this->readJsonFile($dirs['candidate_dir'].'/forbidden_claim_report.json');
+
+        $this->assertSame(BigFiveCandidatePackageContract::MANIFEST_SCHEMA_VERSION, $manifest['schema_version']);
+        $this->assertSame(325, $manifest['payload_count']);
+        $this->assertSame('staging_only', $manifest['runtime_use']);
+        $this->assertFalse((bool) $manifest['production_use_allowed']);
+        $this->assertFalse((bool) $manifest['ready_for_runtime']);
+        $this->assertFalse((bool) $manifest['ready_for_production']);
+        $this->assertSame(hash_file('sha256', $dirs['candidate_dir'].'/candidate_manifest.json'), $hashes['candidate_manifest_sha256']);
+        $this->assertSame(hash_file('sha256', base_path(BigFiveCandidatePackageContract::SOURCE_ASSETS_RELATIVE_PATH)), $hashes['source_assets_sha256']);
+        $this->assertSame(0, $sourceMapping['source_mapping_failure_count']);
+        $this->assertSame(0, $metadataLeakage['metadata_leak_count']);
+        $this->assertSame(0, $forbiddenClaim['forbidden_claim_count']);
+    }
+
+    public function test_exporter_payload_hashes_are_reproducible_for_same_source_assets(): void
+    {
+        $first = $this->freshDirs('exporter_repro_first');
+        $second = $this->freshDirs('exporter_repro_second');
+
+        app(BigFiveProductionEquivalentCandidatePayloadExporter::class)->export($first['candidate_dir'], $first['output_dir']);
+        app(BigFiveProductionEquivalentCandidatePayloadExporter::class)->export($second['candidate_dir'], $second['output_dir']);
+
+        $this->assertSame(
+            $this->readJsonFile($first['candidate_dir'].'/candidate_hashes.json'),
+            $this->readJsonFile($second['candidate_dir'].'/candidate_hashes.json'),
+        );
+        $this->assertSame(
+            hash_file('sha256', $first['candidate_dir'].'/candidate_manifest.json'),
+            hash_file('sha256', $second['candidate_dir'].'/candidate_manifest.json'),
+        );
+    }
+
+    /**
+     * @return array{candidate_dir:string,output_dir:string}
+     */
+    private function freshDirs(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/bigfive_candidate_export/'.$suffix);
+        $outputDir = storage_path('framework/testing/bigfive_candidate_export_output/'.$suffix);
+        File::deleteDirectory($candidateDir);
+        File::deleteDirectory($outputDir);
+
+        return [
+            'candidate_dir' => $candidateDir,
+            'output_dir' => $outputDir,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJsonFile(string $path): array
+    {
+        return json_decode((string) File::get($path), true, flags: JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary
- Add Big Five Result Page V2 production-equivalent candidate package scaffolding for dry-run export and inactive import.
- Export the existing 325 selector-ready assets into caller-provided candidate/output directories only.
- Add deterministic candidate manifest/hash/source-mapping/leakage/forbidden-claim reports and rollback plan generation.
- Add inactive candidate release import that copies artifacts into private storage and upserts release/manifest catalog rows without activation.

## Scope boundaries
- Scaffold and dry-run only.
- No bulk content generation.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.

## Validation
- `php -l` on new command/service/test files and updated freeze test.
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveProductionEquivalentCandidatePayloadExporterTest.php tests/Unit/Services/BigFive/ResultPageV2/Candidate/BigFiveInactiveCandidateReleaseImporterTest.php tests/Feature/Console/BigFiveCandidateReleaseCommandTest.php`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2`
- `php artisan test tests/Feature/Console`
- `php artisan test --filter "(BigFive|Big5|NonMbtiReportContractRegressionTest)" --no-ansi`
- `git diff --check HEAD`

## Intentionally deferred
- Rendered QA over an exported candidate package.
- Runtime activation.
- Production import/write paths.
- New Big Five bulk content generation.
- Frontend expected-hash or rendering changes.