### PR TITLE
SEO-AGENT-L5A-HARDENING-PREFLIGHT-01: harden SEO Agent L5-A defaults

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -227,6 +227,62 @@ OPS_GATE_LEGAL_PAGES_OK=false
 OPS_GATE_CONVERSION_TRACKING_OK=false
 OPS_GATE_GSC_SITEMAP_OK=false
 
+# =========================
+# SEO Intel / SEO Agent L5-A (fail-closed defaults)
+# =========================
+# Keep every write/live switch false in new checkouts. Production operators must
+# set real values in secret storage, never in this example file.
+SEO_INTEL_ENABLED=false
+SEO_INTEL_WRITE_ENABLED=false
+SEO_INTEL_COLLECTORS_ENABLED=false
+SEO_INTEL_DRY_RUN_DEFAULT=true
+SEO_INTEL_ALLOW_EXTERNAL_API_CALLS=false
+
+# Google Search Console readonly adapter. Prefer service-account JSON by path;
+# do not use inline JSON unless an operator has explicitly approved the risk.
+SEO_INTEL_GSC_ENABLED=false
+SEO_INTEL_GSC_LIVE_API_ENABLED=false
+SEO_INTEL_GSC_PROPERTY_URL=
+SEO_INTEL_GSC_AUTH_MODE=disabled
+SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON=
+SEO_INTEL_GSC_SERVICE_ACCOUNT_JSON_PATH=
+SEO_INTEL_GSC_ACCESS_TOKEN=
+SEO_INTEL_GSC_TOKEN_URI=https://oauth2.googleapis.com/token
+SEO_INTEL_GSC_SEARCH_ANALYTICS_ENDPOINT=https://searchconsole.googleapis.com/webmasters/v3/sites/%s/searchAnalytics/query
+SEO_INTEL_GSC_SCOPE=https://www.googleapis.com/auth/webmasters.readonly
+SEO_INTEL_GSC_TIMEOUT_SECONDS=10
+SEO_INTEL_GSC_DEFAULT_LIMIT=250
+SEO_INTEL_GSC_MAX_LIMIT=250
+
+# Search Channel queue and bounded live submission. Queue writes and external
+# live calls remain disabled until a bounded canary is explicitly approved.
+SEO_INTEL_SEARCH_CHANNEL_QUEUE_WRITE_ENABLED=false
+SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=false
+SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=false
+SEO_INTEL_INDEXNOW_ENABLED=false
+SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=false
+SEO_INTEL_INDEXNOW_ENDPOINT=https://api.indexnow.org/indexnow
+SEO_INTEL_INDEXNOW_KEY=
+SEO_INTEL_INDEXNOW_KEY_LOCATION=
+SEO_INTEL_INDEXNOW_TIMEOUT_SECONDS=10
+SEO_INTEL_BAIDU_ENABLED=false
+SEO_INTEL_BAIDU_LIVE_API_ENABLED=false
+SEO_INTEL_BAIDU_PUSH_ENDPOINT=http://data.zz.baidu.com/urls
+SEO_INTEL_BAIDU_SITE=
+SEO_INTEL_BAIDU_PUSH_TOKEN=
+SEO_INTEL_BAIDU_PUSH_TIMEOUT_SECONDS=10
+SEO_INTEL_SO360_ENABLED=false
+SEO_INTEL_SOGOU_ENABLED=false
+SEO_INTEL_SHENMA_ENABLED=false
+
+# Crawler log observation. Production log read and aggregate writes are
+# intentionally disabled by default.
+SEO_INTEL_CHINESE_CRAWLER_LOGS_ENABLED=false
+SEO_INTEL_CRAWLER_LOG_SOURCE=
+SEO_INTEL_CRAWLER_LOG_AGGREGATE_WRITE_ENABLED=false
+SEO_INTEL_ISSUE_QUEUE_ENABLED=false
+SEO_INTEL_ISSUE_SUMMARY_API_ENABLED=false
+
 # Observability
 SENTRY_DSN=
 SENTRY_LARAVEL_DSN=

--- a/backend/app/Services/SeoAgent/AutoApprovalPolicy.php
+++ b/backend/app/Services/SeoAgent/AutoApprovalPolicy.php
@@ -55,6 +55,15 @@ final class AutoApprovalPolicy
         '/\bhiring\s+fit\b/i',
         '/\bmedical\s+advice\b/i',
         '/\btreatment\b/i',
+        '/\bperfect\s+match\b/i',
+        '/\bideal\s+job\b/i',
+        '/\bjob\s+fit\b/i',
+        '/\bcareer\s+match\b/i',
+        '/\bbest\s+career\s+for\s+you\b/i',
+        '/\bdetermin(e|es|ed|ing)?\s+your\s+career\b/i',
+        '/为你匹配最适合的职业/u',
+        '/最适合你的职业/u',
+        '/决定你的职业/u',
     ];
 
     /**

--- a/backend/tests/Feature/SeoIntel/SeoAgentAutoApprovalPolicyTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentAutoApprovalPolicyTest.php
@@ -86,12 +86,18 @@ final class SeoAgentAutoApprovalPolicyTest extends TestCase
         $claim = $policy->evaluateCandidate($this->candidate([
             'proposed_seo_description' => 'Clinically proven diagnostic guidance for hiring fit.',
         ]));
+        $deterministicCareerClaim = $policy->evaluateCandidate($this->candidate([
+            'proposed_seo_title' => 'Find your perfect match and ideal job',
+            'proposed_seo_description' => '为你匹配最适合的职业，并决定你的职业。',
+        ]));
 
         $this->assertSame('blocked', $raw['approval_decision'] ?? null);
         $this->assertContains('forbidden_field_present:raw_url', $raw['reason_codes'] ?? []);
         $this->assertContains('full_url_present', $raw['reason_codes'] ?? []);
         $this->assertSame('blocked', $claim['approval_decision'] ?? null);
         $this->assertContains('forbidden_claim_detected', $claim['reason_codes'] ?? []);
+        $this->assertSame('blocked', $deterministicCareerClaim['approval_decision'] ?? null);
+        $this->assertContains('forbidden_claim_detected', $deterministicCareerClaim['reason_codes'] ?? []);
     }
 
     #[Test]


### PR DESCRIPTION
## What changed
- Added fail-closed SEO Intel / SEO Agent L5-A runtime examples to `backend/.env.example` for GSC, Search Channel, IndexNow, Baidu, domestic search placeholders, crawler log observation, and issue queue gates.
- Hardened `AutoApprovalPolicy` against deterministic career-match and job-fit claims such as perfect match, ideal job, best career for you, and Chinese equivalents.
- Extended the focused auto-approval policy test to prove those claims fail closed.

## Why
The L5-A runtime path already exists, but new checkouts lacked explicit fail-closed environment examples and the policy gate did not yet block career determinism / psychometric marketing language.

## Validation
- `php artisan test --filter SeoAgentAutoApprovalPolicyTest`
- `git diff --check`
- Scope validation: `git diff --name-only` limited to `.env.example`, `AutoApprovalPolicy.php`, and `SeoAgentAutoApprovalPolicyTest.php`

## Intentionally deferred
- No DB changes or migrations.
- No production env changes.
- No cron/scheduler activation.
- No CMS writes, publish actions, Search Channel enqueue/submit, or Google Indexing calls.
- Scheduler preflight mode is deferred to `SEO-AGENT-L5A-SCHEDULER-PREFLIGHT-MODE-01`.
