### PR TITLE
MBTI64-CMS-PROJECTION-DRAFT-88-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\Mbti64CmsProjectionDraftWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityMbti64CmsProjectionDraft extends Command
+{
+    private const OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-88-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'draft-only',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:mbti64-cms-projection-draft
+        {--package= : Path to the MBTI64 agent expansion recommendation JSON package}
+        {--qa= : Path to the MBTI64 agent expansion QA JSON artifact}
+        {--dry-run : Validate and plan without database writes}
+        {--write : Create CMS projection draft revision rows}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--draft-only : Required for --write; confirms revision draft only}
+        {--no-publish : Required for --write; confirms no publish action}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Create MBTI64 agent projection CMS draft revisions with explicit no-publish/no-index guards.';
+
+    public function handle(Mbti64CmsProjectionDraftWriter $writer): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(Mbti64CmsProjectionDraftWriter $writer): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = trim((string) $this->option('package'));
+        if ($packagePath === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $qaPath = trim((string) $this->option('qa'));
+        if ($qaPath === '') {
+            throw new RuntimeException('--qa is required.');
+        }
+
+        $resolvedPackage = $this->resolvePath($packagePath, 'Package');
+        $resolvedQa = $this->resolvePath($qaPath, 'QA artifact');
+        $packageRaw = (string) File::get($resolvedPackage);
+        $qaRaw = (string) File::get($resolvedQa);
+        $package = json_decode($packageRaw, true);
+        $qa = json_decode($qaRaw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+        if (! is_array($qa)) {
+            throw new RuntimeException('QA artifact must be a JSON object.');
+        }
+
+        $summary = $write
+            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), $this->optionsPayload())
+            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), $this->optionsPayload());
+
+        return array_merge($summary, [
+            'package_path' => $resolvedPackage,
+            'qa_path' => $resolvedQa,
+            'command' => 'personality:mbti64-cms-projection-draft',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path, string $label): string
+    {
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException($label.' file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'draft_only' => (bool) $this->option('draft-only'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_index' => (bool) $this->option('no-index'),
+            'no_sitemap' => (bool) $this->option('no-sitemap'),
+            'no_llms' => (bool) $this->option('no-llms'),
+            'no_search_release' => (bool) $this->option('no-search-release'),
+            'operator_approved' => (string) $this->option('operator-approved'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('created_revision_count='.(string) ($summary['created_revision_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_committed' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -164,6 +164,7 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
+use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
 use App\Console\Commands\QualityDailySummary;
@@ -216,6 +217,7 @@ class Kernel extends ConsoleKernel
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64CmsInternalLinkDraft::class,
+        PersonalityMbti64CmsProjectionDraft::class,
         PersonalityMbti64CmsRevisionDraft::class,
         PersonalityMbti64CmsRevisionPromote::class,
         PersonalityMbti64BackendImportContract::class,

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -1,0 +1,555 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use Illuminate\Support\Facades\DB;
+
+final class Mbti64CmsProjectionDraftWriter
+{
+    private const SNAPSHOT_KEY = 'mbti64_agent_projection_draft_v1';
+
+    private const PACKAGE_ARTIFACT = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01';
+
+    private const QA_ARTIFACT = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01';
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256, array $options = []): array
+    {
+        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false, $options);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256, array $options = []): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true, $options));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function buildSummary(
+        array $package,
+        array $qa,
+        string $sourceSha256,
+        string $qaSha256,
+        bool $write,
+        array $options,
+    ): array {
+        $errors = $this->validatePackageAndQa($package, $qa);
+        $warnings = array_values(array_filter((array) ($qa['warnings'] ?? []), static fn (mixed $warning): bool => is_string($warning)));
+        $qaResultsByUrl = $this->qaResultsByUrl($qa);
+
+        $preparedRows = [];
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'unsupported_mbti64_target_url',
+                    'message' => 'Unsupported MBTI64 public profile URL: '.((string) ($recommendation['target_url'] ?? '')),
+                ];
+
+                continue;
+            }
+
+            $target = $this->targetRecord($identity);
+            $targetId = $target['id'] ?? null;
+            $pageType = (string) $identity['page_type'];
+            $targetField = $pageType === 'comparison' ? 'profile_id' : 'personality_profile_variant_id';
+
+            if (! is_int($targetId)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'target_not_found',
+                    'message' => 'CMS target record was not found for MBTI64 agent projection '.$identity['path'],
+                ];
+            }
+
+            if ($this->containsForbiddenRoutePattern(json_encode($recommendation, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '')) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position),
+                    'code' => 'forbidden_public_route_pattern_present',
+                    'message' => 'Recommendation contains a forbidden private route or sensitive query pattern.',
+                ];
+            }
+
+            $existingRevision = is_int($targetId)
+                ? $this->existingRevision($pageType, $targetField, $targetId, $sourceSha256)
+                : null;
+            $nextRevisionNo = is_int($targetId)
+                ? $this->nextRevisionNo($pageType, $targetField, $targetId)
+                : null;
+            $qaResult = $qaResultsByUrl[(string) $recommendation['target_url']] ?? [];
+
+            $preparedRows[] = [
+                'position' => $position + 1,
+                'url' => (string) $recommendation['target_url'],
+                'path' => $identity['path'],
+                'locale' => $identity['locale'],
+                'page_type' => $pageType,
+                'identity' => $identity,
+                'target_table' => $pageType === 'comparison'
+                    ? 'personality_profile_revisions'
+                    : 'personality_profile_variant_revisions',
+                'target_id' => $targetId,
+                'snapshot_key' => self::SNAPSHOT_KEY,
+                'source_sha256' => $sourceSha256,
+                'qa_source_sha256' => $qaSha256,
+                'existing_revision_id' => $existingRevision?->id !== null ? (int) $existingRevision->id : null,
+                'existing_revision_no' => $existingRevision?->revision_no !== null ? (int) $existingRevision->revision_no : null,
+                'next_revision_no' => $nextRevisionNo,
+                'write_mode' => $write ? 'write_draft_revision' : 'dry_run',
+                'action' => 'pending',
+                'snapshot_preview' => $this->snapshotPayload($package, $qa, $recommendation, $identity, $sourceSha256, $qaSha256, $qaResult),
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($preparedRows),
+                'variant_row_count' => $this->countRows($preparedRows, 'variant'),
+                'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
+                'rows' => $preparedRows,
+                'errors' => $errors,
+                'warnings' => $warnings,
+            ]);
+        }
+
+        $created = 0;
+        $skippedExisting = 0;
+        if ($write) {
+            foreach ($preparedRows as &$preparedRow) {
+                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                    $preparedRow['action'] = 'skipped_existing';
+                    $skippedExisting++;
+
+                    continue;
+                }
+
+                $revision = $this->createRevision($preparedRow);
+                $preparedRow['action'] = 'created';
+                $preparedRow['created_revision_id'] = (int) $revision->id;
+                $preparedRow['created_revision_no'] = (int) $revision->revision_no;
+                $created++;
+            }
+            unset($preparedRow);
+        } else {
+            foreach ($preparedRows as &$preparedRow) {
+                if (($preparedRow['existing_revision_id'] ?? null) !== null) {
+                    $preparedRow['action'] = 'would_skip_existing';
+                    $skippedExisting++;
+
+                    continue;
+                }
+
+                $preparedRow['action'] = 'would_create';
+            }
+            unset($preparedRow);
+        }
+
+        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'row_count' => count($preparedRows),
+            'variant_row_count' => $this->countRows($preparedRows, 'variant'),
+            'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
+            'created_revision_count' => $created,
+            'skipped_existing_count' => $skippedExisting,
+            'would_create_revision_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
+            'writes_committed' => $write && $created > 0,
+            'rows' => $preparedRows,
+            'errors' => [],
+            'warnings' => $warnings,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return list<array<string,string>>
+     */
+    private function validatePackageAndQa(array $package, array $qa): array
+    {
+        $errors = [];
+        $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
+        $qaSummary = is_array($qa['summary'] ?? null) ? $qa['summary'] : [];
+
+        if ((string) ($package['artifact'] ?? '') !== self::PACKAGE_ARTIFACT) {
+            $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected package artifact.'];
+        }
+        if ((string) ($package['version'] ?? '') !== 'mbti64.agent_expansion_88_recommendations.v1') {
+            $errors[] = ['field' => 'version', 'code' => 'unsupported_package_version', 'message' => 'Unexpected package version.'];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass_ready_for_qa_gates') {
+            $errors[] = ['field' => 'status', 'code' => 'package_status_not_ready_for_qa', 'message' => 'Package must be ready for QA gates.'];
+        }
+        if (count($this->recommendations($package)) !== 88 || (int) ($summary['recommendation_count'] ?? -1) !== 88) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'unexpected_recommendation_count', 'message' => 'Expected exactly 88 expansion recommendations.'];
+        }
+        if ((int) ($summary['variant_pages'] ?? -1) !== 58 || (int) ($summary['comparison_pages'] ?? -1) !== 30) {
+            $errors[] = ['field' => 'summary', 'code' => 'unexpected_page_type_counts', 'message' => 'Expected 58 variant and 30 comparison recommendations.'];
+        }
+        if ((string) ($qa['artifact'] ?? '') !== self::QA_ARTIFACT) {
+            $errors[] = ['field' => 'qa.artifact', 'code' => 'unsupported_qa_artifact', 'message' => 'Unexpected QA artifact.'];
+        }
+        if ((string) ($qa['final_decision'] ?? '') !== 'PASS_READY_FOR_CMS_DRAFT') {
+            $errors[] = ['field' => 'qa.final_decision', 'code' => 'qa_not_ready_for_cms_draft', 'message' => 'QA final decision must pass before draft write.'];
+        }
+        if ((int) ($qaSummary['checked_recommendation_count'] ?? -1) !== 88
+            || (int) ($qaSummary['pass_ready_for_cms_draft_count'] ?? -1) !== 88
+            || (int) ($qaSummary['blocked_count'] ?? -1) !== 0) {
+            $errors[] = ['field' => 'qa.summary', 'code' => 'qa_summary_not_all_pass', 'message' => 'QA summary must show 88 pass and 0 blocked.'];
+        }
+        if ((array) ($qa['blockers'] ?? []) !== []) {
+            $errors[] = ['field' => 'qa.blockers', 'code' => 'qa_blockers_present', 'message' => 'QA blockers must be empty.'];
+        }
+
+        $recommendationUrls = array_map(static fn (array $item): string => (string) ($item['target_url'] ?? ''), $this->recommendations($package));
+        $qaUrls = array_map(
+            static fn (array $item): string => (string) ($item['target_url'] ?? ''),
+            array_values(array_filter(
+                is_array($qa['page_results'] ?? null) ? $qa['page_results'] : [],
+                static fn (mixed $item): bool => is_array($item)
+            ))
+        );
+        sort($recommendationUrls);
+        sort($qaUrls);
+        if ($recommendationUrls !== $qaUrls) {
+            $errors[] = ['field' => 'qa.page_results', 'code' => 'qa_url_set_mismatch', 'message' => 'QA page result URLs must match recommendation URLs.'];
+        }
+
+        foreach ($this->qaResultsByUrl($qa) as $url => $result) {
+            if ((string) ($result['decision'] ?? '') !== 'PASS_READY_FOR_CMS_DRAFT' || (array) ($result['blockers'] ?? []) !== []) {
+                $errors[] = ['field' => 'qa.page_results.'.$url, 'code' => 'qa_page_not_pass', 'message' => 'Every QA page result must pass with no blockers.'];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $qa
+     * @return array<string,array<string,mixed>>
+     */
+    private function qaResultsByUrl(array $qa): array
+    {
+        $results = [];
+        foreach (is_array($qa['page_results'] ?? null) ? $qa['page_results'] : [] as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $url = (string) ($item['target_url'] ?? '');
+            if ($url !== '') {
+                $results[$url] = $item;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array<string,string>|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        $targetUrl = (string) ($recommendation['target_url'] ?? '');
+        $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-(?<variant>a|t)$#i', $path, $matches) === 1) {
+            $locale = $this->localeFromPrefix((string) $matches['prefix']);
+            $canonicalType = strtoupper((string) $matches['type']);
+            $variantCode = strtoupper((string) $matches['variant']);
+
+            return [
+                'url' => $targetUrl,
+                'path' => $path,
+                'locale' => $locale,
+                'page_type' => 'variant',
+                'canonical_type_code' => $canonicalType,
+                'variant_code' => $variantCode,
+                'runtime_type_code' => $canonicalType.'-'.$variantCode,
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-a-vs-\k<type>-t$#i', $path, $matches) === 1) {
+            $locale = $this->localeFromPrefix((string) $matches['prefix']);
+            $canonicalType = strtoupper((string) $matches['type']);
+
+            return [
+                'url' => $targetUrl,
+                'path' => $path,
+                'locale' => $locale,
+                'page_type' => 'comparison',
+                'canonical_type_code' => $canonicalType,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,string>  $identity
+     * @return array{id?:int}
+     */
+    private function targetRecord(array $identity): array
+    {
+        $profile = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('locale', (string) $identity['locale'])
+            ->where('canonical_type_code', (string) $identity['canonical_type_code'])
+            ->first();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return [];
+        }
+
+        if (($identity['page_type'] ?? null) === 'comparison') {
+            return ['id' => (int) $profile->id];
+        }
+
+        $variant = PersonalityProfileVariant::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', (string) ($identity['runtime_type_code'] ?? ''))
+            ->first();
+
+        return $variant instanceof PersonalityProfileVariant ? ['id' => (int) $variant->id] : [];
+    }
+
+    private function existingRevision(
+        string $pageType,
+        string $targetField,
+        int $targetId,
+        string $sourceSha256,
+    ): PersonalityProfileRevision|PersonalityProfileVariantRevision|null {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        foreach ($query->orderByDesc('revision_no')->get() as $revision) {
+            $snapshot = is_array($revision->snapshot_json) ? $revision->snapshot_json : [];
+            $storedSha = (string) ($snapshot[self::SNAPSHOT_KEY]['source']['source_sha256'] ?? '');
+            if ($storedSha === $sourceSha256) {
+                return $revision;
+            }
+        }
+
+        return null;
+    }
+
+    private function nextRevisionNo(string $pageType, string $targetField, int $targetId): int
+    {
+        $query = $pageType === 'comparison'
+            ? PersonalityProfileRevision::query()->where($targetField, $targetId)
+            : PersonalityProfileVariantRevision::query()->where($targetField, $targetId);
+
+        return ((int) $query->max('revision_no')) + 1;
+    }
+
+    /**
+     * @param  array<string,mixed>  $preparedRow
+     */
+    private function createRevision(array $preparedRow): PersonalityProfileRevision|PersonalityProfileVariantRevision
+    {
+        $pageType = (string) ($preparedRow['page_type'] ?? '');
+        $targetId = (int) ($preparedRow['target_id'] ?? 0);
+        $revisionNo = (int) ($preparedRow['next_revision_no'] ?? 0);
+        $snapshot = is_array($preparedRow['snapshot_preview'] ?? null) ? $preparedRow['snapshot_preview'] : [];
+        $note = $pageType === 'comparison'
+            ? 'mbti64 agent projection comparison draft: '.((string) ($preparedRow['path'] ?? ''))
+            : 'mbti64 agent projection variant draft: '.((string) ($preparedRow['path'] ?? ''));
+
+        if ($pageType === 'comparison') {
+            return PersonalityProfileRevision::query()->create([
+                'profile_id' => $targetId,
+                'revision_no' => $revisionNo,
+                'snapshot_json' => $snapshot,
+                'note' => $note,
+                'created_by_admin_user_id' => null,
+                'created_at' => now(),
+            ]);
+        }
+
+        return PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => $targetId,
+            'revision_no' => $revisionNo,
+            'snapshot_json' => $snapshot,
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $recommendation
+     * @param  array<string,string>  $identity
+     * @param  array<string,mixed>  $qaResult
+     * @return array<string,mixed>
+     */
+    private function snapshotPayload(
+        array $package,
+        array $qa,
+        array $recommendation,
+        array $identity,
+        string $sourceSha256,
+        string $qaSha256,
+        array $qaResult,
+    ): array {
+        $recommended = is_array($recommendation['recommendations'] ?? null) ? $recommendation['recommendations'] : [];
+
+        return [
+            self::SNAPSHOT_KEY => [
+                'source' => [
+                    'artifact' => (string) ($package['artifact'] ?? ''),
+                    'version' => (string) ($package['version'] ?? ''),
+                    'status' => (string) ($package['status'] ?? ''),
+                    'source_sha256' => $sourceSha256,
+                    'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+                    'qa_source_sha256' => $qaSha256,
+                    'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+                ],
+                'identity' => $identity,
+                'first_class_draft_fields' => [
+                    'url' => (string) ($recommendation['target_url'] ?? ''),
+                    'locale' => (string) ($recommendation['locale'] ?? ''),
+                    'page_type' => (string) $identity['page_type'],
+                    'seo' => [
+                        'title' => (string) ($recommended['title']['recommended'] ?? ''),
+                        'description' => (string) ($recommended['description']['recommended'] ?? ''),
+                        'h1' => (string) ($recommended['h1']['recommended'] ?? ''),
+                    ],
+                    'content' => [
+                        'quick_answer' => (string) ($recommended['quick_answer']['recommended'] ?? ''),
+                    ],
+                    'faq' => is_array($recommended['faq'] ?? null) ? array_values((array) $recommended['faq']) : [],
+                    'internal_links' => is_array($recommended['internal_links'] ?? null) ? array_values((array) $recommended['internal_links']) : [],
+                    'differentiation_notes' => is_array($recommended['differentiation_notes'] ?? null)
+                        ? array_values((array) $recommended['differentiation_notes'])
+                        : [],
+                ],
+                'structured_metadata' => [
+                    'current_surface' => is_array($recommendation['current_surface'] ?? null) ? $recommendation['current_surface'] : [],
+                    'observed_signal' => is_array($recommendation['observed_signal'] ?? null) ? $recommendation['observed_signal'] : [],
+                    'reference_patterns_used' => is_array($recommendation['reference_patterns_used'] ?? null)
+                        ? array_values((array) $recommendation['reference_patterns_used'])
+                        : [],
+                    'source_inputs' => is_array($recommendation['source_inputs'] ?? null) ? $recommendation['source_inputs'] : [],
+                    'qa_result' => $qaResult,
+                    'qa_summary' => is_array($qa['summary'] ?? null) ? $qa['summary'] : [],
+                ],
+                'safety_holds' => [
+                    'draft_only' => true,
+                    'publish_attempted' => false,
+                    'index_attempted' => false,
+                    'sitemap_llms_release_attempted' => false,
+                    'search_release_attempted' => false,
+                    'runtime_content_updated' => false,
+                ],
+                'raw_recommendation' => $recommendation,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'qa_source_sha256' => $qaSha256,
+            'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+            'snapshot_key' => self::SNAPSHOT_KEY,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'draft_only' => true,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     */
+    private function countRows(array $rows, string $pageType): int
+    {
+        return count(array_filter(
+            $rows,
+            static fn (array $row): bool => ($row['page_type'] ?? null) === $pageType
+        ));
+    }
+
+    private function localeFromPrefix(string $prefix): string
+    {
+        return strtolower($prefix) === 'zh' ? 'zh-CN' : 'en';
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/docs/seo/personality/mbti64-agent-expansion-88-qa-2026-06-21.json
+++ b/backend/docs/seo/personality/mbti64-agent-expansion-88-qa-2026-06-21.json
@@ -1,0 +1,1813 @@
+{
+  "artifact": "MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01",
+  "generated_at": "2026-06-21T07:49:25.100Z",
+  "status": "pass_ready_for_cms_draft",
+  "input_artifact": "docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json",
+  "scope": "Artifact-only QA gate over 88 MBTI64 public profile draft recommendations. No CMS write, no publish, no index/search release, no sitemap/llms mutation.",
+  "gates": [
+    "schema_validation",
+    "trademark_claim_gate",
+    "claim_risk_gate",
+    "duplicate_template_gate",
+    "private_route_gate",
+    "result_page_leakage_gate",
+    "seo_projection_gate",
+    "bilingual_consistency_gate"
+  ],
+  "summary": {
+    "checked_recommendation_count": 88,
+    "pass_ready_for_cms_draft_count": 88,
+    "blocked_count": 0,
+    "warning_count": 1,
+    "duplicate_signature_group_count": 0,
+    "bilingual_asymmetric_type_count": 0,
+    "gsc_evidence_state": "GSC_EVIDENCE_PENDING"
+  },
+  "gate_rollup": {
+    "schema_validation_failures": 0,
+    "trademark_claim_failures": 0,
+    "claim_risk_failures": 0,
+    "duplicate_template_failures": 0,
+    "private_route_failures": 0,
+    "result_page_leakage_failures": 0,
+    "seo_projection_failures": 0,
+    "bilingual_consistency_failures": 0
+  },
+  "duplicate_template_gate": {
+    "duplicate_signature_group_count": 0,
+    "duplicate_groups": []
+  },
+  "bilingual_consistency_gate": {
+    "checked_type_count": 16,
+    "asymmetric_type_count": 0,
+    "asymmetric_types": []
+  },
+  "page_results": [
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfj-a-vs-enfj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfp-a-vs-enfp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/enfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entj-a-vs-entj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entp-a-vs-entp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/entp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfj-a-vs-esfj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfp-a-vs-esfp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/esfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estj-a-vs-estj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estp-a-vs-estp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/estp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infj-a-vs-infj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infp-a-vs-infp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/infp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/intp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/intp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfj-a-vs-isfj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfp-a-vs-isfp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/isfp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istj-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istj-a-vs-istj-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istj-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istp-a",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istp-a-vs-istp-t",
+      "locale": "en",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/en/personality/istp-t",
+      "locale": "en",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfj-a-vs-enfj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a-vs-enfp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/enfp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entj-a-vs-entj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entp-a-vs-entp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/entp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a-vs-esfj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfp-a-vs-esfp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/esfp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estj-a-vs-estj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estp-a-vs-estp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/estp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infj-a-vs-infj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/infp-a-vs-infp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intj-a-vs-intj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intp-a-vs-intp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/intp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a-vs-isfj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a-vs-isfp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/isfp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istj-a-vs-istj-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istj-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istp-a",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istp-a-vs-istp-t",
+      "locale": "zh-CN",
+      "page_type": "comparison",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    },
+    {
+      "target_url": "https://fermatmind.com/zh/personality/istp-t",
+      "locale": "zh-CN",
+      "page_type": "variant",
+      "gates": {
+        "schema_validation": "pass",
+        "trademark_claim_gate": "pass",
+        "claim_risk_gate": "pass",
+        "duplicate_template_gate": "pass",
+        "private_route_gate": "pass",
+        "result_page_leakage_gate": "pass",
+        "seo_projection_gate": "pass",
+        "bilingual_consistency_gate": "pass"
+      },
+      "blockers": [],
+      "warnings": [
+        "GSC_EVIDENCE_PENDING"
+      ],
+      "decision": "PASS_READY_FOR_CMS_DRAFT"
+    }
+  ],
+  "blockers": [],
+  "warnings": [
+    "GSC_EVIDENCE_PENDING"
+  ],
+  "final_decision": "PASS_READY_FOR_CMS_DRAFT",
+  "recommended_next_task": "MBTI64-CMS-PROJECTION-DRAFT-88-01"
+}

--- a/backend/docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json
+++ b/backend/docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json
@@ -1,0 +1,11377 @@
+{
+  "artifact": "MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01",
+  "version": "mbti64.agent_expansion_88_recommendations.v1",
+  "generated_at": "2026-06-21T05:53:37.631Z",
+  "status": "pass_ready_for_qa_gates",
+  "scope": "Artifact-only draft recommendations for 88 non-pilot MBTI64 public personality URLs. No CMS write, publish, indexability, sitemap/llms, Search Queue, approval, or submission action.",
+  "inputs": {
+    "internal_link_graph": "docs/seo/personality/internal-link-graph-2026-06-18.json",
+    "optimized_pilot_reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+    "runner_schema": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json"
+  },
+  "summary": {
+    "recommendation_count": 88,
+    "variant_pages": 58,
+    "comparison_pages": 30,
+    "pilot_urls_excluded": 8,
+    "gsc_evidence_state": "GSC_EVIDENCE_PENDING",
+    "qa_gate_required_count": 8
+  },
+  "recommendations": [
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfj-a",
+      "target_url": "https://fermatmind.com/en/personality/enfj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-A Protagonist Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENFJ-A Protagonist personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENFJ-A Protagonist Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-A Protagonist Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENFJ-A Meaning: Assertive Protagonist Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENFJ-A Protagonist personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENFJ-A through people leadership, encouragement and shared direction, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-A Protagonist Personality",
+          "recommended": "ENFJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-A combines the ENFJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENFJ-A mean?",
+            "answer": "ENFJ-A combines the ENFJ core pattern with an Assertive identity style, especially around people leadership, encouragement and shared direction.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENFJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENFJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENFJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfj-t",
+            "anchor_text": "ENFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A vs ENFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfj-a with people leadership, encouragement and shared direction rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfj-a-vs-enfj-t",
+      "target_url": "https://fermatmind.com/en/personality/enfj-a-vs-enfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-A vs ENFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ENFJ-A and ENFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ENFJ-A vs ENFJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-A vs ENFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ENFJ-A vs ENFJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ENFJ-A and ENFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ENFJ-A and ENFJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-A vs ENFJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ENFJ-A vs ENFJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-A and ENFJ-T share the same ENFJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ENFJ-A vs ENFJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ENFJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ENFJ-A better than ENFJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ENFJ-A or ENFJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfj-a",
+            "anchor_text": "ENFJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfj-t",
+            "anchor_text": "ENFJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfj-a-vs-enfj-t with people leadership, encouragement and shared direction rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfj-t",
+      "target_url": "https://fermatmind.com/en/personality/enfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-T Protagonist Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENFJ-T Protagonist personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENFJ-T Protagonist Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-T Protagonist Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENFJ-T Meaning: Turbulent Protagonist Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENFJ-T Protagonist personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENFJ-T through people leadership, encouragement and shared direction, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-T Protagonist Personality",
+          "recommended": "ENFJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-T combines the ENFJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENFJ-T mean?",
+            "answer": "ENFJ-T combines the ENFJ core pattern with an Turbulent identity style, especially around people leadership, encouragement and shared direction.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENFJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENFJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENFJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfj-a",
+            "anchor_text": "ENFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A vs ENFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfj-t with people leadership, encouragement and shared direction rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfp-a",
+      "target_url": "https://fermatmind.com/en/personality/enfp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-A Campaigner Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENFP-A Campaigner personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENFP-A Campaigner Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-A Campaigner Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENFP-A Meaning: Assertive Campaigner Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENFP-A Campaigner personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENFP-A through possibility, connection and creative momentum, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-A Campaigner Personality",
+          "recommended": "ENFP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-A combines the ENFP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENFP-A mean?",
+            "answer": "ENFP-A combines the ENFP core pattern with an Assertive identity style, especially around possibility, connection and creative momentum.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENFP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENFP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENFP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfp-t",
+            "anchor_text": "ENFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A vs ENFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfp-a with possibility, connection and creative momentum rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfp-a-vs-enfp-t",
+      "target_url": "https://fermatmind.com/en/personality/enfp-a-vs-enfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-A vs ENFP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ENFP-A and ENFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ENFP-A vs ENFP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-A vs ENFP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ENFP-A vs ENFP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ENFP-A and ENFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ENFP-A and ENFP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-A vs ENFP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ENFP-A vs ENFP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-A and ENFP-T share the same ENFP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ENFP-A vs ENFP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ENFP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ENFP-A better than ENFP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ENFP-A or ENFP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfp-a",
+            "anchor_text": "ENFP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfp-t",
+            "anchor_text": "ENFP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfp-a-vs-enfp-t with possibility, connection and creative momentum rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/enfp-t",
+      "target_url": "https://fermatmind.com/en/personality/enfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-T Campaigner Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENFP-T Campaigner personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENFP-T Campaigner Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-T Campaigner Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENFP-T Meaning: Turbulent Campaigner Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENFP-T Campaigner personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENFP-T through possibility, connection and creative momentum, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-T Campaigner Personality",
+          "recommended": "ENFP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-T combines the ENFP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENFP-T mean?",
+            "answer": "ENFP-T combines the ENFP core pattern with an Turbulent identity style, especially around possibility, connection and creative momentum.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENFP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENFP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENFP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/enfp-a",
+            "anchor_text": "ENFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A vs ENFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/enfp-t with possibility, connection and creative momentum rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entj-a",
+      "target_url": "https://fermatmind.com/en/personality/entj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-A Commander Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENTJ-A Commander personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENTJ-A Commander Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-A Commander Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENTJ-A Meaning: Assertive Commander Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENTJ-A Commander personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENTJ-A through leadership, execution and systems decisions, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-A Commander Personality",
+          "recommended": "ENTJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-A combines the ENTJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENTJ-A mean?",
+            "answer": "ENTJ-A combines the ENTJ core pattern with an Assertive identity style, especially around leadership, execution and systems decisions.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENTJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENTJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENTJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entj-t",
+            "anchor_text": "ENTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A vs ENTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entj-a with leadership, execution and systems decisions rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entj-a-vs-entj-t",
+      "target_url": "https://fermatmind.com/en/personality/entj-a-vs-entj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-A vs ENTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ENTJ-A and ENTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ENTJ-A vs ENTJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-A vs ENTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ENTJ-A vs ENTJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ENTJ-A and ENTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ENTJ-A and ENTJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-A vs ENTJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ENTJ-A vs ENTJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-A and ENTJ-T share the same ENTJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ENTJ-A vs ENTJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ENTJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ENTJ-A better than ENTJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ENTJ-A or ENTJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entj-a",
+            "anchor_text": "ENTJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entj-t",
+            "anchor_text": "ENTJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entj-a-vs-entj-t with leadership, execution and systems decisions rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entj-t",
+      "target_url": "https://fermatmind.com/en/personality/entj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-T Commander Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENTJ-T Commander personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENTJ-T Commander Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-T Commander Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENTJ-T Meaning: Turbulent Commander Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENTJ-T Commander personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENTJ-T through leadership, execution and systems decisions, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-T Commander Personality",
+          "recommended": "ENTJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-T combines the ENTJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENTJ-T mean?",
+            "answer": "ENTJ-T combines the ENTJ core pattern with an Turbulent identity style, especially around leadership, execution and systems decisions.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENTJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENTJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENTJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entj-a",
+            "anchor_text": "ENTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A vs ENTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entj-t with leadership, execution and systems decisions rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entp-a",
+      "target_url": "https://fermatmind.com/en/personality/entp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-A Debater Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENTP-A Debater personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENTP-A Debater Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-A Debater Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENTP-A Meaning: Assertive Debater Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENTP-A Debater personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENTP-A through debate, experimentation and idea testing, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-A Debater Personality",
+          "recommended": "ENTP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-A combines the ENTP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENTP-A mean?",
+            "answer": "ENTP-A combines the ENTP core pattern with an Assertive identity style, especially around debate, experimentation and idea testing.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENTP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENTP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENTP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entp-t",
+            "anchor_text": "ENTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A vs ENTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entp-a with debate, experimentation and idea testing rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entp-a-vs-entp-t",
+      "target_url": "https://fermatmind.com/en/personality/entp-a-vs-entp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-A vs ENTP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ENTP-A and ENTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ENTP-A vs ENTP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-A vs ENTP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ENTP-A vs ENTP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ENTP-A and ENTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ENTP-A and ENTP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-A vs ENTP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ENTP-A vs ENTP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-A and ENTP-T share the same ENTP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ENTP-A vs ENTP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ENTP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ENTP-A better than ENTP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ENTP-A or ENTP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entp-a",
+            "anchor_text": "ENTP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entp-t",
+            "anchor_text": "ENTP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entp-a-vs-entp-t with debate, experimentation and idea testing rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/entp-t",
+      "target_url": "https://fermatmind.com/en/personality/entp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-T Debater Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ENTP-T Debater personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ENTP-T Debater Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-T Debater Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ENTP-T Meaning: Turbulent Debater Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ENTP-T Debater personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ENTP-T through debate, experimentation and idea testing, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-T Debater Personality",
+          "recommended": "ENTP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-T combines the ENTP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ENTP-T mean?",
+            "answer": "ENTP-T combines the ENTP core pattern with an Turbulent identity style, especially around debate, experimentation and idea testing.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ENTP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ENTP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ENTP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/entp-a",
+            "anchor_text": "ENTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A vs ENTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/entp-t with debate, experimentation and idea testing rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfj-a",
+      "target_url": "https://fermatmind.com/en/personality/esfj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-A Consul Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESFJ-A Consul personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESFJ-A Consul Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-A Consul Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESFJ-A Meaning: Assertive Consul Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESFJ-A Consul personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESFJ-A through support, belonging and practical coordination, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-A Consul Personality",
+          "recommended": "ESFJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-A combines the ESFJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESFJ-A mean?",
+            "answer": "ESFJ-A combines the ESFJ core pattern with an Assertive identity style, especially around support, belonging and practical coordination.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESFJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESFJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESFJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfj-t",
+            "anchor_text": "ESFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A vs ESFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfj-a with support, belonging and practical coordination rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfj-a-vs-esfj-t",
+      "target_url": "https://fermatmind.com/en/personality/esfj-a-vs-esfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-A vs ESFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ESFJ-A and ESFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ESFJ-A vs ESFJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-A vs ESFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ESFJ-A vs ESFJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ESFJ-A and ESFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ESFJ-A and ESFJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-A vs ESFJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ESFJ-A vs ESFJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-A and ESFJ-T share the same ESFJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ESFJ-A vs ESFJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ESFJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ESFJ-A better than ESFJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ESFJ-A or ESFJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfj-a",
+            "anchor_text": "ESFJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfj-t",
+            "anchor_text": "ESFJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfj-a-vs-esfj-t with support, belonging and practical coordination rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfj-t",
+      "target_url": "https://fermatmind.com/en/personality/esfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-T Consul Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESFJ-T Consul personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESFJ-T Consul Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-T Consul Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESFJ-T Meaning: Turbulent Consul Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESFJ-T Consul personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESFJ-T through support, belonging and practical coordination, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-T Consul Personality",
+          "recommended": "ESFJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-T combines the ESFJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESFJ-T mean?",
+            "answer": "ESFJ-T combines the ESFJ core pattern with an Turbulent identity style, especially around support, belonging and practical coordination.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESFJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESFJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESFJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfj-a",
+            "anchor_text": "ESFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A vs ESFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfj-t with support, belonging and practical coordination rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfp-a",
+      "target_url": "https://fermatmind.com/en/personality/esfp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-A Entertainer Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESFP-A Entertainer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESFP-A Entertainer Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-A Entertainer Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESFP-A Meaning: Assertive Entertainer Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESFP-A Entertainer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESFP-A through energy, presence and shared experience, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-A Entertainer Personality",
+          "recommended": "ESFP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-A combines the ESFP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESFP-A mean?",
+            "answer": "ESFP-A combines the ESFP core pattern with an Assertive identity style, especially around energy, presence and shared experience.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESFP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESFP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESFP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfp-t",
+            "anchor_text": "ESFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A vs ESFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfp-a with energy, presence and shared experience rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfp-a-vs-esfp-t",
+      "target_url": "https://fermatmind.com/en/personality/esfp-a-vs-esfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-A vs ESFP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ESFP-A and ESFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ESFP-A vs ESFP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-A vs ESFP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ESFP-A vs ESFP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ESFP-A and ESFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ESFP-A and ESFP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-A vs ESFP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ESFP-A vs ESFP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-A and ESFP-T share the same ESFP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ESFP-A vs ESFP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ESFP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ESFP-A better than ESFP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ESFP-A or ESFP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfp-a",
+            "anchor_text": "ESFP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfp-t",
+            "anchor_text": "ESFP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfp-a-vs-esfp-t with energy, presence and shared experience rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/esfp-t",
+      "target_url": "https://fermatmind.com/en/personality/esfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-T Entertainer Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESFP-T Entertainer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESFP-T Entertainer Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-T Entertainer Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESFP-T Meaning: Turbulent Entertainer Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESFP-T Entertainer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESFP-T through energy, presence and shared experience, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-T Entertainer Personality",
+          "recommended": "ESFP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-T combines the ESFP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESFP-T mean?",
+            "answer": "ESFP-T combines the ESFP core pattern with an Turbulent identity style, especially around energy, presence and shared experience.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESFP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESFP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESFP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/esfp-a",
+            "anchor_text": "ESFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A vs ESFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/esfp-t with energy, presence and shared experience rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estj-a",
+      "target_url": "https://fermatmind.com/en/personality/estj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-A Executive Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESTJ-A Executive personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESTJ-A Executive Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-A Executive Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESTJ-A Meaning: Assertive Executive Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESTJ-A Executive personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESTJ-A through structure, decisions and operational follow-through, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-A Executive Personality",
+          "recommended": "ESTJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-A combines the ESTJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESTJ-A mean?",
+            "answer": "ESTJ-A combines the ESTJ core pattern with an Assertive identity style, especially around structure, decisions and operational follow-through.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESTJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESTJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESTJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estj-t",
+            "anchor_text": "ESTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A vs ESTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estj-a with structure, decisions and operational follow-through rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estj-a-vs-estj-t",
+      "target_url": "https://fermatmind.com/en/personality/estj-a-vs-estj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-A vs ESTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ESTJ-A and ESTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ESTJ-A vs ESTJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-A vs ESTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ESTJ-A vs ESTJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ESTJ-A and ESTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ESTJ-A and ESTJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-A vs ESTJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ESTJ-A vs ESTJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-A and ESTJ-T share the same ESTJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ESTJ-A vs ESTJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ESTJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ESTJ-A better than ESTJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ESTJ-A or ESTJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estj-a",
+            "anchor_text": "ESTJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estj-t",
+            "anchor_text": "ESTJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estj-a-vs-estj-t with structure, decisions and operational follow-through rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estj-t",
+      "target_url": "https://fermatmind.com/en/personality/estj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-T Executive Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESTJ-T Executive personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESTJ-T Executive Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-T Executive Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESTJ-T Meaning: Turbulent Executive Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESTJ-T Executive personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESTJ-T through structure, decisions and operational follow-through, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-T Executive Personality",
+          "recommended": "ESTJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-T combines the ESTJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESTJ-T mean?",
+            "answer": "ESTJ-T combines the ESTJ core pattern with an Turbulent identity style, especially around structure, decisions and operational follow-through.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESTJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESTJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESTJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estj-a",
+            "anchor_text": "ESTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A vs ESTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estj-t with structure, decisions and operational follow-through rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estp-a",
+      "target_url": "https://fermatmind.com/en/personality/estp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-A Entrepreneur Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESTP-A Entrepreneur personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESTP-A Entrepreneur Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-A Entrepreneur Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESTP-A Meaning: Assertive Entrepreneur Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESTP-A Entrepreneur personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESTP-A through action, opportunity and real-time adaptation, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-A Entrepreneur Personality",
+          "recommended": "ESTP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-A combines the ESTP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESTP-A mean?",
+            "answer": "ESTP-A combines the ESTP core pattern with an Assertive identity style, especially around action, opportunity and real-time adaptation.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESTP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESTP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESTP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estp-t",
+            "anchor_text": "ESTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A vs ESTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estp-a with action, opportunity and real-time adaptation rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estp-a-vs-estp-t",
+      "target_url": "https://fermatmind.com/en/personality/estp-a-vs-estp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-A vs ESTP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ESTP-A and ESTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ESTP-A vs ESTP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-A vs ESTP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ESTP-A vs ESTP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ESTP-A and ESTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ESTP-A and ESTP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-A vs ESTP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ESTP-A vs ESTP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-A and ESTP-T share the same ESTP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ESTP-A vs ESTP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ESTP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ESTP-A better than ESTP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ESTP-A or ESTP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estp-a",
+            "anchor_text": "ESTP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estp-t",
+            "anchor_text": "ESTP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estp-a-vs-estp-t with action, opportunity and real-time adaptation rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/estp-t",
+      "target_url": "https://fermatmind.com/en/personality/estp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-T Entrepreneur Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ESTP-T Entrepreneur personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ESTP-T Entrepreneur Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-T Entrepreneur Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ESTP-T Meaning: Turbulent Entrepreneur Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ESTP-T Entrepreneur personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ESTP-T through action, opportunity and real-time adaptation, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-T Entrepreneur Personality",
+          "recommended": "ESTP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-T combines the ESTP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ESTP-T mean?",
+            "answer": "ESTP-T combines the ESTP core pattern with an Turbulent identity style, especially around action, opportunity and real-time adaptation.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ESTP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ESTP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ESTP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/estp-a",
+            "anchor_text": "ESTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A vs ESTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/estp-t with action, opportunity and real-time adaptation rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infj-a",
+      "target_url": "https://fermatmind.com/en/personality/infj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-A Advocate Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INFJ-A Advocate personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INFJ-A Advocate Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-A Advocate Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INFJ-A Meaning: Assertive Advocate Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INFJ-A Advocate personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INFJ-A through insight, values and long-term meaning, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-A Advocate Personality",
+          "recommended": "INFJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-A combines the INFJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INFJ-A mean?",
+            "answer": "INFJ-A combines the INFJ core pattern with an Assertive identity style, especially around insight, values and long-term meaning.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INFJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INFJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INFJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infj-t",
+            "anchor_text": "INFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A vs INFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infj-a with insight, values and long-term meaning rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infj-a-vs-infj-t",
+      "target_url": "https://fermatmind.com/en/personality/infj-a-vs-infj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-A vs INFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare INFJ-A and INFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "INFJ-A vs INFJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-A vs INFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "INFJ-A vs INFJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare INFJ-A and INFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare INFJ-A and INFJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-A vs INFJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "INFJ-A vs INFJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-A and INFJ-T share the same INFJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main INFJ-A vs INFJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the INFJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is INFJ-A better than INFJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am INFJ-A or INFJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infj-a",
+            "anchor_text": "INFJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infj-t",
+            "anchor_text": "INFJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infj-a-vs-infj-t with insight, values and long-term meaning rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infj-t",
+      "target_url": "https://fermatmind.com/en/personality/infj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-T Advocate Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INFJ-T Advocate personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INFJ-T Advocate Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-T Advocate Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INFJ-T Meaning: Turbulent Advocate Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INFJ-T Advocate personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INFJ-T through insight, values and long-term meaning, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-T Advocate Personality",
+          "recommended": "INFJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-T combines the INFJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INFJ-T mean?",
+            "answer": "INFJ-T combines the INFJ core pattern with an Turbulent identity style, especially around insight, values and long-term meaning.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INFJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INFJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INFJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infj-a",
+            "anchor_text": "INFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A vs INFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infj-t with insight, values and long-term meaning rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infp-a",
+      "target_url": "https://fermatmind.com/en/personality/infp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFP-A Mediator Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INFP-A Mediator personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INFP-A Mediator Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFP-A Mediator Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INFP-A Meaning: Assertive Mediator Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INFP-A Mediator personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INFP-A through values, empathy and personal meaning, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFP-A Mediator Personality",
+          "recommended": "INFP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFP-A combines the INFP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INFP-A mean?",
+            "answer": "INFP-A combines the INFP core pattern with an Assertive identity style, especially around values, empathy and personal meaning.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INFP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INFP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INFP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infp-t",
+            "anchor_text": "INFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A vs INFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infp-a with values, empathy and personal meaning rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infp-a-vs-infp-t",
+      "target_url": "https://fermatmind.com/en/personality/infp-a-vs-infp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFP-A vs INFP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare INFP-A and INFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "INFP-A vs INFP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFP-A vs INFP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "INFP-A vs INFP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare INFP-A and INFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare INFP-A and INFP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFP-A vs INFP-T: Traits, Careers, Love & Rarity",
+          "recommended": "INFP-A vs INFP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFP-A and INFP-T share the same INFP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main INFP-A vs INFP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the INFP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is INFP-A better than INFP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am INFP-A or INFP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infp-a",
+            "anchor_text": "INFP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infp-t",
+            "anchor_text": "INFP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infp-a-vs-infp-t with values, empathy and personal meaning rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/infp-t",
+      "target_url": "https://fermatmind.com/en/personality/infp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFP-T Mediator Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INFP-T Mediator personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INFP-T Mediator Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFP-T Mediator Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INFP-T Meaning: Turbulent Mediator Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INFP-T Mediator personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INFP-T through values, empathy and personal meaning, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFP-T Mediator Personality",
+          "recommended": "INFP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFP-T combines the INFP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INFP-T mean?",
+            "answer": "INFP-T combines the INFP core pattern with an Turbulent identity style, especially around values, empathy and personal meaning.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INFP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INFP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INFP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/infp-a",
+            "anchor_text": "INFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A vs INFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/infp-t with values, empathy and personal meaning rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/intp-a",
+      "target_url": "https://fermatmind.com/en/personality/intp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTP-A Logician Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INTP-A Logician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INTP-A Logician Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTP-A Logician Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INTP-A Meaning: Assertive Logician Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INTP-A Logician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INTP-A through analysis, curiosity and independent problem solving, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTP-A Logician Personality",
+          "recommended": "INTP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTP-A combines the INTP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INTP-A mean?",
+            "answer": "INTP-A combines the INTP core pattern with an Assertive identity style, especially around analysis, curiosity and independent problem solving.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INTP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INTP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INTP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/intp-t",
+            "anchor_text": "INTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A vs INTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/intp-a with analysis, curiosity and independent problem solving rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/intp-t",
+      "target_url": "https://fermatmind.com/en/personality/intp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTP-T Logician Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the INTP-T Logician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "INTP-T Logician Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTP-T Logician Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "INTP-T Meaning: Turbulent Logician Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the INTP-T Logician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand INTP-T through analysis, curiosity and independent problem solving, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTP-T Logician Personality",
+          "recommended": "INTP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTP-T combines the INTP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does INTP-T mean?",
+            "answer": "INTP-T combines the INTP core pattern with an Turbulent identity style, especially around analysis, curiosity and independent problem solving.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits INTP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common INTP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is INTP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/intp-a",
+            "anchor_text": "INTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A vs INTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/intp-t with analysis, curiosity and independent problem solving rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfj-a",
+      "target_url": "https://fermatmind.com/en/personality/isfj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-A Defender Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISFJ-A Defender personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISFJ-A Defender Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-A Defender Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISFJ-A Meaning: Assertive Defender Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISFJ-A Defender personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISFJ-A through care, memory and dependable support, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-A Defender Personality",
+          "recommended": "ISFJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-A combines the ISFJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISFJ-A mean?",
+            "answer": "ISFJ-A combines the ISFJ core pattern with an Assertive identity style, especially around care, memory and dependable support.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISFJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISFJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISFJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfj-t",
+            "anchor_text": "ISFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A vs ISFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfj-a with care, memory and dependable support rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfj-a-vs-isfj-t",
+      "target_url": "https://fermatmind.com/en/personality/isfj-a-vs-isfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-A vs ISFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ISFJ-A and ISFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ISFJ-A vs ISFJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-A vs ISFJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ISFJ-A vs ISFJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ISFJ-A and ISFJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ISFJ-A and ISFJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-A vs ISFJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ISFJ-A vs ISFJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-A and ISFJ-T share the same ISFJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ISFJ-A vs ISFJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ISFJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ISFJ-A better than ISFJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ISFJ-A or ISFJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfj-a",
+            "anchor_text": "ISFJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfj-t",
+            "anchor_text": "ISFJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfj-a-vs-isfj-t with care, memory and dependable support rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfj-t",
+      "target_url": "https://fermatmind.com/en/personality/isfj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-T Defender Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISFJ-T Defender personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISFJ-T Defender Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-T Defender Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISFJ-T Meaning: Turbulent Defender Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISFJ-T Defender personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISFJ-T through care, memory and dependable support, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-T Defender Personality",
+          "recommended": "ISFJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-T combines the ISFJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISFJ-T mean?",
+            "answer": "ISFJ-T combines the ISFJ core pattern with an Turbulent identity style, especially around care, memory and dependable support.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISFJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISFJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISFJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfj-a",
+            "anchor_text": "ISFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A vs ISFJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfj-t with care, memory and dependable support rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfp-a",
+      "target_url": "https://fermatmind.com/en/personality/isfp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-A Adventurer Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISFP-A Adventurer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISFP-A Adventurer Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-A Adventurer Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISFP-A Meaning: Assertive Adventurer Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISFP-A Adventurer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISFP-A through taste, experience and quiet personal expression, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-A Adventurer Personality",
+          "recommended": "ISFP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-A combines the ISFP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISFP-A mean?",
+            "answer": "ISFP-A combines the ISFP core pattern with an Assertive identity style, especially around taste, experience and quiet personal expression.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISFP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISFP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISFP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfp-t",
+            "anchor_text": "ISFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A vs ISFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfp-a with taste, experience and quiet personal expression rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfp-a-vs-isfp-t",
+      "target_url": "https://fermatmind.com/en/personality/isfp-a-vs-isfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-A vs ISFP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ISFP-A and ISFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ISFP-A vs ISFP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-A vs ISFP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ISFP-A vs ISFP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ISFP-A and ISFP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ISFP-A and ISFP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-A vs ISFP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ISFP-A vs ISFP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-A and ISFP-T share the same ISFP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ISFP-A vs ISFP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ISFP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ISFP-A better than ISFP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ISFP-A or ISFP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfp-a",
+            "anchor_text": "ISFP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfp-t",
+            "anchor_text": "ISFP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfp-a-vs-isfp-t with taste, experience and quiet personal expression rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/isfp-t",
+      "target_url": "https://fermatmind.com/en/personality/isfp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-T Adventurer Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISFP-T Adventurer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISFP-T Adventurer Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-T Adventurer Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISFP-T Meaning: Turbulent Adventurer Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISFP-T Adventurer personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISFP-T through taste, experience and quiet personal expression, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-T Adventurer Personality",
+          "recommended": "ISFP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-T combines the ISFP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISFP-T mean?",
+            "answer": "ISFP-T combines the ISFP core pattern with an Turbulent identity style, especially around taste, experience and quiet personal expression.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISFP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISFP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISFP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/isfp-a",
+            "anchor_text": "ISFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A vs ISFP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/isfp-t with taste, experience and quiet personal expression rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istj-a",
+      "target_url": "https://fermatmind.com/en/personality/istj-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTJ-A Logistician Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISTJ-A Logistician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISTJ-A Logistician Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTJ-A Logistician Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISTJ-A Meaning: Assertive Logistician Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISTJ-A Logistician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISTJ-A through responsibility, order and reliable execution, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTJ-A Logistician Personality",
+          "recommended": "ISTJ-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTJ-A combines the ISTJ core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISTJ-A mean?",
+            "answer": "ISTJ-A combines the ISTJ core pattern with an Assertive identity style, especially around responsibility, order and reliable execution.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISTJ-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISTJ-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISTJ-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istj-t",
+            "anchor_text": "ISTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A vs ISTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istj-a with responsibility, order and reliable execution rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istj-a-vs-istj-t",
+      "target_url": "https://fermatmind.com/en/personality/istj-a-vs-istj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTJ-A vs ISTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ISTJ-A and ISTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ISTJ-A vs ISTJ-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTJ-A vs ISTJ-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ISTJ-A vs ISTJ-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ISTJ-A and ISTJ-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ISTJ-A and ISTJ-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTJ-A vs ISTJ-T: Traits, Careers, Love & Rarity",
+          "recommended": "ISTJ-A vs ISTJ-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTJ-A and ISTJ-T share the same ISTJ core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ISTJ-A vs ISTJ-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ISTJ core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ISTJ-A better than ISTJ-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ISTJ-A or ISTJ-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istj-a",
+            "anchor_text": "ISTJ-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istj-t",
+            "anchor_text": "ISTJ-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istj-a-vs-istj-t with responsibility, order and reliable execution rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istj-t",
+      "target_url": "https://fermatmind.com/en/personality/istj-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTJ-T Logistician Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISTJ-T Logistician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISTJ-T Logistician Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTJ-T Logistician Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISTJ-T Meaning: Turbulent Logistician Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISTJ-T Logistician personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISTJ-T through responsibility, order and reliable execution, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTJ-T Logistician Personality",
+          "recommended": "ISTJ-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTJ-T combines the ISTJ core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISTJ-T mean?",
+            "answer": "ISTJ-T combines the ISTJ core pattern with an Turbulent identity style, especially around responsibility, order and reliable execution.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISTJ-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISTJ-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISTJ-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istj-a",
+            "anchor_text": "ISTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A vs ISTJ-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istj-t with responsibility, order and reliable execution rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istp-a",
+      "target_url": "https://fermatmind.com/en/personality/istp-a",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-A Virtuoso Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISTP-A Virtuoso personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISTP-A Virtuoso Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-A Virtuoso Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISTP-A Meaning: Assertive Virtuoso Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISTP-A Virtuoso personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISTP-A through hands-on problem solving, autonomy and calm troubleshooting, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-A Virtuoso Personality",
+          "recommended": "ISTP-A Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-A combines the ISTP core pattern with an Assertive identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISTP-A mean?",
+            "answer": "ISTP-A combines the ISTP core pattern with an Assertive identity style, especially around hands-on problem solving, autonomy and calm troubleshooting.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISTP-A?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISTP-A strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISTP-A different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istp-t",
+            "anchor_text": "ISTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A vs ISTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istp-a with hands-on problem solving, autonomy and calm troubleshooting rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istp-a-vs-istp-t",
+      "target_url": "https://fermatmind.com/en/personality/istp-a-vs-istp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-A vs ISTP-T: Traits, Careers, Love & Rarity | FermatMind",
+        "description": "Compare ISTP-A and ISTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+        "h1": "ISTP-A vs ISTP-T: Traits, Careers, Love & Rarity",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-A vs ISTP-T: Traits, Careers, Love & Rarity | FermatMind",
+          "recommended": "ISTP-A vs ISTP-T: Confidence, Stress and Work Style | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Compare ISTP-A and ISTP-T traits, A/T differences, strengths, blind spots, relationships, career fit, rarity, and how to confirm your type with an MBTI test.",
+          "recommended": "Compare ISTP-A and ISTP-T by confidence, stress recovery, feedback style, work rhythm and relationship communication.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-A vs ISTP-T: Traits, Careers, Love & Rarity",
+          "recommended": "ISTP-A vs ISTP-T: Key Differences",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-A and ISTP-T share the same ISTP core. The useful difference is how the two A/T styles handle confidence, pressure, feedback and self-correction, not which one is better.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What is the main ISTP-A vs ISTP-T difference?",
+            "answer": "The main difference is usually confidence style, stress response, feedback processing and self-correction, not a change in the ISTP core.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is ISTP-A better than ISTP-T?",
+            "answer": "No. A/T describes style differences, not a ranking. Different contexts can reward steadiness, caution or revision in different ways.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "How can I tell whether I am ISTP-A or ISTP-T?",
+            "answer": "Look at your response to pressure, criticism, uncertainty and post-decision review rather than treating the label as a verdict.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Can this comparison decide my career path?",
+            "answer": "No. It can support work-style reflection, but it should not replace skills, experience, values or context.",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "Is A/T an official MBTI dimension?",
+            "answer": "This page treats A/T as an identity-style layer in FermatMind public profiles, not as an official native MBTI dimension.",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istp-a",
+            "anchor_text": "ISTP-A profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istp-t",
+            "anchor_text": "ISTP-T profile",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istp-a-vs-istp-t with hands-on problem solving, autonomy and calm troubleshooting rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/en/personality/istp-t",
+      "target_url": "https://fermatmind.com/en/personality/istp-t",
+      "framework": "mbti64",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-T Virtuoso Personality: Traits, Careers & Relationships | FermatMind",
+        "description": "Explore the ISTP-T Virtuoso personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+        "h1": "ISTP-T Virtuoso Personality",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-T Virtuoso Personality: Traits, Careers & Relationships | FermatMind",
+          "recommended": "ISTP-T Meaning: Turbulent Virtuoso Traits | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "Explore the ISTP-T Virtuoso personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.",
+          "recommended": "Understand ISTP-T through hands-on problem solving, autonomy and calm troubleshooting, strengths, blind spots, work style, relationships and self-check prompts.",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-T Virtuoso Personality",
+          "recommended": "ISTP-T Meaning",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-T combines the ISTP core pattern with an Turbulent identity style. Read it as a public profile for self-understanding, communication and work-style reflection, not as a career or relationship verdict.",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "What does ISTP-T mean?",
+            "answer": "ISTP-T combines the ISTP core pattern with an Turbulent identity style, especially around hands-on problem solving, autonomy and calm troubleshooting.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What work environment fits ISTP-T?",
+            "answer": "Use the profile to reflect on work rhythm, communication and environment fit, not to make a deterministic career decision.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "What are common ISTP-T strengths and blind spots?",
+            "answer": "Strengths and blind spots depend on context; the same style can help or hinder depending on team, pressure and task structure.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "How is ISTP-T different from the other A/T variant?",
+            "answer": "The practical difference is usually stress response, confidence stability, feedback processing and revision intensity.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "Can this page replace a test result?",
+            "answer": "No. This is a public explanation page. Personal interpretation should come from a completed test and full report context.",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/istp-a",
+            "anchor_text": "ISTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A vs ISTP-T",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI personality test",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five personality test",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /en/personality/istp-t with hands-on problem solving, autonomy and calm troubleshooting rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfj-a",
+      "target_url": "https://fermatmind.com/zh/personality/enfj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-A 主人公人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENFJ-A 主人公人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFJ-A 主人公人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-A 主人公人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENFJ-A 人格特点：人际带动、鼓励和共同方向 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENFJ-A 主人公人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENFJ-A 的人际带动、鼓励和共同方向、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-A 主人公人格",
+          "recommended": "ENFJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-A 是 ENFJ 核心加上 A 型身份风格的公开人格画像，通常会围绕人际带动、鼓励和共同方向展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFJ-A 人格特点是什么？",
+            "answer": "ENFJ-A 通常把 ENFJ 核心与 A 型身份风格结合起来，重点体现在人际带动、鼓励和共同方向。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfj-t",
+            "anchor_text": "ENFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A 与 ENFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfj-a with 人际带动、鼓励和共同方向 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfj-a-vs-enfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/enfj-a-vs-enfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-A 和 ENFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ENFJ-A 与 ENFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFJ-A 和 ENFJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-A 和 ENFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ENFJ-A vs ENFJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ENFJ-A 与 ENFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ENFJ-A 和 ENFJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-A 和 ENFJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ENFJ-A vs ENFJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-A 和 ENFJ-T 共享同一个 ENFJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFJ-A 和 ENFJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ENFJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ENFJ-A 比 ENFJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ENFJ-A 还是 ENFJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfj-a",
+            "anchor_text": "ENFJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfj-t",
+            "anchor_text": "ENFJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfj-a-vs-enfj-t with 人际带动、鼓励和共同方向 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/enfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFJ-T 主人公人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENFJ-T 主人公人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFJ-T 主人公人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFJ-T 主人公人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENFJ-T 人格特点：人际带动、鼓励和共同方向 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENFJ-T 主人公人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENFJ-T 的人际带动、鼓励和共同方向、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFJ-T 主人公人格",
+          "recommended": "ENFJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFJ-T 是 ENFJ 核心加上 T 型身份风格的公开人格画像，通常会围绕人际带动、鼓励和共同方向展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFJ-T 人格特点是什么？",
+            "answer": "ENFJ-T 通常把 ENFJ 核心与 T 型身份风格结合起来，重点体现在人际带动、鼓励和共同方向。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfj-a",
+            "anchor_text": "ENFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfj-a-vs-enfj-t",
+            "anchor_text": "ENFJ-A 与 ENFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfj-t with 人际带动、鼓励和共同方向 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfp-a",
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-A 竞选者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENFP-A 竞选者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFP-A 活动家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-A 竞选者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENFP-A 人格特点：可能性、人际连接和创意动力 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENFP-A 竞选者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENFP-A 的可能性、人际连接和创意动力、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-A 活动家人格",
+          "recommended": "ENFP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-A 是 ENFP 核心加上 A 型身份风格的公开人格画像，通常会围绕可能性、人际连接和创意动力展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFP-A 人格特点是什么？",
+            "answer": "ENFP-A 通常把 ENFP 核心与 A 型身份风格结合起来，重点体现在可能性、人际连接和创意动力。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfp-t",
+            "anchor_text": "ENFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A 与 ENFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfp-a with 可能性、人际连接和创意动力 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfp-a-vs-enfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/enfp-a-vs-enfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-A 和 ENFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ENFP-A 与 ENFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFP-A 和 ENFP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-A 和 ENFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ENFP-A vs ENFP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ENFP-A 与 ENFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ENFP-A 和 ENFP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-A 和 ENFP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ENFP-A vs ENFP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-A 和 ENFP-T 共享同一个 ENFP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFP-A 和 ENFP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ENFP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ENFP-A 比 ENFP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ENFP-A 还是 ENFP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfp-a",
+            "anchor_text": "ENFP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfp-t",
+            "anchor_text": "ENFP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfp-a-vs-enfp-t with 可能性、人际连接和创意动力 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/enfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/enfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENFP-T 竞选者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENFP-T 竞选者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENFP-T 竞选人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENFP-T 竞选者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENFP-T 人格特点：可能性、人际连接和创意动力 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENFP-T 竞选者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENFP-T 的可能性、人际连接和创意动力、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENFP-T 竞选人格",
+          "recommended": "ENFP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENFP-T 是 ENFP 核心加上 T 型身份风格的公开人格画像，通常会围绕可能性、人际连接和创意动力展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENFP-T 人格特点是什么？",
+            "answer": "ENFP-T 通常把 ENFP 核心与 T 型身份风格结合起来，重点体现在可能性、人际连接和创意动力。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENFP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/enfp-a",
+            "anchor_text": "ENFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/enfp-a-vs-enfp-t",
+            "anchor_text": "ENFP-A 与 ENFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/enfp-t with 可能性、人际连接和创意动力 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entj-a",
+      "target_url": "https://fermatmind.com/zh/personality/entj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-A 指挥官人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENTJ-A 指挥官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTJ-A 指挥官人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-A 指挥官人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENTJ-A 人格特点：领导、执行和系统决策 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENTJ-A 指挥官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENTJ-A 的领导、执行和系统决策、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-A 指挥官人格",
+          "recommended": "ENTJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-A 是 ENTJ 核心加上 A 型身份风格的公开人格画像，通常会围绕领导、执行和系统决策展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTJ-A 人格特点是什么？",
+            "answer": "ENTJ-A 通常把 ENTJ 核心与 A 型身份风格结合起来，重点体现在领导、执行和系统决策。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entj-t",
+            "anchor_text": "ENTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A 与 ENTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entj-a with 领导、执行和系统决策 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entj-a-vs-entj-t",
+      "target_url": "https://fermatmind.com/zh/personality/entj-a-vs-entj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-A 和 ENTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ENTJ-A 与 ENTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTJ-A 和 ENTJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-A 和 ENTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ENTJ-A vs ENTJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ENTJ-A 与 ENTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ENTJ-A 和 ENTJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-A 和 ENTJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ENTJ-A vs ENTJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-A 和 ENTJ-T 共享同一个 ENTJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTJ-A 和 ENTJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ENTJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ENTJ-A 比 ENTJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ENTJ-A 还是 ENTJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entj-a",
+            "anchor_text": "ENTJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entj-t",
+            "anchor_text": "ENTJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entj-a-vs-entj-t with 领导、执行和系统决策 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entj-t",
+      "target_url": "https://fermatmind.com/zh/personality/entj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTJ-T 指挥官人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENTJ-T 指挥官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTJ-T 指挥官人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTJ-T 指挥官人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENTJ-T 人格特点：领导、执行和系统决策 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENTJ-T 指挥官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENTJ-T 的领导、执行和系统决策、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTJ-T 指挥官人格",
+          "recommended": "ENTJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTJ-T 是 ENTJ 核心加上 T 型身份风格的公开人格画像，通常会围绕领导、执行和系统决策展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTJ-T 人格特点是什么？",
+            "answer": "ENTJ-T 通常把 ENTJ 核心与 T 型身份风格结合起来，重点体现在领导、执行和系统决策。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entj-a",
+            "anchor_text": "ENTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entj-a-vs-entj-t",
+            "anchor_text": "ENTJ-A 与 ENTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entj-t with 领导、执行和系统决策 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entp-a",
+      "target_url": "https://fermatmind.com/zh/personality/entp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-A 辩论家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENTP-A 辩论家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTP-A 辩论家人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-A 辩论家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENTP-A 人格特点：辩论、实验和想法验证 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENTP-A 辩论家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENTP-A 的辩论、实验和想法验证、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-A 辩论家人格",
+          "recommended": "ENTP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-A 是 ENTP 核心加上 A 型身份风格的公开人格画像，通常会围绕辩论、实验和想法验证展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTP-A 人格特点是什么？",
+            "answer": "ENTP-A 通常把 ENTP 核心与 A 型身份风格结合起来，重点体现在辩论、实验和想法验证。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entp-t",
+            "anchor_text": "ENTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A 与 ENTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entp-a with 辩论、实验和想法验证 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entp-a-vs-entp-t",
+      "target_url": "https://fermatmind.com/zh/personality/entp-a-vs-entp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-A 和 ENTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ENTP-A 与 ENTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTP-A 和 ENTP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-A 和 ENTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ENTP-A vs ENTP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ENTP-A 与 ENTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ENTP-A 和 ENTP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-A 和 ENTP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ENTP-A vs ENTP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-A 和 ENTP-T 共享同一个 ENTP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTP-A 和 ENTP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ENTP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ENTP-A 比 ENTP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ENTP-A 还是 ENTP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entp-a",
+            "anchor_text": "ENTP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entp-t",
+            "anchor_text": "ENTP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entp-a-vs-entp-t with 辩论、实验和想法验证 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/entp-t",
+      "target_url": "https://fermatmind.com/zh/personality/entp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ENTP-T 辩论家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ENTP-T 辩论家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ENTP-T 辩论家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ENTP-T 辩论家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ENTP-T 人格特点：辩论、实验和想法验证 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ENTP-T 辩论家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ENTP-T 的辩论、实验和想法验证、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ENTP-T 辩论家人格",
+          "recommended": "ENTP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ENTP-T 是 ENTP 核心加上 T 型身份风格的公开人格画像，通常会围绕辩论、实验和想法验证展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ENTP-T 人格特点是什么？",
+            "answer": "ENTP-T 通常把 ENTP 核心与 T 型身份风格结合起来，重点体现在辩论、实验和想法验证。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ENTP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/entp-a",
+            "anchor_text": "ENTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/entp-a-vs-entp-t",
+            "anchor_text": "ENTP-A 与 ENTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/entp-t with 辩论、实验和想法验证 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfj-a",
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-A 执政官人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESFJ-A 执政官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFJ-A 执政官人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-A 执政官人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESFJ-A 人格特点：支持、归属和实际协调 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESFJ-A 执政官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESFJ-A 的支持、归属和实际协调、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-A 执政官人格",
+          "recommended": "ESFJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-A 是 ESFJ 核心加上 A 型身份风格的公开人格画像，通常会围绕支持、归属和实际协调展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFJ-A 人格特点是什么？",
+            "answer": "ESFJ-A 通常把 ESFJ 核心与 A 型身份风格结合起来，重点体现在支持、归属和实际协调。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfj-t",
+            "anchor_text": "ESFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A 与 ESFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfj-a with 支持、归属和实际协调 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfj-a-vs-esfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/esfj-a-vs-esfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-A 和 ESFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ESFJ-A 与 ESFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFJ-A 和 ESFJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-A 和 ESFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ESFJ-A vs ESFJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ESFJ-A 与 ESFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ESFJ-A 和 ESFJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-A 和 ESFJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ESFJ-A vs ESFJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-A 和 ESFJ-T 共享同一个 ESFJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFJ-A 和 ESFJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ESFJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ESFJ-A 比 ESFJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ESFJ-A 还是 ESFJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfj-a",
+            "anchor_text": "ESFJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfj-t",
+            "anchor_text": "ESFJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfj-a-vs-esfj-t with 支持、归属和实际协调 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/esfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFJ-T 执政官人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESFJ-T 执政官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFJ-T 执政官人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFJ-T 执政官人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESFJ-T 人格特点：支持、归属和实际协调 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESFJ-T 执政官人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESFJ-T 的支持、归属和实际协调、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFJ-T 执政官人格",
+          "recommended": "ESFJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFJ-T 是 ESFJ 核心加上 T 型身份风格的公开人格画像，通常会围绕支持、归属和实际协调展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFJ-T 人格特点是什么？",
+            "answer": "ESFJ-T 通常把 ESFJ 核心与 T 型身份风格结合起来，重点体现在支持、归属和实际协调。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfj-a",
+            "anchor_text": "ESFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfj-a-vs-esfj-t",
+            "anchor_text": "ESFJ-A 与 ESFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfj-t with 支持、归属和实际协调 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfp-a",
+      "target_url": "https://fermatmind.com/zh/personality/esfp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-A 表演者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESFP-A 表演者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFP-A 表演者人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-A 表演者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESFP-A 人格特点：活力、现场感和共同体验 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESFP-A 表演者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESFP-A 的活力、现场感和共同体验、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-A 表演者人格",
+          "recommended": "ESFP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-A 是 ESFP 核心加上 A 型身份风格的公开人格画像，通常会围绕活力、现场感和共同体验展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFP-A 人格特点是什么？",
+            "answer": "ESFP-A 通常把 ESFP 核心与 A 型身份风格结合起来，重点体现在活力、现场感和共同体验。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfp-t",
+            "anchor_text": "ESFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A 与 ESFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfp-a with 活力、现场感和共同体验 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfp-a-vs-esfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/esfp-a-vs-esfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-A 和 ESFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ESFP-A 与 ESFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFP-A 和 ESFP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-A 和 ESFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ESFP-A vs ESFP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ESFP-A 与 ESFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ESFP-A 和 ESFP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-A 和 ESFP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ESFP-A vs ESFP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-A 和 ESFP-T 共享同一个 ESFP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFP-A 和 ESFP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ESFP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ESFP-A 比 ESFP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ESFP-A 还是 ESFP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfp-a",
+            "anchor_text": "ESFP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfp-t",
+            "anchor_text": "ESFP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfp-a-vs-esfp-t with 活力、现场感和共同体验 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/esfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/esfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESFP-T 表演者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESFP-T 表演者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESFP-T 表演者人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESFP-T 表演者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESFP-T 人格特点：活力、现场感和共同体验 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESFP-T 表演者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESFP-T 的活力、现场感和共同体验、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESFP-T 表演者人格",
+          "recommended": "ESFP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESFP-T 是 ESFP 核心加上 T 型身份风格的公开人格画像，通常会围绕活力、现场感和共同体验展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESFP-T 人格特点是什么？",
+            "answer": "ESFP-T 通常把 ESFP 核心与 T 型身份风格结合起来，重点体现在活力、现场感和共同体验。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESFP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/esfp-a",
+            "anchor_text": "ESFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/esfp-a-vs-esfp-t",
+            "anchor_text": "ESFP-A 与 ESFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/esfp-t with 活力、现场感和共同体验 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estj-a",
+      "target_url": "https://fermatmind.com/zh/personality/estj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-A 总经理人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESTJ-A 总经理人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTJ-A 总经理人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-A 总经理人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESTJ-A 人格特点：结构、决策和运营推进 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESTJ-A 总经理人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESTJ-A 的结构、决策和运营推进、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-A 总经理人格",
+          "recommended": "ESTJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-A 是 ESTJ 核心加上 A 型身份风格的公开人格画像，通常会围绕结构、决策和运营推进展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTJ-A 人格特点是什么？",
+            "answer": "ESTJ-A 通常把 ESTJ 核心与 A 型身份风格结合起来，重点体现在结构、决策和运营推进。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estj-t",
+            "anchor_text": "ESTJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A 与 ESTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estj-a with 结构、决策和运营推进 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estj-a-vs-estj-t",
+      "target_url": "https://fermatmind.com/zh/personality/estj-a-vs-estj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-A 和 ESTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ESTJ-A 与 ESTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTJ-A 和 ESTJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-A 和 ESTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ESTJ-A vs ESTJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ESTJ-A 与 ESTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ESTJ-A 和 ESTJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-A 和 ESTJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ESTJ-A vs ESTJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-A 和 ESTJ-T 共享同一个 ESTJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTJ-A 和 ESTJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ESTJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ESTJ-A 比 ESTJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ESTJ-A 还是 ESTJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estj-a",
+            "anchor_text": "ESTJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estj-t",
+            "anchor_text": "ESTJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estj-a-vs-estj-t with 结构、决策和运营推进 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estj-t",
+      "target_url": "https://fermatmind.com/zh/personality/estj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTJ-T 总经理人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESTJ-T 总经理人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTJ-T 总经理人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTJ-T 总经理人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESTJ-T 人格特点：结构、决策和运营推进 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESTJ-T 总经理人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESTJ-T 的结构、决策和运营推进、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTJ-T 总经理人格",
+          "recommended": "ESTJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTJ-T 是 ESTJ 核心加上 T 型身份风格的公开人格画像，通常会围绕结构、决策和运营推进展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTJ-T 人格特点是什么？",
+            "answer": "ESTJ-T 通常把 ESTJ 核心与 T 型身份风格结合起来，重点体现在结构、决策和运营推进。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estj-a",
+            "anchor_text": "ESTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estj-a-vs-estj-t",
+            "anchor_text": "ESTJ-A 与 ESTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estj-t with 结构、决策和运营推进 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estp-a",
+      "target_url": "https://fermatmind.com/zh/personality/estp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-A 企业家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESTP-A 企业家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTP-A 企业家人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-A 企业家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESTP-A 人格特点：行动、机会和现场应变 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESTP-A 企业家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESTP-A 的行动、机会和现场应变、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-A 企业家人格",
+          "recommended": "ESTP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-A 是 ESTP 核心加上 A 型身份风格的公开人格画像，通常会围绕行动、机会和现场应变展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTP-A 人格特点是什么？",
+            "answer": "ESTP-A 通常把 ESTP 核心与 A 型身份风格结合起来，重点体现在行动、机会和现场应变。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estp-t",
+            "anchor_text": "ESTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A 与 ESTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estp-a with 行动、机会和现场应变 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estp-a-vs-estp-t",
+      "target_url": "https://fermatmind.com/zh/personality/estp-a-vs-estp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-A 和 ESTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ESTP-A 与 ESTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTP-A 和 ESTP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-A 和 ESTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ESTP-A vs ESTP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ESTP-A 与 ESTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ESTP-A 和 ESTP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-A 和 ESTP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ESTP-A vs ESTP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-A 和 ESTP-T 共享同一个 ESTP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTP-A 和 ESTP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ESTP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ESTP-A 比 ESTP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ESTP-A 还是 ESTP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estp-a",
+            "anchor_text": "ESTP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estp-t",
+            "anchor_text": "ESTP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estp-a-vs-estp-t with 行动、机会和现场应变 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/estp-t",
+      "target_url": "https://fermatmind.com/zh/personality/estp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ESTP-T 企业家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ESTP-T 企业家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ESTP-T 企业家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ESTP-T 企业家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ESTP-T 人格特点：行动、机会和现场应变 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ESTP-T 企业家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ESTP-T 的行动、机会和现场应变、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ESTP-T 企业家人格",
+          "recommended": "ESTP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ESTP-T 是 ESTP 核心加上 T 型身份风格的公开人格画像，通常会围绕行动、机会和现场应变展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ESTP-T 人格特点是什么？",
+            "answer": "ESTP-T 通常把 ESTP 核心与 T 型身份风格结合起来，重点体现在行动、机会和现场应变。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ESTP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/estp-a",
+            "anchor_text": "ESTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/estp-a-vs-estp-t",
+            "anchor_text": "ESTP-A 与 ESTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/estp-t with 行动、机会和现场应变 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/infj-a",
+      "target_url": "https://fermatmind.com/zh/personality/infj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-A 提倡者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 INFJ-A 提倡者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INFJ-A 提倡者人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-A 提倡者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "INFJ-A 人格特点：洞察、价值感和长期意义 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 INFJ-A 提倡者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 INFJ-A 的洞察、价值感和长期意义、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-A 提倡者人格",
+          "recommended": "INFJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-A 是 INFJ 核心加上 A 型身份风格的公开人格画像，通常会围绕洞察、价值感和长期意义展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INFJ-A 人格特点是什么？",
+            "answer": "INFJ-A 通常把 INFJ 核心与 A 型身份风格结合起来，重点体现在洞察、价值感和长期意义。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infj-t",
+            "anchor_text": "INFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A 与 INFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/infj-a with 洞察、价值感和长期意义 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/infj-a-vs-infj-t",
+      "target_url": "https://fermatmind.com/zh/personality/infj-a-vs-infj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-A 和 INFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 INFJ-A 与 INFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INFJ-A 和 INFJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-A 和 INFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "INFJ-A vs INFJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 INFJ-A 与 INFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 INFJ-A 和 INFJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-A 和 INFJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "INFJ-A vs INFJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-A 和 INFJ-T 共享同一个 INFJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INFJ-A 和 INFJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 INFJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "INFJ-A 比 INFJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 INFJ-A 还是 INFJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infj-a",
+            "anchor_text": "INFJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infj-t",
+            "anchor_text": "INFJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/infj-a-vs-infj-t with 洞察、价值感和长期意义 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/infj-t",
+      "target_url": "https://fermatmind.com/zh/personality/infj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFJ-T 提倡者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 INFJ-T 提倡者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INFJ-T 提倡者人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFJ-T 提倡者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "INFJ-T 人格特点：洞察、价值感和长期意义 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 INFJ-T 提倡者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 INFJ-T 的洞察、价值感和长期意义、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFJ-T 提倡者人格",
+          "recommended": "INFJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFJ-T 是 INFJ 核心加上 T 型身份风格的公开人格画像，通常会围绕洞察、价值感和长期意义展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INFJ-T 人格特点是什么？",
+            "answer": "INFJ-T 通常把 INFJ 核心与 T 型身份风格结合起来，重点体现在洞察、价值感和长期意义。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infj-a",
+            "anchor_text": "INFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infj-a-vs-infj-t",
+            "anchor_text": "INFJ-A 与 INFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/infj-t with 洞察、价值感和长期意义 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/infp-a",
+      "target_url": "https://fermatmind.com/zh/personality/infp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFP-A 调停者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 INFP-A 调停者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INFP-A 调停者人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFP-A 调停者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "INFP-A 人格特点：价值观、同理心和个人意义 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 INFP-A 调停者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 INFP-A 的价值观、同理心和个人意义、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFP-A 调停者人格",
+          "recommended": "INFP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFP-A 是 INFP 核心加上 A 型身份风格的公开人格画像，通常会围绕价值观、同理心和个人意义展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INFP-A 人格特点是什么？",
+            "answer": "INFP-A 通常把 INFP 核心与 A 型身份风格结合起来，重点体现在价值观、同理心和个人意义。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INFP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infp-t",
+            "anchor_text": "INFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infp-a-vs-infp-t",
+            "anchor_text": "INFP-A 与 INFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/infp-a with 价值观、同理心和个人意义 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/infp-a-vs-infp-t",
+      "target_url": "https://fermatmind.com/zh/personality/infp-a-vs-infp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INFP-A 和 INFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 INFP-A 与 INFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INFP-A 和 INFP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INFP-A 和 INFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "INFP-A vs INFP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 INFP-A 与 INFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 INFP-A 和 INFP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INFP-A 和 INFP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "INFP-A vs INFP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INFP-A 和 INFP-T 共享同一个 INFP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INFP-A 和 INFP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 INFP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "INFP-A 比 INFP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 INFP-A 还是 INFP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/infp-a",
+            "anchor_text": "INFP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/infp-t",
+            "anchor_text": "INFP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/infp-a-vs-infp-t with 价值观、同理心和个人意义 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/intj-a-vs-intj-t",
+      "target_url": "https://fermatmind.com/zh/personality/intj-a-vs-intj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTJ-A 和 INTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 INTJ-A 与 INTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INTJ-A 和 INTJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTJ-A 和 INTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "INTJ-A vs INTJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 INTJ-A 与 INTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 INTJ-A 和 INTJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTJ-A 和 INTJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "INTJ-A vs INTJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTJ-A 和 INTJ-T 共享同一个 INTJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INTJ-A 和 INTJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 INTJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "INTJ-A 比 INTJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 INTJ-A 还是 INTJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intj-a",
+            "anchor_text": "INTJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intj-t",
+            "anchor_text": "INTJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/intj-a-vs-intj-t with 战略规划、独立判断和长期目标 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/intp-a",
+      "target_url": "https://fermatmind.com/zh/personality/intp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTP-A 逻辑学家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 INTP-A 逻辑学家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INTP-A 逻辑学家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTP-A 逻辑学家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "INTP-A 人格特点：分析、好奇心和独立解题 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 INTP-A 逻辑学家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 INTP-A 的分析、好奇心和独立解题、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTP-A 逻辑学家人格",
+          "recommended": "INTP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTP-A 是 INTP 核心加上 A 型身份风格的公开人格画像，通常会围绕分析、好奇心和独立解题展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INTP-A 人格特点是什么？",
+            "answer": "INTP-A 通常把 INTP 核心与 A 型身份风格结合起来，重点体现在分析、好奇心和独立解题。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intp-t",
+            "anchor_text": "INTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A 与 INTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/intp-a with 分析、好奇心和独立解题 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/intp-a-vs-intp-t",
+      "target_url": "https://fermatmind.com/zh/personality/intp-a-vs-intp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTP-A 和 INTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 INTP-A 与 INTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INTP-A 和 INTP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTP-A 和 INTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "INTP-A vs INTP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 INTP-A 与 INTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 INTP-A 和 INTP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTP-A 和 INTP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "INTP-A vs INTP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTP-A 和 INTP-T 共享同一个 INTP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INTP-A 和 INTP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 INTP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "INTP-A 比 INTP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 INTP-A 还是 INTP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intp-a",
+            "anchor_text": "INTP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intp-t",
+            "anchor_text": "INTP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/intp-a-vs-intp-t with 分析、好奇心和独立解题 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/intp-t",
+      "target_url": "https://fermatmind.com/zh/personality/intp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "INTP-T 逻辑学家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 INTP-T 逻辑学家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "INTP-T 逻辑学家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "INTP-T 逻辑学家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "INTP-T 人格特点：分析、好奇心和独立解题 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 INTP-T 逻辑学家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 INTP-T 的分析、好奇心和独立解题、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "INTP-T 逻辑学家人格",
+          "recommended": "INTP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "INTP-T 是 INTP 核心加上 T 型身份风格的公开人格画像，通常会围绕分析、好奇心和独立解题展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "INTP-T 人格特点是什么？",
+            "answer": "INTP-T 通常把 INTP 核心与 T 型身份风格结合起来，重点体现在分析、好奇心和独立解题。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "INTP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/intp-a",
+            "anchor_text": "INTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/intp-a-vs-intp-t",
+            "anchor_text": "INTP-A 与 INTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/intp-t with 分析、好奇心和独立解题 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfj-a",
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-A 守卫者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISFJ-A 守卫者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFJ-A 守护者人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-A 守卫者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISFJ-A 人格特点：照顾、经验记忆和可靠支持 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISFJ-A 守卫者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISFJ-A 的照顾、经验记忆和可靠支持、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-A 守护者人格",
+          "recommended": "ISFJ-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-A 是 ISFJ 核心加上 A 型身份风格的公开人格画像，通常会围绕照顾、经验记忆和可靠支持展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFJ-A 人格特点是什么？",
+            "answer": "ISFJ-A 通常把 ISFJ 核心与 A 型身份风格结合起来，重点体现在照顾、经验记忆和可靠支持。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfj-t",
+            "anchor_text": "ISFJ-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A 与 ISFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfj-a with 照顾、经验记忆和可靠支持 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfj-a-vs-isfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/isfj-a-vs-isfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-A 和 ISFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ISFJ-A 与 ISFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFJ-A 和 ISFJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-A 和 ISFJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ISFJ-A vs ISFJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ISFJ-A 与 ISFJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ISFJ-A 和 ISFJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-A 和 ISFJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ISFJ-A vs ISFJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-A 和 ISFJ-T 共享同一个 ISFJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFJ-A 和 ISFJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ISFJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ISFJ-A 比 ISFJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ISFJ-A 还是 ISFJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfj-a",
+            "anchor_text": "ISFJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfj-t",
+            "anchor_text": "ISFJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfj-a-vs-isfj-t with 照顾、经验记忆和可靠支持 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfj-t",
+      "target_url": "https://fermatmind.com/zh/personality/isfj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFJ-T 守卫者人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISFJ-T 守卫者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFJ-T 守护者人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFJ-T 守卫者人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISFJ-T 人格特点：照顾、经验记忆和可靠支持 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISFJ-T 守卫者人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISFJ-T 的照顾、经验记忆和可靠支持、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFJ-T 守护者人格",
+          "recommended": "ISFJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFJ-T 是 ISFJ 核心加上 T 型身份风格的公开人格画像，通常会围绕照顾、经验记忆和可靠支持展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFJ-T 人格特点是什么？",
+            "answer": "ISFJ-T 通常把 ISFJ 核心与 T 型身份风格结合起来，重点体现在照顾、经验记忆和可靠支持。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfj-a",
+            "anchor_text": "ISFJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfj-a-vs-isfj-t",
+            "anchor_text": "ISFJ-A 与 ISFJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfj-t with 照顾、经验记忆和可靠支持 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfp-a",
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-A 探险家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISFP-A 探险家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFP-A 探险家人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-A 探险家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISFP-A 人格特点：审美、体验和安静表达 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISFP-A 探险家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISFP-A 的审美、体验和安静表达、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-A 探险家人格",
+          "recommended": "ISFP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-A 是 ISFP 核心加上 A 型身份风格的公开人格画像，通常会围绕审美、体验和安静表达展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFP-A 人格特点是什么？",
+            "answer": "ISFP-A 通常把 ISFP 核心与 A 型身份风格结合起来，重点体现在审美、体验和安静表达。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfp-t",
+            "anchor_text": "ISFP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A 与 ISFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfp-a with 审美、体验和安静表达 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfp-a-vs-isfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/isfp-a-vs-isfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-A 和 ISFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ISFP-A 与 ISFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFP-A 和 ISFP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-A 和 ISFP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ISFP-A vs ISFP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ISFP-A 与 ISFP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ISFP-A 和 ISFP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-A 和 ISFP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ISFP-A vs ISFP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-A 和 ISFP-T 共享同一个 ISFP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFP-A 和 ISFP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ISFP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ISFP-A 比 ISFP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ISFP-A 还是 ISFP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfp-a",
+            "anchor_text": "ISFP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfp-t",
+            "anchor_text": "ISFP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfp-a-vs-isfp-t with 审美、体验和安静表达 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/isfp-t",
+      "target_url": "https://fermatmind.com/zh/personality/isfp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISFP-T 探险家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISFP-T 探险家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISFP-T 探险家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISFP-T 探险家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISFP-T 人格特点：审美、体验和安静表达 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISFP-T 探险家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISFP-T 的审美、体验和安静表达、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISFP-T 探险家人格",
+          "recommended": "ISFP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISFP-T 是 ISFP 核心加上 T 型身份风格的公开人格画像，通常会围绕审美、体验和安静表达展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISFP-T 人格特点是什么？",
+            "answer": "ISFP-T 通常把 ISFP 核心与 T 型身份风格结合起来，重点体现在审美、体验和安静表达。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISFP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/isfp-a",
+            "anchor_text": "ISFP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/isfp-a-vs-isfp-t",
+            "anchor_text": "ISFP-A 与 ISFP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/isfp-t with 审美、体验和安静表达 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/istj-a-vs-istj-t",
+      "target_url": "https://fermatmind.com/zh/personality/istj-a-vs-istj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTJ-A 和 ISTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ISTJ-A 与 ISTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISTJ-A 和 ISTJ-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTJ-A 和 ISTJ-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ISTJ-A vs ISTJ-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ISTJ-A 与 ISTJ-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ISTJ-A 和 ISTJ-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTJ-A 和 ISTJ-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ISTJ-A vs ISTJ-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTJ-A 和 ISTJ-T 共享同一个 ISTJ 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISTJ-A 和 ISTJ-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ISTJ 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ISTJ-A 比 ISTJ-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ISTJ-A 还是 ISTJ-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istj-a",
+            "anchor_text": "ISTJ-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istj-t",
+            "anchor_text": "ISTJ-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/istj-a-vs-istj-t with 责任、秩序和稳定执行 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/istj-t",
+      "target_url": "https://fermatmind.com/zh/personality/istj-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTJ-T 物流师人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISTJ-T 物流师人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISTJ-T 物流师人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTJ-T 物流师人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISTJ-T 人格特点：责任、秩序和稳定执行 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISTJ-T 物流师人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISTJ-T 的责任、秩序和稳定执行、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTJ-T 物流师人格",
+          "recommended": "ISTJ-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTJ-T 是 ISTJ 核心加上 T 型身份风格的公开人格画像，通常会围绕责任、秩序和稳定执行展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISTJ-T 人格特点是什么？",
+            "answer": "ISTJ-T 通常把 ISTJ 核心与 T 型身份风格结合起来，重点体现在责任、秩序和稳定执行。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTJ-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTJ-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTJ-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istj-a",
+            "anchor_text": "ISTJ-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istj-a-vs-istj-t",
+            "anchor_text": "ISTJ-A 与 ISTJ-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/istj-t with 责任、秩序和稳定执行 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/istp-a",
+      "target_url": "https://fermatmind.com/zh/personality/istp-a",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-A 鉴赏家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISTP-A 鉴赏家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISTP-A 鉴赏家人格",
+        "quick_answer": "",
+        "faq_count": 17,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-A 鉴赏家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISTP-A 人格特点：动手解题、自主和冷静排障 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISTP-A 鉴赏家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISTP-A 的动手解题、自主和冷静排障、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-A 鉴赏家人格",
+          "recommended": "ISTP-A 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-A 是 ISTP 核心加上 A 型身份风格的公开人格画像，通常会围绕动手解题、自主和冷静排障展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISTP-A 人格特点是什么？",
+            "answer": "ISTP-A 通常把 ISTP 核心与 A 型身份风格结合起来，重点体现在动手解题、自主和冷静排障。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-A 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-A 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-A 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istp-t",
+            "anchor_text": "ISTP-T",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A 与 ISTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/istp-a with 动手解题、自主和冷静排障 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/istp-a-vs-istp-t",
+      "target_url": "https://fermatmind.com/zh/personality/istp-a-vs-istp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-A 和 ISTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+        "description": "对比 ISTP-A 与 ISTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISTP-A 和 ISTP-T 区别：特点、职业、爱情与稀有度",
+        "quick_answer": "",
+        "faq_count": 13,
+        "internal_link_count": 38
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "a_vs_t_comparison_structure",
+          "source_url": "https://fermatmind.com/en/personality/intj-a-vs-intj-t",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-A 和 ISTP-T 区别：特点、职业、爱情与稀有度 | FermatMind",
+          "recommended": "ISTP-A vs ISTP-T：差异、压力反应与关系沟通 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "对比 ISTP-A 与 ISTP-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "比较 ISTP-A 和 ISTP-T 在自信、压力恢复、反馈处理、工作节奏和关系沟通上的差异。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-A 和 ISTP-T 区别：特点、职业、爱情与稀有度",
+          "recommended": "ISTP-A vs ISTP-T：关键差异",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-A 和 ISTP-T 共享同一个 ISTP 核心；差异主要体现在自信稳定度、压力反应、反馈处理和自我修正方式。这个页面适合用来比较两种 A/T 风格，而不是判断哪一种更好。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISTP-A 和 ISTP-T 最大差异是什么？",
+            "answer": "主要差异通常在自信、压力反应、反馈处理和自我修正节奏上，而不是 ISTP 核心是否改变。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "ISTP-A 比 ISTP-T 更好吗？",
+            "answer": "不是。A/T 是风格差异，不是优劣等级。不同场景会奖励不同的稳定性、谨慎度和修正能力。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "如何判断自己更像 ISTP-A 还是 ISTP-T？",
+            "answer": "观察你在压力、批评、选择后复盘和不确定环境中的自然反应，比只看标签更可靠。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "这个比较可以用于职业决定吗？",
+            "answer": "不建议直接用于职业决定。它可以帮助你理解工作节奏和沟通偏好，但不能替代能力、经验和环境判断。",
+            "reason": "Covers comparison intent and claim boundary."
+          },
+          {
+            "question": "A/T 是官方 MBTI 维度吗？",
+            "answer": "这里把 A/T 作为 FermatMind 公共画像中的身份风格层来解释，不把它表述为官方 MBTI 原生维度。",
+            "reason": "Covers comparison intent and claim boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istp-a",
+            "anchor_text": "ISTP-A 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istp-t",
+            "anchor_text": "ISTP-T 人格",
+            "reason": "Return comparison readers to the underlying A/T variant profile pages.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/istp-a-vs-istp-t with 动手解题、自主和冷静排障 rather than generic MBTI copy.",
+          "Comparison copy must compare A and T directly; do not paste two variant profiles together.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    },
+    {
+      "recommendation_id": "mbti64-agent-expansion-88:/zh/personality/istp-t",
+      "target_url": "https://fermatmind.com/zh/personality/istp-t",
+      "framework": "mbti64",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "live_html_surface_fetch",
+        "reference_pack": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "docs/seo/personality/mbti64-optimized-pilot-reference-pack-2026-06-21.json"
+      },
+      "current_surface": {
+        "title": "ISTP-T 鉴赏家人格：特点、爱情、职业与适合工作 | FermatMind",
+        "description": "了解 ISTP-T 鉴赏家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+        "h1": "ISTP-T 探险家人格",
+        "quick_answer": "",
+        "faq_count": 16,
+        "internal_link_count": 51
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC page/query evidence was not available in repo artifacts for the 88-page expansion at generation time."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "variant_profile_structure",
+          "source_url": "https://fermatmind.com/zh/personality/istj-a",
+          "how_used": "Used for section purpose, QA boundary and internal-link pattern only; wording must not be copied verbatim."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "ISTP-T 鉴赏家人格：特点、爱情、职业与适合工作 | FermatMind",
+          "recommended": "ISTP-T 人格特点：动手解题、自主和冷静排障 | FermatMind",
+          "reason": "Align title with type, A/T intent and single-brand suffix pattern from the optimized pilot."
+        },
+        "description": {
+          "current": "了解 ISTP-T 鉴赏家人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。",
+          "recommended": "系统了解 ISTP-T 的动手解题、自主和冷静排障、优势盲点、职业工作风格、关系沟通和自我校准建议。",
+          "reason": "Make the SERP description answer the page intent while preserving method boundaries."
+        },
+        "h1": {
+          "current": "ISTP-T 探险家人格",
+          "recommended": "ISTP-T 人格特点",
+          "reason": "Keep H1 concise and aligned with the canonical page query."
+        },
+        "quick_answer": {
+          "current": "",
+          "recommended": "ISTP-T 是 ISTP 核心加上 T 型身份风格的公开人格画像，通常会围绕动手解题、自主和冷静排障展开。它适合用于自我理解和沟通校准，不适合作为职业或关系结论。",
+          "reason": "Add an answer-first summary that distinguishes this page without deterministic claims."
+        },
+        "faq": [
+          {
+            "question": "ISTP-T 人格特点是什么？",
+            "answer": "ISTP-T 通常把 ISTP 核心与 T 型身份风格结合起来，重点体现在动手解题、自主和冷静排障。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-T 适合什么工作环境？",
+            "answer": "更适合讨论工作节奏、沟通方式和环境偏好，不能直接推出职业结论或招聘判断。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-T 的优势和盲点是什么？",
+            "answer": "优势和盲点需要结合具体情境看待；同一种风格在不同团队、压力和任务结构中会有不同表现。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "ISTP-T 和另一种 A/T 有什么不同？",
+            "answer": "主要看压力反应、自信稳定度、反馈处理和复盘强度，而不是人格核心是否完全不同。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          },
+          {
+            "question": "这个页面可以替代测试结果吗？",
+            "answer": "不能。它是公共解释页，适合先理解概念；个人结果仍应以正式测试和完整报告为准。",
+            "reason": "Covers variant meaning, work-style reflection and boundary."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/istp-a",
+            "anchor_text": "ISTP-A",
+            "reason": "Connect A/T sibling pages so readers can compare confidence-style variants without leaving the type cluster.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/istp-a-vs-istp-t",
+            "anchor_text": "ISTP-A 与 ISTP-T 对比",
+            "reason": "Connect variant pages to the dedicated A-vs-T comparison page for the same MBTI code.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "anchor_text": "MBTI 人格测试",
+            "reason": "Connect organic readers to the safe public MBTI test route.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Offer a dimensional-model cross-check without private result routes.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Differentiate /zh/personality/istp-t with 动手解题、自主和冷静排障 rather than generic MBTI copy.",
+          "Variant copy must describe this A/T pole and link to the sibling variant plus comparison page.",
+          "Keep A/T as a public identity-style layer; do not state that it is official MBTI."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "draft_recommendation"
+    }
+  ],
+  "blockers": [],
+  "warnings": [],
+  "recommended_next_task": "PERSONALITY-AGENT-QA-GATES-01"
+}

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -1,0 +1,605 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PILOT_PATHS = [
+        '/en/personality/intj-a-vs-intj-t',
+        '/zh/personality/istj-a',
+        '/en/personality/intp-a-vs-intp-t',
+        '/zh/personality/infp-t',
+        '/en/personality/intj-a',
+        '/en/personality/intj-t',
+        '/zh/personality/intj-a',
+        '/zh/personality/intj-t',
+    ];
+
+    public function test_dry_run_plans_eighty_eight_projection_drafts_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(88, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(30, $payload['comparison_row_count']);
+        $this->assertSame(88, $payload['would_create_revision_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_write_creates_eighty_eight_draft_revisions_without_changing_live_records(): void
+    {
+        $targets = $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFJ-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(88, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame(30, PersonalityProfileRevision::query()->count());
+        $this->assertSame(58, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $comparison = PersonalityProfileRevision::query()
+            ->where('profile_id', (int) $targets['en|ENFJ']->id)
+            ->firstOrFail();
+        $variant = PersonalityProfileVariantRevision::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|ENFJ-A']->id)
+            ->firstOrFail();
+
+        $this->assertProjectionSnapshot($comparison->snapshot_json);
+        $this->assertProjectionSnapshot($variant->snapshot_json);
+    }
+
+    public function test_second_write_is_idempotent_for_same_source_package_hash(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $firstExit = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(88, $payload['skipped_existing_count']);
+        $this->assertSame(30, PersonalityProfileRevision::query()->count());
+        $this->assertSame(58, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_changed_source_hash_creates_next_projection_revision_version(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $mutatedPackage = $package;
+        $mutatedPackage['generated_at'] = '2026-06-21T00:00:01Z';
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $this->validQa());
+        [$mutatedPackagePath] = $this->writeArtifacts($mutatedPackage, $this->validQa());
+
+        $firstExit = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($mutatedPackagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(88, $payload['created_revision_count']);
+        $this->assertSame(60, PersonalityProfileRevision::query()->count());
+        $this->assertSame(116, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_missing_required_write_flag_fails_closed_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        unset($options['--no-search-release']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertStringContainsString('--no-search-release is required', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_missing_target_blocks_entire_write_batch(): void
+    {
+        $this->seedAllTargets(skip: ['en|ENFJ-A']);
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('target_not_found', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_forbidden_private_route_pattern_is_rejected_before_writes(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $package['recommendations'][0]['recommendations']['internal_links'][] = [
+            'href' => '/results/lookup',
+            'anchor_text' => 'Forbidden',
+            'role' => 'forbidden',
+            'safe_public_route' => false,
+        ];
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('forbidden_public_route_pattern_present', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_qa_not_pass_blocks_writes(): void
+    {
+        $this->seedAllTargets();
+        $qa = $this->validQa();
+        $qa['final_decision'] = 'NO_GO_BLOCKED_BY_QA';
+        $qa['summary']['blocked_count'] = 1;
+        $qa['blockers'] = ['fixture blocker'];
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $qa);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('qa_not_ready_for_cms_draft', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    /**
+     * @return array<string,PersonalityProfile|PersonalityProfileVariant>
+     */
+    private function seedAllTargets(array $skip = []): array
+    {
+        $targets = [];
+        foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $profile = $this->createProfile($locale, $typeCode);
+                $targets[$locale.'|'.$typeCode] = $profile;
+
+                foreach (['A', 'T'] as $variantCode) {
+                    $runtimeTypeCode = $typeCode.'-'.$variantCode;
+                    if (in_array($locale.'|'.$runtimeTypeCode, $skip, true)) {
+                        continue;
+                    }
+
+                    $targets[$locale.'|'.$runtimeTypeCode] = $this->createVariant($profile, $runtimeTypeCode);
+                }
+            }
+        }
+
+        return $targets;
+    }
+
+    private function createProfile(string $locale, string $typeCode): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' fixture',
+            'type_name' => $typeCode,
+            'nickname' => $typeCode,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => $locale === 'zh-CN' ? $typeCode.' 类型摘要' : $typeCode.' type summary',
+            'hero_kicker' => $typeCode,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function profileLiveState(PersonalityProfile $profile): array
+    {
+        $fresh = $profile->fresh();
+        $this->assertInstanceOf(PersonalityProfile::class, $fresh);
+
+        return [
+            'status' => (string) $fresh->status,
+            'is_public' => (bool) $fresh->is_public,
+            'is_indexable' => (bool) $fresh->is_indexable,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function variantLiveState(PersonalityProfileVariant $variant): array
+    {
+        $fresh = $variant->fresh();
+        $this->assertInstanceOf(PersonalityProfileVariant::class, $fresh);
+
+        return [
+            'is_published' => (bool) $fresh->is_published,
+            'published_at' => $fresh->published_at?->toJSON(),
+        ];
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function liveSurfaceCounts(): array
+    {
+        return [
+            'profile_sections' => PersonalityProfileSection::query()->count(),
+            'variant_sections' => PersonalityProfileVariantSection::query()->count(),
+            'profile_seo_meta' => PersonalityProfileSeoMeta::query()->count(),
+            'variant_seo_meta' => PersonalityProfileVariantSeoMeta::query()->count(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $snapshot
+     */
+    private function assertProjectionSnapshot(array $snapshot): void
+    {
+        $this->assertArrayHasKey('mbti64_agent_projection_draft_v1', $snapshot);
+        $payload = $snapshot['mbti64_agent_projection_draft_v1'];
+        $this->assertSame('MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01', $payload['source']['artifact']);
+        $this->assertSame('PASS_READY_FOR_CMS_DRAFT', $payload['source']['qa_final_decision']);
+        $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['title']);
+        $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['description']);
+        $this->assertNotSame('', $payload['first_class_draft_fields']['seo']['h1']);
+        $this->assertNotSame('', $payload['first_class_draft_fields']['content']['quick_answer']);
+        $this->assertCount(5, $payload['first_class_draft_fields']['faq']);
+        $this->assertNotEmpty($payload['first_class_draft_fields']['internal_links']);
+        $this->assertFalse((bool) $payload['safety_holds']['publish_attempted']);
+        $this->assertFalse((bool) $payload['safety_holds']['index_attempted']);
+        $this->assertFalse((bool) $payload['safety_holds']['sitemap_llms_release_attempted']);
+        $this->assertFalse((bool) $payload['safety_holds']['search_release_attempted']);
+        $this->assertFalse((bool) $payload['safety_holds']['runtime_content_updated']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $recommendations = [];
+        foreach ($this->targetPaths() as $path) {
+            $recommendations[] = $this->recommendation($path);
+        }
+
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01',
+            'version' => 'mbti64.agent_expansion_88_recommendations.v1',
+            'generated_at' => '2026-06-21T00:00:00Z',
+            'status' => 'pass_ready_for_qa_gates',
+            'summary' => [
+                'recommendation_count' => 88,
+                'variant_pages' => 58,
+                'comparison_pages' => 30,
+                'pilot_urls_excluded' => 8,
+                'gsc_evidence_state' => 'GSC_EVIDENCE_PENDING',
+                'qa_gate_required_count' => 8,
+            ],
+            'recommendations' => $recommendations,
+            'blockers' => [],
+            'warnings' => ['GSC_EVIDENCE_PENDING'],
+            'recommended_next_task' => 'PERSONALITY-AGENT-QA-GATES-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validQa(): array
+    {
+        $pageResults = [];
+        foreach ($this->targetPaths() as $path) {
+            $pageResults[] = [
+                'target_url' => 'https://fermatmind.com'.$path,
+                'locale' => str_starts_with($path, '/zh/') ? 'zh-CN' : 'en',
+                'page_type' => str_contains($path, '-a-vs-') ? 'comparison' : 'variant',
+                'gates' => [
+                    'schema_validation' => 'pass',
+                    'trademark_claim_gate' => 'pass',
+                    'claim_risk_gate' => 'pass',
+                    'duplicate_template_gate' => 'pass',
+                    'private_route_gate' => 'pass',
+                    'result_page_leakage_gate' => 'pass',
+                    'seo_projection_gate' => 'pass',
+                    'bilingual_consistency_gate' => 'pass',
+                ],
+                'blockers' => [],
+                'warnings' => ['GSC_EVIDENCE_PENDING'],
+                'decision' => 'PASS_READY_FOR_CMS_DRAFT',
+            ];
+        }
+
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01',
+            'generated_at' => '2026-06-21T00:00:00Z',
+            'status' => 'pass_ready_for_cms_draft',
+            'input_artifact' => 'docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json',
+            'summary' => [
+                'checked_recommendation_count' => 88,
+                'pass_ready_for_cms_draft_count' => 88,
+                'blocked_count' => 0,
+                'warning_count' => 1,
+            ],
+            'page_results' => $pageResults,
+            'blockers' => [],
+            'warnings' => ['GSC_EVIDENCE_PENDING'],
+            'final_decision' => 'PASS_READY_FOR_CMS_DRAFT',
+            'recommended_next_task' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetPaths(): array
+    {
+        $paths = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $lower = strtolower($typeCode);
+                $comparison = '/'.$prefix.'/personality/'.$lower.'-a-vs-'.$lower.'-t';
+                if (! in_array($comparison, self::PILOT_PATHS, true)) {
+                    $paths[] = $comparison;
+                }
+                foreach (['a', 't'] as $variant) {
+                    $path = '/'.$prefix.'/personality/'.$lower.'-'.$variant;
+                    if (! in_array($path, self::PILOT_PATHS, true)) {
+                        $paths[] = $path;
+                    }
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $path): array
+    {
+        $locale = str_starts_with($path, '/zh/') ? 'zh-CN' : 'en';
+        $slug = basename($path);
+        $pageType = str_contains($path, '-a-vs-') ? 'comparison' : 'variant';
+        $title = $locale === 'zh-CN'
+            ? strtoupper(substr($slug, 0, 4)).' 页面含义 | FermatMind'
+            : strtoupper(substr($slug, 0, 4)).' Meaning Guide | FermatMind';
+
+        return [
+            'recommendation_id' => 'fixture:'.$path,
+            'target_url' => 'https://fermatmind.com'.$path,
+            'framework' => 'mbti64',
+            'locale' => $locale,
+            'source_inputs' => [
+                'cms_or_api_snapshot' => 'fixture',
+                'reference_pack' => 'fixture',
+                'seo_signal' => 'GSC_EVIDENCE_PENDING',
+            ],
+            'current_surface' => [
+                'title' => 'Current '.$slug,
+                'description' => 'Current description',
+                'h1' => 'Current H1',
+                'quick_answer' => '',
+                'faq_count' => 0,
+                'internal_link_count' => 0,
+            ],
+            'observed_signal' => [
+                'evidence_state' => 'gsc_pending',
+                'impressions' => null,
+                'clicks' => null,
+            ],
+            'reference_patterns_used' => [
+                ['pattern_id' => 'fixture_reference', 'source_url' => 'https://fermatmind.com/en/personality/intj-a'],
+            ],
+            'recommendations' => [
+                'title' => ['current' => 'Current '.$slug, 'recommended' => $title, 'reason' => 'Fixture reason.'],
+                'description' => [
+                    'current' => 'Current description',
+                    'recommended' => $locale === 'zh-CN'
+                        ? '理解这个公开人格页面的行为倾向、压力线索、沟通方式和自我核对，不作为诊断或职业决定。'
+                        : 'Understand this public personality page through behavior patterns, stress cues, communication style and self-check prompts.',
+                    'reason' => 'Fixture reason.',
+                ],
+                'h1' => ['current' => 'Current H1', 'recommended' => strtoupper($slug).' Meaning', 'reason' => 'Fixture reason.'],
+                'quick_answer' => [
+                    'current' => '',
+                    'recommended' => $locale === 'zh-CN'
+                        ? '这是一个公开人格解释页面，用于自我理解、沟通和学习反思，不是诊断、招聘筛选或确定性结论。'
+                        : 'This is a public personality explanation page for self-understanding, communication and learning reflection, not a diagnosis or deterministic verdict.',
+                    'reason' => 'Fixture reason.',
+                ],
+                'faq' => array_map(
+                    static fn (int $index): array => [
+                        'question' => 'Fixture question '.$index.'?',
+                        'answer' => 'Fixture answer '.$index.' for safe public profile reading.',
+                        'reason' => 'Fixture QA.',
+                    ],
+                    [1, 2, 3, 4, 5]
+                ),
+                'internal_links' => [
+                    [
+                        'href' => $locale === 'zh-CN' ? '/zh/personality' : '/en/personality',
+                        'anchor_text' => $locale === 'zh-CN' ? '人格首页' : 'Personality hub',
+                        'role' => 'hub',
+                        'safe_public_route' => true,
+                    ],
+                    [
+                        'href' => $locale === 'zh-CN'
+                            ? '/zh/tests/mbti-personality-test-16-personality-types'
+                            : '/en/tests/mbti-personality-test-16-personality-types',
+                        'anchor_text' => $locale === 'zh-CN' ? 'MBTI 测试' : 'MBTI test',
+                        'role' => 'related_test',
+                        'safe_public_route' => true,
+                    ],
+                ],
+                'differentiation_notes' => [
+                    'Fixture differentiation note one.',
+                    'Fixture differentiation note two.',
+                ],
+            ],
+            'qa_required' => [
+                'schema_validation',
+                'trademark_claim_gate',
+                'claim_risk_gate',
+                'duplicate_template_gate',
+                'private_route_gate',
+                'result_page_leakage_gate',
+                'seo_projection_gate',
+                'bilingual_consistency_gate',
+            ],
+            'blocked_reason' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeArtifacts(array $package, array $qa): array
+    {
+        $packagePath = sys_get_temp_dir().'/mbti64-cms-projection-package-'.bin2hex(random_bytes(6)).'.json';
+        $qaPath = sys_get_temp_dir().'/mbti64-cms-projection-qa-'.bin2hex(random_bytes(6)).'.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath, string $qaPath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -333,6 +333,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti64_cms_projection_draft_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityMbti64CmsProjectionDraft;',
+            '+        PersonalityMbti64CmsProjectionDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -3612,6 +3627,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbti64CmsProjectionDraftFile($file)) {
+                continue;
+            }
+
             if ($this->isMbti64CmsRevisionPromoteFile($file)) {
                 continue;
             }
@@ -4502,6 +4521,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64BackendImportContractOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbti64CmsProjectionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -4656,6 +4676,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbti64CmsInternalLinkDraft.php',
             'backend/app/Services/Cms/Mbti64CmsInternalLinkDraftWriter.php',
+        ], true);
+    }
+
+    private function isMbti64CmsProjectionDraftFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php',
+            'backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php',
         ], true);
     }
 
@@ -7424,6 +7452,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         }
 
         return $containsInternalLinkDraftRegistration;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbti64CmsProjectionDraftOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbti64CmsProjectionDraft\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added `personality:mbti64-cms-projection-draft`, a controlled CMS draft command for the 88 non-pilot MBTI64 agent recommendations.
- Added `Mbti64CmsProjectionDraftWriter` to validate the recommendation package plus QA artifact, resolve CMS targets, and create draft-only revisions.
- Added backend copies of the fap-web recommendation and QA artifacts as immutable inputs for this draft contract.
- Added focused feature tests for dry-run, write, idempotency, changed source hash, missing target rollback, forbidden route blocking, and QA fail-closed behavior.

## Why
This is the backend contract for `MBTI64-CMS-PROJECTION-DRAFT-88-01`: agent recommendations that passed QA can be converted into CMS draft revisions without mutating live content, index state, sitemap/llms, or search release state.

## Safety boundaries
- No production write was run.
- No live profile or variant rows are updated by this PR.
- No publish/index/sitemap/llms/search release side effects.
- Write mode requires all safety flags plus `--operator-approved=MBTI64-CMS-PROJECTION-DRAFT-88-01`.
- Same target + same source package hash is idempotent; source hash changes create a new draft revision.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php tests/Feature/Console/PersonalityMbti64CmsInternalLinkDraftCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `jq empty backend/docs/seo/personality/mbti64-agent-expansion-88-recommendations-2026-06-21.json backend/docs/seo/personality/mbti64-agent-expansion-88-qa-2026-06-21.json`
- `git diff --check`

## Deferred
- Production dry-run/write remains separate and requires exact SHA + command authorization.
- No CMS promotion or publish.
- No sitemap/llms/search queue/search submit.
- No frontend changes.
