### PR TITLE
RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/README.md
@@ -1,0 +1,22 @@
+# RIASEC Result Page V2 Render Preview Handoff v0.1
+
+- Task: `RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01`
+- Runtime use: `staging_only`
+- Production use allowed: `false`
+- Ready for runtime: `false`
+- Ready for production: `false`
+
+This package is a backend-owned handoff for fap-web rendered preview QA. It contains fixture references and expected assertions only. It does not modify fap-web, import CMS data, enable runtime selectors, or open pilot/production gates.
+
+Preview coverage:
+
+- result page
+- PDF
+- share
+- history
+- compare
+- locked/free redaction
+- low-quality
+- fallback/route miss
+
+The fixture manifest references current staging QA artifacts from the route matrix, golden cases, selector-ready share-safety pilot, and QA reports. Public payload expectations remain allowlisted and private score/vector/percentile fields must stay absent.

--- a/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/expected_assertions.json
+++ b/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/expected_assertions.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.render_preview_expected_assertions.v0.1",
+  "task_id": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01",
+  "created_at": "2026-06-21T17:45:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "global_assertions": [
+    "no_cms_write",
+    "no_runtime_wrapper_enablement",
+    "no_frontend_fallback_copy",
+    "no_production_gate_change",
+    "all_missing_route_specific_assets_fail_closed",
+    "share_surface_uses_public_payload_allowlist_only"
+  ],
+  "forbidden_public_fields": [
+    "attempt_id",
+    "user_id",
+    "private_url",
+    "private_path",
+    "raw_score",
+    "raw_scores",
+    "score_vector",
+    "dimension_vector",
+    "percentile",
+    "percentiles",
+    "selector_trace",
+    "selector_basis",
+    "editor_notes",
+    "qa_notes",
+    "internal_metadata",
+    "production_use_allowed",
+    "ready_for_runtime",
+    "ready_for_production"
+  ],
+  "surface_assertions": {
+    "result_page": [
+      "owner-only result state may render backend-authoritative shell",
+      "missing route-specific selector assets omit V2 modules",
+      "free/locked mode must not expose deep selector payload"
+    ],
+    "pdf": [
+      "PDF preview may render share-safe boundary candidate only",
+      "PDF preview must not contain raw scores or vectors",
+      "PDF preview must not infer missing route copy"
+    ],
+    "share": [
+      "share preview renders only public_payload allowlist fields",
+      "share preview omits private identifiers and selector traces",
+      "share preview must not contain deterministic identity or outcome claims"
+    ],
+    "history": [
+      "history preview is snapshot-bound",
+      "history preview does not expose raw vector fields publicly",
+      "history preview does not synthesize missing V2 modules"
+    ],
+    "compare": [
+      "compare preview blocks raw cross-form deltas",
+      "compare preview uses method-boundary-only state when norm status is unavailable",
+      "compare preview does not rank or percentile users"
+    ],
+    "low_quality": [
+      "low-quality preview hides strong profile modules",
+      "low-quality preview keeps user-not-blamed boundary",
+      "low-quality preview does not upsell 140Q as a repair path"
+    ],
+    "fallback": [
+      "route miss omits result_page_v2 modules",
+      "frontend fallback copy is forbidden",
+      "QA trace may exist only in private reports, not public payload"
+    ]
+  }
+}

