### PR TITLE
RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/README.md
@@ -1,0 +1,13 @@
+# RIASEC Result Page V2 Selector QA Policy v0.1
+
+This package is advisory QA policy for `RIASEC-RESULT-SELECTOR-QA-REPAIR-01`.
+
+It repairs the missing policy layer identified by the existing asset gap audit:
+
+- coverage warning taxonomy for absent selector-ready assets, route matrix, golden cases, share-safe registry, low-quality binding, and locale gaps;
+- slot/module naming rules for future `module_*` and registry keys;
+- banned terms and public payload leak rules;
+- fail-closed fallback rules for missing content, low-quality responses, unavailable norms, route misses, and share/PDF/history surfaces;
+- golden case grouping scaffold for the next route matrix QA PR.
+
+This package is staging-only. It does not generate selector/content assets, import CMS data, enable runtime wrappers, open production gates, or authorize frontend fallback.

--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_qa_policy.v0.1",
+  "policy_key": "riasec_result_page_v2.conflict_resolution.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "policy_use": "advisory_only",
+  "no_runtime_wiring": true,
+  "no_frontend_fallback": true,
+  "priority_order": [
+    "safety_boundary",
+    "quality_boundary",
+    "share_surface_boundary",
+    "method_boundary",
+    "route_specific_selector",
+    "scenario_action",
+    "activity_example"
+  ],
+  "mutual_exclusion_rules": [
+    {
+      "rule_key": "low_quality_blocks_profile_shape",
+      "when": "quality_state=low_quality",
+      "block_registries": [
+        "profile_shape_registry",
+        "pair_blend_registry",
+        "top3_chain_registry"
+      ]
+    },
+    {
+      "rule_key": "share_surface_blocks_private_payload",
+      "when": "surface=share",
+      "block_fields": [
+        "attempt_id",
+        "user_id",
+        "raw_score",
+        "score_vector",
+        "percentile",
+        "selector_trace",
+        "internal_metadata"
+      ]
+    },
+    {
+      "rule_key": "norm_unavailable_blocks_rank_claim",
+      "when": "norm_status=unavailable",
+      "block_terms": [
+        "percentile",
+        "population rank",
+        "超过多少人",
+        "常模排名"
+      ]
+    }
+  ],
+  "banned_terms": [
+    "career match",
+    "occupation match",
+    "job fit",
+    "fit score",
+    "success prediction",
+    "success probability",
+    "hiring suitability",
+    "ability proof",
+    "140Q more accurate",
+    "raw score delta",
+    "60Q wrong",
+    "职业匹配",
+    "岗位匹配",
+    "匹配度",
+    "推荐职业",
+    "职业推荐",
+    "岗位胜任",
+    "成功概率",
+    "职业成功",
+    "更准确",
+    "更准",
+    "最终答案",
+    "你就是",
+    "天生适合",
+    "招聘筛选"
+  ],
+  "public_payload_forbidden_fields": [
+    "attempt_id",
+    "user_id",
+    "private_url",
+    "private_path",
+    "raw_score",
+    "raw_scores",
+    "score_vector",
+    "percentile",
+    "percentiles",
+    "selector_trace",
+    "selector_basis",
+    "editor_notes",
+    "qa_notes",
+    "internal_metadata",
+    "production_use_allowed",
+    "ready_for_runtime",
+    "ready_for_production"
+  ],
+  "fallback_rules": {
+    "missing_content": "omit_module_fail_closed",
+    "invalid_selector_asset": "drop_asset_emit_QA_error",
+    "selector_conflict": "choose_highest_safety_then_specificity",
+    "route_matrix_miss": "omit_result_page_v2_modules",
+    "share_safety_violation": "omit_share_block",
+    "pdf_history_compare_redaction_failure": "omit_secondary_surface"
+  }
+}

