### PR TITLE
Enneagram: add result page source ledger and validator harness scaffold

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php
@@ -15,7 +15,8 @@ final class EnneagramResultPageAgentReadinessCommand extends Command
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/enneagram_result_page_agent}
         {--candidate-dir= : Optional existing Phase8B candidate directory to check for required artifact names}
-        {--strict : Return non-zero when a provided candidate directory is missing required artifacts}
+        {--source-ledger-dir= : Optional source ledger directory; defaults to backend/content_assets/enneagram/result_page/source_ledger}
+        {--strict : Return non-zero when the source ledger or provided candidate directory is invalid}
         {--json : Emit machine-readable summary}';
 
     protected $description = 'Read-only Enneagram result page content asset agent readiness/control-packet audit.';
@@ -33,6 +34,7 @@ final class EnneagramResultPageAgentReadinessCommand extends Command
                 'run_id' => trim((string) $this->option('run-id')),
                 'artifact_dir' => trim((string) $this->option('artifact-dir')),
                 'candidate_dir' => trim((string) $this->option('candidate-dir')),
+                'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
                 'strict' => (bool) $this->option('strict'),
             ]);
 

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php
@@ -6,18 +6,29 @@ namespace App\Services\Enneagram\Assets\Agent;
 
 use Illuminate\Support\Facades\File;
 use RuntimeException;
