### PR TITLE
feat(growth): add free full report mode for assessments

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -785,6 +785,19 @@ class AttemptReadController extends Controller
         $isEq60 = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_EQ_60;
         $isEnneagram = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_ENNEAGRAM;
         $isRiasec = strtoupper(trim((string) ($attempt->scale_code ?? ''))) === ReportAccess::SCALE_RIASEC;
+        $freeFullReportModeRequested = $resultExists && $this->freeFullReportModeEnabledForScale($scaleCode);
+        $freeFullReportModeGate = $freeFullReportModeRequested
+            ? $this->reportGatekeeper->ensureAccess(
+                $orgId,
+                (string) $attempt->id,
+                $readUserId,
+                $readAnonId,
+                $this->currentOrgContext()->role()
+            )
+            : ['ok' => false];
+        $freeFullReportModeEnabled = ($freeFullReportModeGate['ok'] ?? false) === true
+            && ! (bool) ($freeFullReportModeGate['locked'] ?? true)
+            && (bool) ($freeFullReportModeGate['free_full_report_mode'] ?? false);
         $hasBigFiveFullAccess = $isBigFive && $resultExists && $this->hasBigFiveFullAccess($request, $orgId, (string) $attempt->id, $readUserId, $readAnonId);
         if (($hasBigFiveFullAccess || $isEq60 || $isEnneagram || $isRiasec) && $resultExists) {
             $accessState = 'ready';
@@ -812,6 +825,20 @@ class AttemptReadController extends Controller
                     'blur_others' => false,
                 ];
             }
+        }
+        if ($freeFullReportModeEnabled) {
+            $accessState = 'ready';
+            $reportState = 'ready';
+            if ($this->reportAccessSupportsPdfWhenUnlocked($scaleCode)) {
+                $pdfState = 'ready';
+            }
+            $payloadJson = array_merge(
+                $payloadJson,
+                $this->freeFullReportModePayloadForScale(
+                    $scaleCode,
+                    (string) ($freeFullReportModeGate['access_source'] ?? 'free_full_report_mode')
+                )
+            );
         }
 
         if ($repairFailed && $resultExists) {
@@ -920,8 +947,14 @@ class AttemptReadController extends Controller
                     ? ReportAccess::VARIANT_FULL
                     : ReportAccess::VARIANT_FREE)
         ));
+        $payloadJson['access_source'] = trim((string) data_get($payloadJson, 'access_source', 'none')) ?: 'none';
+        $payloadJson['free_full_report_mode'] = (bool) data_get($payloadJson, 'free_full_report_mode', false);
+        $payloadJson['paywall_suppressed'] = (bool) data_get($payloadJson, 'paywall_suppressed', false);
         $responsePayload['unlock_stage'] = $unlockStage;
         $responsePayload['unlock_source'] = $unlockSource;
+        $responsePayload['access_source'] = $payloadJson['access_source'];
+        $responsePayload['free_full_report_mode'] = $payloadJson['free_full_report_mode'];
+        $responsePayload['paywall_suppressed'] = $payloadJson['paywall_suppressed'];
         $inviteSnapshotFailureCode = null;
         $inviteSnapshot = $this->resolveInviteSnapshot(
             (int) ($attempt->org_id ?? 0),
@@ -1325,6 +1358,71 @@ class AttemptReadController extends Controller
         }
 
         return ! (bool) ($gate['locked'] ?? true);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function freeFullReportModePayloadForScale(string $scaleCode, string $accessSource = 'free_full_report_mode'): array
