### PR TITLE
Enneagram: add pilot result-page asset batch scaffold

### DIFF
--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/README.md
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/README.md
@@ -1,0 +1,25 @@
+# Enneagram Result Page Pilot Asset Batch v0.1
+
+Status: `PILOT_SCAFFOLD_ONLY`
+
+This directory contains a minimal Enneagram result-page pilot asset batch for the agent train. It is intentionally tiny: two payloads across two modules. It is not a 630-payload candidate package and must not be imported, activated, used as runtime content, or treated as production-ready result copy.
+
+## Files
+
+- `pilot_batch_manifest.json`: pilot batch contract and negative guarantees.
+- `payloads/*.json`: two staging-only public payload examples.
+- `source_mapping_report.json`: source trace rows for each pilot payload.
+- `safety_report.json`: metadata leakage, forbidden claim, and FC144 boundary zero-hit report.
+- `rollback_plan.md`: rollback and removal shape for this scaffold.
+
+## Boundaries
+
+- No bulk content generation.
+- No candidate export.
+- No inactive import.
+- No production activation.
+- No runtime switch.
+- No production writes.
+- No frontend fallback copy.
+
+The next PR may add a batch runner and eval harness. It should consume this pilot batch as a small contract fixture, not as production content.

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/payloads/pilot_t1_baseline_reflection.json
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/payloads/pilot_t1_baseline_reflection.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "fap.enneagram.result_page.pilot_payload.v0.1",
+  "asset_key": "pilot_t1_baseline_reflection_v0_1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "result_type": "type_1",
+  "module_key": "baseline_reflection",
+  "locale": "zh-CN",
+  "public_payload": {
+    "heading": "把标准感转成可执行的整理动作",
+    "body": "这个结果可以作为一次自我观察入口：当你很快看见哪里不够稳、不够清楚时，先把最重要的一处写成下一步动作，而不是一次性修正全部问题。",
+    "cards": [
+      {
+        "label": "容易卡住的地方",
+        "text": "把多个小瑕疵合并成一个必须马上解决的整体。"
+      },
+      {
+        "label": "更稳的练习",
+        "text": "先选一处影响最大的细节，写下负责人、时间和可接受完成标准。"
+      }
+    ]
+  },
+  "routing_metadata": {
+    "result_state": "baseline",
+    "resonance_band": "clear",
+    "shareability": "private_result_only"
+  },
+  "source_trace": {
+    "source_ids": [
+      "phase8b_candidate_baseline_a9fd",
+      "batch_1r_a_asset_stream",
+      "forbidden_claim_policy"
+    ],
+    "claim_trace": [
+      {
+        "claim_key": "baseline_reflection_safe_action_frame",
+        "source_id": "batch_1r_a_asset_stream",
+        "limitation": "Pilot wording only; not full candidate payload coverage."
+      }
+    ]
+  },
+  "safety_flags": {
+    "staging_only": true,
+    "metadata_leakage_checked": true,
+    "forbidden_claim_checked": true,
+    "fc144_boundary_checked": true
+  }
+}

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/payloads/pilot_t5_fc144_second_lens.json
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/payloads/pilot_t5_fc144_second_lens.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "fap.enneagram.result_page.pilot_payload.v0.1",
+  "asset_key": "pilot_t5_fc144_second_lens_v0_1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "result_type": "type_5",
+  "module_key": "fc144_second_lens",
+  "locale": "zh-CN",
+  "public_payload": {
+    "heading": "把第二视角当作补充观察",
+    "body": "如果你之后选择继续看更细的题组，它只适合帮助你从另一个角度整理主题，不用于替换当前结果，也不用于给分数排序。",
+    "cards": [
+      {
+        "label": "适合观察",
+        "text": "你在收集信息、保持边界和投入行动之间如何分配精力。"
+      },
+      {
+        "label": "不适合判断",
+        "text": "不要把不同题组的数字当成同一把尺子来排列高低。"
+      }
+    ]
+  },
+  "routing_metadata": {
+    "result_state": "fc144_recommendation",
+    "resonance_band": "second_lens",
+    "shareability": "private_result_only"
+  },
+  "source_trace": {
+    "source_ids": [
+      "phase8b_candidate_baseline_a9fd",
+      "batch_1r_h_asset_stream",
+      "fc144_boundary_policy",
+      "forbidden_claim_policy"
+    ],
+    "claim_trace": [
+      {
+        "claim_key": "fc144_second_lens_non_replacement_frame",
+        "source_id": "fc144_boundary_policy",
+        "limitation": "FC144 language remains second-lens only and cannot rank or replace current-result interpretation."
+      }
+    ]
+  },
+  "safety_flags": {
+    "staging_only": true,
+    "metadata_leakage_checked": true,
+    "forbidden_claim_checked": true,
+    "fc144_boundary_checked": true
+  }
+}

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/pilot_batch_manifest.json
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/pilot_batch_manifest.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "fap.enneagram.result_page.pilot_asset_batch.v0.1",
+  "batch_id": "ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "activation_happened": false,
+  "bulk_content_generation_happened": false,
+  "candidate_payload_creation_happened": false,
+  "candidate_export_happened": false,
+  "inactive_import_happened": false,
+  "description": "Minimal pilot fixture for validating Enneagram result-page agent input/output, source trace, claim safety, and rollback shape.",
+  "source_ledger_schema_version": "fap.enneagram.result_page.source_ledger.v0.1",
+  "candidate_contract_reference": {
+    "baseline_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+    "expected_full_candidate_payload_count": 630,
+    "pilot_payload_count": 2
+  },
+  "payloads": [
+    {
+      "asset_key": "pilot_t1_baseline_reflection_v0_1",
+      "relative_path": "payloads/pilot_t1_baseline_reflection.json",
+      "result_type": "type_1",
+      "module_key": "baseline_reflection",
+      "source_ids": [
+        "phase8b_candidate_baseline_a9fd",
+        "batch_1r_a_asset_stream",
+        "forbidden_claim_policy"
+      ]
+    },
+    {
+      "asset_key": "pilot_t5_fc144_second_lens_v0_1",
+      "relative_path": "payloads/pilot_t5_fc144_second_lens.json",
+      "result_type": "type_5",
+      "module_key": "fc144_second_lens",
+      "source_ids": [
+        "phase8b_candidate_baseline_a9fd",
+        "batch_1r_h_asset_stream",
+        "fc144_boundary_policy",
+        "forbidden_claim_policy"
+      ]
+    }
+  ],
+  "required_reports": [
+    "source_mapping_report.json",
+    "safety_report.json",
+    "rollback_plan.md"
+  ],
+  "next_gate": "ENNEAGRAM-RESULT-AGENT-RUNNER-EVAL-HARNESS-01"
+}

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/rollback_plan.md
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/rollback_plan.md
@@ -1,0 +1,23 @@
+# Enneagram Pilot Asset Batch Rollback Plan
+
+Status: `PILOT_SCAFFOLD_ROLLBACK_READY`
+
+This pilot batch is repo-owned scaffold data only. It is not imported, activated, or wired into runtime.
+
+## Rollback
+
+If the pilot batch is rejected, revert the PR that added:
+
+- `backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/`
+- `backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPagePilotAssetBatchTest.php`
+
+No database rollback, storage cleanup, runtime activation rollback, CMS cleanup, or frontend rollback is required because this PR does not write those surfaces.
+
+## Revalidation After Removal
+
+Run:
+
+```bash
+php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi
+git diff --check
+```

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/safety_report.json
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/safety_report.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "fap.enneagram.result_page.pilot_safety_report.v0.1",
+  "batch_id": "ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "metadata_leakage_hit_count": 0,
+  "forbidden_claim_hit_count": 0,
+  "fc144_boundary_violation_count": 0,
+  "legacy_residual_count": 0,
+  "checked_payload_count": 2,
+  "forbidden_claim_families": [
+    "diagnosis_clinical_treatment",
+    "hiring_employment_screening",
+    "final_typing_you_are_this_type",
+    "fixed_type_certainty",
+    "e105_fc144_score_comparison",
+    "fc144_more_accurate_or_replacement_result",
+    "success_salary_performance_prediction",
+    "private_result_identifier_path_or_vector_leakage"
+  ],
+  "notes": [
+    "Pilot payloads are staging-only fixtures.",
+    "FC144 wording is second-lens only and does not rank, replace, or finalize current-result interpretation.",
+    "No private identifiers, private paths, raw vectors, editor notes, or QA notes are present in public payloads."
+  ]
+}