+use SplFileInfo;
 
 final class EnneagramResultPageAgentReadiness
 {
     public const SCHEMA_VERSION = 'fap.enneagram.result_page.agent_readiness.v1';
 
+    public const SOURCE_LEDGER_SCHEMA_VERSION = 'fap.enneagram.result_page.source_ledger.v0.1';
+
     public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_agent';
+
+    private const SOURCE_LEDGER_RELATIVE_DIR = 'content_assets/enneagram/result_page/source_ledger';
+
+    private const SOURCE_LEDGER_PRIMARY_FILENAME = 'source_ledger.json';
 
     private const EXPECTED_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
 
     private const EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
 
     private const EXPECTED_PAYLOAD_COUNT = 630;
+
+    private const LAUNCH_SCOPE_BATCHES = ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'];
+
+    private const OUT_OF_LAUNCH_SCOPE_BATCHES = ['1R-I', '1R-J'];
 
     private const REQUIRED_CANDIDATE_FILES = [
         'candidate_manifest.json',
@@ -35,30 +46,110 @@ final class EnneagramResultPageAgentReadiness
         'candidate_payloads/',
     ];
 
+    private const SOURCE_LEDGER_ALLOWED_LABELS = [
+        'runtime_contract',
+        'compiled_question_contract',
+        'candidate_baseline',
+        'asset_stream_contract',
+        'policy_contract',
+    ];
+
+    private const SOURCE_LEDGER_REQUIRED_SOURCE_IDS = [
+        'enneagram_v2_runtime_registry',
+        'enneagram_e105_compiled_questions',
+        'enneagram_fc144_compiled_questions',
+        'phase8b_candidate_baseline_a9fd',
+        'batch_1r_a_asset_stream',
+        'batch_1r_b_asset_stream',
+        'batch_1r_c_asset_stream',
+        'batch_1r_d_asset_stream',
+        'batch_1r_e_asset_stream',
+        'batch_1r_f_asset_stream',
+        'batch_1r_g_asset_stream',
+        'batch_1r_h_asset_stream',
+        'fc144_boundary_policy',
+        'forbidden_claim_policy',
+    ];
+
     private const FORBIDDEN_CLAIM_FAMILIES = [
-        'diagnosis_or_treatment',
-        'clinical_condition',
-        'hiring_or_employment_screening',
+        'diagnosis_clinical_treatment',
+        'hiring_employment_screening',
+        'final_typing_you_are_this_type',
         'fixed_type_certainty',
-        'you_are_this_type',
-        'final_typing_or_retyping',
-        'score_comparison_between_e105_and_fc144',
-        'fc144_more_accurate_claim',
-        'ability_success_salary_or_performance_prediction',
-        'medical_therapy_or_mental_health_advice',
+        'e105_fc144_score_comparison',
+        'fc144_more_accurate_or_replacement_result',
+        'success_salary_performance_prediction',
+        'private_result_identifier_path_or_vector_leakage',
+    ];
+
+    /**
+     * Field strings are intentionally not emitted into default artifacts.
+     *
+     * @var array<string,string>
+     */
+    private const FORBIDDEN_PUBLIC_FIELD_FAMILY_BY_FIELD = [
+        'attempt_id' => 'private_result_identifier_path_or_vector_leakage',
+        'attempt_uuid' => 'private_result_identifier_path_or_vector_leakage',
+        'private_url' => 'private_result_identifier_path_or_vector_leakage',
+        'private_path' => 'private_result_identifier_path_or_vector_leakage',
+        'raw_score' => 'private_result_identifier_path_or_vector_leakage',
+        'raw_scores' => 'private_result_identifier_path_or_vector_leakage',
+        'raw_score_vector' => 'private_result_identifier_path_or_vector_leakage',
+        'domain_vector' => 'private_result_identifier_path_or_vector_leakage',
+        'facet_vector' => 'private_result_identifier_path_or_vector_leakage',
+        'editor_notes' => 'private_result_identifier_path_or_vector_leakage',
+        'qa_notes' => 'private_result_identifier_path_or_vector_leakage',
+        'source_selection_notes' => 'private_result_identifier_path_or_vector_leakage',
+        'internal_metadata' => 'private_result_identifier_path_or_vector_leakage',
+    ];
+
+    /**
+     * @var array<string,string>
+     */
+    private const FORBIDDEN_TERM_FAMILY_BY_TERM = [
+        'diagnosis' => 'diagnosis_clinical_treatment',
+        'clinical' => 'diagnosis_clinical_treatment',
+        'therapy' => 'diagnosis_clinical_treatment',
+        'treatment' => 'diagnosis_clinical_treatment',
+        'mental health advice' => 'diagnosis_clinical_treatment',
+        'hiring' => 'hiring_employment_screening',
+        'employment screening' => 'hiring_employment_screening',
+        'you are this type' => 'final_typing_you_are_this_type',
+        'you are type' => 'final_typing_you_are_this_type',
+        'final type' => 'final_typing_you_are_this_type',
+        'fixed type' => 'fixed_type_certainty',
+        'certainly type' => 'fixed_type_certainty',
+        'compare e105 and fc144 scores' => 'e105_fc144_score_comparison',
+        'e105 score is higher than fc144' => 'e105_fc144_score_comparison',
+        'fc144 is more accurate' => 'fc144_more_accurate_or_replacement_result',
+        'fc144 replaces your result' => 'fc144_more_accurate_or_replacement_result',
+        'salary prediction' => 'success_salary_performance_prediction',
+        'performance prediction' => 'success_salary_performance_prediction',
+        'success prediction' => 'success_salary_performance_prediction',
+        '诊断' => 'diagnosis_clinical_treatment',
+        '治疗' => 'diagnosis_clinical_treatment',
+        '招聘' => 'hiring_employment_screening',
+        '雇佣筛选' => 'hiring_employment_screening',
+        '你就是这个类型' => 'final_typing_you_are_this_type',
+        '最终类型' => 'final_typing_you_are_this_type',
+        '固定类型' => 'fixed_type_certainty',
+        '分数直接比较' => 'e105_fc144_score_comparison',
+        'fc144 更准确' => 'fc144_more_accurate_or_replacement_result',
+        '成功预测' => 'success_salary_performance_prediction',
+        '薪资预测' => 'success_salary_performance_prediction',
     ];
 
     private const AGENT_BATCHES = [
         [
             'batch_id' => 'ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01',
-            'state' => 'ready_for_review',
+            'state' => 'merged_ready',
             'allowed_output' => 'docs, control packet, readiness artifacts',
             'generation_allowed' => false,
         ],
         [
             'batch_id' => 'ENNEAGRAM-RESULT-SOURCE-LEDGER-01',
-            'state' => 'planned',
-            'allowed_output' => 'source ledger only',
+            'state' => 'scaffold_only',
+            'allowed_output' => 'source ledger and validator harness artifacts',
             'generation_allowed' => false,
         ],
         [
@@ -76,7 +167,7 @@ final class EnneagramResultPageAgentReadiness
     ];
 
     /**
-     * @param  array{run_id?:string,artifact_dir?:string,strict?:bool,candidate_dir?:string}  $options
+     * @param  array{run_id?:string,artifact_dir?:string,strict?:bool,candidate_dir?:string,source_ledger_dir?:string}  $options
      * @return array<string,mixed>
      */
     public function audit(array $options = []): array
@@ -85,36 +176,48 @@ final class EnneagramResultPageAgentReadiness
         $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
         $strict = ($options['strict'] ?? false) === true;
         $candidateDir = trim((string) ($options['candidate_dir'] ?? ''));
+        $sourceLedgerDir = $this->sourceLedgerDir((string) ($options['source_ledger_dir'] ?? ''));
 
         $this->ensureDirectory($artifactDir);
 
         $controlPacket = $this->controlPacket();
         $readinessInventory = $this->readinessInventory($candidateDir);
+        $sourceLedgerInventory = $this->sourceLedgerInventory($sourceLedgerDir);
+        $sourceMappingContractReport = $this->sourceMappingContractReport($candidateDir);
+        $metadataLeakageReport = $this->metadataLeakageReport($candidateDir);
+        $forbiddenClaimReport = $this->forbiddenClaimReport($candidateDir);
+        $validatorHarnessReport = $this->validatorHarnessReport(
+            $candidateDir,
+            $readinessInventory,
+            $sourceLedgerInventory,
+            $sourceMappingContractReport,
+            $metadataLeakageReport,
+            $forbiddenClaimReport
+        );
         $validationCommands = $this->validationCommands();
         $safetyPolicy = $this->safetyPolicy();
-        $goNoGo = $this->goNoGo($readinessInventory);
+        $goNoGo = $this->goNoGo($readinessInventory, $sourceLedgerInventory, $validatorHarnessReport);
+        $strictFailures = $this->strictFailures($strict, $sourceLedgerInventory, $validatorHarnessReport);
 
         $artifacts = [
             'control_packet.json' => $this->writeJson($artifactDir.'/control_packet.json', $controlPacket),
             'readiness_inventory.json' => $this->writeJson($artifactDir.'/readiness_inventory.json', $readinessInventory),
+            'source_ledger_inventory.json' => $this->writeJson($artifactDir.'/source_ledger_inventory.json', $sourceLedgerInventory),
+            'validator_harness_report.json' => $this->writeJson($artifactDir.'/validator_harness_report.json', $validatorHarnessReport),
+            'source_mapping_contract_report.json' => $this->writeJson($artifactDir.'/source_mapping_contract_report.json', $sourceMappingContractReport),
+            'metadata_leakage_report.json' => $this->writeJson($artifactDir.'/metadata_leakage_report.json', $metadataLeakageReport),
+            'forbidden_claim_report.json' => $this->writeJson($artifactDir.'/forbidden_claim_report.json', $forbiddenClaimReport),
             'validation_commands.json' => $this->writeJson($artifactDir.'/validation_commands.json', $validationCommands),
             'safety_policy.json' => $this->writeJson($artifactDir.'/safety_policy.json', $safetyPolicy),
             'go_no_go.md' => $this->writeText($artifactDir.'/go_no_go.md', $goNoGo),
         ];
-
-        $strictFailures = [];
-        if ($strict && (bool) data_get($readinessInventory, 'candidate_dir.provided', false) === true) {
-            foreach ((array) data_get($readinessInventory, 'candidate_dir.missing_required_files', []) as $missing) {
-                $strictFailures[] = 'missing_candidate_artifact:'.$missing;
-            }
-        }
 
         return [
             'schema_version' => self::SCHEMA_VERSION,
             'ok' => $strictFailures === [],
             'status' => $strictFailures === [] ? 'success' : 'blocked',
             'run_id' => $runId,
-            'artifact_dir' => $artifactDir,
+            'artifact_dir' => $this->redactPath($artifactDir),
             'artifacts' => $artifacts,
             'strict' => $strict,
             'strict_failures' => $strictFailures,
@@ -123,6 +226,9 @@ final class EnneagramResultPageAgentReadiness
                 'candidate_payload_count_expected' => self::EXPECTED_PAYLOAD_COUNT,
                 'expected_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
                 'expected_runtime_registry_manifest_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+                'source_ledger_valid' => (bool) data_get($sourceLedgerInventory, 'source_ledger.valid', false),
+                'candidate_dir_provided' => (bool) data_get($validatorHarnessReport, 'candidate_dir.provided', false),
+                'candidate_contract_valid' => (bool) data_get($validatorHarnessReport, 'candidate_contract.valid', false),
                 'ready_for_generation' => false,
                 'ready_for_import' => false,
                 'ready_for_activation' => false,
@@ -146,29 +252,35 @@ final class EnneagramResultPageAgentReadiness
                 'baseline_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
                 'runtime_registry_manifest_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
                 'payload_count' => self::EXPECTED_PAYLOAD_COUNT,
-                'out_of_launch_scope_must_equal' => ['1R-I', '1R-J'],
-                'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
+                'out_of_launch_scope_must_equal' => self::OUT_OF_LAUNCH_SCOPE_BATCHES,
+                'launch_scope_batches' => self::LAUNCH_SCOPE_BATCHES,
+            ],
+            'source_ledger_contract' => [
+                'schema_version' => self::SOURCE_LEDGER_SCHEMA_VERSION,
+                'default_relative_dir' => self::SOURCE_LEDGER_RELATIVE_DIR,
+                'required_source_ids' => self::SOURCE_LEDGER_REQUIRED_SOURCE_IDS,
+                'allowed_source_labels' => self::SOURCE_LEDGER_ALLOWED_LABELS,
             ],
             'agent_batches' => self::AGENT_BATCHES,
             'allowed_actions' => [
                 'read existing docs and code',
                 'write run-scoped readiness artifacts',
                 'write source ledger templates',
+                'validate a provided Phase8B candidate directory without import or activation',
                 'prepare small candidate drafts only in a future explicitly authorized PR',
-                'run Phase8B export QA against a caller-provided candidate directory',
-                'run Phase8D2B inactive import simulation against a caller-provided candidate directory',
             ],
             'forbidden_actions' => [
                 'bulk content generation in this PR',
+                'candidate payload creation in this PR',
                 'production activation',
                 'content_pack_activations write',
                 'runtime registry switch',
                 'production import',
-                'frontend fallback copy',
+                'frontend-side result copy fallback',
                 'fap-web runtime changes',
                 'sitemap or llms exposure',
                 'public SEO profile generation',
-                'private result or attempt identifier export',
+                'private result identifier export',
             ],
             'negative_guarantees' => $this->negativeGuarantees(),
         ];
@@ -230,6 +342,336 @@ final class EnneagramResultPageAgentReadiness
     /**
      * @return array<string,mixed>
      */
+    private function sourceLedgerInventory(string $sourceLedgerDir): array
+    {
+        $errors = [];
+        $files = [];
+        $primaryLedgerPath = rtrim($sourceLedgerDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.self::SOURCE_LEDGER_PRIMARY_FILENAME;
+        $primaryLedger = null;
+
+        if (! is_dir($sourceLedgerDir)) {
+            $errors[] = 'source_ledger_dir missing';
+        } else {
+            foreach (File::files($sourceLedgerDir) as $file) {
+                if (! $file instanceof SplFileInfo) {
+                    continue;
+                }
+
+                $relativePath = self::SOURCE_LEDGER_RELATIVE_DIR.'/'.$file->getBasename();
+                $files[] = [
+                    'relative_path' => $relativePath,
+                    'sha256' => hash_file('sha256', $file->getPathname()) ?: '',
+                    'size' => filesize($file->getPathname()) ?: 0,
+                    'json_valid' => pathinfo($file->getBasename(), PATHINFO_EXTENSION) !== 'json'
+                        || is_array(json_decode((string) file_get_contents($file->getPathname()), true)),
+                ];
+            }
+
+            if (! is_file($primaryLedgerPath)) {
+                $errors[] = self::SOURCE_LEDGER_PRIMARY_FILENAME.' missing';
+            } else {
+                $decoded = json_decode((string) file_get_contents($primaryLedgerPath), true);
+                if (! is_array($decoded)) {
+                    $errors[] = self::SOURCE_LEDGER_PRIMARY_FILENAME.' is not valid JSON';
+                } else {
+                    $primaryLedger = $decoded;
+                    $errors = array_merge($errors, $this->sourceLedgerContractErrors($primaryLedger));
+                }
+            }
+        }
+
+        $sources = is_array($primaryLedger) ? (array) ($primaryLedger['sources'] ?? []) : [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'source_ledger_inventory',
+            'source_ledger' => [
+                'schema_version' => is_array($primaryLedger) ? (string) ($primaryLedger['schema_version'] ?? '') : null,
+                'exists' => is_dir($sourceLedgerDir),
+                'valid' => $errors === [] && is_array($primaryLedger),
+                'source_ledger_dir' => $this->redactPath($sourceLedgerDir),
+                'primary_ledger_path' => is_file($primaryLedgerPath) ? $this->redactPath($primaryLedgerPath) : null,
+                'allowed_source_labels' => self::SOURCE_LEDGER_ALLOWED_LABELS,
+                'required_source_ids' => self::SOURCE_LEDGER_REQUIRED_SOURCE_IDS,
+                'required_source_ids_present' => $this->presentSourceIds($sources),
+                'label_counts' => $this->sourceLabelCounts($sources),
+                'candidate_baseline_hash' => data_get($primaryLedger, 'candidate_contract.baseline_candidate_manifest_sha256'),
+                'runtime_registry_hash' => data_get($primaryLedger, 'candidate_contract.runtime_registry_manifest_sha256'),
+                'expected_payload_count' => data_get($primaryLedger, 'candidate_contract.expected_payload_count'),
+                'launch_scope' => data_get($primaryLedger, 'candidate_contract.launch_scope'),
+                'out_of_launch_scope' => data_get($primaryLedger, 'candidate_contract.out_of_launch_scope'),
+                'negative_guarantees' => [
+                    'cms_write_performed' => data_get($primaryLedger, 'cms_write_performed'),
+                    'runtime_change_performed' => data_get($primaryLedger, 'runtime_change_performed'),
+                    'frontend_fallback_allowed' => data_get($primaryLedger, 'frontend_fallback_allowed'),
+                    'activation_happened' => data_get($primaryLedger, 'activation_happened'),
+                ],
+                'errors' => $errors,
+                'files' => $files,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validatorHarnessReport(
+        string $candidateDir,
+        array $readinessInventory,
+        array $sourceLedgerInventory,
+        array $sourceMappingContractReport,
+        array $metadataLeakageReport,
+        array $forbiddenClaimReport
+    ): array {
+        $provided = $candidateDir !== '';
+        $errors = [];
+        $checks = [
+            'source_ledger_valid' => (bool) data_get($sourceLedgerInventory, 'source_ledger.valid', false),
+            'candidate_dir_provided' => $provided,
+            'candidate_required_artifacts_present' => true,
+            'candidate_manifest_hash_matches' => null,
+            'runtime_registry_hash_matches' => null,
+            'candidate_payload_count_matches' => null,
+            'out_of_launch_scope_matches' => null,
+            'source_mapping_zero_failures' => (bool) data_get($sourceMappingContractReport, 'status.source_mapping_zero_failures', true),
+            'metadata_leakage_zero' => (bool) data_get($metadataLeakageReport, 'status.leakage_zero', true),
+            'forbidden_claim_zero' => (bool) data_get($forbiddenClaimReport, 'status.forbidden_claim_zero', true),
+            'legacy_residual_zero' => null,
+            'fc144_boundary_zero' => null,
+        ];
+
+        if (! $checks['source_ledger_valid']) {
+            $errors[] = 'source_ledger_invalid';
+        }
+
+        if ($provided) {
+            foreach ((array) data_get($readinessInventory, 'candidate_dir.missing_required_files', []) as $missing) {
+                $errors[] = 'missing_candidate_artifact:'.$missing;
+            }
+            $checks['candidate_required_artifacts_present'] = ((array) data_get($readinessInventory, 'candidate_dir.missing_required_files', [])) === [];
+
+            $candidateRoot = rtrim($candidateDir, DIRECTORY_SEPARATOR);
+            $candidateManifestPath = $candidateRoot.'/candidate_manifest.json';
+            $candidateHashesPath = $candidateRoot.'/candidate_hashes.json';
+            $candidateManifest = $this->readJsonFileIfPresent($candidateManifestPath);
+            $candidateHashes = $this->readJsonFileIfPresent($candidateHashesPath);
+            $actualManifestHash = is_file($candidateManifestPath) ? (hash_file('sha256', $candidateManifestPath) ?: '') : null;
+            $actualPayloadCount = $this->candidatePayloadCount($candidateRoot.'/candidate_payloads');
+            $outOfLaunchScope = is_array($candidateManifest) ? (array) ($candidateManifest['out_of_launch_scope'] ?? []) : [];
+
+            $checks['candidate_manifest_hash_matches'] = $actualManifestHash === self::EXPECTED_CANDIDATE_MANIFEST_SHA256;
+            $checks['runtime_registry_hash_matches'] = data_get($candidateHashes, 'runtime_registry_manifest_sha256') === self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256;
+            $checks['candidate_payload_count_matches'] = $actualPayloadCount === self::EXPECTED_PAYLOAD_COUNT;
+            $checks['out_of_launch_scope_matches'] = $this->normalizedList($outOfLaunchScope) === self::OUT_OF_LAUNCH_SCOPE_BATCHES;
+            $checks['legacy_residual_zero'] = $this->reportCounterIsZero($candidateRoot.'/legacy_residual_scan.json', [
+                'legacy_deep_core_residual_count',
+                'legacy_residual_count',
+                'residual_count',
+            ]);
+            $checks['fc144_boundary_zero'] = $this->reportCounterIsZero($candidateRoot.'/fc144_boundary_report.json', [
+                'violation_count',
+                'fc144_boundary_violation_count',
+            ]);
+
+            if (! $checks['candidate_manifest_hash_matches']) {
+                $errors[] = 'candidate_manifest_hash_mismatch';
+            }
+            if (! $checks['runtime_registry_hash_matches']) {
+                $errors[] = 'runtime_registry_hash_mismatch';
+            }
+            if (! $checks['candidate_payload_count_matches']) {
+                $errors[] = 'candidate_payload_count_mismatch';
+            }
+            if (! $checks['out_of_launch_scope_matches']) {
+                $errors[] = 'out_of_launch_scope_mismatch';
+            }
+            if (! $checks['source_mapping_zero_failures']) {
+                $errors[] = 'source_mapping_failures';
+            }
+            if (! $checks['metadata_leakage_zero']) {
+                $errors[] = 'metadata_leakage_hits';
+            }
+            if (! $checks['forbidden_claim_zero']) {
+                $errors[] = 'forbidden_claim_hits';
+            }
+            if ($checks['legacy_residual_zero'] !== true) {
+                $errors[] = 'legacy_residual_hits';
+            }
+            if ($checks['fc144_boundary_zero'] !== true) {
+                $errors[] = 'fc144_boundary_violations';
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'validator_harness_report',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'candidate_dir' => [
+                'provided' => $provided,
+                'path' => $provided ? $this->redactPath($candidateDir) : null,
+                'missing_candidate_dir_is_failure' => false,
+            ],
+            'candidate_contract' => [
+                'valid' => ! $provided || $errors === [],
+                'expected_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+                'expected_runtime_registry_manifest_sha256' => self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256,
+                'expected_payload_count' => self::EXPECTED_PAYLOAD_COUNT,
+                'launch_scope' => self::LAUNCH_SCOPE_BATCHES,
+                'out_of_launch_scope_must_equal' => self::OUT_OF_LAUNCH_SCOPE_BATCHES,
+            ],
+            'checks' => $checks,
+            'error_count' => count($errors),
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sourceMappingContractReport(string $candidateDir): array
+    {
+        $provided = $candidateDir !== '';
+        $issues = [];
+        $status = [
+            'source_mapping_zero_failures' => true,
+            'payload_source_mapping_present' => null,
+        ];
+
+        if ($provided) {
+            $candidateRoot = rtrim($candidateDir, DIRECTORY_SEPARATOR);
+            $sourceMapping = $this->readJsonFileIfPresent($candidateRoot.'/source_mapping_report.json');
+            $payloadMapping = $this->readJsonFileIfPresent($candidateRoot.'/candidate_payload_source_mapping.json');
+
+            $status['payload_source_mapping_present'] = is_array($payloadMapping);
+
+            foreach ([
+                'source_mapping_failure_count',
+                'fallback_source_count',
+                'blocked_source_count',
+                'duplicate_selection_count',
+                'branch_provenance_mismatch_count',
+            ] as $counter) {
+                $value = data_get($sourceMapping, $counter);
+                if ($value !== null && (int) $value !== 0) {
+                    $issues[] = [
+                        'counter' => $counter,
+                        'count' => (int) $value,
+                    ];
+                }
+            }
+
+            if (! is_array($payloadMapping)) {
+                $issues[] = [
+                    'counter' => 'candidate_payload_source_mapping_missing',
+                    'count' => 1,
+                ];
+            }
+        }
+
+        $status['source_mapping_zero_failures'] = $issues === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'source_mapping_contract_report',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'candidate_dir' => [
+                'provided' => $provided,
+                'path' => $provided ? $this->redactPath($candidateDir) : null,
+            ],
+            'status' => $status,
+            'issue_count' => count($issues),
+            'issues' => $issues,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function metadataLeakageReport(string $candidateDir): array
+    {
+        $provided = $candidateDir !== '';
+        $hits = [];
+
+        if ($provided) {
+            $candidateRoot = rtrim($candidateDir, DIRECTORY_SEPARATOR);
+            foreach ($this->candidatePayloadFiles($candidateRoot.'/candidate_payloads') as $file) {
+                $payload = json_decode((string) file_get_contents($file->getPathname()), true);
+                if (is_array($payload)) {
+                    $hits = array_merge($hits, $this->scanPayloadFields($payload, $file->getBasename()));
+                }
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'metadata_leakage_report',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'candidate_dir' => [
+                'provided' => $provided,
+                'path' => $provided ? $this->redactPath($candidateDir) : null,
+            ],
+            'blocked_field_families' => [
+                'private_result_identifier_path_or_vector_leakage',
+                'editorial_or_qa_working_notes',
+                'internal_source_selection_metadata',
+            ],
+            'status' => [
+                'leakage_zero' => $hits === [],
+            ],
+            'hit_count' => count($hits),
+            'hits' => array_slice($hits, 0, 100),
+            'truncated' => count($hits) > 100,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function forbiddenClaimReport(string $candidateDir): array
+    {
+        $provided = $candidateDir !== '';
+        $hits = [];
+
+        if ($provided) {
+            $candidateRoot = rtrim($candidateDir, DIRECTORY_SEPARATOR);
+            foreach ($this->candidatePayloadFiles($candidateRoot.'/candidate_payloads') as $file) {
+                $payload = json_decode((string) file_get_contents($file->getPathname()), true);
+                if (is_array($payload)) {
+                    $hits = array_merge($hits, $this->scanPayloadTerms($payload, $file->getBasename()));
+                }
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'forbidden_claim_report',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'candidate_dir' => [
+                'provided' => $provided,
+                'path' => $provided ? $this->redactPath($candidateDir) : null,
+            ],
+            'forbidden_claim_families' => self::FORBIDDEN_CLAIM_FAMILIES,
+            'status' => [
+                'forbidden_claim_zero' => $hits === [],
+            ],
+            'hit_count' => count($hits),
+            'hits' => array_slice($hits, 0, 100),
+            'truncated' => count($hits) > 100,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     private function validationCommands(): array
     {
         return [
@@ -239,6 +681,8 @@ final class EnneagramResultPageAgentReadiness
                 'php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php',
                 'php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php',
                 'cd backend && php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi',
+                'cd backend && php artisan enneagram:result-page-agent audit --run-id=smoke --artifact-dir=<tmpdir> --json',
+                'cd backend && php artisan enneagram:result-page-agent audit --run-id=smoke-strict --artifact-dir=<tmpdir> --strict --json',
                 'git diff --check',
             ],
             'future_candidate_export_gate' => [
@@ -274,17 +718,10 @@ final class EnneagramResultPageAgentReadiness
             'schema_version' => self::SCHEMA_VERSION,
             'task' => 'safety_policy',
             'forbidden_claim_families' => self::FORBIDDEN_CLAIM_FAMILIES,
-            'forbidden_public_payload_fields' => [
-                'attempt_id',
-                'user_id',
-                'private_url',
-                'private_path',
-                'editor_notes',
-                'qa_notes',
-                'source_selection_notes',
-                'internal_metadata',
-                'raw_scores',
-                'raw_score_vector',
+            'blocked_public_payload_field_families' => [
+                'private_result_identifier_path_or_vector_leakage',
+                'editorial_or_qa_working_notes',
+                'internal_source_selection_metadata',
             ],
             'fc144_boundary_rules' => [
                 'FC144 may be suggested as a second lens, not a more accurate final type.',
@@ -301,23 +738,30 @@ final class EnneagramResultPageAgentReadiness
 
     /**
      * @param  array<string,mixed>  $readinessInventory
+     * @param  array<string,mixed>  $sourceLedgerInventory
+     * @param  array<string,mixed>  $validatorHarnessReport
      */
-    private function goNoGo(array $readinessInventory): string
+    private function goNoGo(array $readinessInventory, array $sourceLedgerInventory, array $validatorHarnessReport): string
     {
         return implode("\n", [
             '# Enneagram Result Page Agent Go / No-Go',
             '',
-            '- verdict: CONTROL_PACKET_ONLY',
+            '- verdict: SOURCE_LEDGER_VALIDATOR_SCAFFOLD_ONLY',
             '- candidate_generation_allowed: false',
             '- ready_for_generation: false',
             '- ready_for_import: false',
             '- ready_for_activation: false',
+            '- source_ledger_valid: '.(((bool) data_get($sourceLedgerInventory, 'source_ledger.valid', false)) ? 'true' : 'false'),
+            '- candidate_dir_provided: '.(((bool) data_get($validatorHarnessReport, 'candidate_dir.provided', false)) ? 'true' : 'false'),
+            '- candidate_contract_valid: '.(((bool) data_get($validatorHarnessReport, 'candidate_contract.valid', false)) ? 'true' : 'false'),
             '- expected_candidate_manifest_sha256: `'.self::EXPECTED_CANDIDATE_MANIFEST_SHA256.'`',
             '- expected_runtime_registry_manifest_sha256: `'.self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256.'`',
             '- expected_payload_count: '.self::EXPECTED_PAYLOAD_COUNT,
             '- runtime_registry_matches_expected: '.(((bool) data_get($readinessInventory, 'runtime_registry.matches_expected', false)) ? 'true' : 'false'),
             '- no bulk content generated',
-            '- no production import',
+            '- no candidate payloads created',
+            '- no import',
+            '- no production write',
             '- no activation',
             '- no runtime switch',
             '- no frontend fallback',
@@ -331,7 +775,7 @@ final class EnneagramResultPageAgentReadiness
     private function negativeGuarantees(): array
     {
         return [
-            'runtime_use' => 'staging_only',
+            'runtime_use' => 'not_runtime',
             'production_use_allowed' => false,
             'ready_for_generation' => false,
             'ready_for_import' => false,
@@ -341,8 +785,292 @@ final class EnneagramResultPageAgentReadiness
             'runtime_change_performed' => false,
             'activation_happened' => false,
             'bulk_content_generation_happened' => false,
+            'candidate_payload_creation_happened' => false,
             'frontend_fallback_allowed' => false,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $ledger
+     * @return list<string>
+     */
+    private function sourceLedgerContractErrors(array $ledger): array
+    {
+        $errors = [];
+
+        if (($ledger['schema_version'] ?? null) !== self::SOURCE_LEDGER_SCHEMA_VERSION) {
+            $errors[] = 'source_ledger schema_version mismatch';
+        }
+        if (($ledger['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'source_ledger runtime_use must be not_runtime';
+        }
+        if (($ledger['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'source_ledger production_use_allowed must be false';
+        }
+        foreach (['cms_write_performed', 'runtime_change_performed', 'frontend_fallback_allowed', 'activation_happened'] as $flag) {
+            if (($ledger[$flag] ?? null) !== false) {
+                $errors[] = "source_ledger {$flag} must be false";
+            }
+        }
+
+        $labels = array_values((array) ($ledger['allowed_source_labels'] ?? []));
+        sort($labels);
+        $expectedLabels = self::SOURCE_LEDGER_ALLOWED_LABELS;
+        sort($expectedLabels);
+        if ($labels !== $expectedLabels) {
+            $errors[] = 'source_ledger allowed_source_labels must match the fixed source label contract';
+        }
+
+        if (data_get($ledger, 'candidate_contract.baseline_candidate_manifest_sha256') !== self::EXPECTED_CANDIDATE_MANIFEST_SHA256) {
+            $errors[] = 'source_ledger candidate baseline hash mismatch';
+        }
+        if (data_get($ledger, 'candidate_contract.runtime_registry_manifest_sha256') !== self::EXPECTED_RUNTIME_REGISTRY_MANIFEST_SHA256) {
+            $errors[] = 'source_ledger runtime registry hash mismatch';
+        }
+        if ((int) data_get($ledger, 'candidate_contract.expected_payload_count', 0) !== self::EXPECTED_PAYLOAD_COUNT) {
+            $errors[] = 'source_ledger expected payload count mismatch';
+        }
+        if ($this->normalizedList((array) data_get($ledger, 'candidate_contract.launch_scope', [])) !== self::LAUNCH_SCOPE_BATCHES) {
+            $errors[] = 'source_ledger launch scope mismatch';
+        }
+        if ($this->normalizedList((array) data_get($ledger, 'candidate_contract.out_of_launch_scope', [])) !== self::OUT_OF_LAUNCH_SCOPE_BATCHES) {
+            $errors[] = 'source_ledger out_of_launch_scope mismatch';
+        }
+
+        $sources = (array) ($ledger['sources'] ?? []);
+        if ($sources === []) {
+            $errors[] = 'source_ledger sources missing';
+        }
+
+        $presentIds = $this->presentSourceIds($sources);
+        foreach (self::SOURCE_LEDGER_REQUIRED_SOURCE_IDS as $sourceId) {
+            if (! in_array($sourceId, $presentIds, true)) {
+                $errors[] = "source_ledger missing required source_id {$sourceId}";
+            }
+        }
+
+        foreach ($sources as $index => $source) {
+            if (! is_array($source)) {
+                $errors[] = "source_ledger source row {$index} must be an object";
+
+                continue;
+            }
+
+            $sourceId = (string) ($source['source_id'] ?? 'unknown');
+            $label = (string) ($source['source_label'] ?? '');
+            if (! in_array($label, self::SOURCE_LEDGER_ALLOWED_LABELS, true)) {
+                $errors[] = "source_ledger {$sourceId} has invalid source_label {$label}";
+            }
+            if (! is_array($source['copy_policy'] ?? null)) {
+                $errors[] = "source_ledger {$sourceId} missing copy_policy";
+            }
+            if ($this->containsAbsoluteLocalPath($source)) {
+                $errors[] = "source_ledger {$sourceId} contains an absolute local path";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function strictFailures(bool $strict, array $sourceLedgerInventory, array $validatorHarnessReport): array
+    {
+        if (! $strict) {
+            return [];
+        }
+
+        $failures = [];
+        if ((bool) data_get($sourceLedgerInventory, 'source_ledger.valid', false) !== true) {
+            $failures[] = 'source_ledger_invalid';
+        }
+
+        foreach ((array) data_get($validatorHarnessReport, 'errors', []) as $error) {
+            $failures[] = (string) $error;
+        }
+
+        return array_values(array_unique($failures));
+    }
+
+    /**
+     * @param  list<mixed>|array<int,mixed>  $sources
+     * @return list<string>
+     */
+    private function presentSourceIds(array $sources): array
+    {
+        $ids = [];
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $sourceId = (string) ($source['source_id'] ?? '');
+            if ($sourceId !== '') {
+                $ids[] = $sourceId;
+            }
+        }
+
+        sort($ids);
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @param  list<mixed>|array<int,mixed>  $sources
+     * @return array<string,int>
+     */
+    private function sourceLabelCounts(array $sources): array
+    {
+        $counts = array_fill_keys(self::SOURCE_LEDGER_ALLOWED_LABELS, 0);
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $label = (string) ($source['source_label'] ?? '');
+            if (array_key_exists($label, $counts)) {
+                $counts[$label]++;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizedList(array $values): array
+    {
+        $normalized = array_values(array_map(static fn ($value): string => (string) $value, $values));
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    private function reportCounterIsZero(string $path, array $keys): bool
+    {
+        $report = $this->readJsonFileIfPresent($path);
+        if (! is_array($report)) {
+            return false;
+        }
+
+        foreach ($keys as $key) {
+            $value = data_get($report, $key);
+            if ($value !== null) {
+                return (int) $value === 0;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function readJsonFileIfPresent(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function candidatePayloadCount(string $payloadDir): int
+    {
+        return count($this->candidatePayloadFiles($payloadDir));
+    }
+
+    /**
+     * @return list<SplFileInfo>
+     */
+    private function candidatePayloadFiles(string $payloadDir): array
+    {
+        if (! is_dir($payloadDir)) {
+            return [];
+        }
+
+        $files = [];
+        foreach (File::files($payloadDir) as $file) {
+            if ($file instanceof SplFileInfo && $file->getExtension() === 'json') {
+                $files[] = $file;
+            }
+        }
+
+        usort($files, static fn (SplFileInfo $a, SplFileInfo $b): int => strcmp($a->getBasename(), $b->getBasename()));
+
+        return $files;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function scanPayloadFields(array $payload, string $sourceFile): array
+    {
+        $hits = [];
+        foreach ($payload as $key => $value) {
+            $keyString = strtolower((string) $key);
+            if (array_key_exists($keyString, self::FORBIDDEN_PUBLIC_FIELD_FAMILY_BY_FIELD)) {
+                $hits[] = [
+                    'source_file' => $sourceFile,
+                    'hit_type' => 'field_family',
+                    'family' => self::FORBIDDEN_PUBLIC_FIELD_FAMILY_BY_FIELD[$keyString],
+                    'location' => 'json_key',
+                ];
+            }
+
+            if (is_array($value)) {
+                $hits = array_merge($hits, $this->scanPayloadFields($value, $sourceFile));
+            }
+        }
+
+        return $hits;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function scanPayloadTerms(array $payload, string $sourceFile): array
+    {
+        $text = mb_strtolower(json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+        $hits = [];
+
+        foreach (self::FORBIDDEN_TERM_FAMILY_BY_TERM as $term => $family) {
+            if (str_contains($text, mb_strtolower($term))) {
+                $hits[] = [
+                    'source_file' => $sourceFile,
+                    'hit_type' => 'claim_family',
+                    'family' => $family,
+                    'location' => 'payload_text',
+                ];
+            }
+        }
+
+        return $hits;
+    }
+
+    private function containsAbsoluteLocalPath(mixed $value): bool
+    {
+        if (is_array($value)) {
+            foreach ($value as $child) {
+                if ($this->containsAbsoluteLocalPath($child)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return str_contains($value, '/Users/')
+            || str_contains($value, '/private/tmp/')
+            || preg_match('#^/tmp/#', $value) === 1;
     }
 
     private function sanitizeRunId(string $runId): string
@@ -359,6 +1087,13 @@ final class EnneagramResultPageAgentReadiness
         $root = $artifactDir !== '' ? rtrim($artifactDir, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
 
         return $root.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sourceLedgerDir(string $sourceLedgerDir): string
+    {
+        return $sourceLedgerDir !== ''
+            ? rtrim($sourceLedgerDir, DIRECTORY_SEPARATOR)
+            : base_path(self::SOURCE_LEDGER_RELATIVE_DIR);
     }
 
     /**
@@ -416,6 +1151,14 @@ final class EnneagramResultPageAgentReadiness
             return '<backend>/'.ltrim(substr($path, strlen($base)), DIRECTORY_SEPARATOR);
         }
 
-        return preg_replace('#/Users/[^/]+/#', '/Users/<redacted>/', $path) ?: $path;
+        $tmp = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+        if ($tmp !== '' && str_starts_with($path, $tmp)) {
+            return '<tmp>/'.ltrim(substr($path, strlen($tmp)), DIRECTORY_SEPARATOR);
+        }
+
+        $path = preg_replace('#/Users/[^/]+/#', '/Users/<redacted>/', $path) ?: $path;
+        $path = preg_replace('#/private/tmp/#', '<tmp>/', $path) ?: $path;
+
+        return preg_replace('#^/tmp/#', '<tmp>/', $path) ?: $path;
     }
 }

--- a/backend/content_assets/enneagram/result_page/source_ledger/README.md
+++ b/backend/content_assets/enneagram/result_page/source_ledger/README.md
@@ -1,0 +1,34 @@
+# Enneagram Result Page Source Ledger
+
+Status: `ENNEAGRAM-RESULT-SOURCE-LEDGER-01`
+
+This directory records source authority for the Enneagram result-page asset agent. It is evidence and validator scaffold only. It does not generate candidate payloads, import candidate releases, activate runtime releases, switch production behavior, write CMS data, or provide frontend fallback content.
+
+## Files
+
+- `source_ledger.json`: normalized source-boundary contract consumed by `enneagram:result-page-agent audit`.
+- `source_ledger_template_v0_1.json`: schema-like template for future source ledger rows.
+- `README.md`: operator-facing boundary summary.
+
+## Required Contract
+
+The ledger must keep:
+
+- `schema_version=fap.enneagram.result_page.source_ledger.v0.1`
+- `runtime_use=not_runtime`
+- `production_use_allowed=false`
+- `cms_write_performed=false`
+- `runtime_change_performed=false`
+- `frontend_fallback_allowed=false`
+- `activation_happened=false`
+- candidate baseline SHA `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`
+- runtime registry SHA `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`
+- expected payload count `630`
+- launch scope `1R-A` through `1R-H`
+- out-of-launch scope exactly `1R-I`, `1R-J`
+
+## Source Boundaries
+
+Every future asset claim must trace to one required source id, one allowed source label, a bounded claim category, and an explicit copy policy. Internal asset-stream rows are provenance contracts only; they are not runtime content, not CMS import material, and not permission to copy external or private working paths into public payloads.
+
+The validator harness fails closed when a provided candidate directory has missing required artifacts, mismatched hashes, wrong payload count, source-mapping failures, metadata leakage, forbidden claim families, legacy residuals, or FC144 boundary violations.

--- a/backend/content_assets/enneagram/result_page/source_ledger/source_ledger.json
+++ b/backend/content_assets/enneagram/result_page/source_ledger/source_ledger.json
@@ -1,0 +1,710 @@
+{
+  "schema_version": "fap.enneagram.result_page.source_ledger.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "activation_happened": false,
+  "description": "Source-ledger contract for the Enneagram result-page agent validator harness. This is scaffold and provenance only.",
+  "allowed_source_labels": [
+    "runtime_contract",
+    "compiled_question_contract",
+    "candidate_baseline",
+    "asset_stream_contract",
+    "policy_contract"
+  ],
+  "candidate_contract": {
+    "baseline_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+    "expected_payload_count": 630,
+    "launch_scope": [
+      "1R-A",
+      "1R-B",
+      "1R-C",
+      "1R-D",
+      "1R-E",
+      "1R-F",
+      "1R-G",
+      "1R-H"
+    ],
+    "out_of_launch_scope": [
+      "1R-I",
+      "1R-J"
+    ]
+  },
+  "sources": [
+    {
+      "source_id": "enneagram_v2_runtime_registry",
+      "source_label": "runtime_contract",
+      "title": "Enneagram V2 runtime registry manifest",
+      "authority_level": "primary",
+      "source_ref": {
+        "kind": "repo_path",
+        "value": "content_packs/ENNEAGRAM/v2/registry/manifest.json",
+        "sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f"
+      },
+      "claim_categories": [
+        "runtime_hash",
+        "registry_contract"
+      ],
+      "permitted_use": [
+        "Verify that a provided candidate is checked against the expected runtime registry hash."
+      ],
+      "limitations": [
+        "Evidence-only in this PR; no runtime switch is allowed."
+      ],
+      "disallowed_use": [
+        "Do not activate or mutate runtime rows from this ledger."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Registry manifest is a hash contract, not public result copy."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness"
+      ],
+      "claim_trace_requirements": [
+        "Candidate validation must compare the runtime registry hash to this ledger row."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "runtime_registry_hash_contract",
+          "summary": "Expected runtime registry hash for a9fd baseline validation.",
+          "limitations": [
+            "Does not imply runtime activation."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "enneagram_e105_compiled_questions",
+      "source_label": "compiled_question_contract",
+      "title": "E105 compiled question contract",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "repo_path",
+        "value": "content_packs/ENNEAGRAM/v2",
+        "sha256": null
+      },
+      "claim_categories": [
+        "question_boundary",
+        "method_boundary"
+      ],
+      "permitted_use": [
+        "Preserve E105 as the primary result source boundary for result-page copy."
+      ],
+      "limitations": [
+        "Does not authorize deterministic typing, diagnosis, or E105 versus FC144 score comparison."
+      ],
+      "disallowed_use": [
+        "Do not claim that E105 and FC144 scores are directly comparable."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Question contract only; not reusable public copy."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every E105 method claim must retain the question-boundary limitation."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "e105_question_boundary",
+          "summary": "E105 remains the primary current result flow boundary.",
+          "limitations": [
+            "No score-comparison claim is allowed."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "enneagram_fc144_compiled_questions",
+      "source_label": "compiled_question_contract",
+      "title": "FC144 compiled question contract",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "repo_path",
+        "value": "content_packs/ENNEAGRAM/v2",
+        "sha256": null
+      },
+      "claim_categories": [
+        "question_boundary",
+        "fc144_boundary"
+      ],
+      "permitted_use": [
+        "Frame FC144 only as a second lens or follow-up exploration boundary."
+      ],
+      "limitations": [
+        "FC144 must not be positioned as more accurate, replacement, final typing, or score-superiority evidence."
+      ],
+      "disallowed_use": [
+        "Do not claim FC144 replaces or corrects the E105 result."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Question contract only; not reusable public copy."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every FC144 claim must include the second-lens limitation."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "fc144_second_lens_boundary",
+          "summary": "FC144 is bounded to second-lens language.",
+          "limitations": [
+            "No accuracy-superiority or replacement-result claim is allowed."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "phase8b_candidate_baseline_a9fd",
+      "source_label": "candidate_baseline",
+      "title": "Phase8B a9fd candidate baseline contract",
+      "authority_level": "baseline",
+      "source_ref": {
+        "kind": "contract_hash",
+        "value": "phase8b_candidate_manifest_sha256:a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+        "sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0"
+      },
+      "claim_categories": [
+        "candidate_baseline",
+        "payload_count",
+        "scope_boundary"
+      ],
+      "permitted_use": [
+        "Validate a provided candidate directory against the approved a9fd baseline contract."
+      ],
+      "limitations": [
+        "This ledger does not store candidate payloads and does not prove a candidate directory exists locally."
+      ],
+      "disallowed_use": [
+        "Do not treat another manifest hash as a silent substitute for a9fd."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Hash contract only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness"
+      ],
+      "claim_trace_requirements": [
+        "Candidate validation must compare manifest SHA, runtime registry SHA, payload count, launch scope, and out-of-launch scope."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "a9fd_rebaselined_candidate_contract",
+          "summary": "a9fd is the current approved candidate baseline after the unrecovered prior tmp candidate.",
+          "limitations": [
+            "No candidate payloads are committed in this PR."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_a_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-A asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_A_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-A."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_a_scope",
+          "summary": "1R-A is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_b_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-B asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_B_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-B."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_b_scope",
+          "summary": "1R-B is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_c_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-C asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_C_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-C."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_c_scope",
+          "summary": "1R-C is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_d_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-D asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_D_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-D."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_d_scope",
+          "summary": "1R-D is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_e_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-E asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_E_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-E."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_e_scope",
+          "summary": "1R-E is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_f_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-F asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_F_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-F."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_f_scope",
+          "summary": "1R-F is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_g_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-G asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_G_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-G."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_g_scope",
+          "summary": "1R-G is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "batch_1r_h_asset_stream",
+      "source_label": "asset_stream_contract",
+      "title": "Batch 1R-H asset stream",
+      "authority_level": "supporting",
+      "source_ref": {
+        "kind": "logical_asset_stream",
+        "value": "FermatMind_Enneagram_Content_Expansion_Batch_1R_H_Assets_v6_final.json",
+        "sha256": null
+      },
+      "claim_categories": [
+        "source_mapping",
+        "launch_scope"
+      ],
+      "permitted_use": [
+        "Trace candidate payloads to launch-scope asset stream 1R-H."
+      ],
+      "limitations": [
+        "Logical provenance only; no external asset JSON is copied into this repo."
+      ],
+      "disallowed_use": [
+        "Do not expose machine-local source paths or private working notes."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Asset stream row is provenance only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every payload derived from this stream must map back to the stream id and source checksum."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "batch_1r_h_scope",
+          "summary": "1R-H is in launch scope.",
+          "limitations": [
+            "No public copy is authorized by the ledger row alone."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "fc144_boundary_policy",
+      "source_label": "policy_contract",
+      "title": "FC144 boundary policy",
+      "authority_level": "policy",
+      "source_ref": {
+        "kind": "policy",
+        "value": "enneagram_result_page_fc144_second_lens_policy",
+        "sha256": null
+      },
+      "claim_categories": [
+        "fc144_boundary",
+        "forbidden_claim_boundary"
+      ],
+      "permitted_use": [
+        "Validate that FC144 language stays second-lens only."
+      ],
+      "limitations": [
+        "Policy row only; not public copy."
+      ],
+      "disallowed_use": [
+        "No FC144 accuracy-superiority, replacement-result, final-typing, or direct score-comparison claim."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Policy row only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every FC144 candidate payload must pass the boundary validator."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "fc144_policy_zero_violation_gate",
+          "summary": "Validator requires FC144 boundary violation count to be zero.",
+          "limitations": [
+            "Does not activate or import content."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    },
+    {
+      "source_id": "forbidden_claim_policy",
+      "source_label": "policy_contract",
+      "title": "Forbidden claim policy",
+      "authority_level": "policy",
+      "source_ref": {
+        "kind": "policy",
+        "value": "enneagram_result_page_forbidden_claim_families",
+        "sha256": null
+      },
+      "claim_categories": [
+        "safety_policy",
+        "metadata_leakage",
+        "forbidden_claim_boundary"
+      ],
+      "permitted_use": [
+        "Validate that candidate payloads do not contain forbidden claim families or private metadata leakage."
+      ],
+      "limitations": [
+        "Policy row only; future content generation still needs separate source-backed review."
+      ],
+      "disallowed_use": [
+        "No diagnostic, hiring, final typing, fixed certainty, score-comparison, FC144 replacement, prediction, or private identifier leakage."
+      ],
+      "copy_policy": {
+        "copy_allowed": false,
+        "paraphrase_allowed": false,
+        "public_payload_allowed": false,
+        "notes": "Policy row only."
+      },
+      "asset_scopes_allowed": [
+        "source_ledger",
+        "validator_harness",
+        "candidate_dry_run"
+      ],
+      "claim_trace_requirements": [
+        "Every candidate payload must pass metadata leakage and forbidden claim scans before import QA."
+      ],
+      "evidence_refs": [
+        {
+          "ref_id": "forbidden_claim_zero_gate",
+          "summary": "Validator requires forbidden claim and metadata leakage hit counts to be zero.",
+          "limitations": [
+            "Does not generate or approve new content by itself."
+          ]
+        }
+      ],
+      "review_status": "approved_for_validator_scaffold"
+    }
+  ]
+}

--- a/backend/content_assets/enneagram/result_page/source_ledger/source_ledger_template_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/source_ledger/source_ledger_template_v0_1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "fap.enneagram.result_page.source_ledger.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "activation_happened": false,
+  "description": "Template for source-ledger rows consumed by the Enneagram result-page asset agent validator harness.",
+  "allowed_source_labels": [
+    "runtime_contract",
+    "compiled_question_contract",
+    "candidate_baseline",
+    "asset_stream_contract",
+    "policy_contract"
+  ],
+  "candidate_contract": {
+    "baseline_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+    "expected_payload_count": 630,
+    "launch_scope": [
+      "1R-A",
+      "1R-B",
+      "1R-C",
+      "1R-D",
+      "1R-E",
+      "1R-F",
+      "1R-G",
+      "1R-H"
+    ],
+    "out_of_launch_scope": [
+      "1R-I",
+      "1R-J"
+    ]
+  },
+  "required_row_fields": [
+    "source_id",
+    "source_label",
+    "title",
+    "authority_level",
+    "source_ref",
+    "claim_categories",
+    "permitted_use",
+    "limitations",
+    "disallowed_use",
+    "copy_policy",
+    "asset_scopes_allowed",
+    "claim_trace_requirements",
+    "evidence_refs",
+    "review_status"
+  ],
+  "row_template": {
+    "source_id": "stable_snake_case_id",
+    "source_label": "runtime_contract | compiled_question_contract | candidate_baseline | asset_stream_contract | policy_contract",
+    "title": "Short source title",
+    "authority_level": "primary | supporting | policy | baseline",
+    "source_ref": {
+      "kind": "repo_path | logical_asset_stream | contract_hash | policy",
+      "value": "repository/relative/path-or-logical-source-ref",
+      "sha256": null
+    },
+    "claim_categories": [
+      "runtime_hash",
+      "question_boundary",
+      "candidate_baseline",
+      "source_mapping",
+      "safety_policy",
+      "fc144_boundary"
+    ],
+    "permitted_use": [
+      "Describe the exact bounded use this source supports."
+    ],
+    "limitations": [
+      "Describe uncertainty, ownership, measurement, and generalization limits."
+    ],
+    "disallowed_use": [
+      "Describe forbidden claim or copy use."
+    ],
+    "copy_policy": {
+      "copy_allowed": false,
+      "paraphrase_allowed": false,
+      "public_payload_allowed": false,
+      "notes": "Evidence-only unless a future PR explicitly promotes the row for generated candidate content."
+    },
+    "asset_scopes_allowed": [
+      "source_ledger",
+      "validator_harness",
+      "candidate_dry_run"
+    ],
+    "claim_trace_requirements": [
+      "Every future derived claim must include source_id, evidence_ref, limitation, and reviewer decision."
+    ],
+    "evidence_refs": [
+      {
+        "ref_id": "evidence_ref_id",
+        "summary": "Short evidence summary.",
+        "limitations": [
+          "Known limit"
+        ]
+      }
+    ],
+    "review_status": "template"
+  }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php
@@ -9,7 +9,7 @@ use Tests\TestCase;
 
 final class EnneagramResultPageAgentReadinessTest extends TestCase
 {
-    public function test_audit_service_writes_control_packet_without_generation_or_activation(): void
+    public function test_audit_service_writes_control_packet_and_validator_artifacts_without_generation_or_activation(): void
     {
         $artifactRoot = $this->tempDir('enneagram-agent-readiness');
 
@@ -17,18 +17,26 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
             $summary = app(EnneagramResultPageAgentReadiness::class)->audit([
                 'run_id' => 'unit-run',
                 'artifact_dir' => $artifactRoot,
+                'source_ledger_dir' => $this->sourceLedgerDir(),
             ]);
 
             $this->assertTrue((bool) ($summary['ok'] ?? false));
 
             $runDir = $artifactRoot.'/unit-run';
-            foreach ([
+            $artifactFiles = [
                 'control_packet.json',
                 'readiness_inventory.json',
+                'source_ledger_inventory.json',
+                'validator_harness_report.json',
+                'source_mapping_contract_report.json',
+                'metadata_leakage_report.json',
+                'forbidden_claim_report.json',
                 'validation_commands.json',
                 'safety_policy.json',
                 'go_no_go.md',
-            ] as $filename) {
+            ];
+
+            foreach ($artifactFiles as $filename) {
                 $this->assertFileExists($runDir.'/'.$filename);
             }
 
@@ -37,6 +45,7 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
             $this->assertSame('backend', $controlPacket['content_authority'] ?? null);
             $this->assertSame('ENNEAGRAM', $controlPacket['scale'] ?? null);
             $this->assertFalse((bool) data_get($controlPacket, 'negative_guarantees.bulk_content_generation_happened', true));
+            $this->assertFalse((bool) data_get($controlPacket, 'negative_guarantees.candidate_payload_creation_happened', true));
             $this->assertFalse((bool) data_get($controlPacket, 'negative_guarantees.activation_happened', true));
             $this->assertFalse((bool) data_get($controlPacket, 'agent_batches.0.generation_allowed', true));
 
@@ -48,6 +57,18 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
             );
             $this->assertFalse((bool) ($inventory['production_use_allowed'] ?? true));
 
+            $sourceLedger = $this->readJson($runDir.'/source_ledger_inventory.json');
+            $this->assertTrue((bool) data_get($sourceLedger, 'source_ledger.valid'));
+            $this->assertSame(
+                EnneagramResultPageAgentReadiness::SOURCE_LEDGER_SCHEMA_VERSION,
+                data_get($sourceLedger, 'source_ledger.schema_version')
+            );
+
+            $validator = $this->readJson($runDir.'/validator_harness_report.json');
+            $this->assertFalse((bool) data_get($validator, 'candidate_dir.provided', true));
+            $this->assertTrue((bool) data_get($validator, 'candidate_contract.valid', false));
+            $this->assertSame(0, (int) ($validator['error_count'] ?? -1));
+
             $commands = $this->readJson($runDir.'/validation_commands.json');
             $futureExport = implode("\n", (array) ($commands['future_candidate_export_gate'] ?? []));
             $this->assertStringContainsString('enneagram:export-production-equivalent-candidate-payloads', $futureExport);
@@ -55,26 +76,93 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
 
             $safety = $this->readJson($runDir.'/safety_policy.json');
             $this->assertContains('fixed_type_certainty', $safety['forbidden_claim_families'] ?? []);
-            $this->assertContains('score_comparison_between_e105_and_fc144', $safety['forbidden_claim_families'] ?? []);
+            $this->assertContains('e105_fc144_score_comparison', $safety['forbidden_claim_families'] ?? []);
 
             $goNoGo = (string) file_get_contents($runDir.'/go_no_go.md');
             $this->assertStringContainsString('candidate_generation_allowed: false', $goNoGo);
             $this->assertStringContainsString('no activation', $goNoGo);
 
-            $allArtifacts = implode("\n", array_map(
-                static fn (string $filename): string => (string) file_get_contents($runDir.'/'.$filename),
-                [
-                    'control_packet.json',
-                    'readiness_inventory.json',
-                    'validation_commands.json',
-                    'safety_policy.json',
-                    'go_no_go.md',
-                ]
-            ));
-            $this->assertStringNotContainsString('/Users/rainie/', $allArtifacts);
-            $this->assertStringNotContainsString('attempt_id_example', $allArtifacts);
+            $this->assertArtifactsDoNotLeakPrivateMaterial($runDir, $artifactFiles);
         } finally {
             $this->deleteDirectory($artifactRoot);
+        }
+    }
+
+    public function test_source_ledger_contract_has_required_ids_hashes_scope_and_negative_guarantees(): void
+    {
+        $path = $this->sourceLedgerDir().'/source_ledger.json';
+        $ledger = $this->readJson($path);
+
+        $this->assertSame('fap.enneagram.result_page.source_ledger.v0.1', $ledger['schema_version'] ?? null);
+        $this->assertSame('not_runtime', $ledger['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($ledger['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($ledger['cms_write_performed'] ?? true));
+        $this->assertFalse((bool) ($ledger['runtime_change_performed'] ?? true));
+        $this->assertFalse((bool) ($ledger['frontend_fallback_allowed'] ?? true));
+        $this->assertFalse((bool) ($ledger['activation_happened'] ?? true));
+        $this->assertSame(
+            'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0',
+            data_get($ledger, 'candidate_contract.baseline_candidate_manifest_sha256')
+        );
+        $this->assertSame(
+            'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f',
+            data_get($ledger, 'candidate_contract.runtime_registry_manifest_sha256')
+        );
+        $this->assertSame(630, (int) data_get($ledger, 'candidate_contract.expected_payload_count'));
+        $this->assertSame(['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'], data_get($ledger, 'candidate_contract.launch_scope'));
+        $this->assertSame(['1R-I', '1R-J'], data_get($ledger, 'candidate_contract.out_of_launch_scope'));
+
+        $sourceIds = array_map(
+            static fn (array $source): string => (string) ($source['source_id'] ?? ''),
+            (array) ($ledger['sources'] ?? [])
+        );
+        sort($sourceIds);
+
+        $expected = [
+            'batch_1r_a_asset_stream',
+            'batch_1r_b_asset_stream',
+            'batch_1r_c_asset_stream',
+            'batch_1r_d_asset_stream',
+            'batch_1r_e_asset_stream',
+            'batch_1r_f_asset_stream',
+            'batch_1r_g_asset_stream',
+            'batch_1r_h_asset_stream',
+            'enneagram_e105_compiled_questions',
+            'enneagram_fc144_compiled_questions',
+            'enneagram_v2_runtime_registry',
+            'fc144_boundary_policy',
+            'forbidden_claim_policy',
+            'phase8b_candidate_baseline_a9fd',
+        ];
+        sort($expected);
+        $this->assertSame($expected, $sourceIds);
+    }
+
+    public function test_strict_mode_rejects_malformed_source_ledger(): void
+    {
+        $root = $this->tempDir('enneagram-agent-ledger-strict');
+        $sourceLedgerDir = $root.'/ledger';
+        mkdir($sourceLedgerDir, 0777, true);
+        file_put_contents($sourceLedgerDir.'/source_ledger.json', json_encode([
+            'schema_version' => 'bad',
+            'runtime_use' => 'runtime',
+        ], JSON_PRETTY_PRINT));
+
+        try {
+            $summary = app(EnneagramResultPageAgentReadiness::class)->audit([
+                'run_id' => 'strict-ledger',
+                'artifact_dir' => $root.'/artifacts',
+                'source_ledger_dir' => $sourceLedgerDir,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('source_ledger_invalid', $summary['strict_failures']);
+
+            $inventory = $this->readJson($root.'/artifacts/strict-ledger/source_ledger_inventory.json');
+            $this->assertFalse((bool) data_get($inventory, 'source_ledger.valid', true));
+        } finally {
+            $this->deleteDirectory($root);
         }
     }
 
@@ -89,6 +177,7 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
                 'run_id' => 'strict-run',
                 'artifact_dir' => $root.'/artifacts',
                 'candidate_dir' => $candidateDir,
+                'source_ledger_dir' => $this->sourceLedgerDir(),
                 'strict' => true,
             ]);
 
@@ -102,12 +191,46 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
         }
     }
 
+    public function test_strict_mode_rejects_candidate_payload_with_forbidden_claim_and_metadata_leakage(): void
+    {
+        $root = $this->tempDir('enneagram-agent-leak-strict');
+        $candidateDir = $root.'/candidate';
+        $this->writeLeakyCandidateFixture($candidateDir);
+
+        try {
+            $summary = app(EnneagramResultPageAgentReadiness::class)->audit([
+                'run_id' => 'strict-leak',
+                'artifact_dir' => $root.'/artifacts',
+                'candidate_dir' => $candidateDir,
+                'source_ledger_dir' => $this->sourceLedgerDir(),
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('metadata_leakage_hits', $summary['strict_failures']);
+            $this->assertContains('forbidden_claim_hits', $summary['strict_failures']);
+
+            $metadata = $this->readJson($root.'/artifacts/strict-leak/metadata_leakage_report.json');
+            $this->assertGreaterThan(0, (int) ($metadata['hit_count'] ?? 0));
+
+            $claims = $this->readJson($root.'/artifacts/strict-leak/forbidden_claim_report.json');
+            $this->assertGreaterThan(0, (int) ($claims['hit_count'] ?? 0));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
     private function tempDir(string $prefix): string
     {
         $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
         mkdir($path, 0777, true);
 
         return $path;
+    }
+
+    private function sourceLedgerDir(): string
+    {
+        return dirname(__DIR__, 5).'/content_assets/enneagram/result_page/source_ledger';
     }
 
     /**
@@ -119,6 +242,69 @@ final class EnneagramResultPageAgentReadinessTest extends TestCase
         $this->assertIsArray($decoded);
 
         return $decoded;
+    }
+
+    /**
+     * @param  list<string>  $artifactFiles
+     */
+    private function assertArtifactsDoNotLeakPrivateMaterial(string $runDir, array $artifactFiles): void
+    {
+        $allArtifacts = implode("\n", array_map(
+            static fn (string $filename): string => (string) file_get_contents($runDir.'/'.$filename),
+            $artifactFiles
+        ));
+
+        foreach ([
+            '/Users/rainie/',
+            '/private/tmp/',
+            'attempt_id',
+            'private_url',
+            'raw_score',
+            'domain_vector',
+            'frontend fallback copy',
+        ] as $blocked) {
+            $this->assertStringNotContainsString($blocked, $allArtifacts);
+        }
+    }
+
+    private function writeLeakyCandidateFixture(string $candidateDir): void
+    {
+        mkdir($candidateDir.'/candidate_payloads', 0777, true);
+        file_put_contents($candidateDir.'/candidate_payloads/leaky.json', json_encode([
+            'asset_key' => 'leaky',
+            'public_payload' => [
+                'attempt_id' => 'blocked-example',
+                'body' => 'FC144 is more accurate and replaces your result.',
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        file_put_contents($candidateDir.'/candidate_manifest.json', json_encode([
+            'out_of_launch_scope' => ['1R-I', '1R-J'],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        file_put_contents($candidateDir.'/candidate_hashes.json', json_encode([
+            'candidate_manifest_sha256' => hash_file('sha256', $candidateDir.'/candidate_manifest.json'),
+            'runtime_registry_manifest_sha256' => 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        file_put_contents($candidateDir.'/rollback_plan.md', "# rollback\n");
+        file_put_contents($candidateDir.'/import_diff_summary.json', '{}');
+        file_put_contents($candidateDir.'/replacement_additive_map.json', '{}');
+        file_put_contents($candidateDir.'/source_mapping_report.json', json_encode([
+            'source_mapping_failure_count' => 0,
+            'fallback_source_count' => 0,
+            'blocked_source_count' => 0,
+            'duplicate_selection_count' => 0,
+            'branch_provenance_mismatch_count' => 0,
+        ], JSON_PRETTY_PRINT));
+        file_put_contents($candidateDir.'/legacy_residual_scan.json', json_encode([
+            'legacy_deep_core_residual_count' => 0,
+        ], JSON_PRETTY_PRINT));
+        file_put_contents($candidateDir.'/fc144_boundary_report.json', json_encode([
+            'violation_count' => 0,
+        ], JSON_PRETTY_PRINT));
+        file_put_contents($candidateDir.'/phase8b_summary.json', '{}');
+        file_put_contents($candidateDir.'/candidate_payloads_manifest.json', '{}');
+        file_put_contents($candidateDir.'/candidate_payload_hashes.json', '{}');
+        file_put_contents($candidateDir.'/candidate_payload_source_mapping.json', '{}');
     }
 
     private function deleteDirectory(string $path): void


### PR DESCRIPTION
## What changed
- Added Enneagram result-page source ledger scaffold under `backend/content_assets/enneagram/result_page/source_ledger/`.
- Extended the existing `enneagram:result-page-agent audit` command with `--source-ledger-dir=`.
- Extended the existing `EnneagramResultPageAgentReadiness` service with read-only source-ledger inventory and validator harness reports:
  - `source_ledger_inventory.json`
  - `validator_harness_report.json`
  - `source_mapping_contract_report.json`
  - `metadata_leakage_report.json`
  - `forbidden_claim_report.json`
- Added unit coverage for ledger contracts, strict failure modes, metadata leakage, forbidden claims, and artifact redaction.

## Why
This adds the next guardrail layer for the Enneagram result-page asset agent before any future bulk content work. The ledger fixes the a9fd candidate baseline contract, runtime registry hash, 630-payload expectation, launch scope, out-of-launch scope, source ids, and negative guarantees in a repo-owned, validator-consumable form.

## Validation
- `php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php`
- `php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php`
- `php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi`
- `php artisan enneagram:result-page-agent audit --run-id=smoke --artifact-dir=<tmpdir> --json`
- `php artisan enneagram:result-page-agent audit --run-id=smoke-strict --artifact-dir=<tmpdir> --strict --json`
- `php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `git diff --check HEAD~1..HEAD`

## Intentionally deferred
- No bulk content generation.
- No candidate payload creation.
- No inactive import.
- No production activation.
- No runtime switch.
- No production writes.
- No frontend changes.
