### PR TITLE
Enneagram: record a9fd strict candidate validator dry-run

### DIFF
--- a/backend/docs/enneagram/a9fd-strict-candidate-validator-dry-run-01.md
+++ b/backend/docs/enneagram/a9fd-strict-candidate-validator-dry-run-01.md
@@ -1,0 +1,91 @@
+# Enneagram a9fd Strict Candidate Validator Dry Run
+
+Status: `PASS_STRICT_VALIDATOR_DRY_RUN`
+
+This document records the first post-ledger strict validator dry run for the Enneagram result-page a9fd candidate baseline. It is evidence-only. It does not commit candidate payloads, import an inactive release, activate a release, switch runtime state, write production data, or change frontend behavior.
+
+## Scope
+
+- PR: `Enneagram: record a9fd strict candidate validator dry-run`
+- Branch: `codex/enneagram-a9fd-strict-validator-dry-run-01`
+- Candidate reference: `<tmp>/fm_enneagram_a9fd_renderable_20260619`
+- Candidate manifest SHA: `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`
+- Runtime registry manifest SHA: `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`
+- Payload count: `630`
+- Launch scope: `1R-A`, `1R-B`, `1R-C`, `1R-D`, `1R-E`, `1R-F`, `1R-G`, `1R-H`
+- Out-of-launch scope: `1R-I`, `1R-J`
+
+## Command
+
+```bash
+php artisan enneagram:result-page-agent audit \
+  --run-id=a9fd-candidate-validator \
+  --candidate-dir=<candidate-dir> \
+  --artifact-dir=<tmp-artifact-dir> \
+  --strict \
+  --json
+```
+
+## Result
+
+The command exited successfully with:
+
+- `ok=true`
+- `status=success`
+- `strict_failures=[]`
+- `source_ledger_valid=true`
+- `candidate_dir_provided=true`
+- `candidate_contract_valid=true`
+- `ready_for_generation=false`
+- `ready_for_import=false`
+- `ready_for_activation=false`
+
+## Validator Checks
+
+| Check | Result |
+| --- | --- |
+| Source ledger valid | PASS |
+| Candidate required artifacts present | PASS |
+| Candidate manifest hash matches a9fd baseline | PASS |
+| Runtime registry hash matches expected contract | PASS |
+| Candidate payload count equals 630 | PASS |
+| Out-of-launch scope equals `1R-I`, `1R-J` | PASS |
+| Source mapping zero failures | PASS |
+| Metadata leakage zero | PASS |
+| Forbidden claim zero | PASS |
+| Legacy residual zero | PASS |
+| FC144 boundary zero | PASS |
+
+## Candidate Artifacts Observed
+
+The strict validator confirmed these required candidate artifacts were present:
+
+- `candidate_manifest.json`
+- `candidate_hashes.json`
+- `rollback_plan.md`
+- `import_diff_summary.json`
+- `replacement_additive_map.json`
+- `source_mapping_report.json`
+- `legacy_residual_scan.json`
+- `fc144_boundary_report.json`
+- `phase8b_summary.json`
+- `candidate_payloads_manifest.json`
+- `candidate_payload_hashes.json`
+- `candidate_payload_source_mapping.json`
+- `candidate_payloads/`
+
+## Negative Guarantees
+
+- No bulk content generation happened.
+- No candidate payload creation happened.
+- No inactive import happened.
+- No production import happened.
+- No activation happened.
+- No runtime switch happened.
+- No CMS write happened.
+- No frontend fallback copy was added.
+- No production write happened.
+
+## Follow-Up
+
+The next PR may proceed to the pilot asset batch scaffold. It must remain small-scope and must not generate the full 630 payload set.


### PR DESCRIPTION
## What changed
- Added a small Enneagram a9fd strict validator dry-run evidence document.
- Recorded the redacted candidate reference, expected hashes, 630 payload contract, launch/out-of-launch scope, and validator check results.
- Kept candidate payloads and run artifacts outside the repo.

## Why
This is PR 1 of the Enneagram result-page agent train. It proves the merged source-ledger/validator harness can validate the real a9fd candidate before any pilot asset generation, batch runner work, import, rendered QA, or activation gates proceed.

## Validation
- `php artisan enneagram:result-page-agent audit --run-id=a9fd-candidate-validator --candidate-dir=<candidate-dir> --artifact-dir=<tmp-artifact-dir> --strict --json`
- `git diff --check`

## Scope validation
- Changed files: `backend/docs/enneagram/a9fd-strict-candidate-validator-dry-run-01.md`
- Docs/evidence only.
- No candidate payload artifacts committed.

## Intentionally deferred
- No bulk content generation.
- No candidate payload creation.
- No inactive import.
- No production activation.
- No runtime switch.
- No production writes.
- No frontend changes.