+    {
+        $scaleCode = strtoupper(trim($scaleCode));
+        $viewPolicy = [
+            'free_sections' => $scaleCode === ReportAccess::SCALE_EQ_60
+                ? ReportAccess::eq60FreeSectionKeys()
+                : [],
+            'blur_others' => false,
+            'teaser_percent' => 0.0,
+            'upgrade_sku' => null,
+        ];
+
+        return [
+            'locked' => false,
+            'access_level' => ReportAccess::REPORT_ACCESS_FULL,
+            'variant' => ReportAccess::VARIANT_FULL,
+            'unlock_stage' => ReportAccess::UNLOCK_STAGE_FULL,
+            'unlock_source' => ReportAccess::UNLOCK_SOURCE_NONE,
+            'access_source' => trim($accessSource) !== '' ? $accessSource : 'free_full_report_mode',
+            'free_full_report_mode' => true,
+            'paywall_suppressed' => true,
+            'upgrade_sku' => null,
+            'upgrade_sku_effective' => null,
+            'offers' => [],
+            'modules_allowed' => $this->fullRuntimeModulesForScale($scaleCode),
+            'modules_preview' => [],
+            'view_policy' => $viewPolicy,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fullRuntimeModulesForScale(string $scaleCode): array
+    {
+        return $scaleCode === ReportAccess::SCALE_EQ_60
+            ? ReportAccess::eq60AllRuntimeModules()
+            : ReportAccess::normalizeModules(array_merge(
+                ReportAccess::defaultModulesAllowedForLocked($scaleCode),
+                ReportAccess::allDefaultModulesOffered($scaleCode)
+            ));
+    }
+
+    private function reportAccessSupportsPdfWhenUnlocked(string $scaleCode): bool
+    {
+        return strtoupper(trim($scaleCode)) !== ReportAccess::SCALE_IQ_RAVEN;
+    }
+
+    private function freeFullReportModeEnabledForScale(string $scaleCode): bool
+    {
+        if (! (bool) config('fap.features.free_full_report_mode', false)) {
+            return false;
+        }
+
+        $allowedScales = array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) config('fap.free_full_report_assessments', [])
+        );
+
+        return in_array(strtoupper(trim($scaleCode)), array_values(array_filter($allowedScales)), true);
     }
 
     /**

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -97,12 +97,17 @@ class ReportGatekeeper
             $commercial,
             $forceFreeOnly
         );
-        $hasAccess = (bool) ($accessState['has_full_access'] ?? false)
-            || $this->freemiumLocalePolicy()->grantsFullFree($localePolicy);
+        $freeFullReportMode = $this->accessResolver->freeFullReportModeEnabled($scaleCode);
+        $localeGrantsFullFree = $this->freemiumLocalePolicy()->grantsFullFree($localePolicy);
+        $hasEntitlementFullAccess = (bool) ($accessState['has_entitlement_full_access'] ?? false);
+        $hasAccess = (bool) ($accessState['has_full_access'] ?? false) || $localeGrantsFullFree;
 
         return [
             'ok' => true,
             'locked' => ! $hasAccess,
+            'access_source' => $this->resolveAccessSource($freeFullReportMode, $localeGrantsFullFree, $hasEntitlementFullAccess),
+            'free_full_report_mode' => $freeFullReportMode,
+            'paywall_suppressed' => $freeFullReportMode,
         ];
     }
 
@@ -176,8 +181,15 @@ class ReportGatekeeper
             $commercial,
             $forceFreeOnly
         );
-        $hasFullAccess = (bool) ($accessState['has_full_access'] ?? false)
-            || $this->freemiumLocalePolicy()->grantsFullFree($localePolicy);
+        $freeFullReportMode = $this->accessResolver->freeFullReportModeEnabled($scaleCode);
+        $localeGrantsFullFree = $this->freemiumLocalePolicy()->grantsFullFree($localePolicy);
+        $hasEntitlementFullAccess = (bool) ($accessState['has_entitlement_full_access'] ?? false);
+        $accessSource = $this->resolveAccessSource($freeFullReportMode, $localeGrantsFullFree, $hasEntitlementFullAccess);
+        $paywallSuppressed = $freeFullReportMode;
+        $hasFullAccess = (bool) ($accessState['has_full_access'] ?? false) || $localeGrantsFullFree;
+        if ($freeFullReportMode) {
+            [$paywall, $viewPolicy] = $this->suppressPaywall($paywall, $viewPolicy);
+        }
 
         $modulesOffered = $this->offerResolver->collectModulesFromOffers((array) ($paywall['offers'] ?? []));
         if ($modulesOffered === []) {
@@ -219,6 +231,14 @@ class ReportGatekeeper
         $modulesPreview = (array) ($crisisState['modules_preview'] ?? $modulesPreview);
         $hasFullAccess = (bool) ($crisisState['has_full_access'] ?? $hasFullAccess);
         $hasPaidModuleAccess = (bool) ($crisisState['has_paid_module_access'] ?? $hasPaidModuleAccess);
+        if ($freeFullReportMode) {
+            [$paywall, $viewPolicy] = $this->suppressPaywall($paywall, $viewPolicy);
+            $modulesAllowed = $this->fullRuntimeModulesForScale($scaleCode);
+            $modulesOffered = ReportAccess::allDefaultModulesOffered($scaleCode);
+            $modulesPreview = [];
+            $hasFullAccess = true;
+            $hasPaidModuleAccess = true;
+        }
         if ($scaleCode === ReportAccess::SCALE_EQ_60) {
             $viewPolicy = $this->eq60AllFreeViewPolicy($viewPolicy);
             $paywall = $this->eq60AllFreePaywall($paywall, $viewPolicy);
@@ -289,7 +309,10 @@ class ReportGatekeeper
                     $modulesPreview,
                     $normsPayload,
                     $qualityPayload,
-                    $isMbtiContract
+                    $isMbtiContract,
+                    accessSource: $accessSource,
+                    freeFullReportMode: $freeFullReportMode,
+                    paywallSuppressed: $paywallSuppressed
                 );
             }
         }
@@ -320,7 +343,10 @@ class ReportGatekeeper
                     $modulesPreview,
                     $normsPayload,
                     $qualityPayload,
-                    $isMbtiContract
+                    $isMbtiContract,
+                    accessSource: $accessSource,
+                    freeFullReportMode: $freeFullReportMode,
+                    paywallSuppressed: $paywallSuppressed
                 );
             }
 
@@ -347,7 +373,10 @@ class ReportGatekeeper
                             $modulesPreview,
                             $normsPayload,
                             $qualityPayload,
-                            $isMbtiContract
+                            $isMbtiContract,
+                            accessSource: $accessSource,
+                            freeFullReportMode: $freeFullReportMode,
+                            paywallSuppressed: $paywallSuppressed
                         );
                     }
                 }
@@ -373,7 +402,10 @@ class ReportGatekeeper
                             $modulesPreview,
                             $normsPayload,
                             $qualityPayload,
-                            $isMbtiContract
+                            $isMbtiContract,
+                            accessSource: $accessSource,
+                            freeFullReportMode: $freeFullReportMode,
+                            paywallSuppressed: $paywallSuppressed
                         );
                     }
                 }
@@ -410,7 +442,10 @@ class ReportGatekeeper
                             $modulesPreview,
                             $normsPayload,
                             $qualityPayload,
-                            $isMbtiContract
+                            $isMbtiContract,
+                            accessSource: $accessSource,
+                            freeFullReportMode: $freeFullReportMode,
+                            paywallSuppressed: $paywallSuppressed
                         );
                     }
                 }
@@ -431,7 +466,10 @@ class ReportGatekeeper
                             $modulesPreview,
                             $normsPayload,
                             $qualityPayload,
-                            $isMbtiContract
+                            $isMbtiContract,
+                            accessSource: $accessSource,
+                            freeFullReportMode: $freeFullReportMode,
+                            paywallSuppressed: $paywallSuppressed
                         );
                     }
 
@@ -455,7 +493,10 @@ class ReportGatekeeper
                             $modulesPreview,
                             $normsPayload,
                             $qualityPayload,
-                            $isMbtiContract
+                            $isMbtiContract,
+                            accessSource: $accessSource,
+                            freeFullReportMode: $freeFullReportMode,
+                            paywallSuppressed: $paywallSuppressed
                         );
                     }
                 }
@@ -480,7 +521,10 @@ class ReportGatekeeper
                 $modulesPreview,
                 $normsPayload,
                 $qualityPayload,
-                $isMbtiContract
+                $isMbtiContract,
+                accessSource: $accessSource,
+                freeFullReportMode: $freeFullReportMode,
+                paywallSuppressed: $paywallSuppressed
             );
         }
 
@@ -533,7 +577,10 @@ class ReportGatekeeper
             $modulesPreview,
             $normsPayload,
             $qualityPayload,
-            $isMbtiContract
+            $isMbtiContract,
+            accessSource: $accessSource,
+            freeFullReportMode: $freeFullReportMode,
+            paywallSuppressed: $paywallSuppressed
         );
     }
 
@@ -640,6 +687,21 @@ class ReportGatekeeper
         $paywall['view_policy'] = $viewPolicy;
 
         return $paywall;
+    }
+
+    /**
+     * @return array{0:array<string,mixed>,1:array<string,mixed>}
+     */
+    private function suppressPaywall(array $paywall, array $viewPolicy): array
+    {
+        $viewPolicy['blur_others'] = false;
+        $viewPolicy['teaser_percent'] = 0.0;
+        $viewPolicy['upgrade_sku'] = null;
+
+        return [
+            $this->eq60AllFreePaywall($paywall, $viewPolicy),
+            $viewPolicy,
+        ];
     }
 
     private function canUseAttemptScopedPaidModules(?string $userId, ?string $anonId, ?string $role): bool
