### PR TITLE
BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures

### DIFF
--- a/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/README.md
+++ b/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/README.md
@@ -1,0 +1,20 @@
+# Big Five Result Page V2 fap-web Render Preview Handoff
+
+This package gives fap-web a backend-owned fixture manifest and expected assertion set for rendered preview QA.
+
+It is handoff-only. It does not modify fap-web, generate frontend fallback copy, import CMS data, wire runtime selectors, open pilot access, or open production gates.
+
+## Files
+
+- `render_preview_fixture_manifest.json`: backend fixture and source-contract inventory for fap-web rendered preview tests.
+- `expected_assertions.json`: surface-level visible, redaction, and leak assertions.
+- `go_no_go.md`: explicit gate decision for this handoff package.
+
+## Gate
+
+- `runtime_use`: `staging_only`
+- `production_use_allowed`: `false`
+- `ready_for_runtime`: `false`
+- `ready_for_production`: `false`
+
+fap-web may consume these paths as test fixtures or assertion sources only. It must not copy the content into frontend editorial authority.

--- a/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/expected_assertions.json
+++ b/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/expected_assertions.json
@@ -1,0 +1,194 @@
+{
+  "schema": "fap.big5.result_page_v2.render_preview_expected_assertions.v0_1",
+  "package_key": "big5_result_page_v2.fap_web_render_preview_handoff.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "assertion_profiles": {
+    "result_page_o59_visible_and_safe": {
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "must_render": [
+        "敏锐的独立思考者",
+        "高敏感 × 中高开放 × 克制进入",
+        "Big Five 描述的是连续人格特质，不是固定人格类型",
+        "不用于医学诊断",
+        "不用于招聘筛选",
+        "画像名只是辅助理解标签"
+      ],
+      "must_not_render": [
+        "frontend_fallback",
+        "internal_metadata",
+        "selector_basis",
+        "source_reference",
+        "runtime_use",
+        "production_use_allowed",
+        "[object Object]"
+      ]
+    },
+    "pdf_safe_summary_and_no_metadata": {
+      "surfaces": [
+        "pdf"
+      ],
+      "must_render": [
+        "敏锐的独立思考者",
+        "高敏感 × 中高开放 × 克制进入"
+      ],
+      "must_not_render": [
+        "frontend_fallback",
+        "internal_metadata",
+        "selector_basis",
+        "source_reference",
+        "runtime_use",
+        "production_use_allowed",
+        "[object Object]"
+      ],
+      "required_policy": "backend_payload_only_fail_closed"
+    },
+    "share_safe_summary_only": {
+      "surfaces": [
+        "share_card"
+      ],
+      "must_render": [
+        "敏锐的独立思考者",
+        "画像名只是辅助理解标签"
+      ],
+      "must_not_render": [
+        "raw_score",
+        "raw_scores",
+        "percentile",
+        "percentiles",
+        "facet_vector",
+        "internal_metadata",
+        "selector_basis",
+        "source_reference",
+        "[object Object]"
+      ],
+      "required_policy": "share card must use safe summary only"
+    },
+    "history_safe_snapshot_no_paid_detail": {
+      "surfaces": [
+        "history"
+      ],
+      "must_render": [
+        "敏锐的独立思考者"
+      ],
+      "must_not_render": [
+        "facet_vector",
+        "internal_metadata",
+        "selector_basis",
+        "source_reference",
+        "runtime_use",
+        "production_use_allowed"
+      ],
+      "required_policy": "history entry must not expose full staging metadata or paid-only detail when locked"
+    },
+    "compare_safe_snapshot_no_cross_scale_rank": {
+      "surfaces": [
+        "compare"
+      ],
+      "must_render": [
+        "敏锐的独立思考者"
+      ],
+      "must_not_render": [
+        "MBTI 排名",
+        "Enneagram 排名",
+        "能力排名",
+        "internal_metadata",
+        "selector_basis",
+        "source_reference"
+      ],
+      "required_policy": "compare must not rank good/bad or compare incompatible score spaces"
+    },
+    "norm_unavailable_no_percentile_claim": {
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "must_not_render": [
+        "约高于",
+        "正态曲线",
+        "常模排名",
+        "percentile",
+        "percentiles",
+        "normal_curve_without_norm"
+      ],
+      "required_policy": "norm unavailable blocks percentile and normal curve claims"
+    },
+    "low_quality_boundary_and_retest": {
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "must_render_intent": [
+        "boundary",
+        "method",
+        "retest"
+      ],
+      "must_not_render": [
+        "你就是某一型",
+        "固定人格类型",
+        "能力预测",
+        "招聘筛选",
+        "诊断"
+      ],
+      "required_policy": "low quality blocks persona and deep claims"
+    },
+    "locked_free_redaction": {
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile",
+        "pdf",
+        "history",
+        "compare"
+      ],
+      "must_assert_json_paths": [
+        "locked=true for locked report responses",
+        "variant=free for locked report responses",
+        "access_level=free for locked report responses",
+        "facet_vector is empty or absent when locked",
+        "trait_vector.*.percentile is absent when locked",
+        "trait_vector.*.mean is absent when locked",
+        "controlled_narrative_v1 is absent when locked",
+        "cultural_calibration_v1 is absent when locked",
+        "comparative_v1 is absent when locked",
+        "history access_summary.access_state=locked for locked rows",
+        "PDF X-Report-Variant=free when locked/free"
+      ],
+      "must_not_render": [
+        "raw_score",
+        "percentile",
+        "facet_vector",
+        "controlled_narrative_v1",
+        "cultural_calibration_v1",
+        "comparative_v1",
+        "internal_metadata",
+        "selector_basis"
+      ],
+      "required_policy": "locked/free surfaces must render only redacted free-safe payloads"
+    }
+  },
+  "global_must_not_render": [
+    "frontend_fallback",
+    "internal_metadata",
+    "selector_basis",
+    "source_reference",
+    "review_status",
+    "qa_notes",
+    "runtime_use",
+    "production_use_allowed",
+    "[object Object]"
+  ],
+  "handoff_acceptance": {
+    "fap_web_must_report_tested_surfaces": true,
+    "fap_web_must_report_pending_surfaces": true,
+    "pending_surface_cannot_count_as_pass": true,
+    "backend_fixture_paths_must_remain_backend_authority": true,
+    "frontend_editorial_fallback_allowed": false,
+    "production_enablement_allowed": false
+  }
+}

