### PR TITLE
Enneagram: add result page agent readiness control packet

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageAgentReadiness;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageAgentReadinessCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-agent
+        {action=audit : Only audit is supported in the readiness/control-packet PR}
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/enneagram_result_page_agent}
+        {--candidate-dir= : Optional existing Phase8B candidate directory to check for required artifact names}
+        {--strict : Return non-zero when a provided candidate directory is missing required artifacts}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Read-only Enneagram result page content asset agent readiness/control-packet audit.';
+
+    public function handle(EnneagramResultPageAgentReadiness $readiness): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $readiness->audit([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'candidate_dir' => trim((string) $this->option('candidate-dir')),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('artifact_dir='.(string) ($summary['artifact_dir'] ?? ''));
+        $this->line('candidate_generation_allowed='.(((bool) data_get($summary, 'summary.candidate_generation_allowed', true)) ? 'true' : 'false'));
+        $this->line('candidate_payload_count_expected='.(string) data_get($summary, 'summary.candidate_payload_count_expected', 0));
+        $this->line('ready_for_activation='.(((bool) data_get($summary, 'summary.ready_for_activation', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', data_get($artifact, 'path', '')));
+        }
+
+        foreach ((array) ($summary['strict_failures'] ?? []) as $failure) {
+            $this->line('strict_failure='.(string) $failure);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -112,6 +112,7 @@ use App\Console\Commands\ContentReleaseRevalidate;
 use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
+use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
 use App\Console\Commands\FapEmailLifecycleRollout;
@@ -239,6 +240,7 @@ class Kernel extends ConsoleKernel
         EnneagramExportProductionEquivalentCandidatePayloads::class,
         EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
+        EnneagramResultPageAgentReadinessCommand::class,
         EnneagramRollbackRegistryRelease::class,
         BigFiveExportProductionEquivalentCandidatePayloads::class,
         BigFiveImportInactiveCandidateRelease::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php
@@ -1,0 +1,421 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageAgentReadiness
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.agent_readiness.v1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_agent';
+
+    private const EXPECTED_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
+
+    private const EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
+
+    private const EXPECTED_PAYLOAD_COUNT = 630;
+
+    private const REQUIRED_CANDIDATE_FILES = [
+        'candidate_manifest.json',
+        'candidate_hashes.json',
+        'rollback_plan.md',
+        'import_diff_summary.json',
+        'replacement_additive_map.json',
+        'source_mapping_report.json',
+        'legacy_residual_scan.json',
+        'fc144_boundary_report.json',
+        'phase8b_summary.json',
+        'candidate_payloads_manifest.json',
+        'candidate_payload_hashes.json',
+        'candidate_payload_source_mapping.json',
+        'candidate_payloads/',
+    ];
+
+    private const FORBIDDEN_CLAIM_FAMILIES = [
+        'diagnosis_or_treatment',
+        'clinical_condition',
+        'hiring_or_employment_screening',
+        'fixed_type_certainty',
+        'you_are_this_type',
+        'final_typing_or_retyping',
+        'score_comparison_between_e105_and_fc144',
+        'fc144_more_accurate_claim',
+        'ability_success_salary_or_performance_prediction',
+        'medical_therapy_or_mental_health_advice',
+    ];
+
+    private const AGENT_BATCHES = [
+        [
+            'batch_id' => 'ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01',
+            'state' => 'ready_for_review',
+            'allowed_output' => 'docs, control packet, readiness artifacts',
+            'generation_allowed' => false,
+        ],
+        [
+            'batch_id' => 'ENNEAGRAM-RESULT-SOURCE-LEDGER-01',
+            'state' => 'planned',
+            'allowed_output' => 'source ledger only',
+            'generation_allowed' => false,
+        ],
+        [
+            'batch_id' => 'ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01',
+            'state' => 'blocked_until_validator_and_ledger_pass',
+            'allowed_output' => 'small candidate draft only after explicit PR authorization',
+            'generation_allowed' => false,
+        ],
+        [
+            'batch_id' => 'ENNEAGRAM-RESULT-CANDIDATE-EXPORT-QA-01',
+            'state' => 'blocked_until_candidate_dir_is_provided',
+            'allowed_output' => 'Phase8B/Phase8D2B reports only',
+            'generation_allowed' => false,
+        ],
+    ];
+
+    /**
+     * @param  array{run_id?:string,artifact_dir?:string,strict?:bool,candidate_dir?:string}  $options
+     * @return array<string,mixed>
+     */
+    public function audit(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $strict = ($options['strict'] ?? false) === true;
+        $candidateDir = trim((string) ($options['candidate_dir'] ?? ''));
+
+        $this->ensureDirectory($artifactDir);
+
+        $controlPacket = $this->controlPacket();
+        $readinessInventory = $this->readinessInventory($candidateDir);
+        $validationCommands = $this->validationCommands();
+        $safetyPolicy = $this->safetyPolicy();
+        $goNoGo = $this->goNoGo($readinessInventory);
+
+        $artifacts = [
+            'control_packet.json' => $this->writeJson($artifactDir.'/control_packet.json', $controlPacket),
+            'readiness_inventory.json' => $this->writeJson($artifactDir.'/readiness_inventory.json', $readinessInventory),
+            'validation_commands.json' => $this->writeJson($artifactDir.'/validation_commands.json', $validationCommands),
+            'safety_policy.json' => $this->writeJson($artifactDir.'/safety_policy.json', $safetyPolicy),
+            'go_no_go.md' => $this->writeText($artifactDir.'/go_no_go.md', $goNoGo),
+        ];
+
+        $strictFailures = [];
+        if ($strict && (bool) data_get($readinessInventory, 'candidate_dir.provided', false) === true) {
+            foreach ((array) data_get($readinessInventory, 'candidate_dir.missing_required_files', []) as $missing) {
+                $strictFailures[] = 'missing_candidate_artifact:'.$missing;
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $strictFailures === [],
+            'status' => $strictFailures === [] ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'strict_failures' => $strictFailures,
+            'summary' => [
+                'candidate_generation_allowed' => false,
+                'candidate_payload_count_expected' => self::EXPECTED_PAYLOAD_COUNT,
+                'expected_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+                'expected_runtime_registry_manifest_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+                'ready_for_generation' => false,
+                'ready_for_import' => false,
+                'ready_for_activation' => false,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function controlPacket(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'control_packet',
+            'content_authority' => 'backend',
+            'scale' => 'ENNEAGRAM',
+            'surface' => 'private_result_page',
+            'candidate_contract' => [
+                'baseline_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+                'runtime_registry_manifest_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+                'payload_count' => self::EXPECTED_PAYLOAD_COUNT,
+                'out_of_launch_scope_must_equal' => ['1R-I', '1R-J'],
+                'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
+            ],
+            'agent_batches' => self::AGENT_BATCHES,
+            'allowed_actions' => [
+                'read existing docs and code',
+                'write run-scoped readiness artifacts',
+                'write source ledger templates',
+                'prepare small candidate drafts only in a future explicitly authorized PR',
+                'run Phase8B export QA against a caller-provided candidate directory',
+                'run Phase8D2B inactive import simulation against a caller-provided candidate directory',
+            ],
+            'forbidden_actions' => [
+                'bulk content generation in this PR',
+                'production activation',
+                'content_pack_activations write',
+                'runtime registry switch',
+                'production import',
+                'frontend fallback copy',
+                'fap-web runtime changes',
+                'sitemap or llms exposure',
+                'public SEO profile generation',
+                'private result or attempt identifier export',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readinessInventory(string $candidateDir): array
+    {
+        $candidate = [
+            'provided' => $candidateDir !== '',
+            'path' => $candidateDir === '' ? null : $this->redactPath($candidateDir),
+            'required_files' => self::REQUIRED_CANDIDATE_FILES,
+            'missing_required_files' => [],
+        ];
+
+        if ($candidateDir !== '') {
+            if (! is_dir($candidateDir)) {
+                throw new RuntimeException('Candidate directory does not exist: '.$candidateDir);
+            }
+
+            foreach (self::REQUIRED_CANDIDATE_FILES as $file) {
+                $path = rtrim($candidateDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.rtrim($file, '/');
+                $exists = str_ends_with($file, '/') ? is_dir($path) : is_file($path);
+                if (! $exists) {
+                    $candidate['missing_required_files'][] = $file;
+                }
+            }
+        }
+
+        $runtimeManifest = base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json');
+        $runtimeHash = is_file($runtimeManifest) ? (hash_file('sha256', $runtimeManifest) ?: '') : '';
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'readiness_inventory',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'candidate_dir' => $candidate,
+            'repo_contracts' => [
+                'export_command' => 'php artisan enneagram:export-production-equivalent-candidate-payloads --candidate-dir=<candidate> --output-dir=<tmp> --json',
+                'inactive_import_command' => 'php artisan enneagram:import-inactive-candidate-release --candidate-dir=<candidate> --output-dir=<tmp> --json',
+                'activation_command' => 'php artisan enneagram:activate-registry-release --release-id=<inactive_release_id>',
+                'activation_allowed_in_this_program' => false,
+            ],
+            'runtime_registry' => [
+                'manifest_path' => 'content_packs/ENNEAGRAM/v2/registry/manifest.json',
+                'actual_sha256' => $runtimeHash,
+                'expected_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+                'matches_expected' => $runtimeHash === self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+            ],
+            'expected_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'expected_payload_count' => self::EXPECTED_PAYLOAD_COUNT,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validationCommands(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'validation_commands',
+            'local_pr_validation' => [
+                'php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php',
+                'php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php',
+                'cd backend && php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi',
+                'git diff --check',
+            ],
+            'future_candidate_export_gate' => [
+                'cd backend && PHASE8B_CANDIDATE_DIR=<candidate-dir> PHASE8B1_OUTPUT_DIR=<tmp-output> php artisan enneagram:export-production-equivalent-candidate-payloads --json',
+                'assert phase8b1_summary.json verdict starts with PASS_',
+                'assert total_payload_count == 630',
+                'assert metadata_leak_count == 0',
+                'assert source_mapping_failure_count == 0',
+                'assert fc144_boundary_violation_count == 0',
+            ],
+            'future_inactive_import_gate' => [
+                'cd backend && PHASE8B_CANDIDATE_DIR=<candidate-dir> PHASE8D2B_OUTPUT_DIR=<tmp-output> php artisan enneagram:import-inactive-candidate-release --json',
+                'assert phase8d2b_summary.json verdict == PASS_FOR_PHASE_8D_3_ACTIVATION_ROLLBACK_GATE',
+                'assert activation_happened == false',
+                'assert production_import_happened == false',
+                'assert candidate_payload_count == 630',
+            ],
+            'deferred' => [
+                'production activation',
+                'runtime registry switch',
+                'fap-web rendered QA',
+                'bulk asset generation',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function safetyPolicy(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'safety_policy',
+            'forbidden_claim_families' => self::FORBIDDEN_CLAIM_FAMILIES,
+            'forbidden_public_payload_fields' => [
+                'attempt_id',
+                'user_id',
+                'private_url',
+                'private_path',
+                'editor_notes',
+                'qa_notes',
+                'source_selection_notes',
+                'internal_metadata',
+                'raw_scores',
+                'raw_score_vector',
+            ],
+            'fc144_boundary_rules' => [
+                'FC144 may be suggested as a second lens, not a more accurate final type.',
+                'E105 and FC144 scores must not be directly compared.',
+                'No final typing, retyping, diagnostic, hiring, or certainty claims.',
+            ],
+            'source_mapping_rules' => [
+                'Every candidate payload must map to one approved source batch and source asset checksum.',
+                'Fallback, blocked, duplicate selection, and branch provenance mismatch counts must be zero.',
+                'Machine-local private paths must be redacted from public reports.',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $readinessInventory
+     */
+    private function goNoGo(array $readinessInventory): string
+    {
+        return implode("\n", [
+            '# Enneagram Result Page Agent Go / No-Go',
+            '',
+            '- verdict: CONTROL_PACKET_ONLY',
+            '- candidate_generation_allowed: false',
+            '- ready_for_generation: false',
+            '- ready_for_import: false',
+            '- ready_for_activation: false',
+            '- expected_candidate_manifest_sha256: `'.self::EXPECTED_CANDIDATE_MANIFEST_SHA256.'`',
+            '- expected_runtime_registry_manifest_sha256: `'.self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256.'`',
+            '- expected_payload_count: '.self::EXPECTED_PAYLOAD_COUNT,
+            '- runtime_registry_matches_expected: '.(((bool) data_get($readinessInventory, 'runtime_registry.matches_expected', false)) ? 'true' : 'false'),
+            '- no bulk content generated',
+            '- no production import',
+            '- no activation',
+            '- no runtime switch',
+            '- no frontend fallback',
+            '',
+        ]);
+    }
+
+    /**
+     * @return array<string,bool|string>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_generation' => false,
+            'ready_for_import' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'activation_happened' => false,
+            'bulk_content_generation_happened' => false,
+            'frontend_fallback_allowed' => false,
+        ];
+    }
+
+    private function sanitizeRunId(string $runId): string
+    {
+        $runId = strtolower(trim($runId));
+        $runId = preg_replace('/[^a-z0-9._-]+/', '-', $runId) ?: '';
+        $runId = trim($runId, '-._');
+
+        return $runId !== '' ? $runId : now()->format('Ymd-His');
+    }
+
+    private function artifactDir(string $artifactDir, string $runId): string
+    {
+        $root = $artifactDir !== '' ? rtrim($artifactDir, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $root.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    /**
+     * @return array{path:string,relative_path:string,sha256:string}
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        $this->ensureDirectory(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $this->artifactMeta($path);
+    }
+
+    /**
+     * @return array{path:string,relative_path:string,sha256:string}
+     */
+    private function writeText(string $path, string $contents): array
+    {
+        $this->ensureDirectory(dirname($path));
+        File::put($path, $contents);
+
+        return $this->artifactMeta($path);
+    }
+
+    /**
+     * @return array{path:string,relative_path:string,sha256:string}
+     */
+    private function artifactMeta(string $path): array
+    {
+        return [
+            'path' => $this->redactPath($path),
+            'relative_path' => $this->repoRelativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        File::ensureDirectoryExists($path);
+    }
+
+    private function repoRelativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        $normalized = str_replace('\\', '/', $path);
+        $baseNormalized = str_replace('\\', '/', $base);
+
+        return str_starts_with($normalized, $baseNormalized) ? substr($normalized, strlen($baseNormalized)) : basename($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return '<backend>/'.ltrim(substr($path, strlen($base)), DIRECTORY_SEPARATOR);
+        }
+
+        return preg_replace('#/Users/[^/]+/#', '/Users/<redacted>/', $path) ?: $path;
+    }
+}

--- a/backend/docs/enneagram/result-page-agent-gates.md
+++ b/backend/docs/enneagram/result-page-agent-gates.md
@@ -1,0 +1,111 @@
+# Enneagram Result Page Agent Stage Gates
+
+Status: `ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01`
+
+These gates define how Enneagram result page asset-agent work moves from readiness documentation to eventual rendered QA. They do not authorize production import, runtime switch, or activation.
+
+## Gate 1: Control Packet
+
+Entry: explicit PR authorization.
+
+Pass criteria:
+
+- runbook, artifact protocol, safety policy, and validation commands exist;
+- read-only `enneagram:result-page-agent audit` command exists;
+- no candidate payloads are generated;
+- no runtime, CMS, frontend, production, sitemap, or `llms` files are changed;
+- focused unit test, syntax checks, JSON/YAML parse, and `git diff --check` pass.
+
+Exit state: control packet documented; generation still forbidden.
+
+## Gate 2: Source Ledger
+
+Entry: control packet merged.
+
+Pass criteria:
+
+- every source batch and claim family has source id, checksum, permitted use, limitation, and disallowed use;
+- FC144 language is framed as a second lens, never a more accurate or final type;
+- no generated result-page copy is created.
+
+Exit state: sources traceable; generation still forbidden.
+
+## Gate 3: Validator Harness
+
+Entry: source ledger merged.
+
+Pass criteria:
+
+- validator can inspect a candidate/run directory without mutating runtime state;
+- hash, source mapping, metadata leakage, legacy residual, forbidden claim, FC144 boundary, and payload-count checks fail closed;
+- focused harness tests pass.
+
+Exit state: validation executable; generation still forbidden.
+
+## Gate 4: Pilot Candidate Draft
+
+Entry: validator harness merged and explicit pilot PR authorization.
+
+Pass criteria:
+
+- only a small declared pilot slice is drafted;
+- no bulk generation;
+- all public payloads remain staging-only and private-field-safe;
+- source ledger and validator reports are preserved.
+
+Exit state: pilot draft can be reviewed, but cannot be imported or activated.
+
+## Gate 5: Candidate Export QA
+
+Entry: candidate draft or recovered candidate directory is provided.
+
+Pass criteria:
+
+- `enneagram:export-production-equivalent-candidate-payloads` passes;
+- total payload count is `630`;
+- source mapping failure count is `0`;
+- metadata leak count is `0`;
+- legacy residual count is `0`;
+- FC144 boundary violation count is `0`;
+- candidate manifest hash and runtime registry hash match the approved baseline or an explicitly approved new baseline.
+
+Exit state: candidate package is render/export QA-ready, not import-ready.
+
+## Gate 6: Inactive Import QA
+
+Entry: export QA passed.
+
+Pass criteria:
+
+- `enneagram:import-inactive-candidate-release` passes;
+- inactive release metadata and private storage artifact are created only in the test/output context;
+- no activation row is created;
+- runtime resolver remains unchanged before explicit activation;
+- report states `activation_happened=false` and `production_import_happened=false`.
+
+Exit state: candidate package is inactive-import QA-ready, not activated.
+
+## Gate 7: fap-web Rendered QA
+
+Entry: inactive import QA passed.
+
+Pass criteria:
+
+- fap-web consumes backend-owned candidate fixtures or inactive-release artifacts;
+- no frontend fallback copy is added;
+- result page, PDF, share, history, compare, locked/free redaction, low resonance, partial resonance, diffuse convergence, close call, scene localization, and FC144 recommendation states are rendered safely.
+
+Exit state: rendered QA evidence exists.
+
+## Gate 8: Activation Gate
+
+Entry: rendered QA passed and explicit approval exists.
+
+Pass criteria:
+
+- rollback plan is current;
+- hashes and expected contract are final;
+- activation command is run only in the approved release context;
+- production monitoring and rollback owner are named.
+
+Exit state: activation may be considered. No earlier gate authorizes it.

--- a/backend/docs/enneagram/result-page-agent-runbook.md
+++ b/backend/docs/enneagram/result-page-agent-runbook.md
@@ -1,0 +1,75 @@
+# Enneagram Result Page Agent Runbook
+
+Status: `ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01`
+
+This runbook defines the backend-only operating contract for the Enneagram result page content asset agent. It does not authorize bulk content generation, CMS import, runtime switching, production import, registry activation, frontend fallback copy, sitemap exposure, or public SEO profile generation.
+
+## Authority Model
+
+- Backend Phase8 candidate contracts are the content authority.
+- The current candidate baseline is `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`.
+- The runtime registry manifest contract is `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`.
+- Candidate payload count must remain `630`.
+- Launch scope is `1R-A` through `1R-H`; `out_of_launch_scope` must contain only `1R-I` and `1R-J`.
+- Frontend rendered QA consumes backend candidate payloads later. Frontend-authored fallback interpretation copy is forbidden.
+
+## Agent Responsibilities
+
+The program is split into separate PR scopes:
+
+1. `ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01`: this PR; document runbook, schema, gates, validation commands, and read-only audit command.
+2. `ENNEAGRAM-RESULT-SOURCE-LEDGER-01`: source ledger and allowed-use/disallowed-use map for every claim family.
+3. `ENNEAGRAM-RESULT-VALIDATOR-HARNESS-01`: executable run validator for source mapping, metadata leakage, legacy residuals, FC144 boundaries, hash checks, and payload counts.
+4. `ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01`: explicitly authorized small candidate draft only after the ledger and validator harness pass.
+5. `ENNEAGRAM-RESULT-CANDIDATE-EXPORT-QA-01`: Phase8B export QA against a caller-provided candidate directory.
+6. `ENNEAGRAM-RESULT-INACTIVE-IMPORT-QA-01`: Phase8D2B inactive import simulation against a caller-provided candidate directory.
+7. `ENNEAGRAM-RESULT-WEB-RENDERED-QA-01`: fap-web rendered QA against backend-owned fixtures and candidate payloads.
+8. `ENNEAGRAM-RESULT-ACTIVATION-GATE-01`: separate approval gate only; not implied by any earlier pass.
+
+Each task is one PR scope. A later task must not be implemented in an earlier PR.
+
+## Required Inputs
+
+Every run must declare:
+
+- `run_id`;
+- task id and branch id;
+- target gate;
+- candidate directory when Phase8B or Phase8D2B validation is in scope;
+- expected candidate manifest SHA;
+- expected runtime registry manifest SHA;
+- expected payload count;
+- allowed output paths;
+- forbidden actions;
+- validation commands.
+
+Missing inputs block the run. The agent must not synthesize missing source authority, use old `/tmp` artifacts as proof, or treat visible live content as proof that a candidate package is importable.
+
+## Forbidden Actions
+
+- Bulk content generation in the control-packet PR.
+- Production import.
+- Registry activation.
+- Runtime registry switch.
+- `content_pack_activations` writes.
+- CMS production writes.
+- fap-web runtime changes.
+- Frontend fallback copy.
+- Sitemap, `llms.txt`, `llms-full.txt`, Search Channel, or public profile SEO exposure.
+- Diagnostic, clinical, hiring, final-typing, certainty, score-comparison, or “you are this type” claims.
+
+## Stop Conditions
+
+Stop immediately when:
+
+- changed files drift outside the current PR scope;
+- a candidate directory is missing required artifacts;
+- candidate manifest hash is not the expected baseline or an explicitly approved new baseline;
+- payload count is not exactly `630`;
+- source mapping, metadata leakage, legacy residual, or FC144 boundary reports contain failures;
+- runtime registry hash does not match the expected contract;
+- any artifact implies generation, import, activation, runtime, or production readiness before the matching gate.
+
+## First Generation Default
+
+The first generation-capable PR must be a small pilot batch after the source ledger and validator harness have merged. It must still write only candidate draft artifacts, keep `production_use_allowed=false`, and pass export/import dry-run gates before any rendered QA.

--- a/backend/docs/enneagram/result-page-agent-schema.md
+++ b/backend/docs/enneagram/result-page-agent-schema.md
@@ -1,0 +1,114 @@
+# Enneagram Result Page Agent Artifact Protocol
+
+Status: `ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01`
+
+This protocol defines the artifact shape that later Enneagram result page asset-agent PRs must use. This document is a contract only; it does not generate content assets.
+
+## Directory Contract
+
+Read-only readiness runs write to a run-scoped directory:
+
+```text
+backend/artifacts/enneagram_result_page_agent/<run_id>/
+```
+
+Generated candidate assets are forbidden in this control-packet PR. Future generation-capable PRs must use a separately authorized run directory and must not store large candidate payloads in the repository.
+
+## Required Readiness Artifact Names
+
+The read-only command writes:
+
+```text
+control_packet.json
+readiness_inventory.json
+validation_commands.json
+safety_policy.json
+go_no_go.md
+```
+
+## Shared Metadata
+
+Every JSON artifact must include:
+
+- `schema_version`;
+- task name;
+- `runtime_use: "staging_only"` where applicable;
+- `production_use_allowed: false`;
+- `ready_for_generation: false`;
+- `ready_for_import: false`;
+- `ready_for_runtime: false`;
+- `ready_for_production: false`;
+- `cms_write_performed: false`;
+- `runtime_change_performed: false`;
+- `activation_happened: false`;
+- `bulk_content_generation_happened: false`;
+- `frontend_fallback_allowed: false`.
+
+Artifacts that reference source files must use repository-relative or redacted paths. Public reports must not expose machine-local private paths.
+
+## Candidate Package Contract
+
+Future candidate package validation must require:
+
+- `candidate_manifest.json`;
+- `candidate_hashes.json`;
+- `rollback_plan.md`;
+- `import_diff_summary.json`;
+- `replacement_additive_map.json`;
+- `source_mapping_report.json`;
+- `legacy_residual_scan.json`;
+- `fc144_boundary_report.json`;
+- `phase8b_summary.json`;
+- `candidate_payloads_manifest.json`;
+- `candidate_payload_hashes.json`;
+- `candidate_payload_source_mapping.json`;
+- `candidate_payloads/`.
+
+Required values:
+
+- candidate manifest SHA: `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`;
+- runtime registry manifest SHA: `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`;
+- payload count: `630`;
+- `out_of_launch_scope`: `["1R-I", "1R-J"]`;
+- `production_import_happened=false`;
+- `full_replacement_happened=false`;
+- `activation_happened=false`.
+
+## Public Payload Boundary
+
+Public payloads must not contain:
+
+- attempt id, user id, private URL, private path, editor notes, QA notes, source-selection notes, or internal metadata;
+- raw scores, raw score vectors, private scoring internals, or private report state;
+- diagnostic, clinical, treatment, therapy, hiring, employment suitability, success prediction, salary, or performance claims;
+- final type certainty, “you are this type” framing, retyping claims, or fixed-type language;
+- FC144-as-more-accurate claims;
+- E105 and FC144 direct score comparison claims.
+
+## Run Reports
+
+Future run reports must include:
+
+- source mapping failure counts;
+- metadata leakage counts;
+- legacy residual counts;
+- FC144 boundary violation counts;
+- payload count and payload hash checks;
+- candidate manifest hash and runtime registry hash checks;
+- rollback plan status;
+- explicit negative guarantees.
+
+## State Transitions
+
+Allowed states:
+
+- `control_packet_only`;
+- `source_ledger_ready`;
+- `validator_harness_ready`;
+- `draft_candidate`;
+- `candidate_export_qa_passed`;
+- `inactive_import_qa_passed`;
+- `rendered_qa_ready`;
+- `activation_gate_candidate`.
+
+No state implies the next state. `activation_gate_candidate` is still not activation approval.

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2735,6 +2735,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_readiness_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageAgentReadinessCommand;',
+            '+        EnneagramResultPageAgentReadinessCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -4547,6 +4562,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageAgentReadinessFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -4639,6 +4658,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFiveV2AssetAgentAuditOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2AssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageAgentReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -6449,6 +6469,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageAgentReadinessFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php',
+        ], true);
+    }
+
     private function isBigFiveV2EnParityDraftCatalogFile(string $file): bool
     {
         return $file === 'backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json';
@@ -7486,6 +7514,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\BigFiveResultPageV2AssetAgentAuditCommand;',
             '        BigFiveResultPageV2AssetAgentAuditCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageAgentReadinessOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageAgentReadinessCommand;',
+            '        EnneagramResultPageAgentReadinessCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageAgentReadiness;
+use Tests\TestCase;
+
+final class EnneagramResultPageAgentReadinessTest extends TestCase
+{
+    public function test_audit_service_writes_control_packet_without_generation_or_activation(): void
+    {
+        $artifactRoot = $this->tempDir('enneagram-agent-readiness');
+
+        try {
+            $summary = app(EnneagramResultPageAgentReadiness::class)->audit([
+                'run_id' => 'unit-run',
+                'artifact_dir' => $artifactRoot,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+
+            $runDir = $artifactRoot.'/unit-run';
+            foreach ([
+                'control_packet.json',
+                'readiness_inventory.json',
+                'validation_commands.json',
+                'safety_policy.json',
+                'go_no_go.md',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $controlPacket = $this->readJson($runDir.'/control_packet.json');
+            $this->assertSame(EnneagramResultPageAgentReadiness::SCHEMA_VERSION, $controlPacket['schema_version'] ?? null);
+            $this->assertSame('backend', $controlPacket['content_authority'] ?? null);
+            $this->assertSame('ENNEAGRAM', $controlPacket['scale'] ?? null);
+            $this->assertFalse((bool) data_get($controlPacket, 'negative_guarantees.bulk_content_generation_happened', true));
+            $this->assertFalse((bool) data_get($controlPacket, 'negative_guarantees.activation_happened', true));
+            $this->assertFalse((bool) data_get($controlPacket, 'agent_batches.0.generation_allowed', true));
+
+            $inventory = $this->readJson($runDir.'/readiness_inventory.json');
+            $this->assertSame(630, (int) ($inventory['expected_payload_count'] ?? 0));
+            $this->assertSame(
+                'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f',
+                data_get($inventory, 'runtime_registry.expected_sha256')
+            );
+            $this->assertFalse((bool) ($inventory['production_use_allowed'] ?? true));
+
+            $commands = $this->readJson($runDir.'/validation_commands.json');
+            $futureExport = implode("\n", (array) ($commands['future_candidate_export_gate'] ?? []));
+            $this->assertStringContainsString('enneagram:export-production-equivalent-candidate-payloads', $futureExport);
+            $this->assertStringContainsString('total_payload_count == 630', $futureExport);
+
+            $safety = $this->readJson($runDir.'/safety_policy.json');
+            $this->assertContains('fixed_type_certainty', $safety['forbidden_claim_families'] ?? []);
+            $this->assertContains('score_comparison_between_e105_and_fc144', $safety['forbidden_claim_families'] ?? []);
+
+            $goNoGo = (string) file_get_contents($runDir.'/go_no_go.md');
+            $this->assertStringContainsString('candidate_generation_allowed: false', $goNoGo);
+            $this->assertStringContainsString('no activation', $goNoGo);
+
+            $allArtifacts = implode("\n", array_map(
+                static fn (string $filename): string => (string) file_get_contents($runDir.'/'.$filename),
+                [
+                    'control_packet.json',
+                    'readiness_inventory.json',
+                    'validation_commands.json',
+                    'safety_policy.json',
+                    'go_no_go.md',
+                ]
+            ));
+            $this->assertStringNotContainsString('/Users/rainie/', $allArtifacts);
+            $this->assertStringNotContainsString('attempt_id_example', $allArtifacts);
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
+    public function test_strict_mode_rejects_incomplete_candidate_directory(): void
+    {
+        $root = $this->tempDir('enneagram-agent-strict');
+        $candidateDir = $root.'/candidate';
+        mkdir($candidateDir, 0777, true);
+
+        try {
+            $summary = app(EnneagramResultPageAgentReadiness::class)->audit([
+                'run_id' => 'strict-run',
+                'artifact_dir' => $root.'/artifacts',
+                'candidate_dir' => $candidateDir,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('missing_candidate_artifact:candidate_manifest.json', $summary['strict_failures']);
+
+            $inventory = $this->readJson($root.'/artifacts/strict-run/readiness_inventory.json');
+            $this->assertContains('candidate_hashes.json', data_get($inventory, 'candidate_dir.missing_required_files'));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a backend-only Enneagram result page agent readiness/control-packet command and service.
- Documents the agent input/output contract, safety gates, validation commands, and the current Phase8B/Phase8D2B candidate boundary.
- Records the current a9fd candidate baseline expectation, 630 payload contract, runtime registry hash expectation, and out-of-launch-scope boundary.
- Updates the BigFive runtime freeze guard test allowlist so this Enneagram readiness scaffold is not misclassified as BigFive runtime drift.

## Why
This prepares the Enneagram result page content asset agent lane before any bulk content work. The goal is to make future generation/import work auditable, hash-bound, source-mapped, and reversible instead of creating an ungoverned asset pile.

## Validation
- `php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php`
- `php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php`
- `php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php`
- `php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter 'runtime_paths_have_no_uncommitted_diff|runtime_freeze_classifier_ignores_enneagram_result_page_agent_readiness_scaffold' --no-ansi`
- `php artisan enneagram:result-page-agent audit --run-id=smoke --artifact-dir=<tmpdir> --json`
- `php artisan list --no-ansi | rg 'enneagram:result-page-agent|enneagram:export-production-equivalent|enneagram:import-inactive'`
- `git diff --check && git diff --cached --check`
- scoped changed-file validation against the Enneagram readiness + BigFive freeze guard allowlist

## Deferred / Not Included
- No bulk content generation.
- No generated candidate payload artifacts committed.
- No inactive import execution against production data.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.

## Repository Rule Impact
This is backend-authoritative control scaffolding for a content asset workflow. It does not introduce frontend fallback content or change runtime content authority.