--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_golden_cases.json
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_golden_cases.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_qa_policy.v0.1",
+  "policy_key": "riasec_result_page_v2.golden_case_groups.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "policy_use": "advisory_grouping_scaffold",
+  "golden_case_count": 0,
+  "golden_cases_ready": false,
+  "canonical_profile_count": 0,
+  "route_matrix_required_before_cases": true,
+  "required_groups": [
+    {
+      "group_key": "clear_primary_code",
+      "minimum_future_cases": 6,
+      "purpose": "One clear high primary dimension for each RIASEC code."
+    },
+    {
+      "group_key": "near_tie_pair",
+      "minimum_future_cases": 6,
+      "purpose": "Near-tie pair cases to verify pair blend and ambiguity copy."
+    },
+    {
+      "group_key": "top3_chain",
+      "minimum_future_cases": 6,
+      "purpose": "Top-3 chain cases to verify sequence and activity ladder copy."
+    },
+    {
+      "group_key": "low_quality",
+      "minimum_future_cases": 2,
+      "purpose": "Fail-closed quality boundary and cautious copy."
+    },
+    {
+      "group_key": "share_safe",
+      "minimum_future_cases": 2,
+      "purpose": "Public sharing allowlist and private payload redaction."
+    },
+    {
+      "group_key": "norm_unavailable",
+      "minimum_future_cases": 2,
+      "purpose": "Suppress rank, percentile, and norm-backed claims."
+    },
+    {
+      "group_key": "route_miss",
+      "minimum_future_cases": 1,
+      "purpose": "Route matrix miss omits V2 modules without frontend fallback."
+    }
+  ],
+  "must_not_contain": [
+    "career match",
+    "job fit",
+    "fit score",
+    "success prediction",
+    "hiring suitability",
+    "raw_score",
+    "percentile",
+    "selector_trace",
+    "frontend_fallback",
+    "production_use_allowed",
+    "ready_for_runtime",
+    "ready_for_production"
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_manifest.json
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_manifest.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_qa_policy.v0.1",
+  "package_key": "riasec_result_page_v2.selector_qa_policy.v0_1",
+  "package_role": "selector_qa_policy_advisory_pack",
+  "created_at_utc": "2026-06-21T15:40:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "policy_use": "advisory_only",
+  "no_runtime_wiring": true,
+  "no_frontend_fallback": true,
+  "files": {
+    "readme": "README.md",
+    "selection_policy": "riasec_result_page_v2_selector_qa_policy_v0_1_selection_policy.json",
+    "conflict_resolution": "riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json",
+    "golden_cases": "riasec_result_page_v2_selector_qa_policy_v0_1_golden_cases.json",
+    "repair_report": "riasec_result_page_v2_selector_qa_policy_v0_1_repair_report.json"
+  },
+  "source_gap_register": "backend/content_assets/riasec/result_page_v2/qa/existing_asset_gap_audit/v0_1/riasec_result_page_v2_existing_asset_gap_register_v0_1.json",
+  "guardrails": {
+    "no_formal_asset_generation": true,
+    "no_cms_import": true,
+    "no_runtime_wrapper_enablement": true,
+    "no_production_gate": true,
+    "private_payload_public_export_forbidden": true
+  }
+}

--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_repair_report.json
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_repair_report.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_qa_policy.repair_report.v0.1",
+  "audit_id": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "repair_summary": {
+    "coverage_warnings_defined": true,
+    "golden_case_groups_defined": true,
+    "slot_module_naming_policy_defined": true,
+    "banned_terms_defined": true,
+    "fail_closed_fallback_rules_defined": true,
+    "selector_assets_generated": false,
+    "route_matrix_generated": false,
+    "golden_cases_generated": false
+  },
+  "known_open_gaps_after_repair": [
+    "selector_ready_assets_missing",
+    "route_matrix_missing",
+    "golden_cases_missing",
+    "share_safety_registry_missing",
+    "low_quality_selector_binding_missing",
+    "strict_harness_forbidden_term_hits_existing_corpus"
+  ],
+  "deferred_to": {
+    "pilot_batch": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01",
+    "route_matrix_qa": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+    "render_preview_handoff": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01"
+  }
+}