--- a/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/source_mapping_report.json
+++ b/backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/source_mapping_report.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "fap.enneagram.result_page.pilot_source_mapping_report.v0.1",
+  "batch_id": "ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "source_mapping_failure_count": 0,
+  "fallback_source_count": 0,
+  "blocked_source_count": 0,
+  "duplicate_selection_count": 0,
+  "branch_provenance_mismatch_count": 0,
+  "payload_count": 2,
+  "mappings": [
+    {
+      "asset_key": "pilot_t1_baseline_reflection_v0_1",
+      "payload_path": "payloads/pilot_t1_baseline_reflection.json",
+      "source_ids": [
+        "phase8b_candidate_baseline_a9fd",
+        "batch_1r_a_asset_stream",
+        "forbidden_claim_policy"
+      ],
+      "source_asset_sha256": null,
+      "trace_status": "pilot_scaffold_trace_only"
+    },
+    {
+      "asset_key": "pilot_t5_fc144_second_lens_v0_1",
+      "payload_path": "payloads/pilot_t5_fc144_second_lens.json",
+      "source_ids": [
+        "phase8b_candidate_baseline_a9fd",
+        "batch_1r_h_asset_stream",
+        "fc144_boundary_policy",
+        "forbidden_claim_policy"
+      ],
+      "source_asset_sha256": null,
+      "trace_status": "pilot_scaffold_trace_only"
+    }
+  ]
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPagePilotAssetBatchTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPagePilotAssetBatchTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use Tests\TestCase;
+
+final class EnneagramResultPagePilotAssetBatchTest extends TestCase
+{
+    public function test_pilot_batch_has_schema_source_trace_safety_and_rollback_shape(): void
+    {
+        $root = base_path('content_assets/enneagram/result_page/pilot_asset_batch/v0_1');
+
+        $manifest = $this->readJson($root.'/pilot_batch_manifest.json');
+        $this->assertSame('fap.enneagram.result_page.pilot_asset_batch.v0.1', $manifest['schema_version'] ?? null);
+        $this->assertSame('not_runtime', $manifest['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($manifest['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($manifest['candidate_export_happened'] ?? true));
+        $this->assertFalse((bool) ($manifest['inactive_import_happened'] ?? true));
+        $this->assertFalse((bool) ($manifest['activation_happened'] ?? true));
+        $this->assertSame(2, (int) data_get($manifest, 'candidate_contract_reference.pilot_payload_count'));
+
+        $payloads = (array) ($manifest['payloads'] ?? []);
+        $this->assertCount(2, $payloads);
+
+        $sourceLedger = $this->readJson(base_path('content_assets/enneagram/result_page/source_ledger/source_ledger.json'));
+        $sourceIds = array_map(
+            static fn (array $source): string => (string) ($source['source_id'] ?? ''),
+            (array) ($sourceLedger['sources'] ?? [])
+        );
+
+        foreach ($payloads as $payloadRef) {
+            $this->assertIsArray($payloadRef);
+            $payload = $this->readJson($root.'/'.(string) $payloadRef['relative_path']);
+            $this->assertSame('fap.enneagram.result_page.pilot_payload.v0.1', $payload['schema_version'] ?? null);
+            $this->assertSame('not_runtime', $payload['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($payload['production_use_allowed'] ?? true));
+            $this->assertIsArray($payload['public_payload'] ?? null);
+            $this->assertIsArray(data_get($payload, 'source_trace.source_ids'));
+            $this->assertNotEmpty(data_get($payload, 'source_trace.claim_trace'));
+
+            foreach ((array) data_get($payload, 'source_trace.source_ids', []) as $sourceId) {
+                $this->assertContains($sourceId, $sourceIds);
+            }
+
+            $this->assertPayloadHasNoBlockedMaterial((array) ($payload['public_payload'] ?? []));
+        }
+
+        $sourceMapping = $this->readJson($root.'/source_mapping_report.json');
+        $this->assertSame(0, (int) ($sourceMapping['source_mapping_failure_count'] ?? -1));
+        $this->assertSame(0, (int) ($sourceMapping['fallback_source_count'] ?? -1));
+        $this->assertSame(0, (int) ($sourceMapping['blocked_source_count'] ?? -1));
+        $this->assertSame(2, (int) ($sourceMapping['payload_count'] ?? 0));
+        $this->assertCount(2, (array) ($sourceMapping['mappings'] ?? []));
+
+        $safety = $this->readJson($root.'/safety_report.json');
+        $this->assertSame(0, (int) ($safety['metadata_leakage_hit_count'] ?? -1));
+        $this->assertSame(0, (int) ($safety['forbidden_claim_hit_count'] ?? -1));
+        $this->assertSame(0, (int) ($safety['fc144_boundary_violation_count'] ?? -1));
+        $this->assertSame(0, (int) ($safety['legacy_residual_count'] ?? -1));
+
+        $rollback = (string) file_get_contents($root.'/rollback_plan.md');
+        $this->assertStringContainsString('No database rollback', $rollback);
+        $this->assertStringContainsString('runtime activation rollback', $rollback);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path.' must decode to an array');
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertPayloadHasNoBlockedMaterial(array $payload): void
+    {
+        $encoded = mb_strtolower(json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        foreach ([
+            'attempt_id',
+            'private_url',
+            'private_path',
+            'raw_score',
+            'domain_vector',
+            'facet_vector',
+            '/users/',
+            '/private/tmp/',
+            'diagnosis',
+            'treatment',
+            'hiring',
+            'you are this type',
+            'fixed type',
+            'fc144 is more accurate',
+            'fc144 replaces',
+            'salary prediction',
+            'performance prediction',
+            '诊断',
+            '治疗',
+            '招聘',
+            '你就是这个类型',
+            '固定类型',
+            'fc144 更准确',
+            '成功预测',
+            '薪资预测',
+        ] as $blocked) {
+            $this->assertStringNotContainsString($blocked, $encoded);
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- Added a tiny Enneagram result-page pilot asset batch scaffold under `backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/`.
- Included two staging-only pilot payloads, source mapping report, safety report, and rollback plan.
- Added focused unit coverage for pilot schema, source trace, safety, and rollback shape.

## Why
This is PR 2 of the Enneagram result-page agent train. It validates the agent-facing asset shape with a minimal pilot slice before adding a batch runner/eval harness or generating any 1R batch assets.

## Validation
- `php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPagePilotAssetBatchTest.php`
- JSON parse check for `backend/content_assets/enneagram/result_page/pilot_asset_batch/v0_1/**/*.json`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPagePilotAssetBatchTest.php --no-ansi`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi`
- `php artisan enneagram:result-page-agent audit --run-id=pilot-scaffold-smoke --artifact-dir=<tmpdir> --strict --json`
- `git diff --check`

## Scope validation
- Backend content scaffold and one focused backend unit test only.
- No command/service/runtime wiring added in this PR.
- No candidate package or generated 630-payload artifact committed.

## Intentionally deferred
- No bulk content generation.
- No full 1R batch generation.
- No candidate export.
- No inactive import.
- No production activation.
- No runtime switch.
- No production writes.
- No frontend changes.
