### PR TITLE
SEO-AGENT-AUTO-ROLLBACK-GUARD-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentAutoRollbackGuardCommand.php
+++ b/backend/app/Console/Commands/SeoAgentAutoRollbackGuardCommand.php
@@ -1,0 +1,505 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class SeoAgentAutoRollbackGuardCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-auto-rollback-guard.v1';
+
+    private const SINGLE_PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-canary.v1';
+
+    private const AUTO_PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-auto-canary.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:auto-rollback-guard
+        {--run-evidence= : Path to SEO Agent run/publish evidence JSON}
+        {--mode=preflight : Guard mode: preflight or post-publish}
+        {--artifact-dir= : Directory for rollback guard evidence artifacts}
+        {--execute : Execute at most one eligible ContentPage rollback canary}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'L5-A stop-the-line guard for SEO Agent runs with bounded ContentPage rollback canary support.';
+
+    public function handle(): int
+    {
+        $evidencePath = $this->readablePath((string) $this->option('run-evidence'));
+        if ($evidencePath === null) {
+            return $this->finish($this->failureSummary('run_evidence_unreadable'));
+        }
+
+        $mode = $this->mode();
+        if ($mode === null) {
+            return $this->finish($this->failureSummary('mode_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $raw = (string) file_get_contents($evidencePath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $evidence = json_decode($raw, true);
+        if (! is_array($evidence)) {
+            return $this->finish($this->failureSummary('run_evidence_json_invalid'));
+        }
+
+        $execute = (bool) $this->option('execute');
+        $result = $mode === 'preflight'
+            ? $this->preflight($evidence)
+            : $this->postPublish($evidence, $execute);
+
+        $artifact = $this->writeArtifact($artifactDir, $evidencePath, $mode, $execute, $result);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => (string) ($result['status'] ?? 'pass'),
+            'mode' => $mode,
+            'execute' => $execute,
+            'stop_the_line' => (bool) ($result['stop_the_line'] ?? false),
+            'rollback_executed_count' => (int) ($result['rollback_executed_count'] ?? 0),
+            'artifact' => $artifact,
+            'negative_guarantees' => $this->negativeGuarantees((int) ($result['rollback_executed_count'] ?? 0) > 0),
+        ]);
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function mode(): ?string
+    {
+        $mode = trim((string) $this->option('mode'));
+
+        return in_array($mode, ['preflight', 'post-publish'], true) ? $mode : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/auto-rollback-guard');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function preflight(array $evidence): array
+    {
+        $issues = [];
+        if (($evidence['status'] ?? 'success') === 'blocked') {
+            $issues[] = 'upstream_evidence_blocked';
+        }
+        if ((bool) data_get($evidence, 'negative_guarantees.cms_bulk_publish', false) === true
+            || (bool) data_get($evidence, 'negative_guarantees.google_indexing_api_call', false) === true
+            || (bool) data_get($evidence, 'negative_guarantees.scheduler_activation', false) === true) {
+            $issues[] = 'negative_guarantee_violation';
+        }
+
+        return [
+            'status' => $issues === [] ? 'pass' : 'blocked',
+            'stop_the_line' => $issues !== [],
+            'issues' => array_values(array_unique($issues)),
+            'guard_actions' => $issues === [] ? ['allow_next_step'] : ['pause_publish', 'pause_indexnow'],
+            'rollback_plan' => [
+                'available' => false,
+                'reason' => 'preflight_mode_does_not_rollback',
+            ],
+            'rollback_executed_count' => 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function postPublish(array $evidence, bool $execute): array
+    {
+        $schema = (string) ($evidence['schema_version'] ?? '');
+        if (! in_array($schema, [self::SINGLE_PUBLISH_SCHEMA_VERSION, self::AUTO_PUBLISH_SCHEMA_VERSION], true)) {
+            return [
+                'status' => 'blocked',
+                'stop_the_line' => true,
+                'issues' => ['unsupported_post_publish_evidence_schema'],
+                'guard_actions' => ['pause_publish', 'pause_indexnow'],
+                'rollback_plan' => ['available' => false],
+                'rollback_executed_count' => 0,
+            ];
+        }
+
+        $targets = $this->rollbackTargets($evidence);
+        $issues = [];
+        foreach ($targets as $target) {
+            if (($target['rollback_available'] ?? false) !== true) {
+                $issues[] = 'rollback_evidence_missing';
+            }
+            if (($target['current_state_ok'] ?? false) !== true) {
+                $issues[] = 'post_publish_current_state_not_safe';
+            }
+        }
+        if ($targets === []) {
+            $issues[] = 'published_content_page_target_missing';
+        }
+
+        $rollbackResult = [
+            'attempted' => false,
+            'executed_count' => 0,
+            'skipped_count' => 0,
+            'issues' => [],
+        ];
+
+        if ($execute) {
+            $eligible = array_values(array_filter($targets, static fn (array $target): bool => ($target['rollback_available'] ?? false) === true));
+            if (count($eligible) !== 1) {
+                $issues[] = 'execute_requires_exactly_one_rollback_target';
+            } elseif ($issues === []) {
+                $rollbackResult = $this->executeRollback($eligible[0]);
+                if (($rollbackResult['executed_count'] ?? 0) !== 1) {
+                    $issues[] = 'rollback_execute_failed';
+                }
+            }
+        }
+
+        $issues = array_values(array_unique(array_merge($issues, array_map('strval', (array) ($rollbackResult['issues'] ?? [])))));
+
+        return [
+            'status' => $issues === [] ? 'pass' : 'blocked',
+            'stop_the_line' => $issues !== [],
+            'issues' => $issues,
+            'guard_actions' => $issues === [] ? ['allow_next_step'] : ['pause_publish', 'pause_indexnow'],
+            'targets' => $targets,
+            'rollback_plan' => [
+                'available' => count(array_filter($targets, static fn (array $target): bool => ($target['rollback_available'] ?? false) === true)) === 1,
+                'max_automatic_rollback_count' => 1,
+                'execute_requested' => $execute,
+            ],
+            'rollback_result' => $rollbackResult,
+            'rollback_executed_count' => (int) ($rollbackResult['executed_count'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return list<array<string, mixed>>
+     */
+    private function rollbackTargets(array $evidence): array
+    {
+        $schema = (string) ($evidence['schema_version'] ?? '');
+        $containers = $schema === self::AUTO_PUBLISH_SCHEMA_VERSION
+            ? (array) ($evidence['publish_results'] ?? [])
+            : [$evidence];
+        $targets = [];
+
+        foreach ($containers as $container) {
+            if (! is_array($container)) {
+                continue;
+            }
+            foreach ((array) ($container['affected_refs'] ?? []) as $affected) {
+                if (! is_array($affected) || ($affected['target_model'] ?? '') !== 'content_page') {
+                    continue;
+                }
+                if (! in_array((string) ($affected['status'] ?? ''), ['published', 'skipped_existing'], true)) {
+                    continue;
+                }
+                $targets[] = $this->targetState($affected, is_array($container['rollback_evidence'] ?? null) ? (array) $container['rollback_evidence'] : []);
+            }
+        }
+
+        return $targets;
+    }
+
+    /**
+     * @param  array<string, mixed>  $affected
+     * @param  array<string, mixed>  $rollback
+     * @return array<string, mixed>
+     */
+    private function targetState(array $affected, array $rollback): array
+    {
+        $pageId = $this->contentPageIdFromRef((string) ($affected['subject_ref'] ?? ''));
+        $page = $pageId ? ContentPage::query()->withoutGlobalScopes()->find($pageId) : null;
+        $candidateRevisionId = (int) ($rollback['candidate_revision_id'] ?? $affected['revision_id'] ?? 0);
+        $previousRevisionId = (int) ($rollback['previous_revision_id'] ?? 0);
+        $currentStateOk = $page instanceof ContentPage
+            && (string) $page->status === ContentPage::STATUS_PUBLISHED
+            && (bool) $page->is_public
+            && (bool) $page->is_indexable
+            && $candidateRevisionId > 0
+            && (int) $page->published_revision_id === $candidateRevisionId;
+
+        return [
+            'subject_ref' => (string) ($affected['subject_ref'] ?? ''),
+            'target_model' => 'content_page',
+            'safe_path' => $this->safePath((string) ($affected['safe_path'] ?? '')),
+            'current_state_ok' => $currentStateOk,
+            'rollback_available' => $page instanceof ContentPage
+                && (bool) ($rollback['available'] ?? false)
+                && $candidateRevisionId > 0
+                && $previousRevisionId > 0,
+            'candidate_revision_id' => $candidateRevisionId,
+            'previous_revision_id' => $previousRevisionId > 0 ? $previousRevisionId : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $target
+     * @return array<string, mixed>
+     */
+    private function executeRollback(array $target): array
+    {
+        return DB::transaction(function () use ($target): array {
+            $pageId = $this->contentPageIdFromRef((string) ($target['subject_ref'] ?? ''));
+            $page = $pageId ? ContentPage::query()->withoutGlobalScopes()->lockForUpdate()->find($pageId) : null;
+            if (! $page instanceof ContentPage) {
+                return ['attempted' => true, 'executed_count' => 0, 'skipped_count' => 0, 'issues' => ['content_page_not_found']];
+            }
+
+            $candidateRevisionId = (int) ($target['candidate_revision_id'] ?? 0);
+            $previousRevisionId = (int) ($target['previous_revision_id'] ?? 0);
+            if ($candidateRevisionId < 1 || $previousRevisionId < 1 || (int) $page->published_revision_id !== $candidateRevisionId) {
+                return ['attempted' => true, 'executed_count' => 0, 'skipped_count' => 0, 'issues' => ['rollback_state_mismatch']];
+            }
+
+            $previous = CmsTranslationRevision::query()
+                ->where('content_type', 'content_page')
+                ->where('content_id', (int) $page->id)
+                ->whereKey($previousRevisionId)
+                ->first();
+            $candidate = CmsTranslationRevision::query()
+                ->where('content_type', 'content_page')
+                ->where('content_id', (int) $page->id)
+                ->whereKey($candidateRevisionId)
+                ->first();
+            if (! $previous instanceof CmsTranslationRevision || ! $candidate instanceof CmsTranslationRevision) {
+                return ['attempted' => true, 'executed_count' => 0, 'skipped_count' => 0, 'issues' => ['rollback_revision_missing']];
+            }
+
+            $now = Carbon::now('UTC');
+            $page->forceFill([
+                'published_revision_id' => (int) $previous->id,
+                'working_revision_id' => (int) $previous->id,
+                'reviewer' => 'seo_agent_auto_rollback_guard',
+                'last_reviewed_at' => $now,
+            ])->save();
+            $candidate->forceFill([
+                'revision_status' => CmsTranslationRevision::STATUS_ARCHIVED,
+                'archived_at' => $candidate->archived_at ?? $now,
+            ])->save();
+            $previous->forceFill([
+                'revision_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+                'published_at' => $previous->published_at ?? $now,
+            ])->save();
+
+            return [
+                'attempted' => true,
+                'executed_count' => 1,
+                'skipped_count' => 0,
+                'rolled_back_ref' => (string) ($target['subject_ref'] ?? ''),
+            ];
+        });
+    }
+
+    private function contentPageIdFromRef(string $subjectRef): ?int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== 'content_page' || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            return null;
+        }
+
+        return (int) $parts[1];
+    }
+
+    private function safePath(string $path): string
+    {
+        $parts = parse_url(trim($path));
+        if (is_array($parts) && isset($parts['path'])) {
+            $path = (string) $parts['path'];
+        }
+
+        return preg_replace('#/+#', '/', '/'.ltrim($path, '/')) ?: '/';
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $runEvidencePath, string $mode, bool $execute, array $result): array
+    {
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-AUTO-ROLLBACK-GUARD-01',
+            'status' => (string) ($result['status'] ?? 'pass'),
+            'mode' => $mode,
+            'execute' => $execute,
+            'stop_the_line' => (bool) ($result['stop_the_line'] ?? false),
+            'run_evidence' => $this->artifactRef($runEvidencePath, 'seo-agent-run-evidence'),
+            'result' => $result,
+            'allowed_actions' => [
+                'read_run_evidence',
+                'read_content_page_publish_state',
+                'evidence_artifact_write',
+                'single_content_page_rollback_when_execute_and_evidence_complete',
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'negative_guarantees' => $this->negativeGuarantees((int) ($result['rollback_executed_count'] ?? 0) > 0),
+        ];
+
+        $path = rtrim($artifactDir, '/').'/seo-agent-auto-rollback-guard-'.$timestamp.'.json';
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('rollback_guard_artifact_write_failed');
+        }
+
+        return $this->artifactRef($path, self::SCHEMA_VERSION);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(false),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'cms_bulk_publish',
+            'article_auto_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'google_indexing_api_call',
+            'scheduler_activation',
+            'queue_worker_activation',
+            'frontend_mutation',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(bool $rollbackExecuted): array
+    {
+        return [
+            'cms_bulk_publish' => false,
+            'article_auto_publish' => false,
+            'content_page_rollback_beyond_one' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'google_indexing_api_call' => false,
+            'scheduler_activation' => false,
+            'queue_worker_activation' => false,
+            'frontend_mutation' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsPublishAutoCanaryCommand.php
@@ -387,6 +387,7 @@ final class SeoAgentCmsPublishAutoCanaryCommand extends Command
             'writes_attempted' => (bool) ($summary['writes_attempted'] ?? false),
             'writes_committed' => (bool) ($summary['writes_committed'] ?? false),
             'affected_refs' => array_values((array) ($summary['affected_refs'] ?? [])),
+            'rollback_evidence' => is_array($summary['rollback_evidence'] ?? null) ? (array) $summary['rollback_evidence'] : [],
             'issues' => array_values(array_map('strval', (array) ($summary['issues'] ?? []))),
             'boundaries' => is_array($summary['boundaries'] ?? null) ? (array) $summary['boundaries'] : [],
         ];

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -171,6 +171,7 @@ use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
+use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsPublishAutoCanaryCommand;
@@ -380,6 +381,7 @@ class Kernel extends ConsoleKernel
         ArticleWeeklySeoObservationExport::class,
         MediaAssetsImportSeoImageBundle::class,
         SeoAgentCmsFaqGapScanCommand::class,
+        SeoAgentAutoRollbackGuardCommand::class,
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,

--- a/backend/docs/seo/generated/seo-agent-auto-rollback-guard.v1.json
+++ b/backend/docs/seo/generated/seo-agent-auto-rollback-guard.v1.json
@@ -1,0 +1,54 @@
+{
+  "version": "seo-agent-auto-rollback-guard.v1",
+  "task": "SEO-AGENT-AUTO-ROLLBACK-GUARD-01",
+  "command": "php artisan seo-agent:auto-rollback-guard",
+  "modes": [
+    "preflight",
+    "post-publish"
+  ],
+  "input_schemas": {
+    "preflight": [
+      "seo-agent-run-evidence.v1",
+      "seo-agent-weekly-draft-write-auto.v1",
+      "seo-agent-cms-draft-package-dry-run.v1"
+    ],
+    "post_publish": [
+      "seo-agent-cms-publish-canary.v1",
+      "seo-agent-cms-publish-auto-canary.v1"
+    ]
+  },
+  "default_mode": "guard_evidence_only",
+  "execute_mode": {
+    "requires": [
+      "--execute",
+      "--mode=post-publish",
+      "complete rollback evidence",
+      "exactly one eligible content_page target"
+    ],
+    "max_content_page_rollback_count": 1,
+    "article_rollback": false,
+    "bulk_rollback": false
+  },
+  "guard_actions": [
+    "allow_next_step",
+    "pause_publish",
+    "pause_indexnow"
+  ],
+  "negative_guarantees": {
+    "cms_bulk_publish": false,
+    "article_auto_publish": false,
+    "content_page_rollback_beyond_one": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "google_indexing_api_call": false,
+    "scheduler_activation": false,
+    "queue_worker_activation": false,
+    "frontend_mutation": false
+  },
+  "deferred": [
+    "persistent automation pause state",
+    "multi-page rollback",
+    "article rollback",
+    "search channel rollback"
+  ]
+}

--- a/backend/docs/seo/seo-agent-auto-rollback-guard.md
+++ b/backend/docs/seo/seo-agent-auto-rollback-guard.md
@@ -1,0 +1,35 @@
+# SEO Agent Auto Rollback Guard
+
+`seo-agent:auto-rollback-guard` is the L5-A stop-the-line guard for low-risk SEO Agent automation. It reads run or publish evidence, decides whether downstream publish/IndexNow should continue, writes a guard artifact, and can optionally execute at most one ContentPage rollback canary when publish evidence includes complete rollback metadata.
+
+## Command
+
+```bash
+php artisan seo-agent:auto-rollback-guard \
+  --run-evidence=<seo-agent-evidence.json> \
+  --mode=post-publish \
+  --artifact-dir=/var/www/fap-api/current/backend/storage/app/seo-agent/auto-rollback-guard \
+  --json
+```
+
+Optional rollback canary:
+
+```bash
+php artisan seo-agent:auto-rollback-guard \
+  --run-evidence=<seo-agent-cms-publish-canary-or-auto-canary.json> \
+  --mode=post-publish \
+  --execute \
+  --json
+```
+
+## Contract
+
+- `preflight` mode checks upstream evidence and emits `pause_publish` / `pause_indexnow` when risk or boundary violations are detected.
+- `post-publish` mode accepts `seo-agent-cms-publish-canary.v1` and `seo-agent-cms-publish-auto-canary.v1`.
+- Rollback execution is limited to exactly one eligible ContentPage canary from the same run evidence.
+- Rollback requires `rollback_evidence.available=true`, `candidate_revision_id`, and `previous_revision_id`.
+- The guard never publishes Article content, never performs bulk publish, and never enqueues or submits search channels.
+
+## Boundaries
+
+The command does not call GSC, Google Indexing, IndexNow, Baidu, external model APIs, queue workers, schedulers, or frontend code. Its only write-capable path is a single bounded ContentPage rollback when explicitly run with `--execute` and complete rollback evidence.

--- a/backend/tests/Feature/SeoIntel/SeoAgentAutoRollbackGuardTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentAutoRollbackGuardTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentAutoRollbackGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::parse('2026-06-21 09:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function preflight_blocks_upstream_blocked_evidence_without_writes(): void
+    {
+        $dir = $this->artifactDir();
+        $evidencePath = $this->writeJson($dir, 'blocked-run.json', [
+            'schema_version' => 'seo-agent-run-evidence.v1',
+            'status' => 'blocked',
+            'negative_guarantees' => [
+                'cms_bulk_publish' => false,
+                'google_indexing_api_call' => false,
+                'scheduler_activation' => false,
+            ],
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:auto-rollback-guard', [
+            '--run-evidence' => $evidencePath,
+            '--mode' => 'preflight',
+            '--artifact-dir' => $dir,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $artifact = $this->readJson($this->latestArtifact($dir));
+        $this->assertSame('blocked', $artifact['status'] ?? null);
+        $this->assertTrue((bool) ($artifact['stop_the_line'] ?? false));
+        $this->assertContains('pause_publish', data_get($artifact, 'result.guard_actions'));
+        $this->assertSame(0, data_get($artifact, 'result.rollback_executed_count'));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.search_channel_enqueue', true));
+    }
+
+    #[Test]
+    public function post_publish_plan_validates_rollback_evidence_without_writing(): void
+    {
+        [$page, $previous, $candidate] = $this->createPublishedCanaryState();
+        $dir = $this->artifactDir();
+        $evidencePath = $this->writePublishEvidence($dir, $page, $previous, $candidate);
+
+        $exitCode = Artisan::call('seo-agent:auto-rollback-guard', [
+            '--run-evidence' => $evidencePath,
+            '--mode' => 'post-publish',
+            '--artifact-dir' => $dir,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $artifact = $this->readJson($this->latestArtifact($dir));
+        $this->assertSame('pass', $artifact['status'] ?? null);
+        $this->assertFalse((bool) ($artifact['stop_the_line'] ?? true));
+        $this->assertTrue((bool) data_get($artifact, 'result.rollback_plan.available'));
+        $this->assertSame(0, data_get($artifact, 'result.rollback_executed_count'));
+        $this->assertSame((int) $candidate->id, (int) $page->refresh()->published_revision_id);
+    }
+
+    #[Test]
+    public function execute_rolls_back_one_content_page_canary_only(): void
+    {
+        [$page, $previous, $candidate] = $this->createPublishedCanaryState();
+        $dir = $this->artifactDir();
+        $evidencePath = $this->writePublishEvidence($dir, $page, $previous, $candidate);
+
+        $exitCode = Artisan::call('seo-agent:auto-rollback-guard', [
+            '--run-evidence' => $evidencePath,
+            '--mode' => 'post-publish',
+            '--artifact-dir' => $dir,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $artifact = $this->readJson($this->latestArtifact($dir));
+        $this->assertSame('pass', $artifact['status'] ?? null);
+        $this->assertSame(1, data_get($artifact, 'result.rollback_executed_count'));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.content_page_rollback_beyond_one', true));
+        $this->assertSame((int) $previous->id, (int) $page->refresh()->published_revision_id);
+        $this->assertSame(CmsTranslationRevision::STATUS_ARCHIVED, (string) $candidate->refresh()->revision_status);
+        $this->assertSame(CmsTranslationRevision::STATUS_PUBLISHED, (string) $previous->refresh()->revision_status);
+    }
+
+    #[Test]
+    public function generated_contract_documents_guard_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-auto-rollback-guard.v1.json'));
+
+        $this->assertSame('seo-agent-auto-rollback-guard.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:auto-rollback-guard', $contract['command'] ?? null);
+        $this->assertSame(1, data_get($contract, 'execute_mode.max_content_page_rollback_count'));
+        $this->assertFalse((bool) data_get($contract, 'execute_mode.article_rollback', true));
+        $this->assertFalse((bool) data_get($contract, 'execute_mode.bulk_rollback', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.google_indexing_api_call', true));
+    }
+
+    /**
+     * @return array{0: ContentPage, 1: CmsTranslationRevision, 2: CmsTranslationRevision}
+     */
+    private function createPublishedCanaryState(): array
+    {
+        $page = ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'rollback-guard-page',
+            'path' => '/zh/rollback-guard-page',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Rollback Guard Page',
+            'summary' => 'Existing summary.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => true,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'approved',
+            'published_at' => now()->subDay(),
+        ]);
+
+        $previous = CmsTranslationRevision::query()->create([
+            'org_id' => 0,
+            'content_type' => 'content_page',
+            'content_id' => (int) $page->id,
+            'translation_group_id' => (string) $page->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+            'payload_json' => ['title' => 'Previous'],
+            'published_at' => now()->subDay(),
+        ]);
+        $candidate = CmsTranslationRevision::query()->create([
+            'org_id' => 0,
+            'content_type' => 'content_page',
+            'content_id' => (int) $page->id,
+            'translation_group_id' => (string) $page->translation_group_id,
+            'locale' => 'zh-CN',
+            'source_locale' => 'zh-CN',
+            'revision_number' => 2,
+            'revision_status' => CmsTranslationRevision::STATUS_PUBLISHED,
+            'payload_json' => ['title' => 'Candidate'],
+            'published_at' => now(),
+        ]);
+        $page->forceFill([
+            'working_revision_id' => (int) $candidate->id,
+            'published_revision_id' => (int) $candidate->id,
+        ])->save();
+
+        return [$page->refresh(), $previous, $candidate];
+    }
+
+    private function writePublishEvidence(string $dir, ContentPage $page, CmsTranslationRevision $previous, CmsTranslationRevision $candidate): string
+    {
+        return $this->writeJson($dir, 'publish-evidence.json', [
+            'schema_version' => 'seo-agent-cms-publish-canary.v1',
+            'ok' => true,
+            'status' => 'success',
+            'execute' => true,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'published_count' => 1,
+            'rows_skipped_existing' => 0,
+            'affected_refs' => [[
+                'status' => 'published',
+                'target_model' => 'content_page',
+                'subject_ref' => 'content_page:'.$page->id.':zh-CN',
+                'revision_id' => (int) $candidate->id,
+                'safe_path' => '/zh/rollback-guard-page',
+            ]],
+            'rollback_evidence' => [
+                'available' => true,
+                'content_page_ref' => 'content_page:'.$page->id.':zh-CN',
+                'previous_revision_id' => (int) $previous->id,
+                'candidate_revision_id' => (int) $candidate->id,
+            ],
+            'boundaries' => [
+                'search_channel_enqueue' => false,
+                'indexing_request' => false,
+            ],
+            'negative_guarantees' => [
+                'search_channel_enqueue' => false,
+                'search_channel_submit' => false,
+                'indexing_request' => false,
+                'scheduler_activation' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $dir, string $filename, array $payload): string
+    {
+        $path = rtrim($dir, '/').'/'.$filename;
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+
+        return $path;
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-auto-rollback-guard-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function latestArtifact(string $dir): ?string
+    {
+        $paths = File::glob(rtrim($dir, '/').'/seo-agent-auto-rollback-guard-*.json') ?: [];
+        rsort($paths);
+
+        return $paths[0] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1287,6 +1287,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_auto_rollback_guard_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentAutoRollbackGuardCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentAutoRollbackGuardCommand;',
+            '+        SeoAgentAutoRollbackGuardCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files(): void
     {
         $changed = [
@@ -3906,6 +3920,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentAutoRollbackGuardFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentGscOpportunityAutoDraftFile($file)) {
                 continue;
             }
@@ -4518,6 +4536,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscPostPublishFeedbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
@@ -5259,6 +5278,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscPostPublishFeedbackCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentAutoRollbackGuardFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentAutoRollbackGuardCommand.php',
         ], true);
     }
 
@@ -7194,6 +7220,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentGscPostPublishFeedbackCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentAutoRollbackGuardOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentAutoRollbackGuardCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:auto-rollback-guard`, a stop-the-line guard for L5-A SEO Agent runs with `preflight` and `post-publish` modes.
- Supports bounded rollback canary execution for exactly one eligible ContentPage when publish evidence includes complete rollback metadata.
- Preserves search/indexing/scheduler/frontend boundaries and writes only a sanitized guard artifact by default.
- Includes rollback evidence in `seo-agent:cms-publish-auto-canary` summaries so auto-canary publish output can be audited by the guard.
- Added contract docs/generated JSON and focused feature tests.
- Updated the Big Five runtime freeze allowlist for the new SEO Agent command registration.

## Why
L5 automation needs a guard that can pause downstream publish/IndexNow steps and provide a bounded recovery path if a just-published ContentPage canary is unsafe.

## Validation
```bash
cd backend
php artisan test --filter SeoAgentAutoRollbackGuardTest
php artisan test --filter SeoAgentCmsPublishAutoCanaryTest
php artisan test --filter SeoAgentCmsPublishCanaryTest
php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest
python3 -m json.tool docs/seo/generated/seo-agent-auto-rollback-guard.v1.json >/dev/null
php artisan list --raw | grep 'seo-agent:auto-rollback-guard'
git diff --check
```

## Intentionally deferred
- No persistent automation pause state.
- No multi-page rollback.
- No Article rollback or publish automation.
- No Search Channel, Google Indexing, scheduler, queue worker, or frontend mutation.
