### PR TITLE
RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01: docs(riasec):固化 result asset agent runbook

### DIFF
--- a/backend/docs/riasec/result-asset-agent-gates.md
+++ b/backend/docs/riasec/result-asset-agent-gates.md
@@ -1,0 +1,118 @@
+# RIASEC Result Page Asset Agent Stage Gates
+
+Status: `RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+These gates define how Holland/RIASEC result page asset-agent work moves from documentation to preview handoff. They do not open runtime, CMS, pilot, or production access.
+
+## Gate 1: Runbook
+
+Entry: explicit PR-train authorization.
+
+Pass criteria:
+
+- docs define agent responsibilities, inputs, outputs, forbidden actions, and stop conditions;
+- no runtime, CMS, asset-generation, or production files are changed;
+- `git diff --check` passes.
+
+Exit state: runbook documented, generation still forbidden.
+
+## Gate 2: Source Ledger
+
+Entry: runbook merged.
+
+Pass criteria:
+
+- ledger template exists;
+- first evidence ledger covers Holland/RIASEC public sources, method-boundary references, internal formal drafts, internal long-form drafts, and existing asset packs;
+- every claim row has source, reference, permitted use, limitation, and disallowed use;
+- JSON validates;
+- no generated selector or content assets are created.
+
+Exit state: sources traceable, generation still forbidden.
+
+## Gate 3: Validator Harness
+
+Entry: source ledger merged.
+
+Pass criteria:
+
+- agent run validator can inspect a run directory without mutating runtime state;
+- harness reuses existing RIASEC selector/content validators where available;
+- inventory, checksum, forbidden public field, share leak, and gate report checks exist;
+- strict mode fails closed on invalid inventory, P0 blockers, or leaks;
+- focused harness and selector/content validator tests pass.
+
+Exit state: validation executable, generation still forbidden.
+
+## Gate 4: Existing Asset Gap Audit
+
+Entry: validator harness merged.
+
+Pass criteria:
+
+- current RIASEC result page assets are inventoried;
+- current deep slots are counted and grouped;
+- current route/selector or content reference matrix is counted;
+- current golden cases and canonical profiles are counted;
+- gaps are grouped by registry, scope, scenario, share-safe coverage, low-quality coverage, fallback coverage, and route/golden-case readiness;
+- output is a gap register, not a repair or generated asset batch.
+
+Exit state: gap register ready for targeted repair.
+
+## Gate 5: Selector QA Repair
+
+Entry: existing asset gap audit merged.
+
+Pass criteria:
+
+- known selector/content QA policy issues are repaired: coverage warnings, golden group normalization, slot/module naming, banned terms, and fail-closed fallback rules;
+- assets remain `staging_only`;
+- no runtime wrapper, CMS import, pilot flag, or production flag changes;
+- selector/content import, validator, and golden case tests pass.
+
+Exit state: selector/content QA can act as a staging gate.
+
+## Gate 6: Share-Safety Pilot Batch
+
+Entry: selector QA repair merged.
+
+Pass criteria:
+
+- pilot batch scope is limited to `share_safety` unless the repository scan proves `low_quality cautious copy` is narrower and safer;
+- raw draft, repair draft, final asset, validation report, safety report, and go/no-go report are preserved;
+- every generated asset remains `staging_only` and `production_use_allowed=false`;
+- shareable public payloads contain no raw scores, vectors, percentiles, deterministic type labels, or private fields;
+- strict harness and selector/content validator pass.
+
+Exit state: share-safe draft can be reviewed as staging-only content.
+
+## Gate 7: Route Matrix And Golden Case QA
+
+Entry: share-safety pilot batch merged.
+
+Pass criteria:
+
+- route rows validate at the current repository count;
+- canonical profiles are covered at the current repository count;
+- selector/content references resolve;
+- conflict-resolution rules are deterministic;
+- output is a staging selector input readiness report, not runtime wiring.
+
+Exit state: route matrix can be considered staging selector input.
+
+## Gate 8: Render Preview Handoff
+
+Entry: route matrix and golden case QA merged.
+
+Pass criteria:
+
+- backend fixtures and expected assertions cover result page, PDF, share, history, compare, locked/free redaction, low quality, and fallback behavior;
+- fixtures validate through backend payload and public-surface policies;
+- no frontend content, CMS write, runtime flag, or production gate is changed;
+- fap-web handoff document names the fixture files, expected assertions, and explicit deferred items.
+
+Exit state: fap-web can run rendered preview QA against backend-owned fixtures.
+
+## Production Boundary
+
+None of these gates authorize production. Production requires a separate release package, backend dry-run, staging import, rendered preview pass, API smoke, pilot allowlist, production import gate, and production rollout approval.

--- a/backend/docs/riasec/result-asset-agent-runbook.md
+++ b/backend/docs/riasec/result-asset-agent-runbook.md
@@ -1,0 +1,105 @@
+# RIASEC Result Page Asset Agent Runbook
+
+Status: `RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+This runbook defines the backend-only operating contract for the Holland/RIASEC result page content asset agent. It authorizes documentation, protocol, and gate definition only. It does not authorize asset generation, CMS import, runtime wiring, pilot access, or production rollout.
+
+## Authority Model
+
+The agent must reuse the existing RIASEC backend projection, deep-slot, and fail-closed pattern:
+
+- backend projection and slot contracts are the only authority for result interpretation payloads;
+- frontend inference and frontend-authored interpretation fallback are forbidden;
+- missing, invalid, pending, or unsafe slots are hidden or degraded by backend policy;
+- public payloads are allowlisted and must not expose private scoring, route, QA, source, or editor metadata;
+- stage promotion requires explicit evidence artifacts, not merely generated copy existing in the repository.
+
+The agent is dedicated to private Holland/RIASEC result page assets. It must not be merged with public profile, article SEO, or CMS publication agents because result pages carry attempt-scoped score state, quality flags, share/PDF/history/compare payloads, and route selector risks that public SEO surfaces do not carry.
+
+## Agent Responsibilities
+
+The full program is split into eight PR-train tasks:
+
+1. `RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01`: document runbook, protocol, forbidden actions, and gates.
+2. `RIASEC-RESULT-SOURCE-LEDGER-01`: create source ledger templates and first evidence ledger.
+3. `RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01`: build the agent run validator harness.
+4. `RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01`: audit existing result page assets, deep slots, route/selector, and golden-case gaps.
+5. `RIASEC-RESULT-SELECTOR-QA-REPAIR-01`: repair selector/content QA policy issues while keeping assets staging-only.
+6. `RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01`: dry-run a narrow share-safety pilot batch.
+7. `RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01`: validate route matrix and golden-case selector readiness.
+8. `RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01`: hand off backend fixtures and expected assertions to fap-web rendered preview QA.
+
+Each task is one PR scope. A later task must not be implemented in an earlier PR.
+
+## Subagent Roles
+
+The orchestrator may call bounded subagents, but the output boundary remains this backend artifact protocol:
+
+- Source Ledger Agent: tracks every claim to source, reference, limitation, permitted use, and disallowed use.
+- Asset Factory Agent: emits only RIASEC result page selector/content candidate assets when a generation PR explicitly allows it.
+- Selector Contract QA Agent: validates slot, trigger, priority, mutual exclusion, reading mode, fallback, and public payload allowlist.
+- Safety and Claim QA Agent: blocks deterministic person typing, diagnosis, therapy, hiring, success prediction, ability measurement, unsupported percentile, raw score, vector, and share leak claims.
+- Route Matrix and Golden Case Agent: checks route rows, canonical profiles, selector references, and conflict resolution.
+- Render Preview and Surface QA Agent: creates backend fixtures and expected assertions for result page, PDF, share, history, compare, and locked/free redaction previews.
+- Release Guard Agent: separates draft, validation, staging import candidate, rendered preview, pilot allowlist, production import gate, and production rollout.
+
+## Required Inputs
+
+Every run must declare:
+
+- `run_id`;
+- task id and branch id;
+- target gate: `scan`, `ledger`, `validate`, `gap_audit`, `qa_repair`, `draft`, `route_qa`, or `preview_handoff`;
+- locale set, if content is in scope;
+- input inventory snapshot paths;
+- source ledger path, when claim evaluation is in scope;
+- allowed output paths;
+- forbidden actions;
+- validator and QA commands to run.
+
+When an input is missing or invalid, the agent must fail closed and write a blocked report. It must not synthesize missing source authority or use frontend fallback copy.
+
+## Required Outputs
+
+Runs that create artifacts must follow the protocol in `result-asset-agent-schema.md`. Docs-only tasks may omit run artifacts, but they must keep the same negative guarantees:
+
+- `runtime_use=staging_only`;
+- `production_use_allowed=false`;
+- `ready_for_runtime=false`;
+- `ready_for_production=false`;
+- no CMS writes;
+- no runtime wrapper enablement;
+- no frontend fallback;
+- no private score, raw score, vector, percentile, route, or share leak.
+
+## Forbidden Actions
+
+All RIASEC result page asset-agent tasks forbid:
+
+- modifying public runtime APIs unless the active PR explicitly declares a runtime contract scope;
+- importing or mutating CMS data;
+- setting `production_use_allowed=true`;
+- enabling pilot or production flags;
+- changing RIASEC result runtime wrapper or projection behavior outside an explicit runtime PR;
+- generating frontend fallback interpretation copy;
+- adding sitemap, llms, search queue, public SEO page, or article/profile output;
+- exporting private user identifiers, attempt ids, raw scores, dimension vectors, percentile fields, editor notes, QA notes, import policy, or internal metadata into public payloads;
+- presenting Holland/RIASEC as a diagnosis, ability measurement, hiring screen, guaranteed career fit, success prediction, salary prediction, or official employment suitability decision;
+- copying proprietary report copy, competitor result copy, or internal drafts as user-facing prose sources.
+
+## Stop Conditions
+
+Stop immediately when:
+
+- the working tree contains unrelated changes that cannot be isolated from the current PR scope;
+- a dependency PR is not merged into `main`;
+- changed files drift outside the manifest allowlist;
+- local manifest checks fail;
+- selector/content validator reports critical errors;
+- safety QA reports a forbidden public payload or share payload leak;
+- route matrix or golden case QA cannot prove current-count invariants;
+- any artifact implies runtime, pilot, CMS import, or production readiness before the matching gate.
+
+## First Pilot Default
+
+The first generation-capable dry run defaults to `share_safety`. `low_quality cautious copy` may replace it only if the repository scan proves it is narrower and safer. Combined generation across share safety, low quality, and route-specific scenarios remains deferred until the first narrow gate passes.

