### PR TITLE
SEO-AGENT-PRIORITY-QUEUE-SCHEDULER-01

### DIFF
--- a/backend/app/Console/Commands/SeoAgentPriorityQueueSchedulerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentPriorityQueueSchedulerCommand.php
@@ -1,0 +1,493 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentPriorityQueueSchedulerCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-priority-queue-scheduler.v1';
+
+    protected $signature = 'seo-agent:priority-queue-scheduler
+        {--mode=weekly-l5-low-risk : Scheduler mode; only weekly-l5-low-risk is supported}
+        {--sources=cms-tdk-gap,runtime-seo-qa,cms-faq-gap : Comma-separated readonly discovery sources}
+        {--limit=100 : Discovery candidate limit, bounded 1..250}
+        {--publish-limit=3 : Maximum low-risk ContentPage canaries to publish, 1..3}
+        {--draft-limit=10 : Maximum low-risk CMS draft revisions to write, 1..10}
+        {--base-url= : Public site base URL for IndexNow target resolution}
+        {--artifact-dir= : Directory for L5 scheduler evidence artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'External-cron L5-A low-risk SEO Agent orchestrator; writes drafts, publishes bounded ContentPage canaries, and submits IndexNow only.';
+
+    public function handle(): int
+    {
+        if ((string) $this->option('mode') !== 'weekly-l5-low-risk') {
+            return $this->finish($this->failureSummary('unsupported_mode'));
+        }
+
+        $sources = $this->sources();
+        if ($sources === []) {
+            return $this->finish($this->failureSummary('invalid_sources'));
+        }
+
+        $publishLimit = $this->boundedInt('publish-limit', 1, 3);
+        $draftLimit = $this->boundedInt('draft-limit', 1, 10);
+        if ($publishLimit === null) {
+            return $this->finish($this->failureSummary('publish_limit_out_of_bounds'));
+        }
+        if ($draftLimit === null) {
+            return $this->finish($this->failureSummary('draft_limit_out_of_bounds'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $limit = $this->limit();
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $runDir = rtrim($artifactDir, '/').'/priority-queue-scheduler-run-'.$timestamp;
+        if (! is_dir($runDir) && ! mkdir($runDir, 0775, true) && ! is_dir($runDir)) {
+            return $this->finish($this->failureSummary('run_artifact_dir_unwritable'));
+        }
+
+        $steps = [];
+        $weekly = $this->runSubCommand('seo-agent:weekly-draft-write-auto', [
+            '--sources' => implode(',', $sources),
+            '--limit' => $limit,
+            '--draft-limit' => $draftLimit,
+            '--artifact-dir' => $this->stepDir($runDir, '01-weekly-draft-write-auto'),
+            '--json' => true,
+        ]);
+        $steps['weekly_draft_write_auto'] = $this->stepSummary($weekly);
+        if (! $this->ok($weekly)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'weekly_draft_write_auto_failed',
+            ]);
+        }
+
+        $weeklyArtifactPath = (string) data_get($weekly, 'artifact.path', '');
+        if ($weeklyArtifactPath === '' || ! is_file($weeklyArtifactPath)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'weekly_draft_write_auto_artifact_missing',
+            ]);
+        }
+
+        $weeklyEvidence = $this->readJson($weeklyArtifactPath);
+        $packagePath = (string) data_get($weeklyEvidence, 'filtered_package.path', '');
+        $draftWriteEvidencePath = (string) data_get($weeklyEvidence, 'draft_write.artifact.path', '');
+        if (($draftWriteEvidencePath === '' || ! is_file($draftWriteEvidencePath)) && $packagePath !== '' && is_file($packagePath)) {
+            $draftWriteRef = $this->writeArtifact($this->stepDir($runDir, '01-weekly-draft-write-auto'), 'seo-agent-priority-queue-scheduler-draft-write-evidence-'.$timestamp.'.json', [
+                'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+                'ok' => (bool) data_get($weeklyEvidence, 'draft_write.ok', false),
+                'status' => (string) data_get($weeklyEvidence, 'draft_write.status', ''),
+                'execute' => true,
+                'approval_mode' => 'low_risk_auto_approved',
+                'package_sha256' => hash_file('sha256', $packagePath) ?: '',
+                'writes_attempted' => (bool) data_get($weeklyEvidence, 'draft_write.writes_attempted', false),
+                'writes_committed' => (bool) data_get($weeklyEvidence, 'draft_write.writes_committed', false),
+                'rows_created' => (int) data_get($weeklyEvidence, 'draft_write.rows_created', 0),
+                'rows_skipped_existing' => (int) data_get($weeklyEvidence, 'draft_write.rows_skipped_existing', 0),
+                'negative_guarantees' => [
+                    'cms_publish' => false,
+                    'search_channel_submit' => false,
+                    'indexing_request' => false,
+                ],
+            ]);
+            $draftWriteEvidencePath = (string) $draftWriteRef['path'];
+            $steps['weekly_draft_write_auto']['draft_write_evidence'] = $draftWriteRef;
+        }
+
+        $preflight = $this->runSubCommand('seo-agent:auto-rollback-guard', [
+            '--run-evidence' => $weeklyArtifactPath,
+            '--mode' => 'preflight',
+            '--artifact-dir' => $this->stepDir($runDir, '02-rollback-preflight'),
+            '--json' => true,
+        ]);
+        $steps['rollback_preflight'] = $this->stepSummary($preflight);
+        if (! $this->guardPassed($preflight)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'rollback_preflight_blocked',
+            ]);
+        }
+
+        $draftRows = (int) ($weekly['rows_created'] ?? 0) + (int) ($weekly['rows_skipped_existing'] ?? 0);
+        if ($draftRows < 1 || $packagePath === '' || ! is_file($packagePath) || $draftWriteEvidencePath === '' || ! is_file($draftWriteEvidencePath)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'success', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => null,
+                'skip_reason' => 'no_low_risk_draft_rows_available_for_publish',
+            ]);
+        }
+
+        $publish = $this->runSubCommand('seo-agent:cms-publish-auto-canary', [
+            '--package' => $packagePath,
+            '--draft-write-evidence' => $draftWriteEvidencePath,
+            '--limit' => $publishLimit,
+            '--artifact-dir' => $this->stepDir($runDir, '03-cms-publish-auto-canary'),
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $steps['cms_publish_auto_canary'] = $this->stepSummary($publish);
+        if (! $this->ok($publish)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'cms_publish_auto_canary_failed',
+            ]);
+        }
+
+        $publishArtifactPath = (string) data_get($publish, 'artifact.path', '');
+        $publishedCount = (int) ($publish['published_or_planned_count'] ?? 0);
+        if ($publishedCount < 1 || $publishArtifactPath === '' || ! is_file($publishArtifactPath)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'success', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => null,
+                'skip_reason' => 'no_new_content_page_canary_published',
+            ]);
+        }
+
+        $indexnowInput = [
+            '--publish-evidence' => $publishArtifactPath,
+            '--limit' => $publishLimit,
+            '--artifact-dir' => $this->stepDir($runDir, '04-post-publish-indexnow-auto'),
+            '--execute' => true,
+            '--json' => true,
+        ];
+        $baseUrl = trim((string) $this->option('base-url'));
+        if ($baseUrl !== '') {
+            $indexnowInput['--base-url'] = $baseUrl;
+        }
+        $indexnow = $this->runSubCommand('seo-agent:post-publish-indexnow-auto', $indexnowInput);
+        $steps['post_publish_indexnow_auto'] = $this->stepSummary($indexnow);
+        if (! $this->ok($indexnow)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'post_publish_indexnow_auto_failed',
+            ]);
+        }
+
+        $postPublish = $this->runSubCommand('seo-agent:auto-rollback-guard', [
+            '--run-evidence' => $publishArtifactPath,
+            '--mode' => 'post-publish',
+            '--artifact-dir' => $this->stepDir($runDir, '05-rollback-post-publish'),
+            '--json' => true,
+        ]);
+        $steps['rollback_post_publish'] = $this->stepSummary($postPublish);
+        if (! $this->guardPassed($postPublish)) {
+            return $this->finishWithEvidence($artifactDir, $timestamp, 'blocked', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+                'issue' => 'rollback_post_publish_blocked',
+            ]);
+        }
+
+        return $this->finishWithEvidence($artifactDir, $timestamp, 'success', $sources, $limit, $draftLimit, $publishLimit, $steps, [
+            'issue' => null,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sources(): array
+    {
+        $allowed = ['cms-tdk-gap', 'runtime-seo-qa', 'cms-faq-gap'];
+        $sources = array_values(array_unique(array_filter(array_map(
+            static fn (string $source): string => trim($source),
+            explode(',', (string) $this->option('sources'))
+        ))));
+
+        foreach ($sources as $source) {
+            if (! in_array($source, $allowed, true)) {
+                return [];
+            }
+        }
+
+        return $sources;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 100;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    private function boundedInt(string $option, int $min, int $max): ?int
+    {
+        $value = filter_var($this->option($option), FILTER_VALIDATE_INT);
+
+        return is_int($value) && $value >= $min && $value <= $max ? $value : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/priority-queue-scheduler');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    private function stepDir(string $runDir, string $name): string
+    {
+        $dir = rtrim($runDir, '/').'/'.$name;
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            throw new RuntimeException('step_artifact_dir_unwritable');
+        }
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    private function runSubCommand(string $name, array $input): array
+    {
+        $command = $this->getApplication()?->find($name);
+        if ($command === null) {
+            return $this->failureSummary($name.'_missing');
+        }
+
+        $buffer = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput(['command' => $name, ...$input]), $buffer);
+        $summary = json_decode(trim($buffer->fetch()), true);
+        if (! is_array($summary)) {
+            return $this->failureSummary($name.'_summary_json_invalid', [
+                'exit_code' => $exitCode,
+            ]);
+        }
+
+        $summary['exit_code'] = $exitCode;
+
+        return $summary;
+    }
+
+    private function ok(array $summary): bool
+    {
+        return ($summary['ok'] ?? false) === true && (int) ($summary['exit_code'] ?? 0) === 0;
+    }
+
+    private function guardPassed(array $summary): bool
+    {
+        return $this->ok($summary)
+            && in_array((string) ($summary['status'] ?? ''), ['pass', 'success'], true)
+            && (bool) ($summary['stop_the_line'] ?? true) === false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('artifact_json_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function stepSummary(array $summary): array
+    {
+        return [
+            'schema_version' => (string) ($summary['schema_version'] ?? ''),
+            'ok' => (bool) ($summary['ok'] ?? false),
+            'status' => (string) ($summary['status'] ?? ''),
+            'exit_code' => (int) ($summary['exit_code'] ?? 0),
+            'artifact' => is_array($summary['artifact'] ?? null) ? (array) $summary['artifact'] : [],
+            'issues' => array_values(array_map('strval', (array) ($summary['issues'] ?? []))),
+            'rows_created' => (int) ($summary['rows_created'] ?? 0),
+            'rows_skipped_existing' => (int) ($summary['rows_skipped_existing'] ?? 0),
+            'selected_count' => (int) ($summary['selected_count'] ?? 0),
+            'published_or_planned_count' => (int) ($summary['published_or_planned_count'] ?? 0),
+            'written_items' => (int) ($summary['written_items'] ?? 0),
+            'submitted_count' => (int) ($summary['submitted_count'] ?? 0),
+            'duplicate_submitted_count' => (int) ($summary['duplicate_submitted_count'] ?? 0),
+            'stop_the_line' => (bool) ($summary['stop_the_line'] ?? false),
+            'rollback_executed_count' => (int) ($summary['rollback_executed_count'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sources
+     * @param  array<string, array<string, mixed>>  $steps
+     * @param  array<string, mixed>  $extra
+     */
+    private function finishWithEvidence(
+        string $artifactDir,
+        string $timestamp,
+        string $status,
+        array $sources,
+        int $limit,
+        int $draftLimit,
+        int $publishLimit,
+        array $steps,
+        array $extra
+    ): int {
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-PRIORITY-QUEUE-SCHEDULER-01',
+            'status' => $status,
+            'run_mode' => 'weekly_l5_low_risk',
+            'trigger' => 'external_cron_or_manual_cli',
+            'command' => 'php artisan seo-agent:priority-queue-scheduler',
+            'sources' => $sources,
+            'limit' => $limit,
+            'draft_limit' => $draftLimit,
+            'publish_limit' => $publishLimit,
+            'steps' => $steps,
+            ...$extra,
+            'allowed_actions' => [
+                'readonly_discovery',
+                'auto_approval_policy_evaluation',
+                'cms_draft_revision_write',
+                'content_page_publish_canary',
+                'url_truth_read',
+                'search_channel_queue_write',
+                'search_channel_queue_approve',
+                'indexnow_live_submit',
+                'rollback_guard_preflight',
+                'rollback_guard_post_publish',
+                'evidence_artifact_write',
+            ],
+            'forbidden_actions' => $this->forbiddenActions(),
+            'cron_boundary' => [
+                'external_cron_supported' => true,
+                'laravel_scheduler_enabled_by_pr' => false,
+                'queue_worker_started_by_pr' => false,
+                'recommended_lock' => 'flock -n /tmp/seo-agent-priority-queue-scheduler.lock',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-priority-queue-scheduler-'.$timestamp.'.json', $payload);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $status === 'success',
+            'status' => $status,
+            'issue' => $extra['issue'] ?? null,
+            'skip_reason' => $extra['skip_reason'] ?? null,
+            'artifact' => $artifact,
+            'steps' => $steps,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? self::SCHEMA_VERSION),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (($summary['issue'] ?? null) !== null) {
+                $this->line('issue='.(string) $summary['issue']);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenActions(): array
+    {
+        return [
+            'article_auto_publish',
+            'cms_bulk_publish',
+            'google_indexing_api_call',
+            'baidu_live_submit',
+            'google_sitemap_live_submit',
+            'laravel_scheduler_activation',
+            'queue_worker_activation',
+            'frontend_code_mutation',
+            'production_env_update',
+            'external_model_api_call',
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'article_auto_publish' => false,
+            'cms_bulk_publish' => false,
+            'publish_limit_above_three' => false,
+            'draft_limit_above_ten' => false,
+            'google_indexing_api_call' => false,
+            'baidu_live_submit' => false,
+            'google_sitemap_live_submit' => false,
+            'laravel_scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'frontend_code_mutation' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -185,6 +185,7 @@ use App\Console\Commands\SeoAgentGscPostPublishFeedbackCommand;
 use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
 use App\Console\Commands\SeoAgentPostPublishIndexnowAutoCommand;
 use App\Console\Commands\SeoAgentPostPublishSearchSubmitCommand;
+use App\Console\Commands\SeoAgentPriorityQueueSchedulerCommand;
 use App\Console\Commands\SeoAgentRunCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
@@ -396,6 +397,7 @@ class Kernel extends ConsoleKernel
         SeoAgentGscPostPublishFeedbackCommand::class,
         SeoAgentPostPublishIndexnowAutoCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,
+        SeoAgentPriorityQueueSchedulerCommand::class,
         SeoAgentRuntimeSeoQaScanCommand::class,
         SeoAgentOpportunityAggregateCommand::class,
         SeoAgentRunCommand::class,

--- a/backend/docs/seo/generated/seo-agent-priority-queue-scheduler.v1.json
+++ b/backend/docs/seo/generated/seo-agent-priority-queue-scheduler.v1.json
@@ -1,0 +1,66 @@
+{
+  "version": "seo-agent-priority-queue-scheduler.v1",
+  "task": "SEO-AGENT-PRIORITY-QUEUE-SCHEDULER-01",
+  "command": "php artisan seo-agent:priority-queue-scheduler",
+  "mode": "weekly-l5-low-risk",
+  "trigger": "external_cron_or_manual_cli",
+  "laravel_scheduler_enabled_by_pr": false,
+  "queue_worker_started_by_pr": false,
+  "recommended_lock": "flock -n /tmp/seo-agent-priority-queue-scheduler.lock",
+  "max_draft_rows_per_execution": 10,
+  "max_content_page_publish_canaries_per_execution": 3,
+  "live_submit_channels_v1": [
+    "indexnow"
+  ],
+  "blocked_live_submit_channels_v1": [
+    "google_indexing",
+    "google_sitemap",
+    "baidu_push"
+  ],
+  "delegated_commands": [
+    "php artisan seo-agent:weekly-draft-write-auto",
+    "php artisan seo-agent:auto-rollback-guard --mode=preflight",
+    "php artisan seo-agent:cms-publish-auto-canary --auto-approve-low-risk --execute",
+    "php artisan seo-agent:post-publish-indexnow-auto --execute",
+    "php artisan seo-agent:auto-rollback-guard --mode=post-publish"
+  ],
+  "allowed_actions": [
+    "readonly_discovery",
+    "auto_approval_policy_evaluation",
+    "cms_draft_revision_write",
+    "content_page_publish_canary",
+    "url_truth_read",
+    "search_channel_queue_write",
+    "search_channel_queue_approve",
+    "indexnow_live_submit",
+    "rollback_guard_preflight",
+    "rollback_guard_post_publish",
+    "evidence_artifact_write"
+  ],
+  "forbidden_actions": [
+    "article_auto_publish",
+    "cms_bulk_publish",
+    "google_indexing_api_call",
+    "baidu_live_submit",
+    "google_sitemap_live_submit",
+    "laravel_scheduler_activation",
+    "queue_worker_activation",
+    "frontend_code_mutation",
+    "production_env_update",
+    "external_model_api_call"
+  ],
+  "negative_guarantees": {
+    "article_auto_publish": false,
+    "cms_bulk_publish": false,
+    "publish_limit_above_three": false,
+    "draft_limit_above_ten": false,
+    "google_indexing_api_call": false,
+    "baidu_live_submit": false,
+    "google_sitemap_live_submit": false,
+    "laravel_scheduler_activation": false,
+    "queue_worker_started": false,
+    "frontend_code_mutation": false,
+    "production_env_change": false,
+    "external_model_api_call": false
+  }
+}

--- a/backend/docs/seo/seo-agent-priority-queue-scheduler.md
+++ b/backend/docs/seo/seo-agent-priority-queue-scheduler.md
@@ -1,0 +1,50 @@
+# SEO Agent Priority Queue Scheduler
+
+`SEO-AGENT-PRIORITY-QUEUE-SCHEDULER-01` adds the L5-A low-risk orchestration entrypoint:
+
+```bash
+php artisan seo-agent:priority-queue-scheduler \
+  --mode=weekly-l5-low-risk \
+  --limit=100 \
+  --publish-limit=3 \
+  --draft-limit=10 \
+  --artifact-dir=/var/www/fap-api/current/backend/storage/app/seo-agent/l5-weekly \
+  --json
+```
+
+The command is intended for external cron with `flock`, not Laravel scheduler:
+
+```bash
+cd /var/www/fap-api/current/backend && \
+/usr/bin/flock -n /tmp/seo-agent-priority-queue-scheduler.lock \
+php artisan seo-agent:priority-queue-scheduler \
+  --mode=weekly-l5-low-risk \
+  --limit=100 \
+  --publish-limit=3 \
+  --draft-limit=10 \
+  --artifact-dir=/var/www/fap-api/current/backend/storage/app/seo-agent/l5-weekly \
+  --json >> /var/log/fermatmind-seo-agent-l5-weekly.log 2>&1
+```
+
+## Sequence
+
+1. `seo-agent:weekly-draft-write-auto`
+2. `seo-agent:auto-rollback-guard --mode=preflight`
+3. `seo-agent:cms-publish-auto-canary --auto-approve-low-risk --execute`
+4. `seo-agent:post-publish-indexnow-auto --execute`
+5. `seo-agent:auto-rollback-guard --mode=post-publish`
+6. final `seo-agent-priority-queue-scheduler.v1` evidence
+
+## Boundaries
+
+- Allows low-risk CMS draft writes, at most 10 per run.
+- Allows low-risk ContentPage publish canaries, at most 3 per run.
+- Allows IndexNow queue write, approval, and live submit only for published ContentPage canaries.
+- Does not publish Articles.
+- Does not bulk publish CMS pages.
+- Does not call Google Indexing API.
+- Does not live-submit Baidu or Google sitemap channels.
+- Does not start Laravel scheduler or queue workers.
+- Does not mutate frontend code.
+- Does not call external model APIs.
+

--- a/backend/tests/Feature/SeoIntel/SeoAgentPriorityQueueSchedulerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentPriorityQueueSchedulerTest.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentPriorityQueueSchedulerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.url' => 'https://fermatmind.com',
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
+            'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => 'secret-indexnow-key',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => 'https://fermatmind.com/indexnow.txt',
+            'seo_intel.search_channel_queue.approved_source_authorities' => [
+                'backend_cms',
+                'backend_public_surface',
+                'scale_catalog',
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function command_orchestrates_weekly_l5_low_risk_path_with_indexnow_only(): void
+    {
+        Http::fake([
+            'api.indexnow.test/*' => Http::response('', 202),
+        ]);
+        $page = $this->createContentPage();
+        $this->seedSeoUrl('https://fermatmind.com/zh/priority-scheduler-page', (string) $page->id);
+
+        $artifactDir = $this->artifactDir();
+        $exitCode = Artisan::call('seo-agent:priority-queue-scheduler', [
+            '--mode' => 'weekly-l5-low-risk',
+            '--sources' => 'cms-tdk-gap',
+            '--limit' => 10,
+            '--draft-limit' => 10,
+            '--publish-limit' => 1,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('seo-agent-priority-queue-scheduler.v1', $summary['schema_version'] ?? null);
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(1, data_get($summary, 'steps.weekly_draft_write_auto.rows_created'));
+        $this->assertSame(1, data_get($summary, 'steps.cms_publish_auto_canary.published_or_planned_count'));
+        $this->assertSame(1, data_get($summary, 'steps.post_publish_indexnow_auto.submitted_count'));
+        $this->assertSame('pass', data_get($summary, 'steps.rollback_post_publish.status'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.google_indexing_api_call', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.queue_worker_started', true));
+
+        $fresh = $page->refresh();
+        $this->assertSame('passed', (string) $fresh->claim_gate_status);
+        $this->assertSame('approved', (string) $fresh->review_state);
+        $this->assertNotSame(88, (int) $fresh->published_revision_id);
+        $this->assertSame(1, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $queueItem = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->first();
+        $this->assertSame('indexnow', (string) $queueItem->channel);
+        $this->assertSame('submitted', (string) $queueItem->execution_state);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://api.indexnow.test/indexnow'
+                && $request['urlList'] === ['https://fermatmind.com/zh/priority-scheduler-page'];
+        });
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('SEO-AGENT-PRIORITY-QUEUE-SCHEDULER-01', $artifact['task'] ?? null);
+        $this->assertSame('external_cron_or_manual_cli', $artifact['trigger'] ?? null);
+        $this->assertFalse((bool) data_get($artifact, 'cron_boundary.laravel_scheduler_enabled_by_pr', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_indexing_api_call', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.frontend_code_mutation', true));
+
+        $combined = implode("\n", array_map(
+            static fn ($file): string => (string) file_get_contents($file->getPathname()),
+            File::allFiles($artifactDir)
+        ));
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $combined, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_limits_and_mode(): void
+    {
+        $exitCode = Artisan::call('seo-agent:priority-queue-scheduler', [
+            '--mode' => 'daily-unbounded',
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('unsupported_mode', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:priority-queue-scheduler', [
+            '--publish-limit' => 4,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('publish_limit_out_of_bounds', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:priority-queue-scheduler', [
+            '--draft-limit' => 11,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('draft_limit_out_of_bounds', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_priority_queue_scheduler_boundaries(): void
+    {
+        $artifact = $this->readJson(base_path('docs/seo/generated/seo-agent-priority-queue-scheduler.v1.json'));
+
+        $this->assertSame('seo-agent-priority-queue-scheduler.v1', $artifact['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:priority-queue-scheduler', $artifact['command'] ?? null);
+        $this->assertSame(10, $artifact['max_draft_rows_per_execution'] ?? null);
+        $this->assertSame(3, $artifact['max_content_page_publish_canaries_per_execution'] ?? null);
+        $this->assertSame(['indexnow'], $artifact['live_submit_channels_v1'] ?? null);
+        $this->assertFalse((bool) ($artifact['laravel_scheduler_enabled_by_pr'] ?? true));
+        $this->assertFalse((bool) ($artifact['queue_worker_started_by_pr'] ?? true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.google_indexing_api_call', true));
+    }
+
+    private function createContentPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'priority-scheduler-page',
+            'path' => '/zh/priority-scheduler-page',
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'title' => 'Priority Scheduler Page',
+            'summary' => 'Existing summary.',
+            'seo_title' => '',
+            'seo_description' => '',
+            'meta_description' => '',
+            'canonical_path' => '/zh/priority-scheduler-page',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'zh-CN',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'draft',
+            'published_revision_id' => 88,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function seedSeoUrl(string $canonicalUrl, string $entityId): void
+    {
+        DB::connection('seo_intel')->table('seo_urls')->insert([
+            'canonical_url_hash' => hash('sha256', $canonicalUrl),
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'content_page',
+            'entity_id_or_slug' => $entityId,
+            'cluster' => 'content_page',
+            'source_authority' => 'backend_cms',
+            'indexability_state' => 'indexable',
+            'lastmod_at' => now()->subMinute(),
+            'lastmod_source' => 'content_pages.updated_at',
+            'is_private_flow' => false,
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'metadata_json' => json_encode([
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'content_pages',
+            ], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_urls', function ($table): void {
+            $table->id();
+            $table->char('canonical_url_hash', 64);
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_id_or_slug', 255)->nullable();
+            $table->string('cluster', 64)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('indexability_state', 64);
+            $table->timestamp('lastmod_at')->nullable();
+            $table->string('lastmod_source', 64)->nullable();
+            $table->boolean('is_private_flow')->default(false);
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_batches', function ($table): void {
+            $table->id();
+            $table->string('channel', 64);
+            $table->string('status', 64)->default('draft');
+            $table->unsignedInteger('item_count')->default(0);
+            $table->json('dry_run_report')->nullable();
+            $table->text('approval_note')->nullable();
+            $table->string('created_by', 128)->nullable();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64)->unique();
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-priority-queue-scheduler-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'secret-indexnow-key',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+            'https://fermatmind.com/zh/priority-scheduler-page',
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1316,6 +1316,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_priority_queue_scheduler_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentPriorityQueueSchedulerCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentPriorityQueueSchedulerCommand;',
+            '+        SeoAgentPriorityQueueSchedulerCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files(): void
     {
         $changed = [
@@ -3970,6 +3984,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentPriorityQueueSchedulerFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentGscOpportunityAutoDraftFile($file)) {
                 continue;
             }
@@ -4588,6 +4606,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscPostPublishFeedbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentPriorityQueueSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2AssetAgentAuditOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5345,6 +5364,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentAutoRollbackGuardCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentPriorityQueueSchedulerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentPriorityQueueSchedulerCommand.php',
         ], true);
     }
 
@@ -7308,6 +7334,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentAutoRollbackGuardCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentPriorityQueueSchedulerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentPriorityQueueSchedulerCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:priority-queue-scheduler`, an external-cron L5-A low-risk orchestrator for the SEO Agent.
- The command chains weekly discovery/draft writing, rollback preflight, ContentPage publish canary3, IndexNow auto submit, rollback post-publish, and final evidence.
- Added scheduler contract docs/generated JSON and a focused end-to-end feature test.
- Updated Big Five runtime freeze allowlist for the new SEO Agent command registration.

## Why
L5-A needs one bounded entrypoint that external cron can run without enabling Laravel scheduler or queue workers, while preserving the existing safety gates and evidence chain.

## Validation
```bash
cd backend
php artisan test --filter SeoAgentPriorityQueueSchedulerTest
php artisan test --filter SeoAgentWeeklyDraftWriteAutoTest
php artisan test --filter SeoAgentCmsPublishAutoCanaryTest
php artisan test --filter SeoAgentPostPublishIndexnowAutoTest
php artisan test --filter SeoAgentAutoRollbackGuardTest
php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest
python3 -m json.tool docs/seo/generated/seo-agent-priority-queue-scheduler.v1.json >/dev/null
php artisan list --raw | grep 'seo-agent:priority-queue-scheduler'
git diff --check
```

## Intentionally deferred
- No Laravel scheduler registration.
- No queue worker activation.
- No Article auto-publish.
- No CMS bulk publish.
- No Google Indexing API live call.
- No Baidu/google_sitemap live submit.
- No frontend mutation or deployment.