--- a/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/go_no_go.md
+++ b/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/go_no_go.md
@@ -1,0 +1,19 @@
+# Big Five Result Page V2 fap-web Render Preview Handoff Go/No-Go
+
+status: GO for backend-owned fap-web rendered preview handoff fixtures
+runtime_use: staging_only
+production_use_allowed: false
+ready_for_pilot: false
+ready_for_runtime: false
+ready_for_production: false
+
+This package is a test handoff only. It may be used by fap-web contract tests to import backend fixture paths and expected assertions.
+
+NO-GO for:
+
+- runtime selector wiring
+- CMS import
+- production gate enablement
+- frontend editorial fallback
+- copying backend content assets into frontend authority
+- exposing raw scores, vectors, percentile fields, selector traces, source references, or internal metadata

--- a/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/render_preview_fixture_manifest.json
+++ b/backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/render_preview_fixture_manifest.json
@@ -1,0 +1,126 @@
+{
+  "schema": "fap.big5.result_page_v2.render_preview_fixture_manifest.v0_1",
+  "package_key": "big5_result_page_v2.fap_web_render_preview_handoff.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_pilot": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "production_gate_change_performed": false,
+  "handoff_consumer": "fap-web rendered preview contract tests",
+  "source_authority": "fap-api backend fixtures and QA assets",
+  "fixture_groups": [
+    {
+      "fixture_key": "o59_result_page_route_driven",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/route_driven_o59_canonical_pilot_payload_v0_1.payload.json",
+      "source_route_key": "O3_C2_E2_A3_N4",
+      "profile_key": "sensitive_independent_thinker",
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "assertion_profile": "result_page_o59_visible_and_safe"
+    },
+    {
+      "fixture_key": "o59_pdf_route_driven",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/pdf_o59_route_driven_payload_v0_1.json",
+      "source_route_key": "O3_C2_E2_A3_N4",
+      "profile_key": "sensitive_independent_thinker",
+      "surfaces": [
+        "pdf"
+      ],
+      "assertion_profile": "pdf_safe_summary_and_no_metadata"
+    },
+    {
+      "fixture_key": "o59_share_card_route_driven",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/share_o59_route_driven_payload_v0_1.json",
+      "source_route_key": "O3_C2_E2_A3_N4",
+      "profile_key": "sensitive_independent_thinker",
+      "surfaces": [
+        "share_card"
+      ],
+      "assertion_profile": "share_safe_summary_only"
+    },
+    {
+      "fixture_key": "o59_history_route_driven",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/history_o59_route_driven_payload_v0_1.json",
+      "source_route_key": "O3_C2_E2_A3_N4",
+      "profile_key": "sensitive_independent_thinker",
+      "surfaces": [
+        "history"
+      ],
+      "assertion_profile": "history_safe_snapshot_no_paid_detail"
+    },
+    {
+      "fixture_key": "o59_compare_route_driven",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/compare_o59_route_driven_payload_v0_1.json",
+      "source_route_key": "O3_C2_E2_A3_N4",
+      "profile_key": "sensitive_independent_thinker",
+      "surfaces": [
+        "compare"
+      ],
+      "assertion_profile": "compare_safe_snapshot_no_cross_scale_rank"
+    },
+    {
+      "fixture_key": "norm_unavailable_result_page",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/norm_unavailable.payload.json",
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "assertion_profile": "norm_unavailable_no_percentile_claim"
+    },
+    {
+      "fixture_key": "low_quality_result_page",
+      "fixture_path": "backend/tests/Fixtures/big5_result_page_v2/low_quality.payload.json",
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile"
+      ],
+      "assertion_profile": "low_quality_boundary_and_retest"
+    },
+    {
+      "fixture_key": "locked_free_redaction_contract",
+      "fixture_path": null,
+      "source_contract_paths": [
+        "backend/tests/Feature/V0_3/BigFiveResultEngineFoundationTest.php",
+        "backend/tests/Feature/Content/BigFivePaywallFlagModesTest.php",
+        "backend/tests/Feature/Attempts/BigFiveHistoryCompareTest.php"
+      ],
+      "surfaces": [
+        "result_page_desktop",
+        "result_page_mobile",
+        "pdf",
+        "history",
+        "compare"
+      ],
+      "assertion_profile": "locked_free_redaction"
+    }
+  ],
+  "source_qa_assets": [
+    "backend/content_assets/big5/result_page_v2/qa/rendered_preview/o59_canonical/manifest.json",
+    "backend/content_assets/big5/result_page_v2/qa/rendered_preview/o59_canonical/canonical_o59_rendered_preview_expectations_v0_1.json",
+    "backend/content_assets/big5/result_page_v2/qa/rendered_preview/expanded_surfaces/v0_1/big5_o59_expanded_rendered_qa_report_v0_1.json",
+    "backend/content_assets/big5/result_page_v2/qa/all_surface_public_pilot_readiness/v0_1/big5_all_surface_public_pilot_readiness_summary_v0_1.json",
+    "backend/content_assets/big5/result_page_v2/qa/route_matrix_golden_case_staging_input/v0_1/big5_route_matrix_golden_case_staging_input_qa_report_v0_1.json"
+  ],
+  "required_frontend_handoff_outputs": [
+    "tested_surfaces",
+    "passed_surfaces",
+    "failed_surfaces",
+    "pending_surfaces",
+    "visible_text_assertions",
+    "must_not_render_assertions",
+    "redaction_assertions",
+    "fixture_import_notes"
+  ],
+  "must_not": [
+    "Do not add frontend fallback editorial content.",
+    "Do not copy backend content assets into frontend authority.",
+    "Do not expose raw scores, percentile fields, vectors, selector traces, source references, or internal metadata.",
+    "Do not mark runtime or production ready from this handoff."
+  ]
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T19:08:00+08:00",
+  "updated_at": "2026-06-21T19:22:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -35978,7 +35978,7 @@
   "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-ci-artifact-consumer-split-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "commit_sha": "f42f3017987210b4b6ee9b002f90631ce861bc7e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1768",
     "checks": {
@@ -55587,15 +55587,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2207 checks passed on head 99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
+        "evidence": "PR #2207 checks passed on final head a0f87219093d9b95f6d24b1e660a8fbdb5d1f1a3: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
       }
     },
     "failure_reason": null,
