### PR TITLE
BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases

### DIFF
--- a/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/README.md
+++ b/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/README.md
@@ -1,0 +1,20 @@
+# Big Five Result Page V2 Route Matrix Golden Case Staging Input QA
+
+This package records the staging-input QA decision for the Big Five Result Page V2 route matrix and golden cases.
+
+It does not generate route rows, selector assets, body copy, CMS records, runtime wiring, pilot access, or production gates.
+
+## Decision
+
+- `ready_for_staging_selector_input`: `true`, only with fail-closed unresolved-reference suppression.
+- `ready_for_runtime`: `false`.
+- `ready_for_production`: `false`.
+- `production_use_allowed`: `false`.
+
+## Evidence Boundaries
+
+- Route matrix parser validates 3,125 rows across five O shards.
+- Eight canonical profile families are covered by route-driven backend golden cases.
+- O59 canonical row stays `O3_C2_E2_A3_N4` -> `sensitive_independent_thinker`.
+- Selector QA policy keeps 31 golden cases, including the O59 canonical preview case.
+- Selector reference consistency remains advisory: unresolved refs are suppressed and blocking for runtime selector consumption.

--- a/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json
@@ -1,0 +1,159 @@
+{
+  "schema": "fap.big5.result_page_v2.route_matrix_golden_case_staging_input_qa_report.v0_1",
+  "package_key": "big5_result_page_v2.route_matrix_golden_case_staging_input_qa.v0_1",
+  "version": "0.1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_staging_selector_input": true,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "production_gate_change_performed": false,
+  "staging_selector_input_status": {
+    "status": "go_with_fail_closed_suppression",
+    "ready_for_staging_selector_input": true,
+    "blocking_for_runtime_selector": true,
+    "blocking_for_production": true,
+    "reason": "Route matrix rows and golden cases are structurally valid, but unresolved selector references must remain suppressed until a later resolution PR."
+  },
+  "route_matrix": {
+    "source_package": "backend/content_assets/big5/result_page_v2/route_matrix/v0_1_1",
+    "row_count": 3125,
+    "expected_row_count": 3125,
+    "shard_count": 5,
+    "row_counts_by_shard": {
+      "O1": 625,
+      "O2": 625,
+      "O3": 625,
+      "O4": 625,
+      "O5": 625
+    },
+    "unique_combination_key_count": 3125,
+    "missing_combination_key_count": 0,
+    "duplicate_combination_key_count": 0,
+    "invalid_combination_key_count": 0,
+    "runtime_use": "staging_only",
+    "production_use_allowed": false,
+    "ready_for_pilot": false,
+    "ready_for_runtime": false,
+    "ready_for_production": false,
+    "o59_canonical_row": {
+      "combination_key": "O3_C2_E2_A3_N4",
+      "nearest_canonical_profile_key": "sensitive_independent_thinker",
+      "nearest_canonical_profile_label_zh": "敏锐的独立思考者",
+      "profile_family": "sensitive_independent_thinker",
+      "interpretation_scope": "high_tension_or_mixed",
+      "profile_label_public_allowed": true
+    }
+  },
+  "canonical_profiles": {
+    "source_package": "backend/content_assets/big5/result_page_v2/canonical_profiles/v0_1",
+    "profile_count": 8,
+    "covered_by_route_driven_backend_golden_cases": true,
+    "profile_keys": [
+      "complex_explorer_low_structure",
+      "connective_coordinator",
+      "orderly_supporter",
+      "overloaded_internalizer",
+      "quiet_deep_worker",
+      "sensitive_independent_thinker",
+      "sharp_exploratory_driver",
+      "vigilant_perfectionist"
+    ]
+  },
+  "golden_cases": {
+    "selector_qa_policy_package": "backend/content_assets/big5/result_page_v2/selector_qa_policy/v0_1",
+    "selector_qa_golden_case_count": 31,
+    "selector_qa_groups": {
+      "balanced_or_diffuse": 3,
+      "canonical_o59_preview": 1,
+      "clear_signature": 6,
+      "facet_reframe": 5,
+      "high_tension_or_mixed": 7,
+      "safety_downgrade": 5,
+      "scenario_application": 4
+    },
+    "route_driven_backend_package": "backend/content_assets/big5/result_page_v2/qa/route_driven_golden_cases/v0_1",
+    "route_driven_backend_case_count": 16,
+    "canonical_profile_family_case_count": 8,
+    "variant_case_count": 8,
+    "route_driven_variant_groups": [
+      "norm_unavailable",
+      "degraded_quality",
+      "low_profile_confidence",
+      "unresolved_suppression",
+      "surface_safety",
+      "coupling_alias_resolution",
+      "supplemental_coupling_resolution",
+      "metadata_non_leak"
+    ],
+    "o59_selector_case_key": "golden_case_31_o59_canonical_preview",
+    "o59_route_driven_case_present": true
+  },
+  "selector_reference_resolution": {
+    "source_report": "backend/content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json",
+    "mode": "staging_only_advisory_scan",
+    "unresolved_reference_count": 92,
+    "unresolved_by_type": {
+      "coupling_key": 41,
+      "profile_key": 19,
+      "scenario_key": 32
+    },
+    "route_matrix_to_imported_content_assets_status": "pass",
+    "route_matrix_to_imported_content_assets_unresolved_count": 0,
+    "post_import_unresolved_coupling_key_count": 0,
+    "selector_suppression_behavior_changed": false,
+    "fail_closed_required": true,
+    "may_unsuppress_selector_refs": false
+  },
+  "conflict_resolution": {
+    "source_policy": "backend/content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json",
+    "runtime_use": "staging_only",
+    "resolution_order": [
+      "safety_override",
+      "runtime_scope_override",
+      "reading_mode_filter",
+      "trigger_match_filter",
+      "mutual_exclusion_group_dedupe",
+      "slot_limit_dedupe",
+      "semantic_conflict_guard",
+      "public_payload_sanitization",
+      "rendered_text_leak_scan"
+    ],
+    "mutual_exclusion_rule_count": 7,
+    "semantic_conflict_guard_count": 6,
+    "rendered_text_banned_scan_present": true,
+    "shareable_blocks_require_share_safety_registry": true,
+    "profile_label_as_type_guard_present": true
+  },
+  "staging_input_contract": {
+    "route_matrix_can_feed_selector_input": true,
+    "golden_cases_can_feed_selector_input": true,
+    "selected_unresolved_refs_must_remain_suppressed": true,
+    "body_composition_allowed": false,
+    "public_payload_allowlist_change": false,
+    "frontend_fallback_allowed": false,
+    "cms_write_allowed": false,
+    "production_import_allowed": false
+  },
+  "sidecar_issues": [
+    {
+      "sidecar_id": "B5-SEL-REF-ADVISORY-001",
+      "scope_relation": "external_to_current_pr",
+      "introduced_by_current_pr": false,
+      "summary": "Selector reference consistency remains advisory with 92 unresolved references. Route matrix and golden cases are valid staging selector inputs only while unresolved refs remain fail-closed and suppressed.",
+      "blocking_for_staging_selector_input": false,
+      "blocking_for_runtime_selector": true,
+      "blocking_for_production": true
+    }
+  ],
+  "must_not_change": [
+    "Do not wire route matrix to production runtime.",
+    "Do not import CMS data.",
+    "Do not enable pilot or production flags.",
+    "Do not unsuppress unresolved selector references.",
+    "Do not generate new body copy."
+  ]
+}