--- a/backend/docs/riasec/result-asset-agent-schema.md
+++ b/backend/docs/riasec/result-asset-agent-schema.md
@@ -1,0 +1,121 @@
+# RIASEC Result Page Asset Agent Artifact Protocol
+
+Status: `RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01`
+
+This protocol defines the artifact shape that later Holland/RIASEC result page asset-agent PRs must use. This document is a contract only; it does not generate assets.
+
+## Directory Contract
+
+Generated or audited run artifacts must live under a run-scoped directory:
+
+```text
+backend/content_assets/riasec/result_page_v2/agent_runs/<run_id>/
+```
+
+The directory is allowed only in PRs whose scope explicitly includes agent run artifacts. Docs-only PRs must not create it.
+
+## Required Artifact Names
+
+When a run reaches the matching stage, it must use these stable filenames:
+
+```text
+input_inventory.json
+source_ledger.json
+raw_draft_assets.jsonl
+repaired_draft_assets.jsonl
+final_assets.jsonl
+validation_report.json
+safety_report.json
+route_matrix_report.json
+golden_case_report.json
+render_preview_fixture_manifest.json
+go_no_go.md
+```
+
+The file may be omitted only when the declared gate is earlier than that artifact. Omitted artifacts must be listed in `go_no_go.md` with the reason.
+
+## Shared Metadata
+
+Every JSON artifact must include:
+
+- `schema_version`;
+- `task_id`;
+- `run_id`;
+- `created_at`;
+- `runtime_use: "staging_only"`;
+- `production_use_allowed: false`;
+- `ready_for_runtime: false`;
+- `ready_for_production: false`;
+- `content_authority: "backend"`;
+- `cms_write_performed: false`;
+- `runtime_change_performed: false`;
+- `frontend_fallback_allowed: false`;
+- `private_payload_exported: false`.
+
+Artifacts that reference source files must use repository-relative paths and sha256 checksums. They must not expose machine-local private paths in public reports.
+
+## Candidate Asset Contract
+
+The candidate asset schema for generation-capable tasks is:
+
+```text
+fap.riasec.result_page_v2.selector_asset.v0.1
+```
+
+If the current repository uses a content-slot schema instead of a selector schema for a specific RIASEC surface, the harness must record the local schema name and prove the same safety fields and public payload boundary before promotion from raw draft to repaired draft or final staging candidate.
+
+Required governance fields include:
+
+- `content_source`;
+- `provenance`;
+- `replacement_policy`;
+- `forbidden_public_fields`;
+- `review_status`;
+- `required_evidence_level`;
+- `evidence_level`;
+- `safety_level`;
+- `shareable`;
+- `shareable_policy`;
+- `fallback_policy`;
+- `public_payload`;
+- `internal_metadata`.
+
+## Public Payload Boundary
+
+`public_payload` is an allowlisted reader payload. It must not contain:
+
+- raw scores or raw score labels;
+- RIASEC dimension vectors;
+- percentile, normal-curve, or norm claims when norm state is unavailable;
+- `attempt_id`, user id, private URL, private path, editor notes, QA notes, import policy, selection guidance, or internal metadata;
+- deterministic person type claims, fixed official type labels, or user-confirmed identity claims;
+- diagnosis, treatment, therapy, hiring-screen, employment suitability, success prediction, ability measurement, admission, salary, or performance claims.
+
+`internal_metadata` may contain backend QA details only when downstream reports keep it private and checksums prove it did not leak into public payloads.
+
+## Run Reports
+
+`validation_report.json` must include selector/content validator status, per-asset errors, per-registry counts, reading-mode counts, slot coverage, trigger coverage, mutual exclusion conflicts, fallback policy findings, and checksums for raw, repaired, and final files.
+
+`safety_report.json` must include forbidden term scans, share-safe payload scans, claim-boundary findings, low-quality checks, and pass/block status.
+
+`route_matrix_report.json` must include row count, shard count when sharded, R/I/A/S/E/C band or route coverage, selector/content reference resolution, canonical profile status, and conflict-resolution status.
+
+`golden_case_report.json` must include golden case count, canonical profile coverage, group distribution, expected selector/content refs, and mismatch list.
+
+`render_preview_fixture_manifest.json` must include only backend fixture references and expected assertions. It must not contain frontend fallback body copy.
+
+## State Transitions
+
+Allowed artifact states are:
+
+- `draft_package`;
+- `backend_dry_run`;
+- `validated`;
+- `approved_for_staging_review`;
+- `staging_import_candidate`;
+- `render_preview_ready`;
+- `pilot_allowlist_candidate`;
+- `production_import_gate_candidate`.
+
+No state implies the next state. `production_import_gate_candidate` is still not production authorization.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T22:07:36+08:00",
+  "updated_at": "2026-06-21T22:08:34+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55699,7 +55699,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-asset-agent-runbook-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01: docs(riasec):固化 result asset agent runbook",
     "depends_on": [],