-    "commit_sha": "99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb",
+    "commit_sha": "0d8c99b42b6475d4d6bb90cbdab9256735acf81d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2207",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T10:25:44Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T15:57:09+08:00",
@@ -55616,6 +55616,11 @@
         "at": "2026-06-21T19:08:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2207 GitHub checks passed on head 99b96e2f829d0ae36ae2cf5c72aa6892f5ca76fb; merge state CLEAN. Ready to merge after this state update revalidates."
+      },
+      {
+        "at": "2026-06-21T19:22:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: PR #2207 merged at 2026-06-21T10:25:44Z with merge commit 0d8c99b42b6475d4d6bb90cbdab9256735acf81d; origin/main contains the merge commit; local main equals origin/main; local branch deleted; remote branch absent; post-merge revalidation passed."
       }
     ]
   },
@@ -55623,7 +55628,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-render-preview-handoff-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures",
     "depends_on": [
@@ -55635,8 +55640,26 @@
         "evidence": "User explicitly requested implementation of the eight-item Big Five Result Page V2 asset-agent plan."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waits for BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01 to merge into main."
+        "status": "pass",
+        "evidence": "BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01 is merged; origin/main contains merge commit 0d8c99b42b6475d4d6bb90cbdab9256735acf81d."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ValidatorTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PublicSurfacePolicyTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PdfSurfacePolicyTest --no-ansi",
+          "python3 -m json.tool backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/render_preview_fixture_manifest.json >/dev/null",
+          "python3 -m json.tool backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/expected_assertions.json >/dev/null",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Validator, public surface policy, and PDF surface policy tests passed with existing PHPUnit warning classifications. New fap-web handoff manifest and expected assertions parse as JSON."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/* and docs/codex/pr-train-state.json."
       }
     },
     "failure_reason": null,
