### PR TITLE
RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/README.md
@@ -1,0 +1,13 @@
+# RIASEC Route Matrix And Golden Case QA v0.1
+
+- Task: `RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01`
+- Runtime use: `staging_only`
+- Production use allowed: `false`
+- Ready for runtime: `false`
+- Ready for production: `false`
+
+This QA package validates the current staging inputs for route matrix and golden-case work. It does not enable runtime route selection, CMS import, pilot access, or production gates.
+
+Outcome: `partial_go_share_safety_only`.
+
+The share-safe route resolves to the PR6 dry-run selector candidate. Other canonical route groups remain fail-closed because the full selector-ready RIASEC package is still missing.

--- a/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/conflict_resolution_report.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/conflict_resolution_report.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.conflict_resolution_report.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "policy_source": "backend/content_assets/riasec/result_page_v2/selector_qa_policy/v0_1/riasec_result_page_v2_selector_qa_policy_v0_1_conflict_resolution.json",
+  "priority_order_verified": [
+    "safety_boundary",
+    "quality_boundary",
+    "share_surface_boundary",
+    "method_boundary",
+    "route_specific_selector",
+    "scenario_action",
+    "activity_example"
+  ],
+  "conflict_cases_tested": [
+    {
+      "case_id": "conflict.share_surface_private_payload.qa_v0_1",
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "expected_result": "share_surface_boundary_wins",
+      "status": "pass"
+    },
+    {
+      "case_id": "conflict.route_miss.qa_v0_1",
+      "route_id": "route.miss.qa_v0_1",
+      "expected_result": "omit_result_page_v2_modules",
+      "status": "pass"
+    }
+  ],
+  "conflict_count": 2,
+  "mismatch_count": 0,
+  "resolution_status": "pass_for_staging_qa_seed_only"
+}

--- a/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/golden_case_report.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/golden_case_report.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.golden_case_report.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "golden_case_source": "backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/golden_cases.json",
+  "golden_case_count": 7,
+  "required_group_count": 7,
+  "group_distribution": {
+    "clear_primary_code": 1,
+    "near_tie_pair": 1,
+    "top3_chain": 1,
+    "low_quality": 1,
+    "share_safe": 1,
+    "norm_unavailable": 1,
+    "route_miss": 1
+  },
+  "share_safe_case_status": "pass",
+  "non_share_route_cases_status": "fail_closed_missing_selector_assets",
+  "mismatch_count": 0,
+  "runtime_selector_input_readiness": "no_go",
+  "validation_status": "pass_with_fail_closed_sidecars"
+}

--- a/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.route_matrix_report.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "route_matrix_source": "backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/route_matrix_rows.json",
+  "route_matrix_row_count": 7,
+  "canonical_profile_count": 7,
+  "golden_case_count": 7,
+  "selector_ready_candidate_count": 1,
+  "selector_refs_resolved": 1,
+  "selector_refs_unresolved": 0,
+  "route_specific_asset_groups_missing": [
+    "clear_primary_code",
+    "near_tie_pair",
+    "top3_chain",
+    "low_quality",
+    "norm_unavailable"
+  ],
+  "staging_selector_input_readiness": "partial_go_share_safety_only",
+  "runtime_selector_input_readiness": "no_go",
+  "production_readiness": "no_go",
+  "validation_status": "pass_with_fail_closed_sidecars",
+  "sidecars": [
+    {
+      "sidecar_id": "RIASEC-GAP-V2-SELECTOR-ASSETS-001",
+      "introduced_by_current_pr": false,
+      "status": "open",
+      "evidence": "Only one PR6 share_safety candidate exists; full route-specific selector package remains absent."
+    }
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/selector_ref_resolution_report.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/selector_ref_resolution_report.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.selector_ref_resolution_report.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "selector_sources": [
+    "backend/content_assets/riasec/result_page_v2/selector_ready_assets/share_safety_pilot_20260621T1555Z/assets.jsonl"
+  ],
+  "resolved_refs": [
+    {
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "selector_ref": "candidate.share_safety_registry.share_boundary_summary.final.v0_1",
+      "status": "resolved_staging_candidate",
+      "runtime_use": "staging_only",
+      "production_use_allowed": false
+    }
+  ],
+  "unresolved_refs": [],
+  "fail_closed_routes_without_refs": [
+    "route.clear_primary.R.qa_v0_1",
+    "route.near_tie.R_I.qa_v0_1",
+    "route.top3.I_A_S.qa_v0_1",
+    "route.low_quality.boundary.qa_v0_1",
+    "route.norm_unavailable.boundary.qa_v0_1",
+    "route.miss.qa_v0_1"
+  ],
+  "resolution_status": "partial_pass_share_safety_only"
+}