--- a/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/handoff_report.json
+++ b/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/handoff_report.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.render_preview_handoff_report.v0.1",
+  "task_id": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01",
+  "created_at": "2026-06-21T17:45:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "fixture_manifest": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/render_preview_fixture_manifest.json",
+  "expected_assertions": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/expected_assertions.json",
+  "fixture_case_count": 8,
+  "surface_count": 7,
+  "covered_surfaces": [
+    "result_page",
+    "pdf",
+    "share",
+    "history",
+    "compare",
+    "locked_free_redaction",
+    "low_quality",
+    "fallback"
+  ],
+  "handoff_status": "ready_for_fap_web_rendered_preview_qa",
+  "runtime_status": "no_go",
+  "production_status": "no_go",
+  "deferred_items": [
+    "fap-web rendered preview execution",
+    "runtime selector integration",
+    "CMS import",
+    "pilot allowlist",
+    "production import gate"
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/render_preview_fixture_manifest.json
+++ b/backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/render_preview_fixture_manifest.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.render_preview_fixture_manifest.v0.1",
+  "task_id": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01",
+  "created_at": "2026-06-21T17:45:00Z",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "handoff_scope": {
+    "consumer_repo": "fap-web",
+    "handoff_type": "rendered_preview_qa_fixture_manifest",
+    "fixture_status": "staging_preview_only",
+    "frontend_changes_required": false
+  },
+  "source_artifacts": {
+    "route_matrix_rows": "backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/route_matrix_rows.json",
+    "canonical_profiles": "backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/canonical_profiles.json",
+    "golden_cases": "backend/content_assets/riasec/result_page_v2/route_matrix/staging_qa_v0_1/golden_cases.json",
+    "route_matrix_report": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json",
+    "selector_ref_resolution_report": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/selector_ref_resolution_report.json",
+    "share_safety_selector_candidate": "backend/content_assets/riasec/result_page_v2/selector_ready_assets/share_safety_pilot_20260621T1555Z/assets.jsonl"
+  },
+  "fixture_cases": [
+    {
+      "fixture_id": "riasec_result_page_clear_primary_R_preview",
+      "surface": "result_page",
+      "route_id": "route.clear_primary.R.qa_v0_1",
+      "expected_state": "fail_closed_missing_selector_asset",
+      "expected_modules": [],
+      "redaction_profile": "private_result_snapshot_allowed_for_owner_only"
+    },
+    {
+      "fixture_id": "riasec_pdf_share_safe_boundary_preview",
+      "surface": "pdf",
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "expected_state": "render_share_safe_boundary_only",
+      "expected_selector_refs": [
+        "candidate.share_safety_registry.share_boundary_summary.final.v0_1"
+      ],
+      "redaction_profile": "pdf_public_safe_summary"
+    },
+    {
+      "fixture_id": "riasec_share_public_preview",
+      "surface": "share",
+      "route_id": "route.share_safe.generic.qa_v0_1",
+      "expected_state": "render_share_safe_boundary_only",
+      "expected_selector_refs": [
+        "candidate.share_safety_registry.share_boundary_summary.final.v0_1"
+      ],
+      "redaction_profile": "public_share_allowlist"
+    },
+    {
+      "fixture_id": "riasec_history_snapshot_preview",
+      "surface": "history",
+      "route_id": "route.top3.I_A_S.qa_v0_1",
+      "expected_state": "fail_closed_missing_selector_asset",
+      "expected_modules": [],
+      "redaction_profile": "history_no_raw_vector_public"
+    },
+    {
+      "fixture_id": "riasec_compare_cross_form_guard_preview",
+      "surface": "compare",
+      "route_id": "route.norm_unavailable.boundary.qa_v0_1",
+      "expected_state": "method_boundary_only",
+      "expected_modules": [],
+      "redaction_profile": "compare_no_raw_delta"
+    },
+    {
+      "fixture_id": "riasec_locked_free_redaction_preview",
+      "surface": "result_page",
+      "route_id": "route.near_tie.R_I.qa_v0_1",
+      "expected_state": "locked_free_redaction_visible",
+      "expected_modules": [],
+      "redaction_profile": "free_mode_no_deep_selector_payload"
+    },
+    {
+      "fixture_id": "riasec_low_quality_preview",
+      "surface": "result_page",
+      "route_id": "route.low_quality.boundary.qa_v0_1",
+      "expected_state": "boundary_only_fail_closed",
+      "expected_modules": [],
+      "redaction_profile": "low_quality_no_strong_profile"
+    },
+    {
+      "fixture_id": "riasec_route_miss_preview",
+      "surface": "result_page",
+      "route_id": "route.miss.qa_v0_1",
+      "expected_state": "omit_result_page_v2_modules",
+      "expected_modules": [],
+      "redaction_profile": "frontend_fallback_forbidden"
+    }
+  ],
+  "public_payload_allowlist": [
+    "title_zh",
+    "summary_zh",
+    "boundary_zh"
+  ]
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38349,7 +38349,7 @@
     "merge_commit": "42a8caacb4f4bfa0fb5a83ecd69c25e3b5e83973"
   },
   "AUDIT-SEC-TRAIN-LEDGER-CLOSEOUT-01": {
-    "status": "ready_to_merge",
+    "status": "merged",
     "branch": "audit/sec-train-ledger-closeout-01",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1804",
     "base": "main",
@@ -56510,14 +56510,18 @@
       "github": {
         "status": "pass",
         "evidence": "PR #2236 GitHub required checks passed on head 3ba6e111314ab5cbbcaf05d06af4d79fd572480c; mergeStateStatus CLEAN."
+      },
+      "post_merge": {
+        "status": "pass",
+        "evidence": "PR #2236 merged at 2026-06-21T17:39:15Z with merge commit cad520e300f42d1c7e191e92b05d9cfbabcb7712; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed; post-merge focused validation passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "235ea2b0a7067a011adf79f5657ed0777754da6b",
+    "commit_sha": "cad520e300f42d1c7e191e92b05d9cfbabcb7712",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2236",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T17:39:15Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-21T22:06:47+08:00",
@@ -56538,6 +56542,11 @@
         "at": "2026-06-22T01:11:04+08:00",
         "status": "ready_to_merge",
         "note": "PR #2236 GitHub checks passed on head 3ba6e111314ab5cbbcaf05d06af4d79fd572480c and merge state is CLEAN; pre-merge scope validation passed."
+      },
+      {
+        "at": "2026-06-22T01:42:13+08:00",
+        "status": "merged",
+        "note": "Post-merge reconciliation confirmed PR #2236 merged at 2026-06-21T17:39:15Z with merge commit cad520e300f42d1c7e191e92b05d9cfbabcb7712; origin/main contains the merge commit; local main equals origin/main; local and remote task branch cleanup completed."
       }
     ]
   },