--- a/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_summary_v0_1.json
+++ b/backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_summary_v0_1.json
@@ -1,0 +1,21 @@
+{
+  "schema": "fap.big5.result_page_v2.route_matrix_golden_case_staging_input_qa_summary.v0_1",
+  "package_key": "big5_result_page_v2.route_matrix_golden_case_staging_input_qa.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_staging_selector_input": true,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "route_matrix_row_count": 3125,
+  "route_matrix_shard_count": 5,
+  "canonical_profile_family_count": 8,
+  "selector_qa_golden_case_count": 31,
+  "route_driven_backend_golden_case_count": 16,
+  "o59_combination_key": "O3_C2_E2_A3_N4",
+  "o59_profile_key": "sensitive_independent_thinker",
+  "selector_reference_unresolved_count": 92,
+  "selector_reference_policy": "fail_closed_suppression_required",
+  "staging_input_decision": "go_with_fail_closed_suppression",
+  "production_go": false
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\BigFive\ResultPageV2;
+
+use App\Services\BigFive\ResultPageV2\RouteMatrix\BigFiveV2RouteMatrixParser;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest extends TestCase
+{
+    private const REPORT_PATH = 'content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json';
+
+    private const SUMMARY_PATH = 'content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_summary_v0_1.json';
+
+    public function test_report_matches_route_matrix_parser_and_o59_row(): void
+    {
+        $report = $this->decodeJson(self::REPORT_PATH);
+        $summary = $this->decodeJson(self::SUMMARY_PATH);
+        $parseResult = app(BigFiveV2RouteMatrixParser::class)->parse();
+
+        $this->assertTrue($parseResult->isValid(), implode("\n", $parseResult->errors));
+        $this->assertSame(3125, $parseResult->rowCount());
+        $this->assertSame(3125, data_get($report, 'route_matrix.row_count'));
+        $this->assertSame($parseResult->rowCountsByShard, data_get($report, 'route_matrix.row_counts_by_shard'));
+        $this->assertSame(3125, $summary['route_matrix_row_count'] ?? null);
+        $this->assertSame(5, $summary['route_matrix_shard_count'] ?? null);
+
+        $o59 = $parseResult->row(BigFiveV2RouteMatrixParser::O59_COMBINATION_KEY);
+        $this->assertNotNull($o59);
+        $this->assertSame($o59->combinationKey, data_get($report, 'route_matrix.o59_canonical_row.combination_key'));
+        $this->assertSame($o59->profileKey, data_get($report, 'route_matrix.o59_canonical_row.nearest_canonical_profile_key'));
+        $this->assertSame($o59->profileFamily, data_get($report, 'route_matrix.o59_canonical_row.profile_family'));
+        $this->assertSame($o59->interpretationScope, data_get($report, 'route_matrix.o59_canonical_row.interpretation_scope'));
+        $this->assertSame('sensitive_independent_thinker', $summary['o59_profile_key'] ?? null);
+    }
+
+    public function test_report_matches_selector_and_route_driven_golden_case_sources(): void
+    {
+        $report = $this->decodeJson(self::REPORT_PATH);
+        $selectorCases = $this->decodeJson('content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_golden_cases.json');
+        $routeCases = $this->decodeJson('content_assets/big5/result_page_v2/qa/route_driven_golden_cases/v0_1/big5_route_driven_golden_cases_v0_1.json');
+        $routeSummary = $this->decodeJson('content_assets/big5/result_page_v2/qa/route_driven_golden_cases/v0_1/big5_route_driven_golden_cases_summary_v0_1.json');
+
+        $this->assertCount(31, $selectorCases);
+        $this->assertSame(31, data_get($report, 'golden_cases.selector_qa_golden_case_count'));
+        $this->assertCount(16, $routeCases);
+        $this->assertSame(16, data_get($report, 'golden_cases.route_driven_backend_case_count'));
+        $this->assertSame(8, data_get($report, 'golden_cases.canonical_profile_family_case_count'));
+        $this->assertSame(8, data_get($report, 'golden_cases.variant_case_count'));
+        $this->assertSame($routeSummary['variant_groups'] ?? [], data_get($report, 'golden_cases.route_driven_variant_groups'));
+
+        $o59SelectorCases = array_values(array_filter(
+            $selectorCases,
+            static fn (array $case): bool => ($case['case_key'] ?? null) === 'golden_case_31_o59_canonical_preview'
+        ));
+        $this->assertCount(1, $o59SelectorCases);
+
+        $profileFamilies = array_values(array_unique(array_map(
+            static fn (array $case): string => (string) $case['profile_family'],
+            array_filter($routeCases, static fn (array $case): bool => ($case['golden_group'] ?? null) === 'canonical_profile_family')
+        )));
+        sort($profileFamilies);
+        $this->assertSame(data_get($report, 'canonical_profiles.profile_keys'), $profileFamilies);
+    }
+
+    public function test_selector_reference_and_conflict_resolution_remain_fail_closed(): void
+    {
+        $report = $this->decodeJson(self::REPORT_PATH);
+        $referenceReport = $this->decodeJson('content_assets/big5/result_page_v2/qa/selector_reference_consistency/v0_1/selector_reference_consistency_report_v0_1.json');
+        $conflictPolicy = $this->decodeJson('content_assets/big5/result_page_v2/selector_qa_policy/v0_1/big5_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json');
+
+        $this->assertSame('go_with_fail_closed_suppression', data_get($report, 'staging_selector_input_status.status'));
+        $this->assertTrue((bool) data_get($report, 'ready_for_staging_selector_input'));
+        $this->assertFalse((bool) data_get($report, 'ready_for_runtime', true));
+        $this->assertFalse((bool) data_get($report, 'ready_for_production', true));
+        $this->assertFalse((bool) data_get($report, 'production_use_allowed', true));
+
+        $this->assertSame(data_get($referenceReport, 'summary.unresolved_reference_count'), data_get($report, 'selector_reference_resolution.unresolved_reference_count'));
+        $this->assertSame(data_get($referenceReport, 'summary.unresolved_by_type'), data_get($report, 'selector_reference_resolution.unresolved_by_type'));
+        $this->assertSame(0, data_get($report, 'selector_reference_resolution.route_matrix_to_imported_content_assets_unresolved_count'));
+        $this->assertTrue((bool) data_get($report, 'selector_reference_resolution.fail_closed_required'));
+        $this->assertFalse((bool) data_get($report, 'selector_reference_resolution.may_unsuppress_selector_refs', true));
+
+        $this->assertSame($conflictPolicy['resolution_order'] ?? [], data_get($report, 'conflict_resolution.resolution_order'));
+        $this->assertSame(count((array) ($conflictPolicy['mutual_exclusion_rules'] ?? [])), data_get($report, 'conflict_resolution.mutual_exclusion_rule_count'));
+        $this->assertSame(count((array) ($conflictPolicy['semantic_conflict_guards'] ?? [])), data_get($report, 'conflict_resolution.semantic_conflict_guard_count'));
+        $this->assertTrue((bool) data_get($report, 'conflict_resolution.rendered_text_banned_scan_present'));
+
+        $this->assertFalse((bool) data_get($report, 'staging_input_contract.body_composition_allowed', true));
+        $this->assertFalse((bool) data_get($report, 'staging_input_contract.cms_write_allowed', true));
+        $this->assertFalse((bool) data_get($report, 'staging_input_contract.production_import_allowed', true));
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    private function decodeJson(string $relativePath): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path($relativePath)), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T18:32:00+08:00",
+  "updated_at": "2026-06-21T18:45:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -32664,7 +32664,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE": {
-    "status": "ready_to_merge",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-human-revision-01a-foundation-governance",
     "base": "main",
@@ -55500,15 +55500,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2203 checks passed on head 1f11d40050cb7af5965ef7ee3fe29ff575d59f6b: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
+        "evidence": "PR #2203 checks passed on final head 06fc62cd0f5bbfe0740a0cbbb06eb6ca247e2416: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
       }
     },
     "failure_reason": null,
-    "commit_sha": "1f11d40050cb7af5965ef7ee3fe29ff575d59f6b",
+    "commit_sha": "28a9ae48a6093db59ba1cfcd2116b6f683d33b10",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2203",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T10:05:15Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T15:57:09+08:00",
@@ -55529,6 +55529,11 @@
         "at": "2026-06-21T18:32:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2203 GitHub checks passed on head 1f11d40050cb7af5965ef7ee3fe29ff575d59f6b; merge state CLEAN. Ready to merge after this state update revalidates."
+      },
+      {
+        "at": "2026-06-21T18:45:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: PR #2203 merged at 2026-06-21T10:05:15Z with merge commit 28a9ae48a6093db59ba1cfcd2116b6f683d33b10; origin/main contains the merge commit; local main equals origin/main; local branch deleted; remote branch absent; post-merge revalidation passed with the strict audit sidecar unchanged."
       }
     ],
     "sidecar_issues": [
@@ -55547,7 +55552,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases",
     "depends_on": [
@@ -55559,8 +55564,26 @@
         "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waits for BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01 to merge into main."
+        "status": "pass",
+        "evidence": "BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01 is merged; origin/main contains merge commit 28a9ae48a6093db59ba1cfcd2116b6f683d33b10."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteMatrixParserTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteDrivenGoldenCasesTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest --no-ansi",
+          "python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json >/dev/null",
+          "python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_summary_v0_1.json >/dev/null",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Corrected the current PR manifest validation filter to the repository test class name BigFiveResultPageV2RouteMatrixParserTest. The route matrix parser test, route-driven golden cases test, and new staging-input QA report test passed with existing PHPUnit warning classifications."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/*, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
       }
     },
     "failure_reason": null,
