### PR TITLE
SEO-AGENT-L5A-CMS-DRAFT-WRITE-CANARY1-01: add bounded draft write canary

### DIFF
--- a/backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php
@@ -1,0 +1,616 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentL5aCmsDraftWriteCanaryCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-l5a-cms-draft-write-canary.v1';
+
+    private const CANDIDATE_REVIEW_SCHEMA_VERSION = 'seo-agent-l5a-candidate-review.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const DRAFT_WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    protected $signature = 'seo-agent:l5a-cms-draft-write-canary
+        {--candidate-review= : Path to seo-agent-l5a-candidate-review.v1 JSON artifact}
+        {--limit=1 : Maximum candidate count, fixed to 1 for canary1}
+        {--artifact-dir= : Directory for L5-A draft write canary artifacts}
+        {--confirm-candidate-review-sha256= : Required candidate review sha256 for execute mode}
+        {--auto-approve-low-risk : Required with --execute; delegates only to low-risk draft writer mode}
+        {--execute : Actually create at most one CMS draft revision}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Turn one reviewed L5-A low-risk content_page candidate into a bounded CMS draft write canary.';
+
+    public function handle(): int
+    {
+        $candidateReviewPath = $this->candidateReviewPath();
+        if ($candidateReviewPath === null) {
+            return $this->finish($this->failureSummary('candidate_review_unreadable'));
+        }
+
+        $limit = $this->limit();
+        if ($limit !== 1) {
+            return $this->finish($this->failureSummary('limit_must_be_one'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $candidateReviewRaw = (string) file_get_contents($candidateReviewPath);
+        $forbidden = $this->forbiddenStringsPresent($candidateReviewRaw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_candidate_review_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $candidateReview = json_decode($candidateReviewRaw, true);
+        if (! is_array($candidateReview) || ($candidateReview['schema_version'] ?? null) !== self::CANDIDATE_REVIEW_SCHEMA_VERSION) {
+            return $this->finish($this->failureSummary('candidate_review_schema_invalid'));
+        }
+        if (($candidateReview['status'] ?? null) !== 'success' || (int) ($candidateReview['selected_count'] ?? 0) < 1) {
+            return $this->finish($this->failureSummary('candidate_review_not_success'));
+        }
+
+        $candidate = $this->selectedCandidate($candidateReview);
+        $candidateIssue = $this->validateCandidate($candidate);
+        if ($candidateIssue !== null) {
+            return $this->finish($this->failureSummary($candidateIssue));
+        }
+
+        $sourcePackagePath = $this->sourcePackagePath($candidateReview);
+        if ($sourcePackagePath === null) {
+            return $this->finish($this->failureSummary('source_draft_package_missing'));
+        }
+
+        $sourcePackage = $this->readJson($sourcePackagePath);
+        if (($sourcePackage['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return $this->finish($this->failureSummary('source_draft_package_schema_invalid'));
+        }
+
+        $proposal = $this->matchingProposal($sourcePackage, $candidate);
+        if ($proposal === null) {
+            return $this->finish($this->failureSummary('selected_candidate_proposal_missing'));
+        }
+
+        $filteredPackage = $this->filteredPackage($sourcePackage, $proposal, $candidateReviewPath, $candidate);
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $filteredPackageRef = $this->writeArtifact($artifactDir, 'seo-agent-l5a-cms-draft-write-canary-package-'.$timestamp.'.json', $filteredPackage);
+        $filteredPackagePath = (string) $filteredPackageRef['path'];
+        $filteredPackageSha = (string) $filteredPackageRef['sha256'];
+
+        $execute = (bool) $this->option('execute');
+        if ($execute) {
+            $approvalIssue = $this->executionApprovalIssue($candidateReviewPath);
+            if ($approvalIssue !== null) {
+                return $this->finish($this->failureSummary($approvalIssue, [
+                    'candidate_review_sha256' => hash_file('sha256', $candidateReviewPath) ?: '',
+                    'filtered_package' => $filteredPackageRef,
+                ]));
+            }
+        }
+
+        $draftWriteSummary = $this->runDraftWriter($filteredPackagePath, $execute);
+        $writeOk = ($draftWriteSummary['ok'] ?? false) === true
+            && in_array((string) ($draftWriteSummary['status'] ?? ''), ['planned', 'success'], true);
+
+        $evidence = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-L5A-CMS-DRAFT-WRITE-CANARY1-01',
+            'status' => $writeOk ? ($execute ? 'success' : 'planned') : 'blocked',
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'limit' => 1,
+            'candidate_review' => $this->artifactRef($candidateReviewPath, self::CANDIDATE_REVIEW_SCHEMA_VERSION),
+            'source_package' => $this->artifactRef($sourcePackagePath, self::PACKAGE_SCHEMA_VERSION),
+            'filtered_package' => $filteredPackageRef,
+            'selected_candidate' => $this->sanitizedCandidate($candidate),
+            'planned_count' => (int) ($draftWriteSummary['planned_count'] ?? 1),
+            'rows_created' => (int) ($draftWriteSummary['rows_created'] ?? 0),
+            'rows_skipped_existing' => (int) ($draftWriteSummary['rows_skipped_existing'] ?? 0),
+            'rows_failed' => array_values((array) ($draftWriteSummary['rows_failed'] ?? [])),
+            'draft_refs' => $this->draftRefs($draftWriteSummary),
+            'idempotency_key' => $filteredPackageSha,
+            'rollback_pointer' => $this->rollbackPointer($candidate, $draftWriteSummary),
+            'draft_write' => $this->draftWriteEvidenceSummary($draftWriteSummary),
+            'allowed_actions' => $execute ? ['cms_draft_revision_write'] : ['cms_draft_write_plan'],
+            'blocked_actions' => [
+                'cms_publish',
+                'search_channel_queue_write',
+                'search_channel_submit',
+                'indexnow_live_submit',
+                'google_indexing_api_call',
+                'scheduler_activation',
+                'queue_worker_activation',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-l5a-cms-draft-write-canary-'.$timestamp.'.json', $evidence);
+
+        if (! $writeOk) {
+            return $this->finish($this->failureSummary('cms_draft_write_canary_failed', [
+                'artifact' => $artifact,
+                'draft_write' => $this->draftWriteEvidenceSummary($draftWriteSummary),
+            ]));
+        }
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $execute ? 'success' : 'planned',
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'planned_count' => (int) ($evidence['planned_count'] ?? 0),
+            'rows_created' => (int) ($evidence['rows_created'] ?? 0),
+            'rows_skipped_existing' => (int) ($evidence['rows_skipped_existing'] ?? 0),
+            'draft_refs' => $evidence['draft_refs'],
+            'idempotency_key' => $filteredPackageSha,
+            'rollback_pointer' => $evidence['rollback_pointer'],
+            'artifact' => $artifact,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function candidateReviewPath(): ?string
+    {
+        $path = trim((string) $this->option('candidate-review'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function limit(): ?int
+    {
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+
+        return is_int($limit) ? $limit : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/l5a-cms-draft-write-canary');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidateReview
+     * @return array<string, mixed>
+     */
+    private function selectedCandidate(array $candidateReview): array
+    {
+        $candidate = $candidateReview['selected_candidate'] ?? null;
+        if (is_array($candidate)) {
+            return $candidate;
+        }
+
+        $candidates = array_values(array_filter(
+            (array) ($candidateReview['selected_candidates'] ?? []),
+            static fn ($item): bool => is_array($item)
+        ));
+
+        return (array) ($candidates[0] ?? []);
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function validateCandidate(array $candidate): ?string
+    {
+        if ((string) ($candidate['target_model'] ?? '') !== 'content_page'
+            || (string) ($candidate['subject_type'] ?? '') !== 'content_page') {
+            return 'selected_candidate_not_content_page';
+        }
+        if (! in_array((string) ($candidate['source_family'] ?? ''), ['cms_tdk_gap', 'cms_faq_gap'], true)) {
+            return 'selected_candidate_source_family_not_low_risk';
+        }
+        if (! in_array((string) ($candidate['severity'] ?? ''), ['p1', 'p2'], true)) {
+            return 'selected_candidate_severity_not_low_risk';
+        }
+        $safePath = (string) ($candidate['safe_path'] ?? '');
+        if ($safePath === '' || preg_match('#https?://#i', $safePath) === 1) {
+            return 'selected_candidate_safe_path_invalid';
+        }
+        if ($this->forbiddenStringsPresent(json_encode($candidate, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '') !== []) {
+            return 'selected_candidate_forbidden_field_present';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidateReview
+     */
+    private function sourcePackagePath(array $candidateReview): ?string
+    {
+        $path = trim((string) data_get($candidateReview, 'input_artifacts.cms_draft_package_dry_run.path'));
+        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            throw new RuntimeException('artifact_contains_forbidden_fields');
+        }
+
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('artifact_json_invalid');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>|null
+     */
+    private function matchingProposal(array $package, array $candidate): ?array
+    {
+        $items = array_values(array_filter(
+            (array) ($package['proposal_items'] ?? $package['draft_briefs'] ?? []),
+            static fn ($item): bool => is_array($item)
+        ));
+
+        foreach ($items as $item) {
+            if ((string) ($item['source_id'] ?? '') !== ''
+                && (string) ($item['source_id'] ?? '') === (string) ($candidate['source_id'] ?? '')) {
+                return $item;
+            }
+        }
+
+        foreach ($items as $item) {
+            if ((string) ($item['subject_ref'] ?? '') === (string) ($candidate['subject_ref'] ?? '')
+                && (string) ($item['safe_path'] ?? '') === (string) ($candidate['safe_path'] ?? '')) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourcePackage
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function filteredPackage(array $sourcePackage, array $proposal, string $candidateReviewPath, array $candidate): array
+    {
+        $package = $sourcePackage;
+        $package['draft_brief_count'] = 1;
+        $package['draft_briefs'] = [$proposal];
+        $package['proposal_count'] = 1;
+        $package['proposal_items'] = [$proposal];
+        $package['l5a_canary'] = [
+            'task' => 'SEO-AGENT-L5A-CMS-DRAFT-WRITE-CANARY1-01',
+            'source_candidate_review_sha256' => hash_file('sha256', $candidateReviewPath) ?: '',
+            'selected_subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'selected_safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'max_rows_per_execution' => 1,
+            'publish_allowed' => false,
+            'search_channel_enqueue_allowed' => false,
+            'indexnow_live_submit_allowed' => false,
+        ];
+
+        return $package;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runDraftWriter(string $packagePath, bool $execute): array
+    {
+        $command = $this->getApplication()?->find('seo-agent:cms-draft-write');
+        if ($command === null) {
+            return $this->failureSummary('cms_draft_write_command_missing');
+        }
+
+        $input = [
+            'command' => 'seo-agent:cms-draft-write',
+            '--package' => $packagePath,
+            '--limit' => 1,
+            '--json' => true,
+        ];
+        if ($execute) {
+            $input['--auto-approve-low-risk'] = true;
+            $input['--execute'] = true;
+        }
+
+        $buffer = new BufferedOutput();
+        $exitCode = $command->run(new ArrayInput($input), $buffer);
+        $summary = json_decode(trim($buffer->fetch()), true);
+        if (! is_array($summary)) {
+            return $this->failureSummary('cms_draft_write_summary_json_invalid', [
+                'draft_write_exit_code' => $exitCode,
+            ]);
+        }
+        $summary['draft_write_exit_code'] = $exitCode;
+
+        return $summary;
+    }
+
+    private function executionApprovalIssue(string $candidateReviewPath): ?string
+    {
+        if ((bool) $this->option('auto-approve-low-risk') !== true) {
+            return 'execute_requires_auto_approve_low_risk';
+        }
+        $expectedSha = hash_file('sha256', $candidateReviewPath) ?: '';
+        if ((string) $this->option('confirm-candidate-review-sha256') !== $expectedSha) {
+            return 'candidate_review_sha256_confirmation_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $draftWriteSummary
+     * @return list<array<string, mixed>>
+     */
+    private function draftRefs(array $draftWriteSummary): array
+    {
+        $refs = [];
+        foreach ((array) ($draftWriteSummary['affected_refs'] ?? []) as $ref) {
+            if (! is_array($ref)) {
+                continue;
+            }
+            $refs[] = [
+                'status' => (string) ($ref['status'] ?? ''),
+                'target_model' => (string) ($ref['target_model'] ?? ''),
+                'subject_ref' => (string) ($ref['subject_ref'] ?? ''),
+                'revision_id' => $ref['revision_id'] ?? null,
+            ];
+        }
+
+        return $refs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @param  array<string, mixed>  $draftWriteSummary
+     * @return array<string, mixed>
+     */
+    private function rollbackPointer(array $candidate, array $draftWriteSummary): array
+    {
+        $pageId = $this->contentPageId((string) ($candidate['subject_ref'] ?? ''));
+        $page = $pageId > 0 ? ContentPage::query()->withoutGlobalScopes()->find($pageId) : null;
+        $revisionId = null;
+        foreach ($this->draftRefs($draftWriteSummary) as $ref) {
+            if (($ref['target_model'] ?? '') === 'content_page') {
+                $revisionId = $ref['revision_id'] ?? null;
+                break;
+            }
+        }
+
+        return [
+            'available' => $page instanceof ContentPage,
+            'target_model' => 'content_page',
+            'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'candidate_revision_id' => is_numeric($revisionId) ? (int) $revisionId : null,
+            'previous_working_revision_id' => $page instanceof ContentPage && $page->working_revision_id ? (int) $page->working_revision_id : null,
+            'previous_published_revision_id' => $page instanceof ContentPage && $page->published_revision_id ? (int) $page->published_revision_id : null,
+            'latest_draft_revision_id' => $this->latestDraftRevisionId($pageId),
+        ];
+    }
+
+    private function contentPageId(string $subjectRef): int
+    {
+        $parts = explode(':', $subjectRef);
+
+        return ($parts[0] ?? '') === 'content_page' && isset($parts[1]) && ctype_digit($parts[1])
+            ? (int) $parts[1]
+            : 0;
+    }
+
+    private function latestDraftRevisionId(int $pageId): ?int
+    {
+        if ($pageId <= 0) {
+            return null;
+        }
+
+        $id = CmsTranslationRevision::query()
+            ->where('content_type', 'content_page')
+            ->where('content_id', $pageId)
+            ->where('revision_status', CmsTranslationRevision::STATUS_DRAFT)
+            ->max('id');
+
+        return is_numeric($id) ? (int) $id : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function draftWriteEvidenceSummary(array $summary): array
+    {
+        return [
+            'schema_version' => (string) ($summary['schema_version'] ?? self::DRAFT_WRITE_SCHEMA_VERSION),
+            'ok' => (bool) ($summary['ok'] ?? false),
+            'status' => (string) ($summary['status'] ?? ''),
+            'dry_run' => (bool) ($summary['dry_run'] ?? false),
+            'execute' => (bool) ($summary['execute'] ?? false),
+            'planned_count' => (int) ($summary['planned_count'] ?? 0),
+            'rows_created' => (int) ($summary['rows_created'] ?? 0),
+            'rows_skipped_existing' => (int) ($summary['rows_skipped_existing'] ?? 0),
+            'rows_failed' => array_values((array) ($summary['rows_failed'] ?? [])),
+            'writes_attempted' => (bool) ($summary['writes_attempted'] ?? false),
+            'writes_committed' => (bool) ($summary['writes_committed'] ?? false),
+            'affected_refs' => $this->draftRefs($summary),
+            'issues' => array_values(array_map('strval', (array) ($summary['issues'] ?? []))),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function sanitizedCandidate(array $candidate): array
+    {
+        return [
+            'source_id' => (string) ($candidate['source_id'] ?? ''),
+            'source_family' => (string) ($candidate['source_family'] ?? ''),
+            'subject_type' => (string) ($candidate['subject_type'] ?? ''),
+            'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'target_model' => (string) ($candidate['target_model'] ?? ''),
+            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'severity' => (string) ($candidate['severity'] ?? ''),
+            'gap_codes' => array_values(array_map('strval', (array) ($candidate['gap_codes'] ?? []))),
+            'target_fields' => array_values(array_map('strval', (array) ($candidate['target_fields'] ?? []))),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach ([
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'service_account_json',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'token',
+            'cookie',
+            'session',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ] as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return array_values(array_unique($matches));
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return $this->artifactRef($path, (string) ($payload['schema_version'] ?? 'unknown'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexnow_live_submit' => false,
+            'indexing_request' => false,
+            'google_indexing_api_call' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+            'frontend_code_mutation' => false,
+        ];
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\CmsTranslationRevision;
+use App\Models\ContentPage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentL5aCmsDraftWriteCanaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_builds_filtered_package_and_never_writes_cms(): void
+    {
+        $page = $this->createContentPage();
+        [$candidateReviewPath] = $this->writeCandidateReview($page);
+        $artifactDir = storage_path('framework/testing/l5a-draft-write-'.Str::uuid()->toString());
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['dry_run'] ?? false));
+        $this->assertSame(1, $summary['planned_count'] ?? null);
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.indexnow_live_submit', true));
+
+        $artifactPath = (string) data_get($summary, 'artifact.path');
+        $this->assertFileExists($artifactPath);
+        $artifact = $this->readJson($artifactPath);
+        $this->assertSame('seo-agent-l5a-cms-draft-write-canary.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('content_page:'.$page->id.':en', data_get($artifact, 'selected_candidate.subject_ref'));
+        $this->assertSame(1, $artifact['planned_count'] ?? null);
+        $this->assertNoForbiddenStrings($artifact);
+    }
+
+    #[Test]
+    public function execute_fails_closed_without_matching_candidate_review_sha(): void
+    {
+        $page = $this->createContentPage();
+        [$candidateReviewPath] = $this->writeCandidateReview($page);
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--confirm-candidate-review-sha256' => str_repeat('0', 64),
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('candidate_review_sha256_confirmation_mismatch', $summary['issues'] ?? []);
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+    }
+
+    #[Test]
+    public function execute_writes_one_content_page_draft_then_skips_duplicate(): void
+    {
+        $page = $this->createContentPage();
+        [$candidateReviewPath] = $this->writeCandidateReview($page);
+        $sha = hash_file('sha256', $candidateReviewPath) ?: '';
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--confirm-candidate-review-sha256' => $sha,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertFalse((bool) ($summary['dry_run'] ?? true));
+        $this->assertSame(1, $summary['rows_created'] ?? null);
+        $this->assertSame(0, $summary['rows_skipped_existing'] ?? null);
+        $this->assertSame(1, CmsTranslationRevision::query()->count());
+        $this->assertNotSame('', (string) ($summary['idempotency_key'] ?? ''));
+        $this->assertSame((int) $page->published_revision_id, data_get($summary, 'rollback_pointer.previous_published_revision_id'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_submit', true));
+
+        $revision = CmsTranslationRevision::query()->firstOrFail();
+        $this->assertSame(CmsTranslationRevision::STATUS_DRAFT, $revision->revision_status);
+        $this->assertNull($revision->published_at);
+        $this->assertSame('content_page:'.$page->id.':en', data_get($revision->payload_json, 'seo_agent.subject_ref'));
+        $this->assertSame('/about', data_get($revision->payload_json, 'proposal.proposed_canonical_path'));
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--confirm-candidate-review-sha256' => $sha,
+            '--auto-approve-low-risk' => true,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(0, $summary['rows_created'] ?? null);
+        $this->assertSame(1, $summary['rows_skipped_existing'] ?? null);
+        $this->assertSame(1, CmsTranslationRevision::query()->count());
+        $this->assertNoForbiddenStrings($summary);
+    }
+
+    #[Test]
+    public function candidate_review_with_forbidden_field_is_rejected(): void
+    {
+        $page = $this->createContentPage();
+        [$candidateReviewPath, , $candidateReview] = $this->writeCandidateReview($page);
+        $candidateReview['selected_candidate']['raw_url'] = 'https://example.test/about';
+        File::put($candidateReviewPath, json_encode($candidateReview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_candidate_review_field_present', $summary['issues'] ?? []);
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+    }
+
+    private function createContentPage(): ContentPage
+    {
+        return ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'about',
+            'path' => '/about',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'about',
+            'title' => 'About FermatMind',
+            'summary' => 'Existing summary.',
+            'seo_title' => 'About FermatMind | FermatMind',
+            'seo_description' => 'Learn about FermatMind and its product boundaries.',
+            'template' => 'company',
+            'animation_profile' => 'none',
+            'locale' => 'en',
+            'translation_group_id' => 'about',
+            'source_locale' => 'en',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => false,
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'review_state' => 'draft',
+            'published_revision_id' => 88,
+            'working_revision_id' => null,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: array<string, mixed>}
+     */
+    private function writeCandidateReview(ContentPage $page): array
+    {
+        $candidate = [
+            'source_id' => hash('sha256', 'content_page'.$page->id.'canonical'),
+            'source_family' => 'cms_tdk_gap',
+            'subject_type' => 'content_page',
+            'subject_ref' => 'content_page:'.$page->id.':en',
+            'target_model' => 'content_page',
+            'safe_path' => '/about',
+            'severity' => 'p1',
+            'gap_codes' => ['missing_canonical'],
+            'target_fields' => ['canonical_url_or_path'],
+            'recommended_next_step' => 'cms_draft_write_canary_limit_1',
+            'risk_flags' => [],
+            'blocked_actions' => ['cms_publish', 'search_channel_submit', 'indexnow_live_submit'],
+        ];
+        $package = [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_count' => 1,
+            'proposal_items' => [[
+                ...$candidate,
+                'proposed_seo_title' => null,
+                'proposed_seo_description' => null,
+                'proposed_faq_items' => [],
+                'proposed_canonical_path' => '/about',
+                'proposed_indexability' => null,
+                'draft_instructions' => [
+                    'prepare_field_level_proposal_only',
+                    'do_not_generate_final_body_copy',
+                    'run_claim_gate_before_any_cms_write',
+                ],
+                'claim_gate_required' => true,
+                'human_approval_required' => true,
+                'execution_permission' => false,
+            ]],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ];
+        $dir = storage_path('framework/testing/l5a-candidate-review-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/source-package.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        $candidateReview = [
+            'schema_version' => 'seo-agent-l5a-candidate-review.v1',
+            'task' => 'SEO-AGENT-L5A-PREFLIGHT-CANDIDATE-REVIEW-01',
+            'status' => 'success',
+            'run_mode' => 'readonly_l5a_preflight_candidate_review',
+            'limit' => 1,
+            'selected_count' => 1,
+            'selected_candidates' => [$candidate],
+            'selected_candidate' => $candidate,
+            'input_artifacts' => [
+                'cms_draft_package_dry_run' => [
+                    'path' => $packagePath,
+                    'size' => filesize($packagePath) ?: 0,
+                    'sha256' => hash_file('sha256', $packagePath) ?: '',
+                    'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+                ],
+            ],
+            'negative_guarantees' => [
+                'cms_write' => false,
+                'cms_publish' => false,
+                'search_channel_submit' => false,
+                'indexnow_live_submit' => false,
+            ],
+        ];
+        $candidateReviewPath = $dir.'/candidate-review.json';
+        File::put($candidateReviewPath, json_encode($candidateReview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return [$candidateReviewPath, $packagePath, $candidateReview];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function assertNoForbiddenStrings(array $payload): void
+    {
+        $encoded = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach (['raw_url', 'raw_query', 'credential_path', 'client_email', 'private_key', 'Bearer ', 'content_md', 'content_html', 'cms_draft_body'] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1339,6 +1339,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_l5a_cms_draft_write_canary_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_opportunity_auto_draft_files(): void
     {
         $changed = [
@@ -4040,6 +4049,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentL5aCmsDraftWriteCanaryFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentGscOpportunityAutoDraftFile($file)) {
                 continue;
             }
@@ -5440,6 +5453,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentL5aCandidateReviewCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentL5aCmsDraftWriteCanaryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added `seo-agent:l5a-cms-draft-write-canary`, a thin L5-A adapter that reads `seo-agent-l5a-candidate-review.v1`, extracts the selected low-risk `content_page` proposal from the referenced draft package, and delegates to the existing controlled CMS draft writer.
- Defaults to dry-run and writes sanitized `seo-agent-l5a-cms-draft-write-canary.v1` evidence.
- Execute mode requires `--execute`, `--confirm-candidate-review-sha256=<sha>`, `--auto-approve-low-risk`, and `--limit=1`.
- Added focused tests and BigFive freeze guard coverage for the new SEO Agent command.

## Why
This is the second L5-A canary train step: convert the single safest candidate selected by PR #2208 into a bounded CMS draft/revision write canary without publishing or search submission.

## Validation commands
- `cd backend && php -l app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php && php -l tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php`
- `cd backend && php artisan test --filter SeoAgentL5aCmsDraftWriteCanaryTest`
- `cd backend && php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `cd backend && php artisan test --filter 'BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_agent_l5a_cms_draft_write_canary_files'`\n- `git diff --check`\n\n## Intentionally deferred\n- No ContentPage publish canary.\n- No Search Channel enqueue or IndexNow submit.\n- No canary3 upgrade.\n- No scheduler or cron activation.\n- No Article auto-publish.\n\n## Negative guarantees\n- No CMS publish.\n- No live published content mutation.\n- No Search Channel queue write or submit.\n- No IndexNow live submit.\n- No Google Indexing API call.\n- No Laravel scheduler or queue worker activation.\n- No fap-web/frontend mutation.\n- No raw URL, raw body, token, cookie, private key, or client email in artifacts.