@@ -56545,7 +56554,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-render-preview-handoff-01",
     "base": "main",
-    "status": "pending_authorization",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures",
     "depends_on": [
@@ -56555,6 +56564,24 @@
       "authorization": {
         "status": "pass",
         "evidence": "User explicitly authorized the eight-item RIASEC Result Page asset-agent PR train and docs/codex manifest/state updates in the goal objective."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "RIASEC-RESULT-ROUTE-MATRIX-GOLDEN-CASE-QA-01 merged as PR #2236; origin/main contains merge commit cad520e300f42d1c7e191e92b05d9cfbabcb7712."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "find backend/content_assets/riasec/result_page_v2/rendered_preview -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\;",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "notes": "Added backend-owned rendered preview fixture manifest, expected assertions, and handoff report covering result page, PDF, share, history, compare, locked/free redaction, low-quality, and fallback surfaces. No fap-web changes, frontend fallback, CMS import, runtime selector wiring, pilot gate, or production gate."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to backend/content_assets/riasec/result_page_v2/rendered_preview and docs/codex state bookkeeping."
       }
     },
     "failure_reason": null,
@@ -56568,6 +56595,11 @@
         "at": "2026-06-21T22:06:47+08:00",
         "status": "pending_authorization",
         "note": "Manifest/state entry authorized for the RIASEC Result Page asset-agent train. Implementation waits for its dependency order."
+      },
+      {
+        "at": "2026-06-22T01:42:13+08:00",
+        "status": "local_checks_passed",
+        "note": "Produced rendered preview handoff fixture manifest, expected assertions, and handoff report. JSON/YAML, diff, and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56554,7 +56554,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-render-preview-handoff-01",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures",
     "depends_on": [
@@ -56582,6 +56582,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to backend/content_assets/riasec/result_page_v2/rendered_preview and docs/codex state bookkeeping."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2237 GitHub required checks passed on head 296f249a9463ae80fa133cfb860b364838c44873; mergeStateStatus CLEAN."
       }
     },
     "failure_reason": null,
@@ -56605,6 +56609,11 @@
         "at": "2026-06-22T01:43:45+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2237 from head 259859f44611903584ce8990daf1f84ba260cfa4; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T01:50:06+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2237 GitHub checks passed on head 296f249a9463ae80fa133cfb860b364838c44873 and merge state is CLEAN; pre-merge scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56554,7 +56554,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-render-preview-handoff-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "riasec_result_page_v2_asset_agent",
     "title": "RIASEC-RESULT-RENDER-PREVIEW-HANDOFF-01: docs(riasec):交付 rendered preview fixtures",
     "depends_on": [
@@ -56585,8 +56585,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "259859f44611903584ce8990daf1f84ba260cfa4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2237",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56600,6 +56600,11 @@
         "at": "2026-06-22T01:42:13+08:00",
         "status": "local_checks_passed",
         "note": "Produced rendered preview handoff fixture manifest, expected assertions, and handoff report. JSON/YAML, diff, and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T01:43:45+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2237 from head 259859f44611903584ce8990daf1f84ba260cfa4; waiting for required GitHub checks."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added backend-owned rendered preview handoff artifacts for RIASEC Result Page V2.
- Added fixture manifest, expected assertions, handoff report, and README under `rendered_preview/handoff_v0_1`.
- Covered result page, PDF, share, history, compare, locked/free redaction, low-quality, and fallback/route-miss surfaces.
- Reconciled the previous route matrix/golden case QA PR state after merge and cleanup.

## Why
- This gives fap-web a backend-authoritative preview QA handoff without adding frontend fallback content or enabling runtime/production gates.

## Validation
- `find backend/content_assets/riasec/result_page_v2/rendered_preview -name "*.json" -print -exec python3 -m json.tool {} >/dev/null \;`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- Scope validation passed: changed files are limited to rendered preview handoff artifacts and docs/codex state bookkeeping.

## Intentionally deferred
- No fap-web changes.
- No frontend fallback content.
- No CMS import, runtime selector wiring, pilot allowlist, production import gate, or production rollout.