--- a/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_selection_policy.json
+++ b/backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_selection_policy.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_qa_policy.v0.1",
+  "policy_key": "riasec_result_page_v2.selection_policy.v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "policy_use": "advisory_only",
+  "no_runtime_wiring": true,
+  "no_frontend_fallback": true,
+  "selection_algorithm_order": [
+    "filter_by_runtime_use_staging_only",
+    "filter_by_review_status",
+    "filter_by_quality_state",
+    "filter_by_route_matrix_match",
+    "filter_by_reading_mode",
+    "filter_by_trigger_match",
+    "rank_by_specificity_then_priority",
+    "apply_mutual_exclusion",
+    "apply_module_slot_limits",
+    "apply_public_payload_sanitizer",
+    "emit_selector_trace_for_QA_only"
+  ],
+  "allowed_reading_modes": [
+    "quick",
+    "standard",
+    "deep"
+  ],
+  "registry_contract": {
+    "allowed_registries": [
+      "profile_shape_registry",
+      "dimension_deep_copy_registry",
+      "pair_blend_registry",
+      "top3_chain_registry",
+      "scenario_action_registry",
+      "activity_example_registry",
+      "share_safety_registry",
+      "method_boundary_registry",
+      "fallback_boundary_registry"
+    ],
+    "missing_registries_are_blocking_warnings": true,
+    "selector_asset_schema": "fap.riasec.result_page_v2.selector_asset.v0.1"
+  },
+  "slot_module_naming_policy": {
+    "module_key_pattern": "^module_[0-9]{2}_[a-z0-9_]+$",
+    "slot_key_pattern": "^module_[0-9]{2}_[a-z0-9_]+\\.[a-z0-9_]+\\.[a-z0-9_.-]+$",
+    "registry_key_pattern": "^[a-z0-9_]+_registry$",
+    "dimension_codes_allowed": [
+      "R",
+      "I",
+      "A",
+      "S",
+      "E",
+      "C"
+    ],
+    "module_key_is_not_personality_type": true,
+    "slot_key_must_not_encode_raw_score": true
+  },
+  "scope_overrides": {
+    "low_quality": {
+      "allowed_registries": [
+        "fallback_boundary_registry",
+        "method_boundary_registry",
+        "share_safety_registry"
+      ],
+      "blocked_registries": [
+        "profile_shape_registry",
+        "pair_blend_registry",
+        "top3_chain_registry",
+        "scenario_action_registry"
+      ],
+      "fallback_policy": "boundary_only_omit_unsafe_modules",
+      "max_blocks_total": 4
+    },
+    "norm_unavailable": {
+      "suppress_fields": [
+        "percentile",
+        "population_rank",
+        "normal_curve",
+        "raw_score_delta"
+      ],
+      "fallback_policy": "method_boundary_only",
+      "allow_score_band_copy": false
+    },
+    "share_surface": {
+      "allowed_registries": [
+        "share_safety_registry",
+        "method_boundary_registry"
+      ],
+      "public_payload_allowlist_required": true,
+      "fallback_policy": "omit_share_block"
+    },
+    "route_miss": {
+      "fallback_policy": "omit_result_page_v2_modules",
+      "frontend_fallback_allowed": false,
+      "emit_trace_only": true
+    }
+  },
+  "coverage_warnings": [
+    "selector_ready_assets_missing",
+    "route_matrix_missing",
+    "golden_cases_missing",
+    "share_safety_registry_missing",
+    "low_quality_selector_binding_missing",
+    "fallback_policy_not_route_tested",
+    "en_locale_substantive_asset_gap"
+  ]
+}

