### PR TITLE
Add Big Five staging candidate import gate

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,11 +11,14 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
         {--source-ledger-dir= : Optional source ledger directory for tests}
+        {--candidate-dir= : Candidate artifact directory for stage-candidates}
+        {--staging-output-dir= : Optional staging package output directory for stage-candidates}
+        {--allow-staging-write : Permit stage-candidates to write the reviewed staging package}
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
         {--json : Emit machine-readable summary}';
 
@@ -38,11 +41,18 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'artifact_dir' => trim((string) $this->option('artifact-dir')),
                     'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
                 ]),
+                'stage-candidates' => $agent->stageCandidates([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'candidate_dir' => trim((string) $this->option('candidate-dir')),
+                    'staging_output_dir' => trim((string) $this->option('staging-output-dir')),
+                    'allow_staging_write' => (bool) $this->option('allow-staging-write'),
+                ]),
                 default => null,
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -239,6 +239,156 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   candidate_dir?:string,
+     *   staging_output_dir?:string,
+     *   allow_staging_write?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function stageCandidates(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $candidateDir = trim((string) ($options['candidate_dir'] ?? '')) === ''
+            ? ''
+            : $this->absolutePath((string) ($options['candidate_dir'] ?? ''));
+        $stagingOutputDir = $this->optionalPath(
+            (string) ($options['staging_output_dir'] ?? ''),
+            base_path('content_assets/big5/result_page_v2/staging_candidate_imports/'.$runId)
+        );
+        $allowStagingWrite = ($options['allow_staging_write'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $selectorCandidates = $candidateDir === '' ? [] : $this->readJsonl($candidateDir.'/selector_asset_candidates.jsonl');
+        $contentCandidates = $candidateDir === '' ? [] : $this->readJsonl($candidateDir.'/content_asset_candidates.jsonl');
+        $reviewManifest = $candidateDir === '' ? null : $this->readOptionalJson($candidateDir.'/review_manifest.json');
+        $validation = $this->candidateValidationReport($selectorCandidates, $contentCandidates);
+        $reviewErrors = $this->reviewManifestErrors($reviewManifest);
+        $leakScan = $this->candidateLeakScan($selectorCandidates, $contentCandidates);
+
+        $stagingWritePerformed = false;
+        $stagingArtifacts = [];
+        $ok = ((int) ($validation['error_count'] ?? 0)) === 0
+            && $reviewErrors === []
+            && ((int) ($leakScan['hit_count'] ?? 0)) === 0;
+
+        $repairLog = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_repair_log',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'repair_required' => ! $ok,
+            'entries' => array_values(array_merge(
+                (array) ($validation['errors'] ?? []),
+                $reviewErrors,
+                array_map(static fn (array $hit): string => 'leak: '.(string) ($hit['value'] ?? ''), (array) ($leakScan['hits'] ?? []))
+            )),
+        ];
+
+        $validationReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_validation',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'candidate_dir' => $this->redactPath($candidateDir),
+            'staging_output_dir' => $this->redactPath($stagingOutputDir),
+            'allow_staging_write' => $allowStagingWrite,
+            'staging_write_performed' => false,
+            'review_manifest' => [
+                'present' => $reviewManifest !== null,
+                'valid' => $reviewErrors === [],
+                'errors' => $reviewErrors,
+            ],
+            'candidate_counts' => [
+                'selector_asset' => count($selectorCandidates),
+                'content_asset' => count($contentCandidates),
+            ],
+            'candidate_validation' => $validation,
+            'leak_scan' => $leakScan,
+            'negative_guarantees' => $allowStagingWrite ? $this->stagingImportNegativeGuarantees() : $this->candidateNegativeGuarantees(),
+        ];
+
+        if ($ok && $allowStagingWrite) {
+            $this->ensureDirectory($stagingOutputDir);
+            $validationReport['staging_write_performed'] = true;
+            $stagingArtifacts = [
+                'selector_asset_candidates.staging.jsonl' => $this->writeJsonl($stagingOutputDir.'/selector_asset_candidates.staging.jsonl', $selectorCandidates),
+                'content_asset_candidates.staging.jsonl' => $this->writeJsonl($stagingOutputDir.'/content_asset_candidates.staging.jsonl', $contentCandidates),
+                'staging_import_manifest.json' => $this->writeJson($stagingOutputDir.'/staging_import_manifest.json', [
+                    'schema_version' => self::SCHEMA_VERSION,
+                    'task' => 'staging_import_manifest',
+                    'runtime_use' => 'staging_only',
+                    'production_use_allowed' => false,
+                    'ready_for_pilot' => false,
+                    'ready_for_runtime' => false,
+                    'ready_for_production' => false,
+                    'candidate_dir' => $this->redactPath($candidateDir),
+                    'selector_asset_candidate_count' => count($selectorCandidates),
+                    'content_asset_candidate_count' => count($contentCandidates),
+                    'review_manifest' => [
+                        'review_status' => (string) ($reviewManifest['review_status'] ?? ''),
+                        'reviewed_at' => (string) ($reviewManifest['reviewed_at'] ?? ''),
+                    ],
+                    'negative_guarantees' => $this->stagingImportNegativeGuarantees(),
+                ]),
+                'staging_import_validation_report.json' => $this->writeJson($stagingOutputDir.'/staging_import_validation_report.json', $validationReport),
+                'repair_log.json' => $this->writeJson($stagingOutputDir.'/repair_log.json', $repairLog),
+            ];
+            $stagingWritePerformed = true;
+        }
+
+        $artifactSummary = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_gate',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'ok' => $ok,
+            'staging_write_performed' => $stagingWritePerformed,
+            'staging_artifacts' => $stagingArtifacts,
+            'validation_report' => $validationReport,
+            'repair_log' => $repairLog,
+        ];
+
+        $artifacts = [
+            'staging_import_summary.json' => $this->writeJson($artifactDir.'/staging_import_summary.json', $artifactSummary),
+            'staging_import_validation_report.json' => $this->writeJson($artifactDir.'/staging_import_validation_report.json', $validationReport),
+            'repair_log.json' => $this->writeJson($artifactDir.'/repair_log.json', $repairLog),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'staging_artifacts' => $stagingArtifacts,
+            'summary' => [
+                'selector_candidate_count' => count($selectorCandidates),
+                'content_candidate_count' => count($contentCandidates),
+                'validation_error_count' => (int) ($validation['error_count'] ?? 0),
+                'review_error_count' => count($reviewErrors),
+                'leak_hit_count' => (int) ($leakScan['hit_count'] ?? 0),
+                'staging_write_performed' => $stagingWritePerformed,
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $allowStagingWrite ? $this->stagingImportNegativeGuarantees() : $this->candidateNegativeGuarantees(),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function buildInventory(string $contentAssetRoot, string $sourceLedgerDir): array
@@ -1027,6 +1177,12 @@ final class BigFiveResultPageV2AssetAgent
     private function candidateValidationReport(array $selectorCandidates, array $contentCandidates): array
     {
         $errors = [];
+        if ($selectorCandidates === []) {
+            $errors[] = 'selector_asset candidates missing';
+        }
+        if ($contentCandidates === []) {
+            $errors[] = 'content_asset candidates missing';
+        }
         foreach ($this->selectorValidator->validateAssetSet($selectorCandidates) as $error) {
             $errors[] = 'selector_asset: '.$error;
         }
@@ -1137,6 +1293,81 @@ final class BigFiveResultPageV2AssetAgent
             'hit_count' => count($hits),
             'hits' => $hits,
         ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function readJsonl(string $path): array
+    {
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                $rows[] = $decoded;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function readOptionalJson(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $reviewManifest
+     * @return list<string>
+     */
+    private function reviewManifestErrors(?array $reviewManifest): array
+    {
+        if ($reviewManifest === null) {
+            return ['review_manifest.json missing'];
+        }
+
+        $errors = [];
+        if (($reviewManifest['human_reviewed'] ?? null) !== true) {
+            $errors[] = 'review_manifest human_reviewed must be true';
+        }
+        if (($reviewManifest['review_status'] ?? null) !== 'approved_for_staging') {
+            $errors[] = 'review_manifest review_status must be approved_for_staging';
+        }
+        if (($reviewManifest['runtime_use'] ?? null) !== 'staging_only') {
+            $errors[] = 'review_manifest runtime_use must be staging_only';
+        }
+        if (($reviewManifest['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'review_manifest production_use_allowed must be false';
+        }
+        if (($reviewManifest['ready_for_pilot'] ?? null) !== false) {
+            $errors[] = 'review_manifest ready_for_pilot must be false';
+        }
+        if ((string) ($reviewManifest['reviewed_by'] ?? '') === '') {
+            $errors[] = 'review_manifest reviewed_by missing';
+        }
+        if ((string) ($reviewManifest['reviewed_at'] ?? '') === '') {
+            $errors[] = 'review_manifest reviewed_at missing';
+        }
+        foreach (['selector_asset_candidates.jsonl', 'content_asset_candidates.jsonl'] as $filename) {
+            if (! in_array($filename, (array) ($reviewManifest['approved_candidate_files'] ?? []), true)) {
+                $errors[] = "review_manifest approved_candidate_files missing {$filename}";
+            }
+        }
+
+        return $errors;
     }
 
     /**
@@ -1366,6 +1597,23 @@ final class BigFiveResultPageV2AssetAgent
             'database_write' => false,
             'cms_write' => false,
             'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function stagingImportNegativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
             'frontend_copy_write' => false,
             'final_result_payload_generation' => false,
             'runtime_flag_change' => false,

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -268,6 +268,117 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_stage_candidates_fails_closed_without_human_review_manifest(): void
+    {
+        $artifactRoot = $this->tempDir('big5-v2-agent-stage-missing-review');
+        $stagingDir = $artifactRoot.'/staging-package';
+
+        try {
+            app(BigFiveResultPageV2AssetAgent::class)->generateCandidates([
+                'run_id' => 'candidate-run',
+                'artifact_dir' => $artifactRoot,
+            ]);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'stage-candidates',
+                '--run-id' => 'stage-run',
+                '--artifact-dir' => $artifactRoot,
+                '--candidate-dir' => $artifactRoot.'/candidate-run',
+                '--staging-output-dir' => $stagingDir,
+                '--allow-staging-write' => true,
+                '--json' => true,
+            ])->assertExitCode(1);
+
+            $summary = $this->readJson($artifactRoot.'/stage-run/staging_import_summary.json');
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertFalse((bool) ($summary['staging_write_performed'] ?? true));
+            $this->assertStringContainsString(
+                'review_manifest.json missing',
+                implode("\n", (array) data_get($summary, 'repair_log.entries', []))
+            );
+            $this->assertFileDoesNotExist($stagingDir.'/staging_import_manifest.json');
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
+    public function test_stage_candidates_imports_only_reviewed_candidates_to_staging_package(): void
+    {
+        $artifactRoot = $this->tempDir('big5-v2-agent-stage-reviewed');
+        $candidateDir = $artifactRoot.'/candidate-run';
+        $stagingDir = $artifactRoot.'/content_assets/big5/result_page_v2/staging_candidate_imports/reviewed-run';
+
+        try {
+            app(BigFiveResultPageV2AssetAgent::class)->generateCandidates([
+                'run_id' => 'candidate-run',
+                'artifact_dir' => $artifactRoot,
+            ]);
+            file_put_contents($candidateDir.'/review_manifest.json', json_encode([
+                'schema_version' => 'fap.big5.result_page_v2.staging_review_manifest.v0.1',
+                'human_reviewed' => true,
+                'review_status' => 'approved_for_staging',
+                'runtime_use' => 'staging_only',
+                'production_use_allowed' => false,
+                'ready_for_pilot' => false,
+                'reviewed_by' => 'unit_test_editorial_gate',
+                'reviewed_at' => '2026-06-21T00:00:00Z',
+                'approved_candidate_files' => [
+                    'selector_asset_candidates.jsonl',
+                    'content_asset_candidates.jsonl',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'stage-candidates',
+                '--run-id' => 'stage-run',
+                '--artifact-dir' => $artifactRoot,
+                '--candidate-dir' => $candidateDir,
+                '--staging-output-dir' => $stagingDir,
+                '--allow-staging-write' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            foreach ([
+                'selector_asset_candidates.staging.jsonl',
+                'content_asset_candidates.staging.jsonl',
+                'staging_import_manifest.json',
+                'staging_import_validation_report.json',
+                'repair_log.json',
+            ] as $filename) {
+                $this->assertFileExists($stagingDir.'/'.$filename);
+            }
+
+            $summary = $this->readJson($artifactRoot.'/stage-run/staging_import_summary.json');
+            $validation = $this->readJson($stagingDir.'/staging_import_validation_report.json');
+            $manifest = $this->readJson($stagingDir.'/staging_import_manifest.json');
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertTrue((bool) ($summary['staging_write_performed'] ?? false));
+            $this->assertTrue((bool) ($validation['staging_write_performed'] ?? false));
+            $this->assertSame('pass', data_get($validation, 'candidate_validation.status'));
+            $this->assertSame('pass', data_get($validation, 'leak_scan.status'));
+            $this->assertSame('staging_only', $manifest['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($manifest['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($manifest['ready_for_pilot'] ?? true));
+
+            $allStagingArtifacts = implode("\n", array_map(
+                static fn (string $filename): string => (string) file_get_contents($stagingDir.'/'.$filename),
+                [
+                    'selector_asset_candidates.staging.jsonl',
+                    'content_asset_candidates.staging.jsonl',
+                    'staging_import_manifest.json',
+                    'staging_import_validation_report.json',
+                    'repair_log.json',
+                ]
+            ));
+            foreach (['private_url', 'attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allStagingArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_strict_mode_rejects_public_payload_and_shareable_score_leaks(): void
     {
         $root = $this->tempDir('big5-v2-agent-leak');


### PR DESCRIPTION
## What changed
- Added `stage-candidates` to `php artisan big5:result-page-v2-agent`.
- Reads M4 candidate artifacts and fails closed unless `review_manifest.json` proves human review approval for staging.
- Validates selector/content candidates, leak scan, review status, and staging-only/production-disallowed flags before any write.
- Writes staging package files only when `--allow-staging-write` is explicitly provided and the review gate passes.
- Adds staging import validation report and repair log artifacts.
- Adds PHPUnit coverage for missing-review rejection and reviewed staging import.

## Why
M5 establishes the staging import gate without bypassing the manual review boundary. Candidate artifacts can move into a staging package only after explicit review approval; nothing touches runtime, production, rollout, or fap-web copy.

## Validation
- `php artisan test --filter=BigFiveResultPageV2AssetAgentTest`
- `php artisan test --filter=BigFiveResultPageV2SelectorAssetValidatorTest`
- `php artisan test --filter=BigFiveResultPageV2ContentAssetLookupTest`
- `php artisan test --filter=BigFiveResultPageV2DeterministicSelectorTest`
- `php artisan test --filter=BigFiveResultPageV2StagingComposerTest`
- `php artisan test --filter=BigFiveResultPageV2ValidatorTest`
- `php artisan test --filter=BigFiveResultPageV2RouteDrivenFixtureTest`
- `php artisan test --filter=BigFiveResultPageV2SelectorAssetImportV03Test`
- `./vendor/bin/pint --test app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php`
- `git diff --check`

## Intentionally deferred
- No real reviewed content batch is imported in this PR. The gate requires an approved review manifest before writing staging files.
- No final `big5_result_page_v2` payload generation.
- No fap-web result-page copy.
- No release snapshot, production import gate, rollout gate, Ops panel, or runtime flag changes.
- M6 rendered preview and frontend consumer QA remain separate.