@@ -55650,6 +55673,11 @@
         "at": "2026-06-21T15:57:09+08:00",
         "status": "pending_dependency",
         "note": "Manifest/state entry authorized; implementation waits for the route matrix and golden case QA PR."
+      },
+      {
+        "at": "2026-06-21T19:22:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Added backend-owned fap-web render preview handoff bundle with fixture manifest, expected assertions, and go/no-go. Covers result page, PDF, share, history, compare, locked/free redaction, low-quality, and norm-unavailable assertions. No fap-web changes, frontend fallback, CMS import, runtime selector wiring, pilot flag, or production gate change."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T19:30:00+08:00",
+  "updated_at": "2026-06-21T19:42:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55628,7 +55628,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-render-preview-handoff-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures",
     "depends_on": [
@@ -55662,12 +55662,12 @@
         "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/* and docs/codex/pr-train-state.json."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2210 opened from head 67793ee4f68d94f4eeae51afb2ab3c3245468e54; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2210 checks passed on head 610da0870dd76e07ac14cd7a157a3dc6db6dbbed: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload."
       }
     },
     "failure_reason": null,
-    "commit_sha": "67793ee4f68d94f4eeae51afb2ab3c3245468e54",
+    "commit_sha": "610da0870dd76e07ac14cd7a157a3dc6db6dbbed",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2210",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55687,6 +55687,11 @@
         "at": "2026-06-21T19:30:00+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2210 from commit 67793ee4f68d94f4eeae51afb2ab3c3245468e54; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-21T19:42:00+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2210 GitHub checks passed on head 610da0870dd76e07ac14cd7a157a3dc6db6dbbed; merge state CLEAN. Ready to merge after this state update revalidates."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T19:22:00+08:00",
+  "updated_at": "2026-06-21T19:30:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55628,7 +55628,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-render-preview-handoff-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "BIG5-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(big5):交付 rendered preview fixtures",
     "depends_on": [
@@ -55660,11 +55660,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/* and docs/codex/pr-train-state.json."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2210 opened from head 67793ee4f68d94f4eeae51afb2ab3c3245468e54; waiting for required GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "67793ee4f68d94f4eeae51afb2ab3c3245468e54",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2210",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55678,6 +55682,11 @@
         "at": "2026-06-21T19:22:00+08:00",
         "status": "local_checks_passed",
         "note": "Added backend-owned fap-web render preview handoff bundle with fixture manifest, expected assertions, and go/no-go. Covers result page, PDF, share, history, compare, locked/free redaction, low-quality, and norm-unavailable assertions. No fap-web changes, frontend fallback, CMS import, runtime selector wiring, pilot flag, or production gate change."
+      },
+      {
+        "at": "2026-06-21T19:30:00+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2210 from commit 67793ee4f68d94f4eeae51afb2ab3c3245468e54; waiting for required GitHub checks."
       }
     ]
   }


### PR DESCRIPTION
What changed
- Added a backend-owned fap-web rendered preview handoff bundle under backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/.
- Added render_preview_fixture_manifest.json with backend fixture paths and source-contract references for result page, PDF, share, history, compare, norm-unavailable, low-quality, and locked/free redaction.
- Added expected_assertions.json and go_no_go.md for visible text, leak, redaction, and production-disallowed gates.
- Reconciled BIG5-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01 as merged/cleaned up in docs/codex/pr-train-state.json.

Why
- Gives fap-web a backend-authoritative handoff for rendered preview QA without moving editorial/content authority into frontend code.

Validation
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2ValidatorTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PublicSurfacePolicyTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2PdfSurfacePolicyTest --no-ansi
- python3 -m json.tool backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/render_preview_fixture_manifest.json >/dev/null
- python3 -m json.tool backend/content_assets/big5/result_page_v2/rendered_preview/fap_web_handoff/v0_1/expected_assertions.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- git diff --check
- staged scope validation passed for manifest allowed paths

Intentionally deferred
- No fap-web modifications.
- No frontend fallback content.
- No CMS import.
- No runtime selector wiring.
- No pilot or production gate enablement.
- No copying backend content assets into frontend authority.