### PR TITLE
Add Big Five asset candidate generator

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Milestone 1 supports audit only}
+        {action=audit : Supported actions: audit, generate-candidates}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -19,24 +19,33 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
         {--json : Emit machine-readable summary}';
 
-    protected $description = 'Read-only Big Five Result Page V2 content asset agent audit harness.';
+    protected $description = 'Read-only Big Five Result Page V2 content asset agent audit and candidate harness.';
 
     public function handle(BigFiveResultPageV2AssetAgent $agent): int
     {
         try {
-            if ($this->argument('action') !== 'audit') {
-                $this->error('Unsupported action. Milestone 1 supports only: audit');
+            $action = (string) $this->argument('action');
+            $summary = match ($action) {
+                'audit' => $agent->audit([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'content_asset_root' => trim((string) $this->option('content-asset-root')),
+                    'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
+                    'strict' => (bool) $this->option('strict'),
+                ]),
+                'generate-candidates' => $agent->generateCandidates([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
+                ]),
+                default => null,
+            };
+
+            if (! is_array($summary)) {
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates');
 
                 return self::FAILURE;
             }
-
-            $summary = $agent->audit([
-                'run_id' => trim((string) $this->option('run-id')),
-                'artifact_dir' => trim((string) $this->option('artifact-dir')),
-                'content_asset_root' => trim((string) $this->option('content-asset-root')),
-                'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
-                'strict' => (bool) $this->option('strict'),
-            ]);
 
             if ((bool) $this->option('json')) {
                 $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -44,6 +44,8 @@ final class BigFiveResultPageV2AssetAgent
 
     private const SELECTOR_ASSET_RELATIVE_PATH = 'selector_ready_assets/v0_3_p0_full/assets.jsonl';
 
+    private const CONTENT_ASSET_SCHEMA_RELATIVE_PATH = 'content_assets/big5/result_page_v2/governance/content_asset_factory_spec/big5_content_asset_schema_v0_1.json';
+
     private const FORBIDDEN_PUBLIC_FIELDS = [
         'attempt_id',
         'private_url',
@@ -152,6 +154,87 @@ final class BigFiveResultPageV2AssetAgent
                 'ready_for_production' => false,
             ],
             'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   source_ledger_dir?:string
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function generateCandidates(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $sourceLedgerDir = $this->optionalPath(
+            (string) ($options['source_ledger_dir'] ?? ''),
+            base_path(self::SOURCE_LEDGER_RELATIVE_PATH)
+        );
+
+        $this->ensureDirectory($artifactDir);
+
+        $sourceLedger = $this->sourceLedgerSummary($sourceLedgerDir);
+        $selectorCandidates = $this->draftSelectorAssetCandidates();
+        $contentCandidates = $this->draftContentAssetCandidates();
+        $validation = $this->candidateValidationReport($selectorCandidates, $contentCandidates);
+        $leakScan = $this->candidateLeakScan($selectorCandidates, $contentCandidates);
+
+        $ok = (bool) ($sourceLedger['valid'] ?? false)
+            && ((int) ($validation['error_count'] ?? 0)) === 0
+            && ((int) ($leakScan['hit_count'] ?? 0)) === 0;
+
+        $summary = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'candidate_generator',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'run_id' => $runId,
+            'source_ledger' => [
+                'valid' => (bool) ($sourceLedger['valid'] ?? false),
+                'primary_ledger_path' => $sourceLedger['primary_ledger_path'] ?? null,
+                'allowed_source_labels' => $sourceLedger['allowed_source_labels'] ?? [],
+                'bfi_2_policy_valid' => (bool) ($sourceLedger['bfi_2_policy_valid'] ?? false),
+                'errors' => $sourceLedger['errors'] ?? [],
+            ],
+            'candidate_counts' => [
+                'selector_asset' => count($selectorCandidates),
+                'content_asset' => count($contentCandidates),
+            ],
+            'validation' => $validation,
+            'leak_scan' => $leakScan,
+            'negative_guarantees' => $this->candidateNegativeGuarantees(),
+        ];
+
+        $artifacts = [
+            'selector_asset_candidates.jsonl' => $this->writeJsonl($artifactDir.'/selector_asset_candidates.jsonl', $selectorCandidates),
+            'content_asset_candidates.jsonl' => $this->writeJsonl($artifactDir.'/content_asset_candidates.jsonl', $contentCandidates),
+            'candidate_generation_summary.json' => $this->writeJson($artifactDir.'/candidate_generation_summary.json', $summary),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'selector_candidate_count' => count($selectorCandidates),
+                'content_candidate_count' => count($contentCandidates),
+                'validation_error_count' => (int) ($validation['error_count'] ?? 0),
+                'leak_hit_count' => (int) ($leakScan['hit_count'] ?? 0),
+                'source_ledger_valid' => (bool) ($sourceLedger['valid'] ?? false),
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->candidateNegativeGuarantees(),
         ];
     }
 
@@ -797,6 +880,268 @@ final class BigFiveResultPageV2AssetAgent
     /**
      * @return list<array<string,mixed>>
      */
+    private function draftSelectorAssetCandidates(): array
+    {
+        return [
+            [
+                'version' => BigFiveResultPageV2SelectorAssetContract::SCHEMA_VERSION,
+                'asset_key' => 'candidate_m4_boundary_method_non_runtime_v0_1',
+                'registry_key' => 'boundary_registry',
+                'module_key' => 'module_00_trust_bar',
+                'block_key' => 'module_00_trust_bar.candidate_m4_boundary_method_non_runtime_v0_1',
+                'block_kind' => 'trust_bar',
+                'slot_key' => 'trust_bar.boundary_core',
+                'trigger' => [
+                    'reading_mode' => ['quick', 'standard'],
+                    'scenario' => ['global'],
+                    'interpretation_scopes' => ['all'],
+                    'source_label' => 'citation_only',
+                ],
+                'priority' => 90,
+                'mutual_exclusion_group' => 'candidate_m4.boundary_method',
+                'can_stack_with' => ['method_registry'],
+                'reading_modes' => ['quick', 'standard'],
+                'scenario' => 'global',
+                'scope' => 'all',
+                'required_evidence_level' => 'descriptive',
+                'evidence_level' => 'descriptive',
+                'safety_level' => 'boundary',
+                'shareable' => false,
+                'shareable_policy' => 'not_shareable',
+                'fallback_policy' => 'backend_required',
+                'content_source' => 'gpt_selector_asset_batch',
+                'provenance' => [
+                    'runtime_use' => 'staging_only',
+                    'production_use_allowed' => false,
+                    'source_id' => 'internal_big5_v2_formal_doc',
+                    'source_label' => 'citation_only',
+                    'candidate_stage' => 'm4_generate_candidates',
+                ],
+                'replacement_policy' => [
+                    'runtime_use' => 'staging_only',
+                    'production_use_allowed' => false,
+                    'requires_human_review' => true,
+                    'requires_staging_import_gate' => true,
+                ],
+                'forbidden_public_fields' => [],
+                'review_status' => 'draft',
+                'public_payload' => [
+                    'candidate_ref' => 'candidate_content_m4_method_boundary_v0_1',
+                    'payload_kind' => 'selector_asset_candidate',
+                    'runtime_use' => 'staging_only',
+                    'production_use_allowed' => false,
+                    'ready_for_pilot' => false,
+                ],
+                'internal_metadata' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function draftContentAssetCandidates(): array
+    {
+        return [
+            [
+                'asset_id' => 'candidate_content_m4_method_boundary_v0_1',
+                'asset_key' => 'candidate_m4_method_boundary_contract_scaffold',
+                'asset_version' => 'v0_1',
+                'asset_type' => 'method_boundary',
+                'asset_layer' => 'L0_governance',
+                'module_key' => 'module_10_method_privacy',
+                'section_key' => 'method_privacy',
+                'slot_key' => 'method_boundary.method_norm_privacy',
+                'copy_role' => 'schema_candidate',
+                'reading_mode' => ['standard'],
+                'title_zh' => null,
+                'body_zh' => null,
+                'short_body_zh' => null,
+                'cta_zh' => null,
+                'applies_to' => [
+                    'scale_code' => ['BIG5_OCEAN'],
+                    'source_label' => ['citation_only'],
+                    'candidate_stage' => ['m4_generate_candidates'],
+                ],
+                'avoid_when' => [
+                    [
+                        'field' => 'qa_status',
+                        'operator' => 'not_equals',
+                        'value' => 'draft',
+                        'action' => 'manual_review_required',
+                    ],
+                ],
+                'can_combine_with' => ['boundary_registry'],
+                'cannot_combine_with' => ['runtime_use', 'production_use'],
+                'dedupe_group' => 'candidate_m4.method_boundary',
+                'selection_priority' => 0,
+                'selection_specificity' => 0,
+                'fallback_allowed' => false,
+                'render_surface' => [],
+                'body_quality' => [
+                    'body_chars' => 0,
+                    'sentence_count' => 0,
+                    'has_trait_layer' => false,
+                    'has_score_band_layer' => false,
+                    'has_coupling_layer' => false,
+                    'has_facet_layer' => false,
+                    'has_real_world_layer' => false,
+                    'has_cost_layer' => false,
+                    'has_strength_layer' => false,
+                    'has_action_layer' => false,
+                    'has_boundary_layer' => true,
+                    'has_editorial_leakage' => false,
+                    'template_risk' => 'candidate_scaffold_only',
+                    'rendered_preview_required' => true,
+                ],
+                'safety_tags' => [
+                    'candidate_scaffold',
+                    'not_user_visible',
+                    'staging_only',
+                    'source_trace_required',
+                ],
+                'qa_status' => 'draft',
+                'ready_for_pilot' => false,
+                'runtime_use' => 'staging_only',
+                'production_use_allowed' => false,
+                'source_trace' => [
+                    'source_pack' => 'BIG5_RESULT_PAGE_V2_SOURCE_LEDGER',
+                    'source_role' => 'citation_only',
+                    'derived_from' => [
+                        'internal_big5_v2_formal_doc',
+                        'source_ledger.json',
+                    ],
+                    'forbidden_copy_sources_excluded' => true,
+                    'bfi_2_copy_used' => false,
+                ],
+                'repair_log_refs' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $selectorCandidates
+     * @param  list<array<string,mixed>>  $contentCandidates
+     * @return array<string,mixed>
+     */
+    private function candidateValidationReport(array $selectorCandidates, array $contentCandidates): array
+    {
+        $errors = [];
+        foreach ($this->selectorValidator->validateAssetSet($selectorCandidates) as $error) {
+            $errors[] = 'selector_asset: '.$error;
+        }
+        foreach ($contentCandidates as $index => $candidate) {
+            foreach ($this->validateContentAssetCandidate($candidate) as $error) {
+                $errors[] = "content_asset {$index}: {$error}";
+            }
+        }
+
+        return [
+            'status' => $errors === [] ? 'pass' : 'blocked',
+            'selector_asset_candidate_count' => count($selectorCandidates),
+            'content_asset_candidate_count' => count($contentCandidates),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $candidate
+     * @return list<string>
+     */
+    private function validateContentAssetCandidate(array $candidate): array
+    {
+        $schema = $this->contentAssetSchema();
+        $errors = [];
+
+        foreach ((array) ($schema['required_fields'] ?? []) as $field) {
+            if (is_string($field) && ! array_key_exists($field, $candidate)) {
+                $errors[] = "content asset missing {$field}";
+            }
+        }
+
+        foreach ([
+            'asset_type' => (array) ($schema['asset_type_enum'] ?? []),
+            'asset_layer' => (array) ($schema['asset_layer_enum'] ?? []),
+            'qa_status' => (array) data_get($schema, 'field_definitions.qa_status.allowed', []),
+            'runtime_use' => (array) data_get($schema, 'field_definitions.runtime_use.allowed', []),
+        ] as $field => $allowed) {
+            if (! in_array((string) ($candidate[$field] ?? ''), $allowed, true)) {
+                $errors[] = "{$field} is invalid: ".(string) ($candidate[$field] ?? '');
+            }
+        }
+
+        foreach ((array) ($candidate['reading_mode'] ?? []) as $mode) {
+            if (! in_array($mode, (array) data_get($schema, 'field_definitions.reading_mode.allowed', []), true)) {
+                $errors[] = "reading_mode is invalid: {$mode}";
+            }
+        }
+
+        if (($candidate['ready_for_pilot'] ?? null) !== false) {
+            $errors[] = 'ready_for_pilot must be false';
+        }
+        if (($candidate['runtime_use'] ?? null) !== 'staging_only') {
+            $errors[] = 'runtime_use must be staging_only';
+        }
+        if (($candidate['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed must be false';
+        }
+        if (! is_array($candidate['source_trace'] ?? null)) {
+            $errors[] = 'source_trace must be an object';
+        }
+        if (data_get($candidate, 'source_trace.bfi_2_copy_used') !== false) {
+            $errors[] = 'source_trace.bfi_2_copy_used must be false';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function contentAssetSchema(): array
+    {
+        $path = base_path(self::CONTENT_ASSET_SCHEMA_RELATIVE_PATH);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Content asset schema is not valid JSON.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $selectorCandidates
+     * @param  list<array<string,mixed>>  $contentCandidates
+     * @return array<string,mixed>
+     */
+    private function candidateLeakScan(array $selectorCandidates, array $contentCandidates): array
+    {
+        $hits = [];
+        foreach ($selectorCandidates as $index => $candidate) {
+            $hits = array_merge(
+                $hits,
+                $this->scanPayload((array) ($candidate['public_payload'] ?? []), "selector_asset_candidate:{$index}", 'selector_public_payload')
+            );
+        }
+        foreach ($contentCandidates as $index => $candidate) {
+            $publicFields = array_intersect_key($candidate, array_flip(['title_zh', 'body_zh', 'short_body_zh', 'cta_zh']));
+            $hits = array_merge(
+                $hits,
+                $this->scanPayload($publicFields, "content_asset_candidate:{$index}", 'content_public_fields')
+            );
+        }
+
+        return [
+            'status' => $hits === [] ? 'pass' : 'blocked',
+            'hit_count' => count($hits),
+            'hits' => $hits,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
     private function collectSelectorAssets(string $contentAssetRoot): array
     {
         $path = rtrim($contentAssetRoot, '/').'/'.self::SELECTOR_ASSET_RELATIVE_PATH;
@@ -923,6 +1268,28 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,mixed>
+     */
+    private function writeJsonl(string $path, array $rows): array
+    {
+        $lines = [];
+        foreach ($rows as $row) {
+            $encoded = json_encode($row, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            if (! is_string($encoded)) {
+                throw new RuntimeException('Unable to encode JSONL artifact: '.$this->redactPath($path));
+            }
+            $lines[] = $encoded;
+        }
+
+        if (file_put_contents($path, implode(PHP_EOL, $lines).PHP_EOL) === false) {
+            throw new RuntimeException('Unable to write artifact: '.$this->redactPath($path));
+        }
+
+        return $this->fileRef($path);
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function writeText(string $path, string $text): array
@@ -983,6 +1350,24 @@ final class BigFiveResultPageV2AssetAgent
             'cms_write' => false,
             'frontend_copy_write' => false,
             'selector_asset_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function candidateNegativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
             'runtime_flag_change' => false,
             'release_snapshot_change' => false,
             'production_import_gate_change' => false,

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -192,6 +192,82 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_generate_candidates_writes_staging_only_selector_and_content_asset_drafts(): void
+    {
+        $artifactRoot = $this->tempDir('big5-v2-agent-candidates');
+
+        try {
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'generate-candidates',
+                '--run-id' => 'candidate-run',
+                '--artifact-dir' => $artifactRoot,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/candidate-run';
+            foreach ([
+                'selector_asset_candidates.jsonl',
+                'content_asset_candidates.jsonl',
+                'candidate_generation_summary.json',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $selectorCandidates = $this->readJsonl($runDir.'/selector_asset_candidates.jsonl');
+            $contentCandidates = $this->readJsonl($runDir.'/content_asset_candidates.jsonl');
+            $summary = $this->readJson($runDir.'/candidate_generation_summary.json');
+
+            $this->assertCount(1, $selectorCandidates);
+            $this->assertCount(1, $contentCandidates);
+            $this->assertSame('staging_only', $summary['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($summary['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($summary['ready_for_pilot'] ?? true));
+            $this->assertFalse((bool) ($summary['ready_for_runtime'] ?? true));
+            $this->assertFalse((bool) ($summary['ready_for_production'] ?? true));
+            $this->assertSame('pass', data_get($summary, 'validation.status'));
+            $this->assertSame(0, data_get($summary, 'validation.error_count'));
+            $this->assertSame('pass', data_get($summary, 'leak_scan.status'));
+            $this->assertSame(0, data_get($summary, 'leak_scan.hit_count'));
+            $this->assertTrue((bool) data_get($summary, 'source_ledger.valid'));
+            $this->assertTrue((bool) data_get($summary, 'source_ledger.bfi_2_policy_valid'));
+
+            $selector = $selectorCandidates[0];
+            $this->assertSame('draft', $selector['review_status'] ?? null);
+            $this->assertFalse((bool) ($selector['shareable'] ?? true));
+            $this->assertSame('staging_only', data_get($selector, 'public_payload.runtime_use'));
+            $this->assertFalse((bool) data_get($selector, 'public_payload.production_use_allowed', true));
+
+            $content = $contentCandidates[0];
+            $this->assertSame('draft', $content['qa_status'] ?? null);
+            $this->assertSame('staging_only', $content['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($content['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($content['ready_for_pilot'] ?? true));
+            $this->assertFalse((bool) data_get($content, 'source_trace.bfi_2_copy_used', true));
+
+            $allArtifacts = implode("\n", array_map(
+                static fn (string $filename): string => (string) file_get_contents($runDir.'/'.$filename),
+                [
+                    'selector_asset_candidates.jsonl',
+                    'content_asset_candidates.jsonl',
+                    'candidate_generation_summary.json',
+                ]
+            ));
+            foreach ([
+                'private_url',
+                'attempt_id',
+                'raw_score',
+                'percentile',
+                'fixed_type',
+                'user_confirmed_type',
+                'type_code',
+            ] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_strict_mode_rejects_public_payload_and_shareable_score_leaks(): void
     {
         $root = $this->tempDir('big5-v2-agent-leak');
@@ -272,6 +348,21 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         $this->assertIsArray($decoded);
 
         return $decoded;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function readJsonl(string $path): array
+    {
+        $rows = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            $this->assertIsArray($decoded);
+            $rows[] = $decoded;
+        }
+
+        return $rows;
     }
 
     private function deleteDirectory(string $path): void


### PR DESCRIPTION
## What changed
- Added `generate-candidates` to `php artisan big5:result-page-v2-agent`.
- Generates artifact-only `selector_asset` and `content_asset` draft candidates under the run artifact directory.
- Validates selector drafts with the existing selector asset validator and validates content drafts against the content asset schema requirements.
- Adds candidate leak scanning and keeps ready flags false with `runtime_use=staging_only` and `production_use_allowed=false`.
- Adds PHPUnit coverage for artifact-only generation, source-ledger enforcement, validation pass, leak pass, and no private/result token output.

## Why
M4 starts candidate generation while preserving the Big Five V2 content authority boundary: candidates stay in artifacts, do not become runtime payloads, and do not enter staging content packages until a later reviewed import gate.

## Validation
- `php artisan big5:result-page-v2-agent audit --run-id=m4-audit-verify --json`
- `php artisan big5:result-page-v2-agent generate-candidates --run-id=m4-candidate-verify --json`
- `php artisan test --filter=BigFiveResultPageV2AssetAgentTest`
- `./vendor/bin/pint --test app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php`
- `git diff --check`

## Intentionally deferred
- No writes to `content_assets/**` staging packages.
- No final `big5_result_page_v2` payload generation.
- No fap-web result-page copy.
- No release snapshot, production import gate, rollout gate, Ops panel, or runtime flag changes.
- M5 staging import gate remains a separate PR.