@@ -862,6 +924,35 @@ class ReportGatekeeper
             || (bool) config('fap.features.submit_async_v2', false);
     }
 
+    private function resolveAccessSource(
+        bool $freeFullReportMode,
+        bool $localeGrantsFullFree,
+        bool $hasEntitlementFullAccess
+    ): string {
+        if ($freeFullReportMode) {
+            return 'free_full_report_mode';
+        }
+
+        if ($localeGrantsFullFree) {
+            return 'freemium_locale_policy';
+        }
+
+        return $hasEntitlementFullAccess ? 'payment' : 'none';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fullRuntimeModulesForScale(string $scaleCode): array
+    {
+        return $scaleCode === ReportAccess::SCALE_EQ_60
+            ? ReportAccess::eq60AllRuntimeModules()
+            : ReportAccess::normalizeModules(array_merge(
+                ReportAccess::defaultModulesAllowedForLocked($scaleCode),
+                ReportAccess::allDefaultModulesOffered($scaleCode)
+            ));
+    }
+
     private function enqueueSnapshotBuild(int $orgId, Attempt $attempt, Result $result): void
     {
         $attemptId = trim((string) ($attempt->id ?? ''));
@@ -909,7 +1000,10 @@ class ReportGatekeeper
         array $quality = [],
         bool $isMbtiContract = false,
         ?string $unlockStage = null,
-        ?string $unlockSource = null
+        ?string $unlockSource = null,
+        string $accessSource = 'none',
+        bool $freeFullReportMode = false,
+        bool $paywallSuppressed = false
     ): array {
         $generating = (bool) ($meta['generating'] ?? false);
         $snapshotError = (bool) ($meta['snapshot_error'] ?? false);
@@ -947,6 +1041,9 @@ class ReportGatekeeper
             'variant' => ReportAccess::normalizeVariant($variant),
             'unlock_stage' => $normalizedUnlockStage,
             'unlock_source' => ReportAccess::normalizeUnlockSource($unlockSource ?? ReportAccess::UNLOCK_SOURCE_NONE),
+            'access_source' => trim($accessSource) !== '' ? $accessSource : 'none',
+            'free_full_report_mode' => $freeFullReportMode,
+            'paywall_suppressed' => $paywallSuppressed,
             'upgrade_sku' => $paywall['upgrade_sku'] ?? ($viewPolicy['upgrade_sku'] ?? null),
             'upgrade_sku_effective' => $paywall['upgrade_sku_effective'] ?? ($viewPolicy['upgrade_sku'] ?? null),
             'offers' => $paywall['offers'] ?? [],

--- a/backend/app/Services/Report/Resolvers/AccessResolver.php
+++ b/backend/app/Services/Report/Resolvers/AccessResolver.php
@@ -10,7 +10,7 @@ class AccessResolver
     public function __construct(private EntitlementManager $entitlements) {}
 
     /**
-     * @return array{benefit_code:?string,has_full_access:bool}
+     * @return array{benefit_code:?string,has_full_access:bool,has_entitlement_full_access:bool}
      */
     public function resolveAccess(
         string $scaleCode,
@@ -23,20 +23,24 @@ class AccessResolver
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
         $benefitCode = $this->resolveBenefitCode($commercial);
-        $hasFullAccess = $benefitCode !== ''
+        $hasEntitlementFullAccess = $benefitCode !== ''
             ? $this->entitlements->hasFullAccess($orgId, $userId, $anonId, $attemptId, $benefitCode)
             : false;
+        $hasFullAccess = $hasEntitlementFullAccess;
+        $freeFullReportMode = $this->freeFullReportModeEnabled($scaleCode);
 
-        if ($forceFreeOnly && ! $this->isForceFreeFullAccessScale($scaleCode)) {
+        if ($freeFullReportMode) {
+            $hasFullAccess = true;
+        } elseif ($forceFreeOnly && ! $this->isForceFreeFullAccessScale($scaleCode)) {
             $hasFullAccess = false;
-        }
-        if ($forceFreeOnly && $this->isForceFreeFullAccessScale($scaleCode)) {
+        } elseif ($forceFreeOnly && $this->isForceFreeFullAccessScale($scaleCode)) {
             $hasFullAccess = true;
         }
 
         return [
             'benefit_code' => $benefitCode !== '' ? $benefitCode : null,
             'has_full_access' => $hasFullAccess,
+            'has_entitlement_full_access' => $hasEntitlementFullAccess,
         ];
     }
 
@@ -56,13 +60,11 @@ class AccessResolver
         ?string $anonId = null
     ): array {
         $scaleCode = strtoupper(trim($scaleCode));
-        if ($forceFreeOnly && $this->isForceFreeFullAccessScale($scaleCode)) {
-            $modulesAllowed = $scaleCode === ReportAccess::SCALE_EQ_60
-                ? ReportAccess::eq60AllRuntimeModules()
-                : ReportAccess::normalizeModules(array_merge(
-                    ReportAccess::defaultModulesAllowedForLocked($scaleCode),
-                    ReportAccess::allDefaultModulesOffered($scaleCode)
-                ));
+        if (
+            ($forceFreeOnly && $this->isForceFreeFullAccessScale($scaleCode))
+            || $this->freeFullReportModeEnabled($scaleCode)
+        ) {
+            $modulesAllowed = $this->fullRuntimeModulesForScale($scaleCode);
 
             return [
                 'modules_allowed' => $modulesAllowed,
@@ -115,6 +117,27 @@ class AccessResolver
         ];
     }
 
+    public function freeFullReportModeEnabled(string $scaleCode): bool
+    {
+        $scaleCode = strtoupper(trim($scaleCode));
+        $container = \Illuminate\Container\Container::getInstance();
+        if (! $container || ! $container->bound('config')) {
+            return false;
+        }
+
+        $config = $container->make('config');
+        if (! (bool) $config->get('fap.features.free_full_report_mode', false)) {
+            return false;
+        }
+
+        $allowedScales = array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) $config->get('fap.free_full_report_assessments', [])
+        );
+
+        return in_array($scaleCode, array_values(array_filter($allowedScales)), true);
+    }
+
     private function resolveBenefitCode(array $commercial): string
     {
         $benefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
@@ -133,6 +156,19 @@ class AccessResolver
             ReportAccess::SCALE_ENNEAGRAM,
             ReportAccess::SCALE_RIASEC,
         ], true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fullRuntimeModulesForScale(string $scaleCode): array
+    {
+        return $scaleCode === ReportAccess::SCALE_EQ_60
+            ? ReportAccess::eq60AllRuntimeModules()
+            : ReportAccess::normalizeModules(array_merge(
+                ReportAccess::defaultModulesAllowedForLocked($scaleCode),
+                ReportAccess::allDefaultModulesOffered($scaleCode)
+            ));
     }
 
     /**

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -25,10 +25,16 @@ return [
             'FAP_FEATURE_EMAIL_FIRST_RESULT_ACCESS',
             env('APP_ENV') === 'production'
         ),
+        'free_full_report_mode' => (bool) env('FAP_FEATURE_FREE_FULL_REPORT_MODE', false),
         'model_router_v2' => (bool) env('FAP_FEATURE_MODEL_ROUTER_V2', true),
         'submit_async_v2' => (bool) env('FAP_FEATURE_SUBMIT_ASYNC_V2', true),
         'report_snapshot_strict_v2' => (bool) env('FAP_FEATURE_REPORT_SNAPSHOT_STRICT_V2', true),
     ],
+
+    'free_full_report_assessments' => array_values(array_filter(array_map(
+        static fn (mixed $value): string => strtoupper(trim((string) $value)),
+        explode(',', (string) env('FAP_FREE_FULL_REPORT_ASSESSMENTS', 'MBTI,BIG5_OCEAN,RIASEC,IQ_RAVEN,EQ_60,ENNEAGRAM'))
+    ))),
 
     'result_email_gate' => [
         'require_binding_for_read' => (bool) env('FAP_RESULT_EMAIL_REQUIRE_BINDING_FOR_READ', false),

--- a/backend/tests/Feature/Commerce/FreemiumLocalePolicyTest.php
+++ b/backend/tests/Feature/Commerce/FreemiumLocalePolicyTest.php
@@ -117,7 +117,6 @@ final class FreemiumLocalePolicyTest extends TestCase
         $token = $this->issueAnonToken($anonId);
 
         $response = $this->withHeaders([
-            'X-Anon-Id' => $anonId,
             'X-Fap-Locale' => 'en',
             'Authorization' => 'Bearer '.$token,
         ])->postJson('/api/v0.3/orders', [
@@ -152,8 +151,6 @@ final class FreemiumLocalePolicyTest extends TestCase
             'anon_id' => $anonId,
             'org_id' => 0,
             'role' => 'public',
-            'expires_at' => now()->addDay(),
-            'revoked_at' => null,
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
@@ -269,6 +269,48 @@ final class AttemptReportAccessReadTest extends TestCase
         ]);
     }
 
+    public function test_mbti_report_access_promotes_to_full_ready_when_free_full_report_mode_is_enabled(): void
+    {
+        config()->set('fap.features.free_full_report_mode', true);
+        config()->set('fap.free_full_report_assessments', ['MBTI']);
+
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_access_free_full_report_mode';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertOk()
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('access_state', 'ready')
+            ->assertJsonPath('report_state', 'ready')
+            ->assertJsonPath('pdf_state', 'ready')
+            ->assertJsonPath('unlock_stage', 'full')
+            ->assertJsonPath('unlock_source', 'none')
+            ->assertJsonPath('access_source', 'free_full_report_mode')
+            ->assertJsonPath('free_full_report_mode', true)
+            ->assertJsonPath('paywall_suppressed', true)
+            ->assertJsonPath('payload.locked', false)
+            ->assertJsonPath('payload.access_level', 'full')
+            ->assertJsonPath('payload.variant', 'full')
+            ->assertJsonPath('payload.unlock_stage', 'full')
+            ->assertJsonPath('payload.unlock_source', 'none')
+            ->assertJsonPath('payload.access_source', 'free_full_report_mode')
+            ->assertJsonPath('payload.free_full_report_mode', true)
+            ->assertJsonPath('payload.paywall_suppressed', true)
+            ->assertJsonPath('payload.upgrade_sku', null)
+            ->assertJsonPath('payload.upgrade_sku_effective', null)
+            ->assertJsonPath('payload.offers', [])
+            ->assertJsonPath('payload.modules_preview', []);
+    }
+
     public function test_it_keeps_projection_missing_pending_when_active_grant_exists_but_result_does_not_exist(): void
     {
         $this->seedScales();
@@ -547,9 +589,9 @@ final class AttemptReportAccessReadTest extends TestCase
 
         Log::shouldHaveReceived('warning')
             ->atLeast()->once()
-            ->withArgs(function (string $message, array $context) use ($attemptId): bool {
+            ->withArgs(function (string $message, array $context): bool {
                 return $message === 'REPORT_ACCESS_INVITE_SNAPSHOT_FAILED'
-                    && (string) ($context['attempt_id'] ?? '') === $attemptId
+                    && is_string($context['attempt_fingerprint'] ?? null)
                     && (string) ($context['failure_code'] ?? '') === 'invite_snapshot_table_missing';
             });
     }
@@ -593,9 +635,9 @@ final class AttemptReportAccessReadTest extends TestCase
 
         Log::shouldHaveReceived('warning')
             ->atLeast()->once()
-            ->withArgs(function (string $message, array $context) use ($attemptId): bool {
+            ->withArgs(function (string $message, array $context): bool {
                 return $message === 'REPORT_ACCESS_PROJECTION_READ_FAILED'
-                    && (string) ($context['attempt_id'] ?? '') === $attemptId
+                    && is_string($context['attempt_fingerprint'] ?? null)
                     && (string) ($context['failure_code'] ?? '') === 'projection_table_missing';
             });
     }

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -205,6 +205,50 @@ final class IqReportContractTest extends TestCase
         $response->assertJsonPath('upgrade_sku', null);
     }
 
+    public function test_iq_report_endpoint_returns_full_report_under_free_full_report_mode_without_answer_key_leak(): void
+    {
+        config()->set('fap.features.free_full_report_mode', true);
+        config()->set('fap.free_full_report_assessments', ['IQ_RAVEN']);
+
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_iq_report_free_full_mode';
+        $token = $this->issueAnonToken($anonId);
+        $this->createAttempt($attemptId, $anonId);
+        $this->createScoredResult($attemptId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('locked', false)
+            ->assertJsonPath('access_level', 'full')
+            ->assertJsonPath('variant', 'full')
+            ->assertJsonPath('unlock_stage', 'full')
+            ->assertJsonPath('unlock_source', 'none')
+            ->assertJsonPath('access_source', 'free_full_report_mode')
+            ->assertJsonPath('free_full_report_mode', true)
+            ->assertJsonPath('paywall_suppressed', true)
+            ->assertJsonPath('upgrade_sku', null)
+            ->assertJsonPath('upgrade_sku_effective', null)
+            ->assertJsonPath('offers', []);
+
+        $payload = $response->json();
+        $this->assertIsArray(data_get($payload, 'report.dimensions'));
+        $this->assertIsArray(data_get($payload, 'report.quality'));
+        $this->assertIsArray(data_get($payload, 'report.scoring'));
+        $this->assertIsArray(data_get($payload, 'report.iq_pro'));
+        $this->assertEquals(21.0, data_get($payload, 'report.summary.raw_score'));
+        $this->assertSame('A', data_get($payload, 'report.quality.level'));
+        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.pdf_payload.status'));
+        $this->assertSame('contract_defined_not_implemented', data_get($payload, 'report.iq_pro.certificate_payload.status'));
+        $this->assertPayloadHasNoAnswerKeyFields($payload);
+    }
+
     public function test_iq_result_endpoint_redacts_legacy_answer_keys_from_public_payload(): void
     {
         $this->seedScales();

--- a/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_120_readable.truth.json
@@ -129,8 +129,8 @@
             }
         ],
         "links": {
-            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
-            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "first": "<local-origin>/api/v0.3/me/attempts?page=1",
+            "last": "<local-origin>/api/v0.3/me/attempts?page=1",
             "next": null,
             "prev": null
         },
@@ -152,6 +152,7 @@
         "x_report_variant": "full"
     },
     "report_access_payload": {
+        "access_source": "none",
         "access_state": "ready",
         "actions": {
             "history_href": null,
@@ -169,6 +170,7 @@
             "scale_code": "BIG5_OCEAN",
             "short_label": "120 questions"
         },
+        "free_full_report_mode": false,
         "invite_unlock_diag_v1": {
             "completed_invitees": 0,
             "invite_status": null,
@@ -198,7 +200,9 @@
         "ok": true,
         "payload": {
             "access_level": "full",
+            "access_source": "none",
             "fallback": true,
+            "free_full_report_mode": false,
             "invite_unlock_diag_v1": {
                 "completed_invitees": 0,
                 "invite_status": null,
@@ -221,11 +225,13 @@
                 "unlock_source": "none",
                 "unlock_stage": "full"
             },
+            "paywall_suppressed": false,
             "result_exists": true,
             "unlock_source": "none",
             "unlock_stage": "full",
             "variant": "full"
         },
+        "paywall_suppressed": false,
         "pdf_state": "ready",
         "projection_version": 1,
         "reason_code": "projection_missing_result_ready",

--- a/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_90_readable.truth.json
@@ -129,8 +129,8 @@
             }
         ],
         "links": {
-            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
-            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "first": "<local-origin>/api/v0.3/me/attempts?page=1",
+            "last": "<local-origin>/api/v0.3/me/attempts?page=1",
             "next": null,
             "prev": null
         },
@@ -152,6 +152,7 @@
         "x_report_variant": "full"
     },
     "report_access_payload": {
+        "access_source": "none",
         "access_state": "ready",
         "actions": {
             "history_href": null,
@@ -169,6 +170,7 @@
             "scale_code": "BIG5_OCEAN",
             "short_label": "90 questions"
         },
+        "free_full_report_mode": false,
         "invite_unlock_diag_v1": {
             "completed_invitees": 0,
             "invite_status": null,
@@ -198,7 +200,9 @@
         "ok": true,
         "payload": {
             "access_level": "full",
+            "access_source": "none",
             "fallback": true,
+            "free_full_report_mode": false,
             "invite_unlock_diag_v1": {
                 "completed_invitees": 0,
                 "invite_status": null,
@@ -221,11 +225,13 @@
                 "unlock_source": "none",
                 "unlock_stage": "full"
             },
+            "paywall_suppressed": false,
             "result_exists": true,
             "unlock_source": "none",
             "unlock_stage": "full",
             "variant": "full"
         },
+        "paywall_suppressed": false,
         "pdf_state": "ready",
         "projection_version": 1,
         "reason_code": "projection_missing_result_ready",

--- a/backend/tests/Fixtures/big5/canonical_degraded.truth.json
+++ b/backend/tests/Fixtures/big5/canonical_degraded.truth.json
@@ -129,8 +129,8 @@
             }
         ],
         "links": {
-            "first": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
-            "last": "http://127.0.0.1:18010/api/v0.3/me/attempts?page=1",
+            "first": "<local-origin>/api/v0.3/me/attempts?page=1",
+            "last": "<local-origin>/api/v0.3/me/attempts?page=1",
             "next": null,
             "prev": null
         },
@@ -152,6 +152,7 @@
         "x_report_variant": "full"
     },
     "report_access_payload": {
+        "access_source": "none",
         "access_state": "ready",
         "actions": {
             "history_href": null,
@@ -169,6 +170,7 @@
             "scale_code": "BIG5_OCEAN",
             "short_label": "120 questions"
         },
+        "free_full_report_mode": false,
         "invite_unlock_diag_v1": {
             "completed_invitees": 0,
             "invite_status": null,
@@ -198,7 +200,9 @@
         "ok": true,
         "payload": {
             "access_level": "full",
+            "access_source": "none",
             "fallback": true,
+            "free_full_report_mode": false,
             "invite_unlock_diag_v1": {
                 "completed_invitees": 0,
                 "invite_status": null,
@@ -221,11 +225,13 @@
                 "unlock_source": "none",
                 "unlock_stage": "full"
             },
+            "paywall_suppressed": false,
             "result_exists": true,
             "unlock_source": "none",
             "unlock_stage": "full",
             "variant": "full"
         },
+        "paywall_suppressed": false,
         "pdf_state": "ready",
         "projection_version": 1,
         "reason_code": "projection_missing_result_ready",

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -562,6 +562,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_free_full_report_mode_feature_flag_files(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+            'backend/app/Services/Report/ReportGatekeeper.php',
+            'backend/app/Services/Report/Resolvers/AccessResolver.php',
+            'backend/config/fap.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_clinical_combo_en_paid_parity_changes(): void
     {
         $changed = [
@@ -4613,6 +4625,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isFreeFullReportModeFeatureFlagFile($file)) {
+                continue;
+            }
+
             if ($this->isClinicalComboEnPaidParityFile($file)) {
                 continue;
             }
@@ -5913,6 +5929,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Commerce/EntitlementManager.php',
             'backend/app/Services/Report/ReportAccess.php',
             'backend/app/Services/Report/Resolvers/AccessResolver.php',
+        ], true);
+    }
+
+    private function isFreeFullReportModeFeatureFlagFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
+            'backend/app/Services/Report/ReportGatekeeper.php',
+            'backend/app/Services/Report/Resolvers/AccessResolver.php',
+            'backend/config/fap.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Report/AccessResolverTest.php
+++ b/backend/tests/Unit/Services/Report/AccessResolverTest.php
@@ -19,8 +19,8 @@ final class AccessResolverTest extends TestCase
             ->with(0, null, 'anon_enneagram', 'attempt_enneagram', 'ENNEAGRAM_REPORT')
             ->willReturn(false);
         $entitlements->expects($this->once())
-            ->method('getAllowedModulesForAttempt')
-            ->with(0, 'attempt_enneagram')
+            ->method('getAllowedModulesForAttemptForActor')
+            ->with(0, 'attempt_enneagram', null, null)
             ->willReturn([ReportAccess::MODULE_ENNEAGRAM_CORE]);
 
         $resolver = new AccessResolver($entitlements);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -55973,5 +55973,64 @@
         "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
       }
     ]
+  },
+  "FREE-FULL-REPORT-MODE-FEATURE-FLAG-01": {
+    "repo": "fap-api",
+    "branch": "codex/free-full-report-mode-feature-flag-01",
+    "base": "main",
+    "status": "pr_open",
+    "train_scope": "free_full_report_mode",
+    "title": "feat(growth): add free full report mode for assessments",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized FREE-FULL-REPORT-MODE-FEATURE-FLAG-01 and allowed docs/codex manifest/state registration before implementation."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "This backend implementation PR was explicitly authorized as a standalone scope with no declared upstream PR-train dependency."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend report access/config/test paths plus docs/codex PR-train metadata."
+      },
+      "local": {
+        "status": "pass_with_warnings",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter FreemiumLocalePolicyTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptReportAccessReadTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter IqReportContractTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AccessResolverTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiReadPathParityContractTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiPhase2AssemblerIntegrationTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_iq_paid_report_entitlement_contract_changes|test_runtime_freeze_classifier_ignores_riasec_snapshot_bound_report_files|test_runtime_freeze_classifier_ignores_iq_report_foundation_changes|test_runtime_freeze_classifier_ignores_free_full_report_mode_feature_flag_files' --no-ansi",
+          "git diff --check"
+        ],
+        "notes": "All required checks exited successfully. Several existing suites emitted file_get_contents warnings while still passing under php artisan test."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2223",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-21T22:37:00+08:00",
+        "status": "in_progress",
+        "note": "Manifest/state entry authorized and backend-only implementation started in a clean origin/main worktree."
+      },
+      {
+        "at": "2026-06-21T23:10:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Feature-flag access changes, report-access sync, focused regressions, MBTI parity, IQ contract, runtime-freeze guard checks, and scoped diff check passed locally."
+      },
+      {
+        "at": "2026-06-21T22:51:45+08:00",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2223 for FREE-FULL-REPORT-MODE-FEATURE-FLAG-01 after local checks passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -25804,3 +25804,50 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: FREE-FULL-REPORT-MODE-FEATURE-FLAG-01
+    repo: fap-api
+    branch: codex/free-full-report-mode-feature-flag-01
+    title: "feat(growth): add free full report mode for assessments"
+    train_scope: free_full_report_mode
+    status: user_authorized
+    scope:
+      - Add a backend-only reversible feature flag for full report read access across MBTI, BIG5_OCEAN, RIASEC, IQ_RAVEN, EQ_60, and ENNEAGRAM.
+      - Intercept read-time access resolution and report-access payloads without mutating payment, order, benefit_grants, benefit_wallets, CMS, or frontend code.
+      - Preserve actor ownership, token and email gates, non-target scale behavior, and IQ answer-key redaction and PDF exclusion.
+    allowed_paths:
+      - backend/config/fap.php
+      - backend/app/Services/Report/Resolvers/AccessResolver.php
+      - backend/app/Services/Report/ReportGatekeeper.php
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/tests/Feature/Commerce/FreemiumLocalePolicyTest.php
+      - backend/tests/Feature/V0_3/AttemptReportAccessReadTest.php
+      - backend/tests/Feature/V0_3/IqReportContractTest.php
+      - backend/tests/Unit/Services/Report/AccessResolverTest.php
+      - backend/tests/Feature/V0_3/MbtiReadPathParityContractTest.php
+      - backend/tests/Feature/Report/MbtiPhase2AssemblerIntegrationTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Modify CMS content, sitemap, robots, llms, schema, hreflang, or deployment config.
+      - Mutate production env vars, production DB state, payment webhooks, refund logic, payment callbacks, order write paths, benefit_grants, or benefit_wallets.
+      - Introduce frontend-only bypasses or broaden private result access.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter FreemiumLocalePolicyTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptReportAccessReadTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter IqReportContractTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AccessResolverTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiReadPathParityContractTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiPhase2AssemblerIntegrationTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_iq_paid_report_entitlement_contract_changes|test_runtime_freeze_classifier_ignores_riasec_snapshot_bound_report_files|test_runtime_freeze_classifier_ignores_iq_report_foundation_changes|test_runtime_freeze_classifier_ignores_free_full_report_mode_feature_flag_files' --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- add `FAP_FEATURE_FREE_FULL_REPORT_MODE` and `FAP_FREE_FULL_REPORT_ASSESSMENTS` backend config, defaulting the mode off
- make `AccessResolver` and `ReportGatekeeper` grant read-time full access for allowlisted scales without mutating payment, order, benefit grant, or wallet state
- suppress paywall payloads for flagged scales and return explicit markers: `access_source=free_full_report_mode`, `free_full_report_mode=true`, `paywall_suppressed=true`
- sync `/api/v0.3/attempts/{id}/report-access` with the new backend gate for MBTI and IQ while preserving existing Big Five / EQ / Enneagram / RIASEC ready-state behavior
- preserve IQ secrecy boundaries by keeping answer keys and correct answers redacted and leaving PDF / certificate runtime status unchanged
- register `FREE-FULL-REPORT-MODE-FEATURE-FLAG-01` in `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`
- add focused regression coverage plus a narrow Big Five runtime-freeze classifier allowance for this feature-flag file set

## Why
- unlock all six major assessments from backend authority under one reversible flag
- avoid frontend-only bypasses and avoid any payment/order/grant side effects
- keep private ownership gates and IQ redaction protections intact while making deployment activation a config-only decision

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter FreemiumLocalePolicyTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AttemptReportAccessReadTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter IqReportContractTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter AccessResolverTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiReadPathParityContractTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter MbtiPhase2AssemblerIntegrationTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_iq_paid_report_entitlement_contract_changes|test_runtime_freeze_classifier_ignores_riasec_snapshot_bound_report_files|test_runtime_freeze_classifier_ignores_iq_report_foundation_changes|test_runtime_freeze_classifier_ignores_free_full_report_mode_feature_flag_files' --no-ansi`
- `git diff --check`

Note: the PHPUnit suites above still emit existing `file_get_contents(...)` warnings in this repo, but the commands exit successfully.

## Production activation
1. Merge this PR.
2. Run readiness only.
3. Set `FAP_FEATURE_FREE_FULL_REPORT_MODE=true` in production backend config.
4. Set `FAP_FREE_FULL_REPORT_ASSESSMENTS=MBTI,BIG5_OCEAN,RIASEC,IQ_RAVEN,EQ_60,ENNEAGRAM` or a narrower subset.
5. Deploy or reload backend only.
6. Validate `/api/v0.3/attempts/{id}/report-access` and `/api/v0.3/attempts/{id}/report` for the six target assessments before any frontend change.

## Rollback
- set `FAP_FEATURE_FREE_FULL_REPORT_MODE=false`
- or remove a scale from `FAP_FREE_FULL_REPORT_ASSESSMENTS`
- redeploy backend only

## Intentionally deferred
- no frontend changes
- no CMS mutation
- no sitemap / robots / llms / schema / hreflang changes
- no deploy in this PR
- no payment/order write-path behavior changes beyond test alignment to the current public order entrypoint contract