@@ -55574,6 +55597,11 @@
         "at": "2026-06-21T15:57:09+08:00",
         "status": "pending_dependency",
         "note": "Manifest/state entry authorized; implementation waits for the share safety pilot PR."
+      },
+      {
+        "at": "2026-06-21T18:45:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Added route matrix/golden case staging-input QA report and focused test. The report validates 3125 route rows, 8 canonical profiles, O59, 31 selector QA golden cases, 16 route-driven backend golden cases, selector reference fail-closed policy, and conflict resolution policy. No runtime, CMS, pilot flag, production gate, or selector unsuppression change."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T18:55:00+08:00",
+  "updated_at": "2026-06-21T19:08:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55552,7 +55552,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases",
     "depends_on": [
@@ -55586,12 +55586,12 @@
         "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/*, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2207 opened from head fa9cd31c3f134785bf276694c8de90f0a196f15b; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2207 checks passed on head 99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
       }
     },
     "failure_reason": null,
-    "commit_sha": "fa9cd31c3f134785bf276694c8de90f0a196f15b",
+    "commit_sha": "99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2207",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55611,6 +55611,11 @@
         "at": "2026-06-21T18:55:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2207 from commit fa9cd31c3f134785bf276694c8de90f0a196f15b; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-21T19:08:00+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2207 GitHub checks passed on head 99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb; merge state CLEAN. Ready to merge after this state update revalidates."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T18:45:00+08:00",
