### PR TITLE
MBTI64-CMS-PROJECTION-PROMOTE-88-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -23,7 +23,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
     ];
 
     protected $signature = 'personality:mbti64-cms-revision-promote
-        {--package= : Path to the MBTI64 pilot V2.1 JSON package}
+        {--package= : Path to the MBTI64 pilot V2.1 or agent projection JSON package}
         {--dry-run : Plan promotion without database writes}
         {--write : Promote latest matching revision snapshots to live CMS content fields}
         {--json : Emit the full JSON summary}
@@ -35,7 +35,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
         {--no-search-release : Required for --write; confirms no search release or queue action}
         {--operator-approved= : Required exact approval token for --write}';
 
-    protected $description = 'Promote MBTI64 pilot V2.1 CMS draft revisions into live CMS content with no index/search side effects.';
+    protected $description = 'Promote MBTI64 CMS draft revisions into live CMS content with no index/search side effects.';
 
     public function handle(Mbti64CmsRevisionPromotionService $service): int
     {

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -20,6 +20,12 @@ final class Mbti64CmsRevisionPromotionService
 
     private const COMPARISON_SNAPSHOT_KEY = 'mbti64_comparison_draft_v2_1';
 
+    private const AGENT_PROJECTION_SNAPSHOT_KEY = 'mbti64_agent_projection_draft_v1';
+
+    private const AGENT_PROJECTION_ARTIFACT = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01';
+
+    private const AGENT_PROJECTION_VERSION = 'mbti64.agent_expansion_88_recommendations.v1';
+
     public function __construct(private readonly Mbti64BackendImportContractPlanner $planner)
     {
     }
@@ -51,7 +57,7 @@ final class Mbti64CmsRevisionPromotionService
      */
     private function buildSummary(array $package, string $sourceSha256, bool $write, array $options): array
     {
-        $contract = $this->planner->plan($package);
+        $contract = $this->promotionContract($package);
         if (($contract['ok'] ?? false) !== true) {
             return array_merge($this->baseSummary($package, $sourceSha256, $write), [
                 'ok' => false,
@@ -69,7 +75,7 @@ final class Mbti64CmsRevisionPromotionService
                 continue;
             }
 
-            $row = $this->packageRow($package, (int) ($plannedRow['position'] ?? 0));
+            $row = $this->packageRow($package, (int) ($plannedRow['position'] ?? 0), $contract);
             $preparedRows[] = $this->prepareRow($plannedRow, $row, $sourceSha256, $write, $errors);
         }
 
@@ -134,6 +140,98 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
+    private function promotionContract(array $package): array
+    {
+        if ($this->isAgentProjectionPackage($package)) {
+            return $this->agentProjectionContract($package);
+        }
+
+        return $this->planner->plan($package);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function isAgentProjectionPackage(array $package): bool
+    {
+        return (string) ($package['artifact'] ?? '') === self::AGENT_PROJECTION_ARTIFACT
+            || (string) ($package['version'] ?? '') === self::AGENT_PROJECTION_VERSION
+            || is_array($package['recommendations'] ?? null);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function agentProjectionContract(array $package): array
+    {
+        $errors = [];
+        $warnings = [];
+        $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
+        $recommendations = $this->recommendations($package);
+
+        if ((string) ($package['artifact'] ?? '') !== self::AGENT_PROJECTION_ARTIFACT) {
+            $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected MBTI64 agent projection artifact.'];
+        }
+        if ((string) ($package['version'] ?? '') !== self::AGENT_PROJECTION_VERSION) {
+            $errors[] = ['field' => 'version', 'code' => 'unsupported_package_version', 'message' => 'Unexpected MBTI64 agent projection version.'];
+        }
+        if ((string) ($package['status'] ?? '') !== 'pass_ready_for_qa_gates') {
+            $errors[] = ['field' => 'status', 'code' => 'package_status_not_ready_for_qa', 'message' => 'Package must be ready for QA gates before promotion planning.'];
+        }
+        if (count($recommendations) !== 88 || (int) ($summary['recommendation_count'] ?? -1) !== 88) {
+            $errors[] = ['field' => 'recommendations', 'code' => 'unexpected_recommendation_count', 'message' => 'Expected exactly 88 MBTI64 agent projection recommendations.'];
+        }
+        if ((int) ($summary['variant_pages'] ?? -1) !== 58 || (int) ($summary['comparison_pages'] ?? -1) !== 30) {
+            $errors[] = ['field' => 'summary', 'code' => 'unexpected_page_type_counts', 'message' => 'Expected 58 variant and 30 comparison recommendations.'];
+        }
+
+        $rows = [];
+        foreach ($recommendations as $index => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $index).'.target_url',
+                    'code' => 'unsupported_mbti64_target_url',
+                    'message' => 'Unsupported MBTI64 public profile URL: '.((string) ($recommendation['target_url'] ?? '')),
+                ];
+
+                continue;
+            }
+
+            $rows[] = [
+                'position' => $index + 1,
+                'url' => (string) $identity['url'],
+                'locale' => (string) $identity['locale'],
+                'page_type' => (string) $identity['page_type'],
+                'identity' => $identity,
+                'target' => [
+                    'target_table' => $identity['page_type'] === 'comparison'
+                        ? 'personality_profile_revisions'
+                        : 'personality_profile_variant_revisions',
+                ],
+                'snapshot_key' => self::AGENT_PROJECTION_SNAPSHOT_KEY,
+            ];
+        }
+
+        return [
+            'ok' => $errors === [],
+            'status' => $errors === [] ? 'pass' : 'fail',
+            'artifact' => 'MBTI64-CMS-PROJECTION-PROMOTE-88-CONTRACT-PATCH-01',
+            'source_kind' => 'mbti64_agent_projection_draft_v1',
+            'row_count' => count($rows),
+            'variant_row_count' => count(array_filter($rows, static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant')),
+            'comparison_row_count' => count(array_filter($rows, static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison')),
+            'rows' => $rows,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
     private function baseSummary(array $package, string $sourceSha256, bool $write): array
     {
         return [
@@ -165,12 +263,31 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
-    private function packageRow(array $package, int $position): array
+    private function packageRow(array $package, int $position, array $contract): array
     {
+        if (($contract['source_kind'] ?? null) === 'mbti64_agent_projection_draft_v1') {
+            $recommendations = $this->recommendations($package);
+            $recommendation = $recommendations[$position - 1] ?? [];
+
+            return is_array($recommendation) ? $recommendation : [];
+        }
+
         $rows = is_array($package['rows'] ?? null) ? array_values((array) $package['rows']) : [];
         $row = $rows[$position - 1] ?? [];
 
         return is_array($row) ? $row : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
     }
 
     /**
@@ -187,7 +304,10 @@ final class Mbti64CmsRevisionPromotionService
         array &$errors,
     ): array {
         $pageType = (string) ($plannedRow['page_type'] ?? '');
-        $snapshotKey = $pageType === 'comparison' ? self::COMPARISON_SNAPSHOT_KEY : self::VARIANT_SNAPSHOT_KEY;
+        $snapshotKey = (string) ($plannedRow['snapshot_key'] ?? '');
+        if ($snapshotKey === '') {
+            $snapshotKey = $pageType === 'comparison' ? self::COMPARISON_SNAPSHOT_KEY : self::VARIANT_SNAPSHOT_KEY;
+        }
         $target = $this->targetRecord($plannedRow);
         $targetId = $target['id'] ?? null;
         $targetField = $pageType === 'comparison' ? 'profile_id' : 'personality_profile_variant_id';
@@ -290,6 +410,46 @@ final class Mbti64CmsRevisionPromotionService
         return $variant instanceof PersonalityProfileVariant ? ['id' => (int) $variant->id] : [];
     }
 
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array<string,string>|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        $targetUrl = (string) ($recommendation['target_url'] ?? '');
+        $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-(?<variant>a|t)$#i', $path, $matches) === 1) {
+            $locale = $this->localeFromPrefix((string) $matches['prefix']);
+            $canonicalType = strtoupper((string) $matches['type']);
+            $variantCode = strtoupper((string) $matches['variant']);
+
+            return [
+                'url' => $targetUrl,
+                'path' => $path,
+                'locale' => $locale,
+                'page_type' => 'variant',
+                'canonical_type_code' => $canonicalType,
+                'variant_code' => $variantCode,
+                'runtime_type_code' => $canonicalType.'-'.$variantCode,
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-a-vs-\k<type>-t$#i', $path, $matches) === 1) {
+            $locale = $this->localeFromPrefix((string) $matches['prefix']);
+            $canonicalType = strtoupper((string) $matches['type']);
+
+            return [
+                'url' => $targetUrl,
+                'path' => $path,
+                'locale' => $locale,
+                'page_type' => 'comparison',
+                'canonical_type_code' => $canonicalType,
+            ];
+        }
+
+        return null;
+    }
+
     private function matchingRevision(
         string $pageType,
         string $targetField,
@@ -355,22 +515,24 @@ final class Mbti64CmsRevisionPromotionService
         $links = is_array($fields['internal_links'] ?? null)
             ? array_values((array) $fields['internal_links'])
             : (is_array($row['internal_links'] ?? null) ? array_values((array) $row['internal_links']) : []);
-        $canonical = (string) ($fields['canonical_target'] ?? ($row['canonical_target'] ?? ($plannedRow['url'] ?? '')));
+        $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+        $canonical = (string) ($fields['canonical_target']
+            ?? ($row['canonical_target'] ?? ($identity['path'] ?? ($plannedRow['url'] ?? ''))));
 
         return [
             'page_type' => $pageType,
             'seo' => [
-                'seo_title' => $this->nullableString($seo['seo_title'] ?? null),
-                'seo_description' => $this->nullableString($seo['seo_description'] ?? null),
+                'seo_title' => $this->nullableString($seo['seo_title'] ?? ($seo['title'] ?? null)),
+                'seo_description' => $this->nullableString($seo['seo_description'] ?? ($seo['description'] ?? null)),
                 'canonical_url' => $canonical,
-                'og_title' => $this->nullableString($seo['og_title'] ?? ($seo['seo_title'] ?? null)),
-                'og_description' => $this->nullableString($seo['og_description'] ?? ($seo['seo_description'] ?? null)),
-                'twitter_title' => $this->nullableString($seo['twitter_title'] ?? ($seo['seo_title'] ?? null)),
-                'twitter_description' => $this->nullableString($seo['twitter_description'] ?? ($seo['seo_description'] ?? null)),
+                'og_title' => $this->nullableString($seo['og_title'] ?? ($seo['seo_title'] ?? ($seo['title'] ?? null))),
+                'og_description' => $this->nullableString($seo['og_description'] ?? ($seo['seo_description'] ?? ($seo['description'] ?? null))),
+                'twitter_title' => $this->nullableString($seo['twitter_title'] ?? ($seo['seo_title'] ?? ($seo['title'] ?? null))),
+                'twitter_description' => $this->nullableString($seo['twitter_description'] ?? ($seo['seo_description'] ?? ($seo['description'] ?? null))),
                 'robots' => 'index,follow',
                 'jsonld_overrides_json' => [
-                    'name' => $this->nullableString($seo['h1'] ?? ($seo['seo_title'] ?? null)),
-                    'description' => $this->nullableString($seo['seo_description'] ?? null),
+                    'name' => $this->nullableString($seo['h1'] ?? ($seo['seo_title'] ?? ($seo['title'] ?? null))),
+                    'description' => $this->nullableString($seo['seo_description'] ?? ($seo['description'] ?? null)),
                     'url' => $canonical,
                 ],
             ],
@@ -399,6 +561,8 @@ final class Mbti64CmsRevisionPromotionService
         array $plannedRow,
         string $snapshotKey,
     ): array {
+        $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+        $canonicalPath = (string) ($identity['path'] ?? ($plannedRow['url'] ?? ''));
         $sections = [];
         $sort = 100;
         foreach ($content as $key => $value) {
@@ -460,8 +624,8 @@ final class Mbti64CmsRevisionPromotionService
             'body_html' => null,
             'payload_json' => [
                 'snapshot_key' => $snapshotKey,
-                'url' => (string) ($plannedRow['url'] ?? ''),
-                'identity' => $plannedRow['identity'] ?? [],
+                'url' => $canonicalPath,
+                'identity' => $identity,
                 'structured_metadata' => $metadata,
                 'raw_row' => $row,
             ],
@@ -492,6 +656,9 @@ final class Mbti64CmsRevisionPromotionService
         array $plannedRow,
         string $snapshotKey,
     ): array {
+        $identity = is_array($plannedRow['identity'] ?? null) ? $plannedRow['identity'] : [];
+        $canonicalPath = (string) ($identity['path'] ?? ($plannedRow['url'] ?? ''));
+
         return [
             'section_key' => 'mbti64_comparison_a_vs_t',
             'title' => $this->nullableString($seo['h1'] ?? ($seo['seo_title'] ?? 'A/T comparison')),
@@ -500,13 +667,13 @@ final class Mbti64CmsRevisionPromotionService
             'body_html' => null,
             'payload_json' => [
                 'snapshot_key' => $snapshotKey,
-                'url' => (string) ($plannedRow['url'] ?? ''),
+                'url' => $canonicalPath,
                 'seo' => $seo,
                 'content' => $content,
                 'faq' => $faq,
                 'internal_links' => $links,
                 'structured_metadata' => $metadata,
-                'identity' => $plannedRow['identity'] ?? [],
+                'identity' => $identity,
                 'raw_row' => $row,
                 'source' => 'mbti64_v2_1_comparison_revision_promotion',
             ],
@@ -709,5 +876,10 @@ final class Mbti64CmsRevisionPromotionService
         $trimmed = trim($value);
 
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function localeFromPrefix(string $prefix): string
+    {
+        return strtolower($prefix) === 'zh' ? 'zh-CN' : 'en';
     }
 }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -20,6 +20,17 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const PILOT_PATHS = [
+        '/en/personality/intj-a-vs-intj-t',
+        '/zh/personality/istj-a',
+        '/en/personality/intp-a-vs-intp-t',
+        '/zh/personality/infp-t',
+        '/en/personality/intj-a',
+        '/en/personality/intj-t',
+        '/zh/personality/intj-a',
+        '/zh/personality/intj-t',
+    ];
+
     public function test_dry_run_lists_eight_latest_revisions_without_live_writes(): void
     {
         $this->seedTargets();
@@ -228,6 +239,91 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_dry_run_supports_eighty_eight_agent_projection_revisions_without_live_writes(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame(88, $payload['row_count']);
+        $this->assertSame(58, $payload['variant_row_count']);
+        $this->assertSame(30, $payload['comparison_row_count']);
+        $this->assertSame(88, $payload['would_promote_count']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame('mbti64_agent_projection_draft_v1', $payload['rows'][0]['snapshot_key']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
+    {
+        $targets = $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+        $profileBefore = $this->profilePublishState($targets['en|ENFJ']);
+        $variantBefore = $this->variantPublishState($targets['en|ENFJ-A']);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['queue_enqueue_attempted']);
+        $this->assertSame(88, $payload['promoted_count']);
+        $this->assertSame(58, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(30, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+        $this->assertSame($profileBefore, $this->profilePublishState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantPublishState($targets['en|ENFJ-A']));
+
+        $seo = PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|ENFJ-A']->id)
+            ->firstOrFail();
+        $this->assertSame('ENFJ-A Meaning Guide | FermatMind', $seo->seo_title);
+        $this->assertSame('/en/personality/enfj-a', $seo->canonical_url);
+
+        $comparison = PersonalityProfileSection::query()
+            ->where('profile_id', (int) $targets['en|ENFJ']->id)
+            ->where('section_key', 'mbti64_comparison_a_vs_t')
+            ->firstOrFail();
+        $this->assertSame('ENFJ-A-VS-ENFJ-T Meaning', $comparison->title);
+        $this->assertSame('/en/personality/enfj-a-vs-enfj-t', $comparison->payload_json['url'] ?? null);
+    }
+
+    public function test_second_agent_projection_write_is_idempotent(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+
+        $this->assertSame(0, Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath)));
+        $secondExit = Artisan::call('personality:mbti64-cms-revision-promote', $this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(88, $payload['skipped_existing_count']);
+    }
+
     /**
      * @return array<string,PersonalityProfile|PersonalityProfileVariant>
      */
@@ -311,6 +407,26 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             'is_published' => true,
             'published_at' => now(),
         ]);
+    }
+
+    /**
+     * @return array<string,PersonalityProfile|PersonalityProfileVariant>
+     */
+    private function seedProjectionTargets(): array
+    {
+        $targets = [];
+        foreach (['en', 'zh-CN'] as $locale) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $profile = $this->createProfile($locale, $typeCode, $typeCode.' fixture');
+                $targets[$locale.'|'.$typeCode] = $profile;
+                foreach (['A', 'T'] as $variantCode) {
+                    $runtimeTypeCode = $typeCode.'-'.$variantCode;
+                    $targets[$locale.'|'.$runtimeTypeCode] = $this->createVariant($profile, $runtimeTypeCode);
+                }
+            }
+        }
+
+        return $targets;
     }
 
     /**
@@ -446,6 +562,209 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function createProjectionDraftRevisions(string $packagePath, string $qaPath): void
+    {
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validProjectionPackage(): array
+    {
+        $recommendations = [];
+        foreach ($this->projectionTargetPaths() as $path) {
+            $recommendations[] = $this->projectionRecommendation($path);
+        }
+
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01',
+            'version' => 'mbti64.agent_expansion_88_recommendations.v1',
+            'generated_at' => '2026-06-21T00:00:00Z',
+            'status' => 'pass_ready_for_qa_gates',
+            'summary' => [
+                'recommendation_count' => 88,
+                'variant_pages' => 58,
+                'comparison_pages' => 30,
+                'pilot_urls_excluded' => 8,
+            ],
+            'recommendations' => $recommendations,
+            'blockers' => [],
+            'warnings' => ['GSC_EVIDENCE_PENDING'],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validProjectionQa(): array
+    {
+        $pageResults = [];
+        foreach ($this->projectionTargetPaths() as $path) {
+            $pageResults[] = [
+                'target_url' => 'https://fermatmind.com'.$path,
+                'locale' => str_starts_with($path, '/zh/') ? 'zh-CN' : 'en',
+                'page_type' => str_contains($path, '-a-vs-') ? 'comparison' : 'variant',
+                'gates' => [
+                    'schema_validation' => 'pass',
+                    'trademark_claim_gate' => 'pass',
+                    'claim_risk_gate' => 'pass',
+                    'duplicate_template_gate' => 'pass',
+                    'private_route_gate' => 'pass',
+                    'result_page_leakage_gate' => 'pass',
+                    'seo_projection_gate' => 'pass',
+                    'bilingual_consistency_gate' => 'pass',
+                ],
+                'blockers' => [],
+                'warnings' => ['GSC_EVIDENCE_PENDING'],
+                'decision' => 'PASS_READY_FOR_CMS_DRAFT',
+            ];
+        }
+
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01',
+            'generated_at' => '2026-06-21T00:00:00Z',
+            'status' => 'pass_ready_for_cms_draft',
+            'summary' => [
+                'checked_recommendation_count' => 88,
+                'pass_ready_for_cms_draft_count' => 88,
+                'blocked_count' => 0,
+            ],
+            'page_results' => $pageResults,
+            'blockers' => [],
+            'warnings' => ['GSC_EVIDENCE_PENDING'],
+            'final_decision' => 'PASS_READY_FOR_CMS_DRAFT',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function projectionTargetPaths(): array
+    {
+        $paths = [];
+        foreach (['en', 'zh'] as $prefix) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $lower = strtolower($typeCode);
+                $comparison = '/'.$prefix.'/personality/'.$lower.'-a-vs-'.$lower.'-t';
+                if (! in_array($comparison, self::PILOT_PATHS, true)) {
+                    $paths[] = $comparison;
+                }
+
+                foreach (['a', 't'] as $variant) {
+                    $path = '/'.$prefix.'/personality/'.$lower.'-'.$variant;
+                    if (! in_array($path, self::PILOT_PATHS, true)) {
+                        $paths[] = $path;
+                    }
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function projectionRecommendation(string $path): array
+    {
+        $locale = str_starts_with($path, '/zh/') ? 'zh-CN' : 'en';
+        $slug = basename($path);
+        $titlePrefix = strtoupper($slug);
+
+        return [
+            'recommendation_id' => 'fixture:'.$path,
+            'target_url' => 'https://fermatmind.com'.$path,
+            'framework' => 'mbti64',
+            'locale' => $locale,
+            'current_surface' => [
+                'title' => 'Current '.$slug,
+                'description' => 'Current description',
+                'h1' => 'Current H1',
+            ],
+            'observed_signal' => ['evidence_state' => 'gsc_pending'],
+            'reference_patterns_used' => [
+                ['pattern_id' => 'fixture_reference', 'source_url' => 'https://fermatmind.com/en/personality/intj-a'],
+            ],
+            'source_inputs' => [
+                'cms_or_api_snapshot' => 'fixture',
+                'reference_pack' => 'fixture',
+                'seo_signal' => 'GSC_EVIDENCE_PENDING',
+            ],
+            'recommendations' => [
+                'title' => ['recommended' => $titlePrefix.' Meaning Guide | FermatMind'],
+                'description' => ['recommended' => 'Safe public personality explanation for '.$slug.'.'],
+                'h1' => ['recommended' => $titlePrefix.' Meaning'],
+                'quick_answer' => ['recommended' => 'This public profile explains '.$slug.' for reflection, not diagnosis or deterministic decisions.'],
+                'faq' => array_map(
+                    static fn (int $index): array => [
+                        'question' => 'Fixture question '.$index.'?',
+                        'answer' => 'Fixture answer '.$index.' for safe public profile reading.',
+                        'reason' => 'Fixture QA.',
+                    ],
+                    [1, 2, 3, 4, 5]
+                ),
+                'internal_links' => [
+                    [
+                        'href' => $locale === 'zh-CN' ? '/zh/personality' : '/en/personality',
+                        'anchor_text' => $locale === 'zh-CN' ? '人格首页' : 'Personality hub',
+                        'role' => 'hub',
+                        'safe_public_route' => true,
+                    ],
+                    [
+                        'href' => $locale === 'zh-CN'
+                            ? '/zh/tests/mbti-personality-test-16-personality-types'
+                            : '/en/tests/mbti-personality-test-16-personality-types',
+                        'anchor_text' => $locale === 'zh-CN' ? 'MBTI 测试' : 'MBTI test',
+                        'role' => 'related_test',
+                        'safe_public_route' => true,
+                    ],
+                ],
+                'differentiation_notes' => ['Fixture differentiation note.'],
+            ],
+            'qa_required' => [
+                'schema_validation',
+                'trademark_claim_gate',
+                'claim_risk_gate',
+                'duplicate_template_gate',
+                'private_route_gate',
+                'result_page_leakage_gate',
+                'seo_projection_gate',
+                'bilingual_consistency_gate',
+            ],
+            'blocked_reason' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeProjectionArtifacts(array $package, array $qa): array
+    {
+        $packagePath = sys_get_temp_dir().'/mbti64-cms-projection-promote-package-'.bin2hex(random_bytes(6)).'.json';
+        $qaPath = sys_get_temp_dir().'/mbti64-cms-projection-promote-qa-'.bin2hex(random_bytes(6)).'.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
     }
 
     /**


### PR DESCRIPTION
## What changed
- Extend `personality:mbti64-cms-revision-promote` planning to accept the 88-page `mbti64_agent_projection_draft_v1` recommendation package.
- Preserve the existing 8-page V2.1 pilot promotion path as fallback through the existing planner.
- Promote agent projection draft revisions using the existing revision tables and safety holds, with no index/search/sitemap/llms side effects.
- Add focused coverage for 88-page dry-run, write promotion, and second-write idempotency.

## Why
The production 88-page promotion dry-run was blocked because the promotion command only understood the older 8-page V2.1 pilot package contract. This patch lets the command recognize the repaired agent projection package and map its 58 variant + 30 comparison rows to the existing CMS revision promotion flow.

## Validation
- `php -l backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php`
- `php -l backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php`
- `cd backend && php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `cd backend && php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

## Deferred
- No production promotion write in this PR.
- No CMS live content mutation during this PR.
- No publish, index/search, sitemap, llms, frontend, scoring, result-route, payment, account, history, share, or private-report changes.
- Next step after merge/deploy is to rerun `MBTI64-CMS-PROJECTION-PROMOTE-88-DRY-RUN-01` on production.
