### PR TITLE
RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/existing_asset_gap_audit/v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/qa/existing_asset_gap_audit/v0_1/README.md
@@ -1,0 +1,14 @@
+# RIASEC Result Page V2 Existing Asset Gap Audit v0.1
+
+This folder is audit evidence only for `RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01`.
+
+It records the current backend content-asset state before any RIASEC Result Page V2 selector/content asset factory work:
+
+- 24 top-level RIASEC v1 asset files.
+- 9 JSONL asset tables with 1470 rows.
+- 13 top-level JSON asset packs plus 2 Markdown FAQ companions.
+- `result_page_v2` currently contains the source ledger only.
+- No RIASEC Result Page V2 selector-ready assets, selector QA policy, route matrix, canonical profile matrix, or golden-case package exists yet.
+- The PR3 read-only harness reports 13 forbidden-term hits in the existing v1 corpus; these are pre-existing and remain sidecar evidence for selector QA repair.
+
+No runtime, CMS, production gate, frontend fallback, or formal asset generation is changed here.

--- a/backend/content_assets/riasec/result_page_v2/qa/existing_asset_gap_audit/v0_1/riasec_result_page_v2_existing_asset_gap_register_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/existing_asset_gap_audit/v0_1/riasec_result_page_v2_existing_asset_gap_register_v0_1.json
@@ -1,0 +1,192 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.existing_asset_gap_register.v0.1",
+  "audit_id": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01",
+  "created_at_utc": "2026-06-21T15:30:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "scope": {
+    "top_level_asset_file_count": 24,
+    "jsonl_asset_file_count": 9,
+    "jsonl_row_count": 1470,
+    "json_asset_file_count": 13,
+    "markdown_companion_file_count": 2,
+    "result_page_v2_source_ledger_present": true,
+    "selector_ready_asset_count": 0,
+    "route_matrix_row_count": 0,
+    "canonical_profile_count": 0,
+    "golden_case_count": 0
+  },
+  "source_files": [
+    "backend/content_assets/riasec/dimension_deep_copy_v1.zh-CN.r3.json",
+    "backend/content_assets/riasec/top3_code_chain_strategy_v1.zh-CN.jsonl",
+    "backend/content_assets/riasec/pair_blend_15_pairs_v1.zh-CN.jsonl",
+    "backend/content_assets/riasec/low_quality_cautious_reading_v1.zh-CN.json",
+    "backend/content_assets/riasec/share_pdf_history_v1.en.json",
+    "backend/content_assets/riasec/share_pdf_history_v1.zh-CN.json",
+    "backend/content_assets/riasec/result_page_v2/source_ledger/v0_1/riasec_result_source_ledger_v0_1.json"
+  ],
+  "inventory_summary": {
+    "top_level_assets": [
+      {
+        "asset_family": "dimension_deep_copy",
+        "files": 1,
+        "rows_or_items": 6,
+        "coverage_note": "Six RIASEC dimensions exist as deep-copy content, but they are not packaged as V2 selector slots."
+      },
+      {
+        "asset_family": "top3_code_chain_strategy",
+        "files": 1,
+        "rows_or_items": 20,
+        "coverage_note": "Top-3 chain copy exists for a subset of code patterns; no 216 route matrix or selector reference layer exists."
+      },
+      {
+        "asset_family": "pair_blend_15_pairs",
+        "files": 1,
+        "rows_or_items": 15,
+        "coverage_note": "Pair blend coverage exists for 15 dimension pairs; not yet expressed as selector conflict-resolution assets."
+      },
+      {
+        "asset_family": "activity_task_examples",
+        "files": 1,
+        "rows_or_items": 360,
+        "coverage_note": "Large activity example table exists in zh-CN only; it is not route-addressable by V2 selector."
+      },
+      {
+        "asset_family": "occupation_examples_boundary",
+        "files": 1,
+        "rows_or_items": 360,
+        "coverage_note": "Occupation examples include safety boundaries but require share-safe and no-recommendation QA before selector use."
+      },
+      {
+        "asset_family": "share_pdf_history",
+        "files": 2,
+        "rows_or_items": null,
+        "coverage_note": "Share/PDF/history copy exists for en and zh-CN, but no dedicated V2 share_safety_registry exists."
+      },
+      {
+        "asset_family": "low_quality_cautious_reading",
+        "files": 1,
+        "rows_or_items": null,
+        "coverage_note": "Low-quality cautious copy exists in zh-CN only; no route matrix or selector fallback binding exists."
+      }
+    ],
+    "jsonl_row_counts": {
+      "140q_task_environment_role_v1.zh-CN.jsonl": 126,
+      "activity_task_examples_v1.zh-CN.jsonl": 360,
+      "aspirations_calibration_v1.zh-CN.jsonl": 70,
+      "disagree_path_v1.zh-CN.jsonl": 45,
+      "feedback_action_lab_v1.zh-CN.jsonl": 204,
+      "next_exploration_nodes_v1.zh-CN.jsonl": 270,
+      "occupation_examples_boundary_v1.zh-CN.jsonl": 360,
+      "pair_blend_15_pairs_v1.zh-CN.jsonl": 15,
+      "top3_code_chain_strategy_v1.zh-CN.jsonl": 20
+    }
+  },
+  "gap_register": [
+    {
+      "gap_id": "RIASEC-GAP-V2-SELECTOR-ASSETS-001",
+      "severity": "P0",
+      "area": "selector_ready_assets",
+      "status": "open",
+      "finding": "No RIASEC Result Page V2 selector-ready asset package exists under result_page_v2.",
+      "evidence": "find backend/content_assets/riasec/result_page_v2 -path '*selector*' returns no selector_ready_assets package.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-ROUTE-MATRIX-001",
+      "severity": "P0",
+      "area": "route_matrix",
+      "status": "open",
+      "finding": "No RIASEC route matrix rows, canonical profile matrix, selector reference resolution table, or conflict-resolution report exists.",
+      "evidence": "result_page_v2 currently contains source_ledger and this QA folder only.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-GOLDEN-CASES-001",
+      "severity": "P0",
+      "area": "golden_cases",
+      "status": "open",
+      "finding": "No canonical-profile or golden-case package exists for RIASEC Result Page V2.",
+      "evidence": "No result_page_v2 selector_qa_policy golden cases or route-driven golden case QA files exist.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-SHARE-SAFE-001",
+      "severity": "P1",
+      "area": "share_safe_coverage",
+      "status": "open",
+      "finding": "Share/PDF/history v1 assets exist, but there is no V2 share_safety registry or selector allowlist that proves public share blocks cannot expose raw scores, private payloads, career-match claims, or occupational ranking.",
+      "evidence": "share_pdf_history_v1.en.json and share_pdf_history_v1.zh-CN.json exist; no share_safety_registry exists under result_page_v2.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-LOW-QUALITY-001",
+      "severity": "P1",
+      "area": "low_quality_coverage",
+      "status": "open",
+      "finding": "Low-quality cautious copy exists only as a zh-CN v1 asset and is not wired to route-matrix fallback, selector trigger policy, or share-safe redaction.",
+      "evidence": "low_quality_cautious_reading_v1.zh-CN.json exists with fallback_behavior=omit_module; no V2 selector trigger matrix exists.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-FALLBACK-001",
+      "severity": "P1",
+      "area": "fail_closed_fallback",
+      "status": "open",
+      "finding": "Many v1 assets declare frontend_fallback_allowed=false and omit-module fallback, but there is no V2 selector policy proving missing content fails closed across route, selector, share, PDF, history, and compare surfaces.",
+      "evidence": "Existing v1 asset flags are local to individual files; no result_page_v2 selector_qa_policy package exists.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-SCENARIO-SCOPE-001",
+      "severity": "P2",
+      "area": "scenario_scope",
+      "status": "open",
+      "finding": "Activity, exploration, feedback, and aspiration tables are broad but not normalized into V2 scenario/action_plan selector registries.",
+      "evidence": "activity_task_examples has 360 rows, next_exploration_nodes has 270 rows, and feedback_action_lab has 204 rows; no V2 scenario registry exists.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-LOCALE-001",
+      "severity": "P2",
+      "area": "locale_coverage",
+      "status": "open",
+      "finding": "Most substantive v1 assets are zh-CN only; en assets exist mainly for FAQ, method boundary, share/PDF/history, and technical summary.",
+      "evidence": "The 9 JSONL tables are zh-CN only. en JSON assets exist for faq, professional_method_boundary, share_pdf_history, and technical_note_user_summary.",
+      "introduced_by_current_pr": false,
+      "deferred_to_pr": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01"
+    },
+    {
+      "gap_id": "RIASEC-GAP-FORBIDDEN-TERMS-001",
+      "severity": "P1",
+      "area": "safety_claim_scan",
+      "status": "open",
+      "finding": "The PR3 strict harness reports 13 forbidden-term hits in the existing RIASEC v1 corpus.",
+      "evidence": "cd backend && APP_ENV=testing php artisan riasec:result-page-v2-agent audit --strict --json --no-ansi exits 1 with strict_failures=[\"forbidden_public_payload_leaks\"], validation_error_count=0, leak_hit_count=13.",
+      "introduced_by_current_pr": false,
+      "sidecar_required": true,
+      "deferred_to_pr": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01"
+    }
+  ],
+  "go_no_go": {
+    "staging_audit_evidence": "go",
+    "selector_input_use": "no_go_until_selector_assets_and_route_matrix_exist",
+    "asset_generation": "no_go",
+    "cms_import": "no_go",
+    "runtime_wrapper_enablement": "no_go",
+    "production_gate": "no_go"
+  }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56047,7 +56047,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-existing-asset-gap-audit-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps",
     "depends_on": [
@@ -56074,15 +56074,15 @@
       },
       "scope_validation": {
         "status": "pass",
-        "evidence": "Changed files are confined to backend/content_assets/riasec/result_page_v2/qa/** and docs/codex state reconciliation."
+        "evidence": "Pre-merge scope validation shows only RIASEC result_page_v2 QA gap audit files and docs/codex state changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2228 opened; waiting for required GitHub checks on current head."
+        "status": "pass",
+        "evidence": "PR #2228 GitHub required checks passed on head 5a05ea77c60d2601e48a351f4187aba55e57294c; mergeStateStatus CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "51bde8d933d13967b56cbf7fc12aa2d4376726f6",
+    "commit_sha": "5a05ea77c60d2601e48a351f4187aba55e57294c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2228",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56107,6 +56107,11 @@
         "at": "2026-06-21T23:20:29+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2228 from commit 51bde8d933d13967b56cbf7fc12aa2d4376726f6; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-21T23:26:57+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2228 GitHub checks passed on head 5a05ea77c60d2601e48a351f4187aba55e57294c and merge state is CLEAN; pre-merge scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56047,7 +56047,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-existing-asset-gap-audit-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps",
     "depends_on": [
@@ -56075,11 +56075,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to backend/content_assets/riasec/result_page_v2/qa/** and docs/codex state reconciliation."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2228 opened; waiting for required GitHub checks on current head."
       }
     },
     "failure_reason": null,
-    "commit_sha": "1ec1e89cbf52bd634e055cdb6c9b28522bd89198",
-    "pr_url": null,
+    "commit_sha": "51bde8d933d13967b56cbf7fc12aa2d4376726f6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2228",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56098,6 +56102,11 @@
         "at": "2026-06-21T23:19:26+08:00",
         "status": "commit_created",
         "note": "Recorded scoped gap-audit commit 1ec1e89cbf52bd634e055cdb6c9b28522bd89198 after local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:20:29+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2228 from commit 51bde8d933d13967b56cbf7fc12aa2d4376726f6; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -55933,7 +55933,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-asset-validator-harness-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01: test(riasec):建 result asset validator harness",
     "depends_on": [
@@ -55974,14 +55974,18 @@
       "github": {
         "status": "pass",
         "evidence": "PR #2224 GitHub required checks passed on head 78d258a47c207d0bffb71a440f7b61195f9e0119 after scoped verify-bigfive freeze guard repair; mergeStateStatus CLEAN."
+      },
+      "post_merge": {
+        "status": "pass",
+        "evidence": "PR #2224 merged with squash commit bba68cd98eb2e10a3338375e22ced1cf7b3f4a2e; origin/main contains the merge commit; local main was synced to origin/main; local task branch deleted; remote task branch absent; post-merge RIASEC harness, slot contract, freeze guard regression, CLI smoke, JSON/YAML, and diff checks passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "78d258a47c207d0bffb71a440f7b61195f9e0119",
+    "commit_sha": "bba68cd98eb2e10a3338375e22ced1cf7b3f4a2e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2224",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T15:14:33Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T22:06:47+08:00",
@@ -56017,6 +56021,11 @@
         "at": "2026-06-21T23:08:52+08:00",
         "status": "ready_to_merge",
         "note": "PR #2224 GitHub checks passed on head 78d258a47c207d0bffb71a440f7b61195f9e0119 and merge state is CLEAN; pre-merge scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:18:58+08:00",
+        "status": "merged",
+        "note": "Reconciled during RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: PR #2224 merged at 2026-06-21T15:14:33Z with merge commit bba68cd98eb2e10a3338375e22ced1cf7b3f4a2e; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed; post-merge focused validation passed."
       }
     ],
     "sidecar_issues": [
@@ -56038,7 +56047,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-existing-asset-gap-audit-01",
     "base": "main",
-    "status": "pending_authorization",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01: docs(riasec):审计现有 result assets gaps",
     "depends_on": [
@@ -56048,6 +56057,24 @@
       "authorization": {
         "status": "pass",
         "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "RIASEC-RESULT-ASSET-VALIDATOR-HARNESS-01 merged as PR #2224; origin/main contains merge commit bba68cd98eb2e10a3338375e22ced1cf7b3f4a2e."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "find backend/content_assets/riasec/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\;",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "notes": "Added RIASEC existing asset gap audit README and JSON register. Audit records 24 top-level v1 asset files, 1470 JSONL rows, no V2 selector-ready assets, no route matrix rows, no canonical profile matrix, and no golden cases."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/content_assets/riasec/result_page_v2/qa/** and docs/codex state reconciliation."
       }
     },
     "failure_reason": null,
@@ -56061,6 +56088,11 @@
         "at": "2026-06-21T22:06:47+08:00",
         "status": "pending_authorization",
         "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      },
+      {
+        "at": "2026-06-21T23:18:58+08:00",
+        "status": "local_checks_passed",
+        "note": "Produced RIASEC Result Page V2 existing asset gap register with 9 open gaps grouped by selector assets, route matrix, golden cases, share-safe coverage, low-quality coverage, fallback, scenario scope, locale coverage, and forbidden-term sidecar. JSON/YAML, diff, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56078,7 +56078,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "1ec1e89cbf52bd634e055cdb6c9b28522bd89198",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56093,6 +56093,11 @@
         "at": "2026-06-21T23:18:58+08:00",
         "status": "local_checks_passed",
         "note": "Produced RIASEC Result Page V2 existing asset gap register with 9 open gaps grouped by selector assets, route matrix, golden cases, share-safe coverage, low-quality coverage, fallback, scenario scope, locale coverage, and forbidden-term sidecar. JSON/YAML, diff, and scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:19:26+08:00",
+        "status": "commit_created",
+        "note": "Recorded scoped gap-audit commit 1ec1e89cbf52bd634e055cdb6c9b28522bd89198 after local checks and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added RIASEC Result Page V2 existing asset gap audit README and JSON register.
- Registered current inventory counts: 24 top-level v1 asset files, 1470 JSONL rows, source ledger present, and zero V2 selector/route/golden assets.
- Grouped 9 open gaps by selector assets, route matrix, golden cases, share-safe coverage, low-quality coverage, fail-closed fallback, scenario scope, locale coverage, and forbidden-term sidecar.
- Reconciled the previous validator harness PR state after merge and cleanup.

## Why
This PR establishes the gap baseline before any RIASEC Result Page V2 selector/content repair or pilot generation work. It makes the next PRs explicit instead of letting the existing v1 asset corpus be mistaken for selector-ready V2 assets.

## Validation commands
- `find backend/content_assets/riasec/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No selector QA repair.
- No official selector/content asset generation.
- No CMS import, runtime wrapper change, public API contract change, frontend fixture, pilot gate, or production gate.
- Existing strict forbidden-term hits remain sidecar `RIASEC-GAP-FORBIDDEN-TERMS-001` for selector QA repair.