--- a/backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use Tests\TestCase;
+
+final class RiasecResultPageSelectorQaPolicyTest extends TestCase
+{
+    public function test_selector_qa_policy_is_staging_only_and_fail_closed(): void
+    {
+        $base = dirname(__DIR__, 4).'/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1';
+
+        foreach ([
+            'riasec_result_page_v2_selector_qa_policy_v0_1_manifest.json',
+            'riasec_result_page_v2_selector_qa_policy_v0_1_selection_policy.json',
+            'riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json',
+            'riasec_result_page_v2_selector_qa_policy_v0_1_golden_cases.json',
+            'riasec_result_page_v2_selector_qa_policy_v0_1_repair_report.json',
+        ] as $filename) {
+            $payload = $this->readJson($base.'/'.$filename);
+
+            $this->assertSame('staging_only', $payload['runtime_use'] ?? null, $filename);
+            $this->assertFalse((bool) ($payload['production_use_allowed'] ?? true), $filename);
+            $this->assertFalse((bool) ($payload['ready_for_runtime'] ?? true), $filename);
+            $this->assertFalse((bool) ($payload['ready_for_production'] ?? true), $filename);
+        }
+
+        $selectionPolicy = $this->readJson($base.'/riasec_result_page_v2_selector_qa_policy_v0_1_selection_policy.json');
+        $this->assertContains('selector_ready_assets_missing', $selectionPolicy['coverage_warnings'] ?? []);
+        $this->assertSame('omit_result_page_v2_modules', data_get($selectionPolicy, 'scope_overrides.route_miss.fallback_policy'));
+        $this->assertSame('^module_[0-9]{2}_[a-z0-9_]+$', data_get($selectionPolicy, 'slot_module_naming_policy.module_key_pattern'));
+
+        $conflictResolution = $this->readJson($base.'/riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json');
+        $this->assertContains('raw_score', $conflictResolution['public_payload_forbidden_fields'] ?? []);
+        $this->assertContains('职业推荐', $conflictResolution['banned_terms'] ?? []);
+        $this->assertSame('omit_share_block', data_get($conflictResolution, 'fallback_rules.share_safety_violation'));
+
+        $goldenCases = $this->readJson($base.'/riasec_result_page_v2_selector_qa_policy_v0_1_golden_cases.json');
+        $this->assertFalse((bool) ($goldenCases['golden_cases_ready'] ?? true));
+        $this->assertSame(0, (int) ($goldenCases['golden_case_count'] ?? -1));
+        $this->assertGreaterThanOrEqual(7, count($goldenCases['required_groups'] ?? []));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56238,7 +56238,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "d6f8756ffefca2cb2d5bb84a9b67040c5aa268e0",
+    "commit_sha": "e8ca8c4e764d68b0bd8b7a48cb4d4db92e2dc0e2",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56257,7 +56257,7 @@
       {
         "at": "2026-06-21T23:41:00+08:00",
         "status": "commit_created",
-        "note": "Recorded scoped selector QA policy commit d6f8756ffefca2cb2d5bb84a9b67040c5aa268e0 after local checks and scope validation passed."
+        "note": "Recorded scoped selector QA policy commit e8ca8c4e764d68b0bd8b7a48cb4d4db92e2dc0e2 after local checks and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56207,7 +56207,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-selector-qa-repair-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy",
     "depends_on": [
@@ -56235,6 +56235,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1, backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php, and docs/codex state bookkeeping."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2231 GitHub required checks passed on head da0e3b34585da9f7f61849cca3ad0775647a0ba8; mergeStateStatus CLEAN."
       }
     },
     "failure_reason": null,
@@ -56263,6 +56267,11 @@
         "at": "2026-06-21T23:41:42+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2231 from head 71cd4f8ce28e19187ef686169d72dadbfe62b07e; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-21T23:47:26+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2231 GitHub checks passed on head da0e3b34585da9f7f61849cca3ad0775647a0ba8 and merge state is CLEAN; pre-merge scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36707,7 +36707,7 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-scheduler-bootstrap-02",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
     "commit_sha": "fecc207643c37dba0d411eda305a376d6eb3a2db",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1774",
@@ -56158,14 +56158,18 @@
       "github": {
         "status": "pass",
         "evidence": "PR #2228 GitHub required checks passed on head 5a05ea77c60d2601e48a351f4187aba55e57294c; mergeStateStatus CLEAN."
+      },
+      "post_merge": {
+        "status": "pass",
+        "evidence": "PR #2228 merged at 2026-06-21T15:33:45Z with merge commit 960380d057685889247a2cc9696c019f1d61f7a0; origin/main contains the merge commit; local main worktree equals origin/main at 18665feefac81262c37bb29493cff60aa5b423a4; local and remote task branches were cleaned up; post-merge validation passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "5a05ea77c60d2601e48a351f4187aba55e57294c",
+    "commit_sha": "960380d057685889247a2cc9696c019f1d61f7a0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2228",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T15:33:45Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T22:06:47+08:00",
@@ -56191,6 +56195,11 @@
         "at": "2026-06-21T23:26:57+08:00",
         "status": "ready_to_merge",
         "note": "PR #2228 GitHub checks passed on head 5a05ea77c60d2601e48a351f4187aba55e57294c and merge state is CLEAN; pre-merge scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:39:00+08:00",
+        "status": "merged",
+        "note": "Post-merge reconciliation confirmed PR #2228 merged at 2026-06-21T15:33:45Z with merge commit 960380d057685889247a2cc9696c019f1d61f7a0; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed."
       }
     ]
   },