--- a/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/README.md
@@ -1,0 +1,21 @@
+# RIASEC Result Page V2 Route Matrix Staging QA Seed
+
+- Task: `RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01`
+- Runtime use: `staging_only`
+- Production use allowed: `false`
+- Ready for runtime: `false`
+- Ready for production: `false`
+
+This directory contains a small QA seed used to test route-matrix and golden-case report mechanics. It is not a complete route matrix and is not wired to runtime selectors.
+
+The seed records seven canonical groups from the selector QA policy:
+
+- clear primary code
+- near-tie pair
+- top3 chain
+- low quality
+- share-safe
+- norm unavailable
+- route miss
+
+Only the share-safe row resolves to an existing selector candidate from `share_safety_pilot_20260621T1555Z`. Other route-specific rows intentionally fail closed until a full selector asset package exists.

--- a/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/canonical_profiles.json
+++ b/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/canonical_profiles.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.route_matrix.canonical_profiles.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "canonical_profile_count": 7,
+  "profiles": [
+    {
+      "canonical_profile_id": "canonical.clear_primary.R.qa_v0_1",
+      "group_key": "clear_primary_code",
+      "route_id": "route.clear_primary.R.qa_v0_1",
+      "expected_behavior": "route-specific modules omitted until selector assets exist"
+    },
+    {
+      "canonical_profile_id": "canonical.near_tie.R_I.qa_v0_1",
+      "group_key": "near_tie_pair",
+      "route_id": "route.near_tie.R_I.qa_v0_1",
+      "expected_behavior": "near-tie modules omitted until selector assets exist"
+    },
+    {
+      "canonical_profile_id": "canonical.top3.I_A_S.qa_v0_1",
+      "group_key": "top3_chain",
+      "route_id": "route.top3.I_A_S.qa_v0_1",
+      "expected_behavior": "top3 modules omitted until selector assets exist"
+    },
+    {
+      "canonical_profile_id": "canonical.low_quality.boundary.qa_v0_1",
+      "group_key": "low_quality",
+      "route_id": "route.low_quality.boundary.qa_v0_1",
+      "expected_behavior": "boundary-only fail-closed"
+    },
+    {
+      "canonical_profile_id": "canonical.share_safe.generic.qa_v0_1",
+      "group_key": "share_safe",
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "expected_behavior": "share-safe selector candidate resolves without private payload"
+    },
+    {
+      "canonical_profile_id": "canonical.norm_unavailable.boundary.qa_v0_1",
+      "group_key": "norm_unavailable",
+      "route_id": "route.norm_unavailable.boundary.qa_v0_1",
+      "expected_behavior": "method-boundary-only fail-closed"
+    },
+    {
+      "canonical_profile_id": "canonical.route_miss.qa_v0_1",
+      "group_key": "route_miss",
+      "route_id": "route.miss.qa_v0_1",
+      "expected_behavior": "omit result_page_v2 modules without frontend fallback"
+    }
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/golden_cases.json
+++ b/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/golden_cases.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.route_matrix.golden_cases.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "golden_case_count": 7,
+  "golden_cases": [
+    {
+      "case_id": "golden.clear_primary.R.qa_v0_1",
+      "canonical_profile_id": "canonical.clear_primary.R.qa_v0_1",
+      "expected_resolution": "fail_closed_missing_selector_asset"
+    },
+    {
+      "case_id": "golden.near_tie.R_I.qa_v0_1",
+      "canonical_profile_id": "canonical.near_tie.R_I.qa_v0_1",
+      "expected_resolution": "fail_closed_missing_selector_asset"
+    },
+    {
+      "case_id": "golden.top3.I_A_S.qa_v0_1",
+      "canonical_profile_id": "canonical.top3.I_A_S.qa_v0_1",
+      "expected_resolution": "fail_closed_missing_selector_asset"
+    },
+    {
+      "case_id": "golden.low_quality.boundary.qa_v0_1",
+      "canonical_profile_id": "canonical.low_quality.boundary.qa_v0_1",
+      "expected_resolution": "fail_closed_boundary_only"
+    },
+    {
+      "case_id": "golden.share_safe.generic.qa_v0_1",
+      "canonical_profile_id": "canonical.share_safe.generic.qa_v0_1",
+      "expected_resolution": "resolved_staging_candidate",
+      "expected_selector_refs": [
+        "candidate.share_safety_registry.share_boundary_summary.final.v0_1"
+      ]
+    },
+    {
+      "case_id": "golden.norm_unavailable.boundary.qa_v0_1",
+      "canonical_profile_id": "canonical.norm_unavailable.boundary.qa_v0_1",
+      "expected_resolution": "fail_closed_method_boundary_only"
+    },
+    {
+      "case_id": "golden.route_miss.qa_v0_1",
+      "canonical_profile_id": "canonical.route_miss.qa_v0_1",
+      "expected_resolution": "fail_closed_omit_result_page_v2_modules"
+    }
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/route_matrix_rows.json
+++ b/backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/route_matrix_rows.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.route_matrix.rows.v0.1",
+  "task_id": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01",
+  "matrix_id": "riasec_result_page_v2_route_matrix_staging_qa_v0_1",
+  "created_at": "2026-06-21T16:50:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "row_count": 7,
+  "route_rows": [
+    {
+      "route_id": "route.clear_primary.R.qa_v0_1",
+      "group_key": "clear_primary_code",
+      "profile_code": "R",
+      "quality_state": "acceptable",
+      "reading_mode": "standard",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_missing_selector_asset"
+    },
+    {
+      "route_id": "route.near_tie.R_I.qa_v0_1",
+      "group_key": "near_tie_pair",
+      "profile_code": "RI",
+      "quality_state": "acceptable",
+      "reading_mode": "standard",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_missing_selector_asset"
+    },
+    {
+      "route_id": "route.top3.I_A_S.qa_v0_1",
+      "group_key": "top3_chain",
+      "profile_code": "IAS",
+      "quality_state": "acceptable",
+      "reading_mode": "deep",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_missing_selector_asset"
+    },
+    {
+      "route_id": "route.low_quality.boundary.qa_v0_1",
+      "group_key": "low_quality",
+      "profile_code": "SCE",
+      "quality_state": "low_quality",
+      "reading_mode": "quick",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_boundary_only"
+    },
+    {
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "group_key": "share_safe",
+      "profile_code": "RIASEC",
+      "quality_state": "acceptable",
+      "reading_mode": "quick",
+      "surface": "share",
+      "expected_selector_refs": [
+        "candidate.share_safety_registry.share_boundary_summary.final.v0_1"
+      ],
+      "resolution_status": "resolved_staging_candidate"
+    },
+    {
+      "route_id": "route.norm_unavailable.boundary.qa_v0_1",
+      "group_key": "norm_unavailable",
+      "profile_code": "ACE",
+      "quality_state": "acceptable",
+      "norm_status": "unavailable",
+      "reading_mode": "standard",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_method_boundary_only"
+    },
+    {
+      "route_id": "route.miss.qa_v0_1",
+      "group_key": "route_miss",
+      "profile_code": "unknown",
+      "quality_state": "acceptable",
+      "reading_mode": "standard",
+      "surface": "result_page",
+      "expected_selector_refs": [],
+      "resolution_status": "fail_closed_omit_result_page_v2_modules"
+    }
+  ]
+}

--- a/backend/tests/Unit/Services/Riasec/RiasecResultPageRouteMatrixQaReportTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecResultPageRouteMatrixQaReportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use PHPUnit\Framework\TestCase;
+
+final class RiasecResultPageRouteMatrixQaReportTest extends TestCase
+{
+    public function test_route_matrix_and_golden_case_qa_reports_are_staging_only(): void
+    {
+        $base = dirname(__DIR__, 4).'/content_assets/riasec/result_page_v2';
+
+        $routeRows = $this->readJson($base.'/route_matrix/staging_qa_v0_1/route_matrix_rows.json');
+        $canonicalProfiles = $this->readJson($base.'/route_matrix/staging_qa_v0_1/canonical_profiles.json');
+        $goldenCases = $this->readJson($base.'/route_matrix/staging_qa_v0_1/golden_cases.json');
+        $routeReport = $this->readJson($base.'/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json');
+        $goldenReport = $this->readJson($base.'/qa/route_matrix_golden_case_qa/v0_1/golden_case_report.json');
+        $selectorReport = $this->readJson($base.'/qa/route_matrix_golden_case_qa/v0_1/selector_ref_resolution_report.json');
+        $conflictReport = $this->readJson($base.'/qa/route_matrix_golden_case_qa/v0_1/conflict_resolution_report.json');
+
+        foreach ([$routeRows, $canonicalProfiles, $goldenCases, $routeReport, $goldenReport, $selectorReport, $conflictReport] as $payload) {
+            self::assertSame('staging_only', $payload['runtime_use']);
+            self::assertFalse($payload['production_use_allowed']);
+            self::assertFalse($payload['ready_for_runtime']);
+            self::assertFalse($payload['ready_for_production']);
+            self::assertFalse($payload['cms_write_performed']);
+            self::assertFalse($payload['runtime_change_performed']);
+            self::assertFalse($payload['frontend_fallback_allowed']);
+            self::assertFalse($payload['private_payload_exported']);
+        }
+
+        self::assertSame(7, $routeRows['row_count']);
+        self::assertSame(7, $canonicalProfiles['canonical_profile_count']);
+        self::assertSame(7, $goldenCases['golden_case_count']);
+        self::assertSame(7, $routeReport['route_matrix_row_count']);
+        self::assertSame(7, $routeReport['canonical_profile_count']);
+        self::assertSame(7, $goldenReport['golden_case_count']);
+        self::assertSame('partial_go_share_safety_only', $routeReport['staging_selector_input_readiness']);
+        self::assertSame('no_go', $routeReport['runtime_selector_input_readiness']);
+        self::assertSame('partial_pass_share_safety_only', $selectorReport['resolution_status']);
+
+        $resolvedRefs = array_column($selectorReport['resolved_refs'], 'selector_ref');
+        self::assertContains('candidate.share_safety_registry.share_boundary_summary.final.v0_1', $resolvedRefs);
+        self::assertCount(6, $selectorReport['fail_closed_routes_without_refs']);
+        self::assertSame(0, $conflictReport['mismatch_count']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        self::assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36944,7 +36944,7 @@
     "id": "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01",
     "repo": "fap-api",
     "branch": "ops/release-train-workflow-production-env-binding-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "commit_sha": "c17da937",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1771",
     "checks": {
@@ -56421,14 +56421,18 @@
       "github": {
         "status": "pass",
         "evidence": "PR #2234 GitHub required checks passed on head 7814d366c7016a733c7d775f7f659836f705dd37; mergeStateStatus CLEAN."
+      },
+      "post_merge": {
+        "status": "pass",
+        "evidence": "PR #2234 merged at 2026-06-21T16:43:43Z with merge commit 79cb4981e95ec9cc1743a781650f23dc9c8e3db7; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed; post-merge focused validation passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "768951018239edbf6df96e4e464dab4b1f0e312c",
+    "commit_sha": "79cb4981e95ec9cc1743a781650f23dc9c8e3db7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2234",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T16:43:43Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T22:06:47+08:00",
@@ -56449,6 +56453,11 @@
         "at": "2026-06-22T00:09:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2234 GitHub checks passed on head 7814d366c7016a733c7d775f7f659836f705dd37 and merge state is CLEAN; pre-merge scope validation passed."
+      },
+      {
+        "at": "2026-06-22T00:48:37+08:00",
+        "status": "merged",
+        "note": "Post-merge reconciliation confirmed PR #2234 merged at 2026-06-21T16:43:43Z with merge commit 79cb4981e95ec9cc1743a781650f23dc9c8e3db7; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed."
       }
     ]
   },
@@ -56456,7 +56465,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "pending_authorization",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases",
     "depends_on": [
@@ -56466,6 +56475,37 @@
       "authorization": {
         "status": "pass",
         "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "RIASEC-RESULT-ASSET-FACTORY-PILOT-BATCH-01 merged as PR #2234; origin/main contains merge commit 79cb4981e95ec9cc1743a781650f23dc9c8e3db7."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecResultPageRouteMatrixQaReportTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi",
+          "find backend/content_assets/riasec/result_page_v2/qa -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\;",
+          "find backend/content_assets/riasec/result_page_v2/route_matrix -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\;",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "notes": "Added staging-only route matrix QA seed, canonical profiles, golden cases, selector ref resolution report, and conflict-resolution report. The reports mark share_safety as the only resolved staging candidate and keep route-specific selector gaps fail-closed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to backend/content_assets/riasec/result_page_v2/route_matrix, backend/content_assets/riasec/result_page_v2/qa, backend/tests/Unit/Services/Riasec/RiasecResultPageRouteMatrixQaReportTest.php, and docs/codex state bookkeeping."
+      },
+      "sidecars": {
+        "status": "open_non_blocking",
+        "items": [
+          {
+            "sidecar_id": "RIASEC-GAP-V2-SELECTOR-ASSETS-001",
+            "introduced_by_current_pr": false,
+            "reason": "Only the PR6 share_safety selector candidate resolves; broad route-specific selector packages remain absent and fail closed."
+          }
+        ]
       }
     },
     "failure_reason": null,
@@ -56479,6 +56519,11 @@
         "at": "2026-06-21T22:06:47+08:00",
         "status": "pending_authorization",
         "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      },
+      {
+        "at": "2026-06-22T00:48:37+08:00",
+        "status": "local_checks_passed",
+        "note": "Produced route matrix and golden-case staging QA seed/reports with 7 canonical groups and one resolved share_safety selector ref. Focused route QA test, full Riasec filter, JSON/YAML, diff, and scope validation passed; unresolved broad selector packages are recorded as non-blocking sidecar because they pre-existed this PR."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56465,7 +56465,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases",
     "depends_on": [
@@ -56509,8 +56509,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "235ea2b0a7067a011adf79f5657ed0777754da6b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2236",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56524,6 +56524,11 @@
         "at": "2026-06-22T00:48:37+08:00",
         "status": "local_checks_passed",
         "note": "Produced route matrix and golden-case staging QA seed/reports with 7 canonical groups and one resolved share_safety selector ref. Focused route QA test, full Riasec filter, JSON/YAML, diff, and scope validation passed; unresolved broad selector packages are recorded as non-blocking sidecar because they pre-existed this PR."
+      },
+      {
+        "at": "2026-06-22T00:51:01+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2236 from head 235ea2b0a7067a011adf79f5657ed0777754da6b; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56465,7 +56465,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-route-matrix-golden-case-qa-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01: test(riasec):验证 route matrix golden cases",
     "depends_on": [
@@ -56506,6 +56506,10 @@
             "reason": "Only the PR6 share_safety selector candidate resolves; broad route-specific selector packages remain absent and fail closed."
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2236 GitHub required checks passed on head 3ba6e111314ab5cbbcaf05d06af4d79fd572480c; mergeStateStatus CLEAN."
       }
     },
     "failure_reason": null,
@@ -56529,6 +56533,11 @@
         "at": "2026-06-22T00:51:01+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2236 from head 235ea2b0a7067a011adf79f5657ed0777754da6b; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T01:11:04+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2236 GitHub checks passed on head 3ba6e111314ab5cbbcaf05d06af4d79fd572480c and merge state is CLEAN; pre-merge scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added a staging-only RIASEC Result Page V2 route matrix QA seed covering 7 canonical/golden groups.
- Added route matrix, golden case, selector ref resolution, and conflict-resolution QA reports.
- Added focused PHPUnit coverage proving all reports remain staging-only/non-runtime and that the PR6 share-safety selector ref resolves while other route-specific gaps fail closed.
- Reconciled the previous share-safety pilot PR state after merge and cleanup.

## Why
- This PR exercises route matrix and golden-case QA mechanics before any rendered preview or runtime selector wiring. It makes current readiness explicit: share-safety is partially usable as staging input, broad route-specific selector assets remain sidecar gaps.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecResultPageRouteMatrixQaReportTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Riasec --no-ansi`
- `find backend/content_assets/riasec/result_page_v2/qa -name "*.json" -print -exec python3 -m json.tool {} >/dev/null \;`
- `find backend/content_assets/riasec/result_page_v2/route_matrix -name "*.json" -print -exec python3 -m json.tool {} >/dev/null \;`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- Scope validation passed: changed files are limited to route matrix QA, QA reports, focused RIASEC test, and docs/codex state bookkeeping.

## Intentionally deferred
- No production/runtime route matrix wiring.
- No CMS import, pilot/production gate, frontend fallback, or rendered preview fixture work.
- Full route-specific selector asset coverage remains open as `RIASEC-GAP-V2-SELECTOR-ASSETS-001` and fail-closed.