@@ -55724,11 +55724,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to backend/docs/riasec/result-asset-agent-*.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No agent run artifacts, runtime files, CMS importers, routes, migrations, or production gates changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2215 opened from commit 4a356f737789651f2ff4c0749841df31642ae692; waiting for required GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "4a356f737789651f2ff4c0749841df31642ae692",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2215",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55747,6 +55751,11 @@
         "at": "2026-06-21T22:07:36+08:00",
         "status": "local_checks_passed",
         "note": "Added RIASEC result asset agent runbook/schema/gates and registered the eight-item train. Checks and scope validation passed. No assets, runtime, CMS, or production gate changes."
+      },
+      {
+        "at": "2026-06-21T22:08:34+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2215 from commit 4a356f737789651f2ff4c0749841df31642ae692; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T22:08:34+08:00",
+  "updated_at": "2026-06-21T22:14:27+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55699,7 +55699,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-asset-agent-runbook-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01: docs(riasec):固化 result asset agent runbook",
     "depends_on": [],
@@ -55726,12 +55726,12 @@
         "evidence": "Changed files are confined to backend/docs/riasec/result-asset-agent-*.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No agent run artifacts, runtime files, CMS importers, routes, migrations, or production gates changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2215 opened from commit 4a356f737789651f2ff4c0749841df31642ae692; waiting for required GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2215 checks passed on head b2976f7638aed2717c0a955d13011d0c920ddfa0: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep OSS, and non-blocking Semgrep SARIF upload. Merge state CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "4a356f737789651f2ff4c0749841df31642ae692",
+    "commit_sha": "b2976f7638aed2717c0a955d13011d0c920ddfa0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2215",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -55756,6 +55756,11 @@
         "at": "2026-06-21T22:08:34+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2215 from commit 4a356f737789651f2ff4c0749841df31642ae692; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-21T22:14:27+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2215 GitHub checks passed on head b2976f7638aed2717c0a955d13011d0c920ddfa0; merge state CLEAN. Ready to merge after this state update revalidates."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-21T19:42:00+08:00",
+  "updated_at": "2026-06-21T22:07:36+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55692,6 +55692,271 @@
         "at": "2026-06-21T19:42:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2210 GitHub checks passed on head 610da0870dd76e07ac14cd7a157a3dc6db6dbbed; merge state CLEAN. Ready to merge after this state update revalidates."
+      }
+    ]
+  },
+  "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-asset-agent-runbook-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01: docs(riasec):固化 result asset agent runbook",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "This runbook PR has no train dependency and started from main c07bf0e135ed409f4b2a5e2a3a3d479591d36618, which matched origin/main at branch creation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Docs-only runbook, schema, gates, manifest, and state parsed and passed whitespace validation."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/riasec/result-asset-agent-*.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No agent run artifacts, runtime files, CMS importers, routes, migrations, or production gates changed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      },
+      {
+        "at": "2026-06-21T22:07:12+08:00",
+        "status": "in_progress",
+        "note": "Started docs-only runbook PR from latest main. Scope is backend/docs/riasec result asset agent docs plus docs/codex manifest/state registration."
+      },
+      {
+        "at": "2026-06-21T22:07:36+08:00",
+        "status": "local_checks_passed",
+        "note": "Added RIASEC result asset agent runbook/schema/gates and registered the eight-item train. Checks and scope validation passed. No assets, runtime, CMS, or production gate changes."
+      }
+    ]
+  },
+  "RIASEC-RESULT-SOURCE-LEDGER-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-source-ledger-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-SOURCE-LEDGER-01: docs(riasec):建 result source ledger",
+    "depends_on": [
+      "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-asset-validator-harness-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01: test(riasec):建 result asset validator harness",
+    "depends_on": [
+      "RIASEC-RESULT-SOURCE-LEDGER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-existing-asset-gap-audit-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps",
+    "depends_on": [
+      "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-SELECTOR-QA-REPAIR-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-selector-qa-repair-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy",
+    "depends_on": [
+      "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-asset-factory-pilot-batch-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01: feat(riasec):dry-run share safety result batch",
+    "depends_on": [
+      "RIASEC-RESULT-SELECTOR-QA-REPAIR-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-route-matrix-golden-case-qa-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases",
+    "depends_on": [
+      "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      }
+    ]
+  },
+  "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-render-preview-handoff-01",
+    "base": "main",
+    "status": "pending_authorization",
+    "train_scope": "riasec_result_page_v2_asset_agent",
+    "title": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures",
+    "depends_on": [
+      "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:06:47+08:00",
+        "status": "pending_authorization",
+        "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24301,6 +24301,285 @@ prs:
     content_authority: backend
     next_task: SEO-CONV-OPS-05 in fap-api after this PR is merged
 
+  - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
+    repo: fap-api
+    branch: codex/riasec-result-asset-agent-runbook-01
+    title: "RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01: docs(riasec):固化 result asset agent runbook"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Document the Holland/RIASEC Result Page backend content-asset agent runbook, input/output protocol, forbidden actions, and stage gates.
+      - Reuse the existing RIASEC projection, deep-slot, and fail-closed pattern as the authority model.
+      - Do not generate assets, import CMS content, change runtime, or open pilot/production gates.
+    allowed_paths:
+      - backend/docs/riasec/**result-asset-agent*.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate `agent_runs` artifacts or selector/content assets.
+      - Modify `backend/app/**`, `backend/routes/**`, `backend/database/**`, runtime wrappers, CMS importers, or production gates.
+      - Set `production_use_allowed=true`, enable pilot access, add frontend fallback, or export private result payload fields.
+    validation:
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-SOURCE-LEDGER-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
+    branch: codex/riasec-result-source-ledger-01
+    title: "RIASEC-RESULT-SOURCE-LEDGER-01: docs(riasec):建 result source ledger"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Add source ledger template and first evidence ledger for Holland/RIASEC public sources, internal formal drafts, internal long-form drafts, and existing asset packs.
+      - Require each claim row to include source, reference, permitted use, limitation, and disallowed use.
+      - Do not generate selector/content assets or CMS imports.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/source_ledger/**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Copy proprietary report copy, competitor result copy, or internal drafts into generated user-facing prose.
+      - Generate official assets, import CMS data, modify runtime, or open production gates.
+    validation:
+      - find backend/content_assets/riasec/result_page_v2/source_ledger -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-SOURCE-LEDGER-01
+    branch: codex/riasec-result-asset-validator-harness-01
+    title: "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01: test(riasec):建 result asset validator harness"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Add agent run directory validator/test wrapper for RIASEC result-page asset-agent runs.
+      - Reuse existing selector/content validators, asset inventory, checksums, forbidden public field scans, and share leak scans.
+      - Keep the harness read-only against runtime and production state.
+    allowed_paths:
+      - backend/app/Console/Commands/*Riasec*AssetAgent*Command.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/Riasec/**/AssetAgent/**
+      - backend/app/Services/RIASEC/**/AssetAgent/**
+      - backend/tests/**/Riasec*AssetAgent*Test.php
+      - backend/tests/**/RIASEC*AssetAgent*Test.php
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate formal selector/content assets or `production_use_allowed=true` artifacts.
+      - Modify runtime wrapper behavior, CMS importers, public API contracts, or frontend fixtures.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecResultPageAssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01
+    branch: codex/riasec-result-existing-asset-gap-audit-01
+    title: "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Produce a gap register for existing RIASEC result page assets, deep slots, route/selector references, and golden cases.
+      - Group gaps by registry, scope, scenario, share-safe coverage, low-quality coverage, fallback coverage, and route/golden-case readiness.
+      - Keep output as audit evidence only.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Repair selector policy, generate official assets, import CMS data, modify runtime, or open gates.
+    validation:
+      - find backend/content_assets/riasec/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-SELECTOR-QA-REPAIR-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01
+    branch: codex/riasec-result-selector-qa-repair-01
+    title: "RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Repair selector/content QA policy coverage warnings, golden case grouping, slot/module naming, banned terms, and fail-closed fallback rules.
+      - Keep every asset and policy artifact staging-only and non-runtime.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/selector_qa_policy/**
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/tests/**/Riasec**
+      - backend/tests/**/RIASEC**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate new official content batches, modify runtime wrapper behavior, import CMS data, or open pilot/production gates.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-SELECTOR-QA-REPAIR-01
+    branch: codex/riasec-result-asset-factory-pilot-batch-01
+    title: "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01: feat(riasec):dry-run share safety result batch"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Dry-run a narrow `share_safety` selector/content asset pilot batch unless the repository scan proves `low_quality cautious copy` is narrower and safer.
+      - Preserve raw draft, repair draft, final asset, validation report, safety report, and go/no-go report.
+      - Keep every output staging-only and production-disallowed.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/agent_runs/**
+      - backend/content_assets/riasec/result_page_v2/selector_ready_assets/**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate broad route-specific assets in this PR.
+      - Import CMS data, wire runtime selectors, enable pilot access, or open production gates.
+    validation:
+      - find backend/content_assets/riasec/result_page_v2/agent_runs -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01
+    branch: codex/riasec-result-route-matrix-golden-case-qa-01
+    title: "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Validate route matrix, canonical profiles, golden cases, selector/content reference resolution, and conflict resolution.
+      - Produce route matrix and golden case staging-input QA reports.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/route_matrix/**
+      - backend/content_assets/riasec/result_page_v2/selector_qa_policy/**
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/tests/**/Riasec**
+      - backend/tests/**/RIASEC**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Wire route matrix to production runtime, import CMS data, or enable pilot/production flags.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi
+      - find backend/content_assets/riasec/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01
+    branch: codex/riasec-result-render-preview-handoff-01
+    title: "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures"
+    train_scope: riasec_result_page_v2_asset_agent
+    status: user_authorized
+    scope:
+      - Generate backend fixture manifest and expected assertions for fap-web rendered preview QA.
+      - Cover result page, PDF, share, history, compare, locked/free redaction, low-quality, and fallback surfaces.
+      - Keep handoff backend-owned and production-disallowed.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/rendered_preview/**
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/docs/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web, add frontend fallback content, import CMS data, wire runtime selectors, or open production gates.
+    validation:
+      - find backend/content_assets/riasec/result_page_v2/rendered_preview -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PERSONALITY-DETAIL-FAQ-SEO-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the RIASEC Result Page asset-agent runbook, artifact protocol, and stage gates.
- Registered the 8-item `riasec_result_page_v2_asset_agent` PR train in `docs/codex/pr-train.yaml`.
- Initialized the 8 PR train state entries in `docs/codex/pr-train-state.json` and advanced this PR to local-checks-passed.

## Why
This establishes the backend-only operating contract before any source ledger, validator harness, asset generation, route QA, or fap-web handoff work. It reuses the existing RIASEC projection/deep-slot/fail-closed pattern and keeps generation blocked until later scoped PRs.

## Validation commands
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- scoped changed-file validation for `backend/docs/riasec/result-asset-agent-*.md`, `docs/codex/pr-train.yaml`, and `docs/codex/pr-train-state.json`

## Intentionally deferred
- No asset generation or `agent_runs` artifacts.
- No source ledger evidence pack.
- No validator harness or runtime code.
- No CMS import, public runtime API change, frontend fallback, pilot flag, or production gate.

## Repository rule impact
This PR adds backend-authoritative RIASEC result-page asset-agent documentation only. It does not change content ownership or runtime behavior; later asset and validator PRs remain gated by the new manifest entries.