@@ -56198,7 +56207,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-selector-qa-repair-01",
     "base": "main",
-    "status": "pending_authorization",
+    "status": "commit_created",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy",
     "depends_on": [
@@ -56208,10 +56217,28 @@
       "authorization": {
         "status": "pass",
         "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "RIASEC-RESULT-EXISTING-ASSET-GAP-AUDIT-01 merged as PR #2228; origin/main contains merge commit 960380d057685889247a2cc9696c019f1d61f7a0."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecResultPageSelectorQaPolicyTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi",
+          "find backend/content_assets/riasec/result_page_v2/selector_qa_policy -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\; && php -l backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php",
+          "git diff --check"
+        ],
+        "notes": "Added staging-only RIASEC selector QA policy files for coverage warnings, slot/module naming, banned terms, golden case grouping scaffold, conflict resolution, and fail-closed fallback rules. No selector assets, route matrix rows, CMS writes, runtime wrapper changes, or production gates were added."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1, backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php, and docs/codex state bookkeeping."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "d6f8756ffefca2cb2d5bb84a9b67040c5aa268e0",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56221,6 +56248,16 @@
         "at": "2026-06-21T22:06:47+08:00",
         "status": "pending_authorization",
         "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      },
+      {
+        "at": "2026-06-21T23:39:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Added staging-only selector QA policy scaffold and focused PHPUnit coverage for coverage warnings, golden grouping, slot/module naming, banned terms, and fail-closed fallback rules. Focused Riasec policy test, full Riasec filter, JSON syntax, PHP lint, diff, and scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:41:00+08:00",
+        "status": "commit_created",
+        "note": "Recorded scoped selector QA policy commit d6f8756ffefca2cb2d5bb84a9b67040c5aa268e0 after local checks and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56207,7 +56207,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-selector-qa-repair-01",
     "base": "main",
-    "status": "commit_created",
+    "status": "github_checks_pending",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-SELECTOR-QA-REPAIR-01: fix(riasec):修 result selector QA policy",
     "depends_on": [
@@ -56238,8 +56238,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "e8ca8c4e764d68b0bd8b7a48cb4d4db92e2dc0e2",
-    "pr_url": null,
+    "commit_sha": "71cd4f8ce28e19187ef686169d72dadbfe62b07e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2231",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56258,6 +56258,11 @@
         "at": "2026-06-21T23:41:00+08:00",
         "status": "commit_created",
         "note": "Recorded scoped selector QA policy commit e8ca8c4e764d68b0bd8b7a48cb4d4db92e2dc0e2 after local checks and scope validation passed."
+      },
+      {
+        "at": "2026-06-21T23:41:42+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2231 from head 71cd4f8ce28e19187ef686169d72dadbfe62b07e; waiting for required GitHub checks."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added a staging-only RIASEC Result Page V2 selector QA policy scaffold for coverage warnings, slot/module naming, banned terms, golden case grouping, conflict resolution, and fail-closed fallback rules.
- Added focused PHPUnit coverage that verifies the policy artifacts remain staging-only/non-production and preserve the expected QA boundaries.
- Reconciled the previous gap-audit PR state after merge and cleanup.

## Why
- This PR fixes the selector QA policy layer before any pilot asset generation so future agent output has explicit coverage, safety, fallback, and conflict-resolution contracts.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecResultPageSelectorQaPolicyTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi`
- `find backend/content_assets/riasec/result_page_v2/selector_qa_policy -name "*.json" -print -exec python3 -m json.tool {} >/dev/null \; && php -l backend/tests/Unit/Services/Riasec/RiasecResultPageSelectorQaPolicyTest.php`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- Scope validation passed: changed files are limited to the RIASEC selector QA policy, focused RIASEC test, and docs/codex state bookkeeping.

## Intentionally deferred
- No official selector/content assets are generated.
- No route matrix, canonical profile matrix, golden-case corpus, CMS import, runtime wrapper enablement, production gate, or frontend fallback is changed.
- Existing forbidden-term sidecar remains open for the downstream pilot/QA repair path.