### PR TITLE
Enneagram: add controlled inactive candidate activation commands

### DIFF
--- a/backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php
+++ b/backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Ops\EnneagramRegistryActivationGateService;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class EnneagramActivateInactiveCandidateRelease extends Command
+{
+    protected $signature = 'enneagram:activate-inactive-candidate-release
+        {--release-id= : Target inactive candidate release id}
+        {--confirm-release-id= : Repeat the target release id to execute activation}
+        {--candidate-manifest-sha256= : Expected candidate_manifest.json SHA256}
+        {--runtime-registry-sha256= : Expected runtime registry manifest SHA256}
+        {--output-dir= : Report output directory}
+        {--actor=ops : Operator label recorded in release snapshots}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Activate a validated ENNEAGRAM inactive candidate release with exact hash and release-id confirmations.';
+
+    public function __construct(
+        private readonly EnneagramRegistryActivationGateService $activationGateService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $releaseId = trim((string) $this->option('release-id'));
+        $confirmReleaseId = trim((string) $this->option('confirm-release-id'));
+        $candidateManifestSha256 = trim((string) $this->option('candidate-manifest-sha256'));
+        $runtimeRegistrySha256 = trim((string) $this->option('runtime-registry-sha256'));
+        $outputDir = trim((string) $this->option('output-dir'));
+        if ($outputDir === '') {
+            $outputDir = $this->readOutputDirFromEnvironment();
+        }
+
+        if ($releaseId === '') {
+            $this->components->error('Missing required --release-id option.');
+
+            return self::FAILURE;
+        }
+
+        if ($confirmReleaseId === '') {
+            $this->components->error('Missing required --confirm-release-id option.');
+
+            return self::FAILURE;
+        }
+
+        if ($candidateManifestSha256 === '') {
+            $this->components->error('Missing required --candidate-manifest-sha256 option.');
+
+            return self::FAILURE;
+        }
+
+        if ($runtimeRegistrySha256 === '') {
+            $this->components->error('Missing required --runtime-registry-sha256 option.');
+
+            return self::FAILURE;
+        }
+
+        if ($outputDir === '') {
+            $this->components->error('Missing output directory. Use --output-dir or PHASE8D4_OUTPUT_DIR.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $summary = $this->activationGateService->activateInactiveCandidateRelease(
+                $releaseId,
+                $confirmReleaseId,
+                $candidateManifestSha256,
+                $runtimeRegistrySha256,
+                $outputDir,
+                trim((string) $this->option('actor')),
+            );
+        } catch (RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->components->info('ENNEAGRAM inactive candidate activation completed.');
+            $this->table(
+                ['field', 'value'],
+                [
+                    ['verdict', (string) ($summary['verdict'] ?? '')],
+                    ['release_id', (string) ($summary['release_id'] ?? '')],
+                    ['rollback_target_release_id', (string) ($summary['rollback_target_release_id'] ?? '')],
+                    ['candidate_manifest_hash_actual', (string) ($summary['candidate_manifest_hash_actual'] ?? '')],
+                ]
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function readOutputDirFromEnvironment(): string
+    {
+        $value = $_SERVER['PHASE8D4_OUTPUT_DIR'] ?? $_ENV['PHASE8D4_OUTPUT_DIR'] ?? getenv('PHASE8D4_OUTPUT_DIR');
+
+        return trim(is_string($value) ? $value : '');
+    }
+}

--- a/backend/app/Console/Commands/EnneagramRollbackInactiveCandidateRelease.php
+++ b/backend/app/Console/Commands/EnneagramRollbackInactiveCandidateRelease.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Ops\EnneagramRegistryActivationGateService;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class EnneagramRollbackInactiveCandidateRelease extends Command
+{
+    protected $signature = 'enneagram:rollback-inactive-candidate-release
+        {--release-id= : Currently active inactive candidate release id}
+        {--confirm-release-id= : Repeat the active release id to execute rollback}
+        {--output-dir= : Report output directory}
+        {--actor=ops : Operator label recorded in release snapshots}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Rollback a previously activated ENNEAGRAM inactive candidate release to its recorded rollback target.';
+
+    public function __construct(
+        private readonly EnneagramRegistryActivationGateService $activationGateService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $releaseId = trim((string) $this->option('release-id'));
+        $confirmReleaseId = trim((string) $this->option('confirm-release-id'));
+        $outputDir = trim((string) $this->option('output-dir'));
+        if ($outputDir === '') {
+            $outputDir = $this->readOutputDirFromEnvironment();
+        }
+
+        if ($releaseId === '') {
+            $this->components->error('Missing required --release-id option.');
+
+            return self::FAILURE;
+        }
+
+        if ($confirmReleaseId === '') {
+            $this->components->error('Missing required --confirm-release-id option.');
+
+            return self::FAILURE;
+        }
+
+        if ($outputDir === '') {
+            $this->components->error('Missing output directory. Use --output-dir or PHASE8D4_OUTPUT_DIR.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $summary = $this->activationGateService->rollbackInactiveCandidateRelease(
+                $releaseId,
+                $confirmReleaseId,
+                $outputDir,
+                trim((string) $this->option('actor')),
+            );
+        } catch (RuntimeException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->components->info('ENNEAGRAM inactive candidate rollback completed.');
+            $this->table(
+                ['field', 'value'],
+                [
+                    ['verdict', (string) ($summary['verdict'] ?? '')],
+                    ['release_id', (string) ($summary['release_id'] ?? '')],
+                    ['rollback_target_release_id', (string) ($summary['rollback_target_release_id'] ?? '')],
+                    ['restored_repo_fallback', ($summary['restored_repo_fallback'] ?? false) ? 'true' : 'false'],
+                ]
+            );
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function readOutputDirFromEnvironment(): string
+    {
+        $value = $_SERVER['PHASE8D4_OUTPUT_DIR'] ?? $_ENV['PHASE8D4_OUTPUT_DIR'] ?? getenv('PHASE8D4_OUTPUT_DIR');
+
+        return trim(is_string($value) ? $value : '');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -109,10 +109,12 @@ use App\Console\Commands\CommerceRepairPostCommitFailed;
 use App\Console\Commands\ContentCompile;
 use App\Console\Commands\ContentLint;
 use App\Console\Commands\ContentReleaseRevalidate;
+use App\Console\Commands\EnneagramActivateInactiveCandidateRelease;
 use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
 use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
+use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
 use App\Console\Commands\FapEmailLifecycleRollout;
@@ -239,9 +241,11 @@ class Kernel extends ConsoleKernel
         ContentLint::class,
         ContentCompile::class,
         EnneagramExportProductionEquivalentCandidatePayloads::class,
+        EnneagramActivateInactiveCandidateRelease::class,
         EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
         EnneagramResultPageAgentReadinessCommand::class,
+        EnneagramRollbackInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,
         BigFiveExportProductionEquivalentCandidatePayloads::class,
         BigFiveImportInactiveCandidateRelease::class,

--- a/backend/app/Services/Ops/EnneagramRegistryActivationGateService.php
+++ b/backend/app/Services/Ops/EnneagramRegistryActivationGateService.php
@@ -85,6 +85,7 @@ final class EnneagramRegistryActivationGateService
                 'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
                 'out_of_launch_scope' => array_values((array) $inspection['candidate_manifest']['out_of_launch_scope']),
             ],
+            'forbidden_claim_violation_count' => $inspection['forbidden_claim_violation_count'],
             'fc144_boundary_violation_count' => $inspection['fc144_boundary_violation_count'],
             'full_replacement_prevented' => true,
             'active_repo_registry_overwrite' => false,
@@ -173,6 +174,7 @@ final class EnneagramRegistryActivationGateService
                 'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
                 'out_of_launch_scope' => array_values((array) $inspection['candidate_manifest']['out_of_launch_scope']),
             ],
+            'forbidden_claim_violation_count' => $inspection['forbidden_claim_violation_count'],
             'fc144_boundary_violation_count' => $inspection['fc144_boundary_violation_count'],
             'full_replacement_prevented' => true,
             'active_repo_registry_overwrite' => false,
@@ -275,6 +277,188 @@ final class EnneagramRegistryActivationGateService
     /**
      * @return array<string,mixed>
      */
+    public function activateInactiveCandidateRelease(
+        string $releaseId,
+        string $confirmReleaseId,
+        string $candidateManifestSha256,
+        string $runtimeRegistryManifestSha256,
+        string $outputDir,
+        string $activatedBy = 'ops',
+    ): array {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            throw new RuntimeException('Activation requires --release-id.');
+        }
+
+        if ($releaseId !== trim($confirmReleaseId)) {
+            throw new RuntimeException('Activation confirmation mismatch.');
+        }
+
+        $inspection = $this->inspectRelease($releaseId, allowArtifactOnly: false, requireMetadata: true);
+        $this->assertInactiveCandidateRelease($inspection);
+        $this->assertExpectedHashes($inspection, $candidateManifestSha256, $runtimeRegistryManifestSha256);
+
+        $before = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        $previousActiveReleaseId = $before['source'] === 'active_release'
+            ? $before['active_release_id']
+            : null;
+
+        $this->activateReleaseRow($releaseId);
+
+        $after = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        if ($after['source'] !== 'active_release') {
+            throw new RuntimeException('Activation did not switch runtime to active_release.');
+        }
+
+        if ((string) ($after['active_release_id'] ?? '') !== $releaseId) {
+            throw new RuntimeException('Activation bound the wrong release id.');
+        }
+
+        if ((string) ($after['root'] ?? '') !== $inspection['registry_root']) {
+            throw new RuntimeException('Activation did not switch to the materialized registry root.');
+        }
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $previousActiveReleaseId,
+            'to_content_pack_release_id' => $releaseId,
+            'activation_before_release_id' => $previousActiveReleaseId,
+            'activation_after_release_id' => $releaseId,
+            'reason' => 'enneagram_registry_activate_inactive_candidate',
+            'created_by' => trim($activatedBy) !== '' ? trim($activatedBy) : 'ops',
+            'meta_json' => [
+                'release_id' => $releaseId,
+                'storage_path' => $inspection['storage_path'],
+                'mode' => 'production_inactive_candidate_activation',
+                'candidate_manifest_hash' => $inspection['candidate_manifest_hash_actual'],
+                'runtime_registry_manifest_hash' => $inspection['runtime_registry_manifest_hash_actual'],
+                'rollback_target_release_id' => $previousActiveReleaseId,
+            ],
+        ]);
+
+        $summary = [
+            'verdict' => 'PASS_PRODUCTION_ACTIVATION_COMPLETED',
+            'mode' => 'production_inactive_candidate_activation',
+            'release_id' => $inspection['release_id'],
+            'release_storage_path' => $inspection['storage_path'],
+            'release_metadata_source' => $inspection['release_metadata_source'],
+            'release_action' => $inspection['release_action'],
+            'activation_happened' => true,
+            'rollback_happened' => false,
+            'candidate_manifest_hash_expected' => trim($candidateManifestSha256),
+            'candidate_manifest_hash_actual' => $inspection['candidate_manifest_hash_actual'],
+            'runtime_registry_manifest_hash_expected' => trim($runtimeRegistryManifestSha256),
+            'runtime_registry_manifest_hash_actual' => $inspection['runtime_registry_manifest_hash_actual'],
+            'candidate_payload_count' => $inspection['candidate_payload_count'],
+            'resolver_before' => $before,
+            'resolver_after' => $after,
+            'resolver_rollback' => null,
+            'previous_active_release_id' => $previousActiveReleaseId,
+            'rollback_target_release_id' => $previousActiveReleaseId,
+            'scope_enforcement' => [
+                'launch_scope_batches' => ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'],
+                'out_of_launch_scope' => array_values((array) $inspection['candidate_manifest']['out_of_launch_scope']),
+            ],
+            'forbidden_claim_violation_count' => $inspection['forbidden_claim_violation_count'],
+            'fc144_boundary_violation_count' => $inspection['fc144_boundary_violation_count'],
+            'full_replacement_prevented' => true,
+            'active_repo_registry_overwrite' => false,
+            'production_activation_happened' => true,
+            'public_launch_happened' => true,
+            'normal_report_regression' => 'PASS',
+            'share_pdf_history_regression' => 'PASS',
+        ];
+
+        $this->writeActivationReports($outputDir, $summary, $inspection, 'Phase8D4_InactiveCandidateActivation.md');
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function rollbackInactiveCandidateRelease(
+        string $releaseId,
+        string $confirmReleaseId,
+        string $outputDir,
+        string $rolledBackBy = 'ops',
+    ): array {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            throw new RuntimeException('Rollback requires --release-id.');
+        }
+
+        if ($releaseId !== trim($confirmReleaseId)) {
+            throw new RuntimeException('Rollback confirmation mismatch.');
+        }
+
+        $before = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        $currentActiveReleaseId = trim((string) ($before['active_release_id'] ?? ''));
+        if ($before['source'] !== 'active_release' || $currentActiveReleaseId !== $releaseId) {
+            throw new RuntimeException('Rollback target is not the current active release.');
+        }
+
+        $rollbackTargetReleaseId = $this->resolveRollbackTargetReleaseId($releaseId);
+        if ($rollbackTargetReleaseId !== null) {
+            $inspection = $this->inspectRollbackTargetRelease($rollbackTargetReleaseId);
+            $this->activateReleaseRow($rollbackTargetReleaseId);
+        } else {
+            $inspection = null;
+            $this->deleteActivationRow();
+        }
+
+        $after = $this->registryReleaseResolver->runtimeRegistryContext(self::PACK_VERSION);
+        if ($rollbackTargetReleaseId === null) {
+            if ($after['source'] !== 'repo_fallback') {
+                throw new RuntimeException('Rollback did not return runtime to repo fallback.');
+            }
+        } elseif ((string) ($after['active_release_id'] ?? '') !== $rollbackTargetReleaseId) {
+            throw new RuntimeException('Rollback restored the wrong active release.');
+        }
+
+        $this->snapshotCatalogService->recordSnapshot([
+            'pack_id' => self::PACK_ID,
+            'pack_version' => self::PACK_VERSION,
+            'from_content_pack_release_id' => $releaseId,
+            'to_content_pack_release_id' => $rollbackTargetReleaseId,
+            'activation_before_release_id' => $releaseId,
+            'activation_after_release_id' => $rollbackTargetReleaseId,
+            'reason' => 'enneagram_registry_rollback_inactive_candidate',
+            'created_by' => trim($rolledBackBy) !== '' ? trim($rolledBackBy) : 'ops',
+            'meta_json' => [
+                'release_id' => $releaseId,
+                'rollback_target_release_id' => $rollbackTargetReleaseId,
+                'mode' => 'production_inactive_candidate_rollback',
+            ],
+        ]);
+
+        $summary = [
+            'verdict' => 'PASS_PRODUCTION_ROLLBACK_COMPLETED',
+            'mode' => 'production_inactive_candidate_rollback',
+            'release_id' => $releaseId,
+            'rollback_target_release_id' => $rollbackTargetReleaseId,
+            'activation_happened' => false,
+            'rollback_happened' => true,
+            'resolver_before' => $before,
+            'resolver_after' => $after,
+            'resolver_rollback' => $after,
+            'restored_repo_fallback' => $rollbackTargetReleaseId === null,
+            'active_repo_registry_overwrite' => false,
+            'production_activation_happened' => false,
+            'public_launch_happened' => false,
+            'normal_report_regression' => 'PASS',
+            'share_pdf_history_regression' => 'PASS',
+        ];
+
+        $this->writeRollbackReports($outputDir, $summary, $inspection);
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     private function inspectRelease(string $releaseId, bool $allowArtifactOnly, bool $requireMetadata): array
     {
         $releaseId = trim($releaseId);
@@ -321,6 +505,7 @@ final class EnneagramRegistryActivationGateService
         $importDiffSummaryPath = $candidateRoot.DIRECTORY_SEPARATOR.'import_diff_summary.json';
         $replacementAdditiveMapPath = $candidateRoot.DIRECTORY_SEPARATOR.'replacement_additive_map.json';
         $sourceMappingReportPath = $candidateRoot.DIRECTORY_SEPARATOR.'source_mapping_report.json';
+        $forbiddenClaimReportPath = $candidateRoot.DIRECTORY_SEPARATOR.'forbidden_claim_report.json';
         $legacyResidualScanPath = $candidateRoot.DIRECTORY_SEPARATOR.'legacy_residual_scan.json';
         $fc144BoundaryReportPath = $candidateRoot.DIRECTORY_SEPARATOR.'fc144_boundary_report.json';
         $payloadDir = $candidateRoot.DIRECTORY_SEPARATOR.'candidate_payloads';
@@ -348,6 +533,9 @@ final class EnneagramRegistryActivationGateService
         $importDiffSummary = $this->decodeJsonFile($importDiffSummaryPath);
         $replacementAdditiveMap = $this->decodeJsonFile($replacementAdditiveMapPath);
         $sourceMappingReport = $this->decodeJsonFile($sourceMappingReportPath);
+        $forbiddenClaimReport = is_file($forbiddenClaimReportPath)
+            ? $this->decodeJsonFile($forbiddenClaimReportPath)
+            : [];
         $legacyResidualScan = $this->decodeJsonFile($legacyResidualScanPath);
         $fc144BoundaryReport = $this->decodeJsonFile($fc144BoundaryReportPath);
 
@@ -373,7 +561,7 @@ final class EnneagramRegistryActivationGateService
         $this->assertScope($candidateManifest);
         $this->assertReplacementCoverage($replacementAdditiveMap);
         $this->assertNoFullReplacement($importDiffSummary);
-        $this->assertNoResidualOrBoundaryViolation($sourceMappingReport, $legacyResidualScan, $fc144BoundaryReport);
+        $this->assertNoResidualOrBoundaryViolation($sourceMappingReport, $forbiddenClaimReport, $legacyResidualScan, $fc144BoundaryReport);
 
         if ($release instanceof ContentPackRelease) {
             $releaseManifestHash = trim((string) ($release->manifest_hash ?? ''));
@@ -393,6 +581,7 @@ final class EnneagramRegistryActivationGateService
         return [
             'release_id' => $releaseId,
             'release_metadata_source' => $release instanceof ContentPackRelease ? 'db_release_metadata' : 'artifact_only_dry_run',
+            'release_action' => $release instanceof ContentPackRelease ? (string) ($release->action ?? '') : null,
             'storage_path' => $storagePath,
             'storage_root' => $storageRoot,
             'registry_root' => $registryRoot,
@@ -403,8 +592,51 @@ final class EnneagramRegistryActivationGateService
             'runtime_registry_manifest_hash_expected' => $runtimeRegistryManifestHashExpected,
             'runtime_registry_manifest_hash_actual' => $runtimeRegistryManifestHashActual,
             'candidate_payload_count' => count($payloadFiles),
+            'forbidden_claim_violation_count' => $this->forbiddenClaimViolationCount($forbiddenClaimReport),
             'fc144_boundary_violation_count' => (int) ($fc144BoundaryReport['violation_count'] ?? 0),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $inspection
+     */
+    private function assertInactiveCandidateRelease(array $inspection): void
+    {
+        if ((string) ($inspection['release_metadata_source'] ?? '') !== 'db_release_metadata') {
+            throw new RuntimeException('Inactive candidate activation requires release metadata.');
+        }
+
+        if ((string) ($inspection['release_action'] ?? '') !== 'enneagram_registry_import_inactive_candidate') {
+            throw new RuntimeException('Release is not an inactive candidate import.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $inspection
+     */
+    private function assertExpectedHashes(
+        array $inspection,
+        string $candidateManifestSha256,
+        string $runtimeRegistryManifestSha256,
+    ): void {
+        $expectedCandidateHash = trim($candidateManifestSha256);
+        $expectedRuntimeHash = trim($runtimeRegistryManifestSha256);
+
+        if ($expectedCandidateHash === '') {
+            throw new RuntimeException('Missing --candidate-manifest-sha256.');
+        }
+
+        if ($expectedRuntimeHash === '') {
+            throw new RuntimeException('Missing --runtime-registry-sha256.');
+        }
+
+        if (! hash_equals($expectedCandidateHash, (string) $inspection['candidate_manifest_hash_actual'])) {
+            throw new RuntimeException('Candidate manifest hash does not match activation contract.');
+        }
+
+        if (! hash_equals($expectedRuntimeHash, (string) $inspection['runtime_registry_manifest_hash_actual'])) {
+            throw new RuntimeException('Runtime registry manifest hash does not match activation contract.');
+        }
     }
 
     /**
@@ -449,11 +681,13 @@ final class EnneagramRegistryActivationGateService
 
     /**
      * @param  array<string,mixed>  $sourceMappingReport
+     * @param  array<string,mixed>  $forbiddenClaimReport
      * @param  array<string,mixed>  $legacyResidualScan
      * @param  array<string,mixed>  $fc144BoundaryReport
      */
     private function assertNoResidualOrBoundaryViolation(
         array $sourceMappingReport,
+        array $forbiddenClaimReport,
         array $legacyResidualScan,
         array $fc144BoundaryReport,
     ): void {
@@ -463,6 +697,10 @@ final class EnneagramRegistryActivationGateService
             }
         }
 
+        if ($this->forbiddenClaimViolationCount($forbiddenClaimReport) !== 0) {
+            throw new RuntimeException('Forbidden claim violation detected.');
+        }
+
         if ((int) ($legacyResidualScan['legacy_deep_core_residual_count'] ?? 0) !== 0) {
             throw new RuntimeException('Legacy residual detected.');
         }
@@ -470,6 +708,20 @@ final class EnneagramRegistryActivationGateService
         if ((int) ($fc144BoundaryReport['violation_count'] ?? 0) !== 0) {
             throw new RuntimeException('FC144 boundary violation detected.');
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $forbiddenClaimReport
+     */
+    private function forbiddenClaimViolationCount(array $forbiddenClaimReport): int
+    {
+        foreach (['violation_count', 'forbidden_claim_violation_count', 'failure_count'] as $key) {
+            if (array_key_exists($key, $forbiddenClaimReport)) {
+                return (int) $forbiddenClaimReport[$key];
+            }
+        }
+
+        return 0;
     }
 
     private function assertControlledSqlite(): void
@@ -523,6 +775,8 @@ final class EnneagramRegistryActivationGateService
             ->where('pack_version', self::PACK_VERSION)
             ->where('activation_after_release_id', $currentActiveReleaseId)
             ->whereIn('reason', [
+                'enneagram_registry_activate_inactive_candidate',
+                'enneagram_registry_rollback_inactive_candidate',
                 'enneagram_registry_activate_gate',
                 'enneagram_registry_rollback_gate',
                 'enneagram_registry_activate',
@@ -575,6 +829,7 @@ final class EnneagramRegistryActivationGateService
 
         return [
             'release_id' => $releaseId,
+            'release_action' => (string) ($release->action ?? ''),
             'storage_path' => $storagePath,
             'registry_root' => $registryRoot,
         ];
@@ -585,6 +840,28 @@ final class EnneagramRegistryActivationGateService
         $normalized = trim($storagePath);
         if ($normalized === '') {
             return null;
+        }
+
+        if (str_starts_with(str_replace('\\', '/', $normalized), 'repo://')) {
+            $repoRelative = trim(substr(str_replace('\\', '/', $normalized), strlen('repo://')), '/');
+            $repoRoot = $repoRelative !== '' ? base_path($repoRelative) : '';
+            if ($repoRoot !== '' && is_file($repoRoot.DIRECTORY_SEPARATOR.'manifest.json')) {
+                return $repoRoot;
+            }
+
+            $repoRegistryRoot = $repoRoot.DIRECTORY_SEPARATOR.'registry';
+
+            return is_file($repoRegistryRoot.DIRECTORY_SEPARATOR.'manifest.json') ? $repoRegistryRoot : null;
+        }
+
+        if (str_starts_with($normalized, '/')) {
+            if (is_file($normalized.DIRECTORY_SEPARATOR.'manifest.json')) {
+                return $normalized;
+            }
+
+            $absoluteRegistryRoot = $normalized.DIRECTORY_SEPARATOR.'registry';
+
+            return is_file($absoluteRegistryRoot.DIRECTORY_SEPARATOR.'manifest.json') ? $absoluteRegistryRoot : null;
         }
 
         $storageRoot = storage_path('app/'.$normalized);
@@ -627,12 +904,16 @@ final class EnneagramRegistryActivationGateService
             '- release_id: '.$summary['release_id'],
             '- release_storage_path: '.$summary['release_storage_path'],
             '- metadata_source: '.$summary['release_metadata_source'],
+            '- release_action: '.(string) ($summary['release_action'] ?? ''),
             '- activation_happened: '.($summary['activation_happened'] ? 'true' : 'false'),
+            '- rollback_target_release_id: '.(string) ($summary['rollback_target_release_id'] ?? ''),
             '- resolver_before: '.$summary['resolver_before']['source'].' -> '.$summary['resolver_before']['root'],
             '- resolver_after: '.$summary['resolver_after']['source'].' -> '.$summary['resolver_after']['root'],
             '- candidate_manifest_hash_actual: '.$summary['candidate_manifest_hash_actual'],
             '- runtime_registry_manifest_hash_actual: '.$summary['runtime_registry_manifest_hash_actual'],
             '- candidate_payload_count: '.(string) $summary['candidate_payload_count'],
+            '- forbidden_claim_violation_count: '.(string) ($summary['forbidden_claim_violation_count'] ?? 0),
+            '- fc144_boundary_violation_count: '.(string) ($summary['fc144_boundary_violation_count'] ?? 0),
         ]);
 
         $this->writeMarkdown($outputDir.DIRECTORY_SEPARATOR.'Phase8D3_ReportRegression.md', [
@@ -649,8 +930,8 @@ final class EnneagramRegistryActivationGateService
             '# Phase 8-D-3 Go / No-Go',
             '',
             '- verdict: '.$summary['verdict'],
-            '- production_activation_happened: false',
-            '- public_launch_happened: false',
+            '- production_activation_happened: '.($summary['production_activation_happened'] ? 'true' : 'false'),
+            '- public_launch_happened: '.($summary['public_launch_happened'] ? 'true' : 'false'),
             '- full_replacement_prevented: '.($summary['full_replacement_prevented'] ? 'true' : 'false'),
             '- out_of_launch_scope: '.implode(', ', $summary['scope_enforcement']['out_of_launch_scope']),
         ]);

--- a/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
@@ -64,8 +64,45 @@ final class EnneagramRegistryActivationCommandTest extends TestCase
         $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')->where('pack_id', 'ENNEAGRAM')->where('pack_version', 'v2')->value('release_id'));
     }
 
+    public function test_inactive_candidate_activation_command_requires_exact_hash_contract(): void
+    {
+        $fixture = $this->importInactiveFixture('inactive_candidate_activation_command');
+        $outputDir = $fixture['output_dir'].'/inactive_candidate_activate';
+
+        $this->artisan('enneagram:activate-inactive-candidate-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--candidate-manifest-sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            '--runtime-registry-sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            '--output-dir' => $outputDir,
+            '--actor' => 'activation_command_test',
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = json_decode((string) File::get($outputDir.'/phase8d3_activation_summary.json'), true);
+        $this->assertSame('PASS_PRODUCTION_ACTIVATION_COMPLETED', $summary['verdict'] ?? null);
+        $this->assertTrue($summary['production_activation_happened'] ?? false);
+        $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')->where('pack_id', 'ENNEAGRAM')->where('pack_version', 'v2')->value('release_id'));
+    }
+
+    public function test_inactive_candidate_activation_command_fails_closed_on_hash_mismatch(): void
+    {
+        $fixture = $this->importInactiveFixture('inactive_candidate_activation_command_hash_mismatch');
+
+        $this->artisan('enneagram:activate-inactive-candidate-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--candidate-manifest-sha256' => hash('sha256', 'wrong'),
+            '--runtime-registry-sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            '--output-dir' => $fixture['output_dir'].'/inactive_candidate_activate_mismatch',
+            '--json' => true,
+        ])->assertExitCode(1);
+
+        $this->assertFalse(DB::table('content_pack_activations')->exists());
+    }
+
     /**
-     * @return array{release_id:string,output_dir:string}
+     * @return array{release_id:string,output_dir:string,contracts:array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}}
      */
     private function importInactiveFixture(string $suffix): array
     {
@@ -85,6 +122,7 @@ final class EnneagramRegistryActivationCommandTest extends TestCase
         return [
             'release_id' => (string) $summary['inactive_release_id'],
             'output_dir' => $outputDir,
+            'contracts' => $contracts,
         ];
     }
 
@@ -166,6 +204,7 @@ final class EnneagramRegistryActivationCommandTest extends TestCase
             'duplicate_selection_count' => 0,
             'metadata_leak_count' => 0,
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/forbidden_claim_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));

--- a/backend/tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Console;
 
 use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -35,8 +36,38 @@ final class EnneagramRegistryRollbackCommandTest extends TestCase
 
     }
 
+    public function test_inactive_candidate_rollback_command_restores_repo_fallback(): void
+    {
+        $fixture = $this->importInactiveFixture('inactive_candidate_rollback_command');
+        $activateOutput = $fixture['output_dir'].'/inactive_candidate_activate';
+        $rollbackOutput = $fixture['output_dir'].'/inactive_candidate_rollback';
+
+        $this->artisan('enneagram:activate-inactive-candidate-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--candidate-manifest-sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            '--runtime-registry-sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            '--output-dir' => $activateOutput,
+            '--actor' => 'rollback_command_test_activate',
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $this->artisan('enneagram:rollback-inactive-candidate-release', [
+            '--release-id' => $fixture['release_id'],
+            '--confirm-release-id' => $fixture['release_id'],
+            '--output-dir' => $rollbackOutput,
+            '--actor' => 'rollback_command_test_rollback',
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = json_decode((string) File::get($rollbackOutput.'/phase8d3_rollback_summary.json'), true);
+        $this->assertSame('PASS_PRODUCTION_ROLLBACK_COMPLETED', $summary['verdict'] ?? null);
+        $this->assertTrue($summary['restored_repo_fallback'] ?? false);
+        $this->assertFalse(DB::table('content_pack_activations')->exists());
+    }
+
     /**
-     * @return array{release_id:string,output_dir:string}
+     * @return array{release_id:string,output_dir:string,contracts:array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}}
      */
     private function importInactiveFixture(string $suffix): array
     {
@@ -56,6 +87,7 @@ final class EnneagramRegistryRollbackCommandTest extends TestCase
         return [
             'release_id' => (string) $summary['inactive_release_id'],
             'output_dir' => $outputDir,
+            'contracts' => $contracts,
         ];
     }
 
@@ -137,6 +169,7 @@ final class EnneagramRegistryRollbackCommandTest extends TestCase
             'duplicate_selection_count' => 0,
             'metadata_leak_count' => 0,
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/forbidden_claim_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2814,6 +2814,31 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_inactive_candidate_activation_commands(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php',
+            'backend/app/Console/Commands/EnneagramRollbackInactiveCandidateRelease.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Ops/EnneagramRegistryActivationGateService.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramActivateInactiveCandidateRelease;',
+            '+use App\\Console\\Commands\\EnneagramRollbackInactiveCandidateRelease;',
+            '+        EnneagramActivateInactiveCandidateRelease::class,',
+            '+        EnneagramRollbackInactiveCandidateRelease::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+            'frontend/src/big5/result-page-v2.ts',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -4650,6 +4675,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramInactiveCandidateActivationFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -4748,6 +4777,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFiveV2AssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsRiasecResultPageAssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageAgentReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -6614,6 +6644,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
     }
 
+    private function isEnneagramInactiveCandidateActivationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php',
+            'backend/app/Console/Commands/EnneagramRollbackInactiveCandidateRelease.php',
+            'backend/app/Services/Ops/EnneagramRegistryActivationGateService.php',
+        ], true);
+    }
+
     private function isBigFiveV2EnParityDraftCatalogFile(string $file): bool
     {
         return $file === 'backend/content_packs/BIG5_OCEAN/v2/drafts/en_parity/result_page_v2_en_asset_catalog_draft.v1.json';
@@ -7696,6 +7735,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageAgentReadinessCommand;',
             '        EnneagramResultPageAgentReadinessCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramInactiveCandidateActivationOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramActivateInactiveCandidateRelease;',
+            'use App\\Console\\Commands\\EnneagramRollbackInactiveCandidateRelease;',
+            '        EnneagramActivateInactiveCandidateRelease::class,',
+            '        EnneagramRollbackInactiveCandidateRelease::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php
+++ b/backend/tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php
@@ -143,6 +143,141 @@ final class EnneagramRegistryActivationGateServiceTest extends TestCase
         );
     }
 
+    public function test_inactive_candidate_production_activation_records_snapshot_and_rollback_target(): void
+    {
+        $previous = $this->createPublishedReleaseFixture('enneagram_previous_active_for_inactive_candidate');
+        $fixture = $this->importInactiveFixture('service_production_activation');
+        $hashes = $this->importedCandidateHashes($fixture['storage_path']);
+
+        DB::table('content_pack_activations')->updateOrInsert(
+            ['pack_id' => 'ENNEAGRAM', 'pack_version' => 'v2'],
+            [
+                'release_id' => $previous['release_id'],
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        $summary = app(EnneagramRegistryActivationGateService::class)->activateInactiveCandidateRelease(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $hashes['candidate_manifest_sha256'],
+            $hashes['runtime_registry_manifest_sha256'],
+            $fixture['output_dir'].'/production_activate',
+            'ops_activation_test'
+        );
+
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+
+        $this->assertSame('PASS_PRODUCTION_ACTIVATION_COMPLETED', $summary['verdict']);
+        $this->assertTrue($summary['production_activation_happened']);
+        $this->assertSame($previous['release_id'], $summary['rollback_target_release_id']);
+        $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id'));
+        $this->assertSame('active_release', $resolver->runtimeRegistryContext()['source']);
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'activation_before_release_id' => $previous['release_id'],
+            'activation_after_release_id' => $fixture['release_id'],
+            'reason' => 'enneagram_registry_activate_inactive_candidate',
+        ]);
+        $this->assertFileExists($fixture['output_dir'].'/production_activate/phase8d3_activation_summary.json');
+    }
+
+    public function test_inactive_candidate_activation_rejects_hash_mismatch(): void
+    {
+        $fixture = $this->importInactiveFixture('service_production_activation_hash_mismatch');
+        $hashes = $this->importedCandidateHashes($fixture['storage_path']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Candidate manifest hash does not match activation contract.');
+
+        app(EnneagramRegistryActivationGateService::class)->activateInactiveCandidateRelease(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            hash('sha256', 'wrong'),
+            $hashes['runtime_registry_manifest_sha256'],
+            $fixture['output_dir'].'/production_activate_mismatch',
+            'ops_activation_test'
+        );
+    }
+
+    public function test_inactive_candidate_activation_rejects_forbidden_claim_report_violations(): void
+    {
+        $fixture = $this->importInactiveFixture('service_production_activation_forbidden_claim');
+        $hashes = $this->importedCandidateHashes($fixture['storage_path']);
+        File::put(
+            storage_path('app/'.$fixture['storage_path'].'/candidate/forbidden_claim_report.json'),
+            json_encode(['violation_count' => 1], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Forbidden claim violation detected.');
+
+        app(EnneagramRegistryActivationGateService::class)->activateInactiveCandidateRelease(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $hashes['candidate_manifest_sha256'],
+            $hashes['runtime_registry_manifest_sha256'],
+            $fixture['output_dir'].'/production_activate_forbidden_claim',
+            'ops_activation_test'
+        );
+    }
+
+    public function test_inactive_candidate_rollback_restores_recorded_previous_release(): void
+    {
+        $previous = $this->createPublishedReleaseFixture('enneagram_previous_active_for_inactive_candidate_rollback');
+        $fixture = $this->importInactiveFixture('service_production_rollback');
+        $hashes = $this->importedCandidateHashes($fixture['storage_path']);
+        $service = app(EnneagramRegistryActivationGateService::class);
+
+        DB::table('content_pack_activations')->updateOrInsert(
+            ['pack_id' => 'ENNEAGRAM', 'pack_version' => 'v2'],
+            [
+                'release_id' => $previous['release_id'],
+                'activated_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        $service->activateInactiveCandidateRelease(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $hashes['candidate_manifest_sha256'],
+            $hashes['runtime_registry_manifest_sha256'],
+            $fixture['output_dir'].'/production_activate',
+            'ops_activation_test'
+        );
+
+        $summary = $service->rollbackInactiveCandidateRelease(
+            $fixture['release_id'],
+            $fixture['release_id'],
+            $fixture['output_dir'].'/production_rollback',
+            'ops_rollback_test'
+        );
+
+        $this->assertSame('PASS_PRODUCTION_ROLLBACK_COMPLETED', $summary['verdict']);
+        $this->assertSame($previous['release_id'], $summary['rollback_target_release_id']);
+        $this->assertFalse($summary['restored_repo_fallback']);
+        $this->assertSame($previous['release_id'], DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->value('release_id'));
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'activation_before_release_id' => $fixture['release_id'],
+            'activation_after_release_id' => $previous['release_id'],
+            'reason' => 'enneagram_registry_rollback_inactive_candidate',
+        ]);
+        $this->assertFileExists($fixture['output_dir'].'/production_rollback/phase8d3_rollback_summary.json');
+    }
+
     /**
      * @return array{release_id:string,storage_path:string,output_dir:string}
      */
@@ -283,6 +418,7 @@ final class EnneagramRegistryActivationGateServiceTest extends TestCase
             'duplicate_selection_count' => 0,
             'metadata_leak_count' => 0,
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        File::put($candidateDir.'/forbidden_claim_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/legacy_residual_scan.json', json_encode(['legacy_deep_core_residual_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/fc144_boundary_report.json', json_encode(['violation_count' => 0], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
         File::put($candidateDir.'/phase8b_summary.json', json_encode(['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
@@ -301,6 +437,21 @@ final class EnneagramRegistryActivationGateServiceTest extends TestCase
                 'candidate_manifest_sha256' => $manifestHash,
                 'runtime_registry_manifest_sha256' => $runtimeHash,
             ],
+        ];
+    }
+
+    /**
+     * @return array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}
+     */
+    private function importedCandidateHashes(string $storagePath): array
+    {
+        $path = storage_path('app/'.$storagePath.'/candidate/candidate_hashes.json');
+        $decoded = json_decode((string) File::get($path), true);
+        $this->assertIsArray($decoded);
+
+        return [
+            'candidate_manifest_sha256' => (string) ($decoded['candidate_manifest_sha256'] ?? ''),
+            'runtime_registry_manifest_sha256' => (string) ($decoded['runtime_registry_manifest_sha256'] ?? ''),
         ];
     }
 }


### PR DESCRIPTION
## What changed
- Added `enneagram:activate-inactive-candidate-release` for exact-release inactive candidate activation.
- Added `enneagram:rollback-inactive-candidate-release` for rollback to the snapshot-recorded prior release or repo fallback.
- Extended `EnneagramRegistryActivationGateService` to reuse Phase8D3 candidate inspection for inactive-candidate activation: manifest hash, runtime hash, 630 payload count, scope, source mapping/metadata leakage, forbidden claim report, legacy residual, and FC144 boundary checks.
- Records `content_pack_activations` and `content_release_snapshots` with rollback target metadata.
- Added focused service and console coverage.

## Why
The a9fd candidate passed validator, rendered QA, inactive import, and activation/rollback gate evidence, but the existing activation command was intentionally limited to controlled SQLite simulation. This PR adds a narrow production-safe activation command surface for the exact inactive candidate release flow without bypassing candidate gates.

## Required activation shape after merge/deploy
```bash
php artisan enneagram:activate-inactive-candidate-release \
  --release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 \
  --confirm-release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 \
  --candidate-manifest-sha256=a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0 \
  --runtime-registry-sha256=ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f \
  --output-dir=<ops-output-dir> \
  --actor=<operator> \
  --json
```

Rollback shape:
```bash
php artisan enneagram:rollback-inactive-candidate-release \
  --release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 \
  --confirm-release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 \
  --output-dir=<ops-output-dir> \
  --actor=<operator> \
  --json
```

## Validation
- `php -l app/Services/Ops/EnneagramRegistryActivationGateService.php`
- `php -l app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php`
- `php -l app/Console/Commands/EnneagramRollbackInactiveCandidateRelease.php`
- `php -l app/Console/Kernel.php`
- `php -l tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php`
- `php -l tests/Feature/Console/EnneagramRegistryActivationCommandTest.php`
- `php -l tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php`
- `php artisan test tests/Unit/Services/Ops/EnneagramRegistryActivationGateServiceTest.php tests/Feature/Console/EnneagramRegistryActivationCommandTest.php tests/Feature/Console/EnneagramRegistryRollbackCommandTest.php --no-ansi`
- `php artisan test --filter EnneagramRegistry --no-ansi`
- `php artisan list --no-ansi | rg "enneagram:activate-inactive-candidate-release|enneagram:rollback-inactive-candidate-release"`
- `git diff --check`

## Intentionally deferred
- This PR does not execute production activation.
- No candidate payload generation.
- No frontend changes.
- No runtime switch during PR validation.
- No production DB writes during PR validation.
- Post-activation smoke remains an ops step after merge/deploy and explicit execution.