+  "updated_at": "2026-06-21T18:55:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55552,7 +55552,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(big5):验证 route matrix golden cases",
     "depends_on": [
@@ -55584,11 +55584,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/*, backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2207 opened from head fa9cd31c3f134785bf276694c8de90f0a196f15b; waiting for required GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "fa9cd31c3f134785bf276694c8de90f0a196f15b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2207",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55602,6 +55606,11 @@
         "at": "2026-06-21T18:45:00+08:00",
         "status": "local_checks_passed",
         "note": "Added route matrix/golden case staging-input QA report and focused test. The report validates 3125 route rows, 8 canonical profiles, O59, 31 selector QA golden cases, 16 route-driven backend golden cases, selector reference fail-closed policy, and conflict resolution policy. No runtime, CMS, pilot flag, production gate, or selector unsuppression change."
+      },
+      {
+        "at": "2026-06-21T18:55:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2207 from commit fa9cd31c3f134785bf276694c8de90f0a196f15b; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24250,7 +24250,7 @@ prs:
     do_not:
       - Wire route matrix to production runtime, import CMS data, or enable pilot/production flags.
     validation:
-      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveV2RouteMatrixParserTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteMatrixParserTest --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteDrivenGoldenCasesTest --no-ansi
       - git diff --check
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null


### PR DESCRIPTION
What changed
- Added a dedicated route matrix / golden case staging-input QA package under backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/.
- Added a focused PHPUnit test tying together 3,125 route rows, five O shards, eight canonical profile families, O59, selector QA golden cases, route-driven golden cases, selector reference policy, and conflict resolution policy.
- Corrected the current PR manifest validation filter to the actual route matrix parser test class name.
- Reconciled BIG5-RESULT-ASSET-FACTORY-PILOT-BATCH-01 as merged/cleaned up in docs/codex/pr-train-state.json.

Why
- Moves the route matrix from asset-exists evidence to explicit staging selector input QA, while preserving fail-closed selector reference suppression.

Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteMatrixParserTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteDrivenGoldenCasesTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2RouteMatrixGoldenCaseStagingInputQaTest --no-ansi
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json >/dev/null
- python3 -m json.tool backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_summary_v0_1.json >/dev/null
- git diff --check
- staged scope validation passed for manifest allowed paths

Intentionally deferred
- No runtime route matrix wiring.
- No CMS import.
- No pilot or production flag enablement.
- No selector ref unsuppression.
- No body copy generation.
- B5-SEL-REF-ADVISORY-001 remains external and blocks runtime/production, not staging selector input.