### PR TITLE
B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -46,6 +46,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('eq60:psychometrics --window=last_90_days')->weeklyOn(1, '04:20')->withoutOverlapping();
+        $schedule->command('big5:result-page-v2-agent audit --strict --json --no-ansi')->dailyAt('04:40')->withoutOverlapping();
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();
         $schedule->command('norms:eq60:drift-check --from=active --to=candidate')->monthlyOn(1, '05:00')->withoutOverlapping();

--- a/backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
+++ b/backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class BigFiveResultPageV2AgentAutomationTest extends TestCase
+{
+    public function test_nightly_audit_is_registered_as_strict_redacted_schedule(): void
+    {
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains(
+                (string) ($event['command'] ?? ''),
+                'big5:result-page-v2-agent audit --strict --json --no-ansi'
+            )
+        );
+
+        $this->assertNotNull(
+            $event,
+            'schedule:list did not include the Big Five V2 strict audit command. Commands: '.json_encode(
+                array_values(array_map(fn (array $item): string => (string) ($item['command'] ?? ''), $events))
+            )
+        );
+        $this->assertSame('40 4 * * *', $event['expression']);
+        $this->assertStringContainsString('--strict', (string) $event['command']);
+        $this->assertStringContainsString('--json', (string) $event['command']);
+        $this->assertStringContainsString('--no-ansi', (string) $event['command']);
+    }
+
+    public function test_strict_nightly_audit_fails_closed_and_keeps_artifacts_redacted(): void
+    {
+        $root = base_path('artifacts/testing/big5-v2-nightly-audit');
+        $artifactRoot = $root.'/artifacts';
+        $sourceLedgerRoot = $root.'/source_ledger';
+
+        $this->deleteDirectory($root);
+        mkdir($sourceLedgerRoot, 0775, true);
+
+        try {
+            file_put_contents($sourceLedgerRoot.'/source_ledger.json', json_encode([
+                'schema_version' => 'malformed',
+                'runtime_use' => 'runtime',
+                'production_use_allowed' => true,
+                'sources' => [],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'audit',
+                '--run-id' => 'nightly-fail-closed',
+                '--artifact-dir' => $artifactRoot,
+                '--source-ledger-dir' => $sourceLedgerRoot,
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(1);
+
+            $runDir = $artifactRoot.'/nightly-fail-closed';
+            foreach ([
+                'input_inventory.json',
+                'validation_report.json',
+                'safety_report.json',
+                'qa_eval_summary.json',
+                'ops_report_summary.json',
+                'go_no_go.md',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $inventory = $this->readJson($runDir.'/input_inventory.json');
+            $this->assertSame('staging_only', $inventory['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($inventory['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) data_get($inventory, 'source_ledger.valid', true));
+            $this->assertStringEndsWith(
+                'artifacts/testing/big5-v2-nightly-audit/source_ledger/source_ledger.json',
+                (string) data_get($inventory, 'source_ledger.primary_ledger_path')
+            );
+            foreach ([
+                'database_write',
+                'cms_write',
+                'frontend_copy_write',
+                'runtime_flag_change',
+                'release_snapshot_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($inventory, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+
+            $qa = $this->readJson($runDir.'/qa_eval_summary.json');
+            $this->assertFalse((bool) data_get($qa, 'ops_metrics.ready_for_pilot', true));
+            $this->assertFalse((bool) data_get($qa, 'ops_metrics.ready_for_runtime', true));
+            $this->assertFalse((bool) data_get($qa, 'ops_metrics.ready_for_production', true));
+
+            $goNoGo = (string) file_get_contents($runDir.'/go_no_go.md');
+            $this->assertStringContainsString('production_use_allowed: false', $goNoGo);
+            $this->assertStringContainsString('ready_for_production: false', $goNoGo);
+
+            $combinedArtifacts = implode("\n", array_map(
+                static fn (string $filename): string => (string) file_get_contents($runDir.'/'.$filename),
+                [
+                    'input_inventory.json',
+                    'validation_report.json',
+                    'safety_report.json',
+                    'qa_eval_summary.json',
+                    'ops_report_summary.json',
+                    'go_no_go.md',
+                ]
+            ));
+            $this->assertStringNotContainsString($root, $combinedArtifacts);
+            $this->assertStringNotContainsString('report_json', $combinedArtifacts);
+            $this->assertStringNotContainsString('report_full_json', $combinedArtifacts);
+            $this->assertStringNotContainsString('payload_json', $combinedArtifacts);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function scheduleListEvents(): array
+    {
+        $process = new Process([PHP_BINARY, base_path('artisan'), 'schedule:list', '--json', '--no-ansi'], base_path());
+        $process->mustRun();
+
+        $decoded = json_decode($process->getOutput(), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+        rmdir($path);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T02:06:00+08:00",
+  "updated_at": "2026-06-22T07:24:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -38415,7 +38415,7 @@
     "branch": "codex/analytics-funnel-ops-org0-visibility-repair-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01 show global org0 funnel rows",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
     ],
@@ -55905,11 +55905,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "7690ad523eab0fd9be50f43377619e71d35a6a56",
+    "commit_sha": "bb6c0abb67dcbb8da214ed2b5418708ce50d8e6c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2232",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T16:43:41Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T01:38:00+08:00",
@@ -55930,6 +55930,71 @@
         "at": "2026-06-22T02:06:00+08:00",
         "status": "ready_to_merge",
         "note": "PR #2232 was rebased onto origin/main bcd4687d0e0539381446a08225ed64a891c9606f, scope validation stayed green, GitHub checks passed on head 7690ad523eab0fd9be50f43377619e71d35a6a56, and mergeStateStatus is CLEAN."
+      },
+      {
+        "at": "2026-06-22T07:10:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01 preflight: GitHub reports PR #2232 merged at 2026-06-21T16:43:41Z with merge commit bb6c0abb67dcbb8da214ed2b5418708ce50d8e6c; origin/main contains the merge commit; local and remote task branches are absent; post-merge strict audit and production ops test had passed."
+      }
+    ]
+  },
+  "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-nightly-audit-scheduler",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big5_result_page_v2_asset_agent_automation",
+    "title": "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit",
+    "depends_on": [
+      "B5-RESULT-M8-PRODUCTION-OPS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the Big Five V2 result-page asset agent full-auto PR train and authorized manifest/state updates for this PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "GitHub shows PR #2232 merged and origin/main contains merge commit bb6c0abb67dcbb8da214ed2b5418708ce50d8e6c."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi",
+          "cd backend && php artisan schedule:list --no-ansi",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Strict audit ok=true with validation_error_count=0 and leak_hit_count=0; AssetAgentTest passed 8 tests/200 assertions; AgentAutomationTest passed 2 tests/35 assertions; schedule:list includes 40 4 * * * php artisan big5:result-page-v2-agent audit --strict --json --no-ansi; YAML/JSON/diff checks passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed PR1 scope: backend/bootstrap/app.php, backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, release snapshot, production import gate, rollout gate, or runtime production enablement changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:10:00+08:00",
+        "status": "in_progress",
+        "note": "Started PR1 from latest origin/main. Scope is nightly strict audit schedule registration, redacted/fail-closed scheduler tests, and docs/codex train registration only."
+      },
+      {
+        "at": "2026-06-22T07:24:00+08:00",
+        "status": "local_validated",
+        "note": "Local validation and scope validation passed for nightly strict audit scheduler PR. Scheduler registration is in bootstrap/app.php because schedule:list uses the Laravel bootstrap schedule in this repo."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:24:00+08:00",
+  "updated_at": "2026-06-22T07:31:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55942,7 +55942,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-nightly-audit-scheduler",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit",
     "depends_on": [
@@ -55976,12 +55976,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2239 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "1a2018316f1a4e2a2743fc2d012a3c501e6d11bf",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2239",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -55995,6 +55995,11 @@
         "at": "2026-06-22T07:24:00+08:00",
         "status": "local_validated",
         "note": "Local validation and scope validation passed for nightly strict audit scheduler PR. Scheduler registration is in bootstrap/app.php because schedule:list uses the Laravel bootstrap schedule in this repo."
+      },
+      {
+        "at": "2026-06-22T07:31:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2239 after local validation and scope validation passed; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:31:00+08:00",
+  "updated_at": "2026-06-22T07:39:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55942,7 +55942,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-nightly-audit-scheduler",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit",
     "depends_on": [
@@ -55975,12 +55975,12 @@
         "evidence": "Changed files are limited to allowed PR1 scope: backend/bootstrap/app.php, backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, release snapshot, production import gate, rollout gate, or runtime production enablement changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2239 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2239 checks completed successfully on head 85841992376a4c5419901cf672ed6f1584a4b1be; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "1a2018316f1a4e2a2743fc2d012a3c501e6d11bf",
+    "commit_sha": "85841992376a4c5419901cf672ed6f1584a4b1be",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2239",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56000,6 +56000,11 @@
         "at": "2026-06-22T07:31:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2239 after local validation and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T07:39:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24427,6 +24427,44 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-M8-PRODUCTION-OPS-01
+    branch: codex/big5-v2-nightly-audit-scheduler
+    title: "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit"
+    train_scope: big5_result_page_v2_asset_agent_automation
+    status: user_authorized
+    scope:
+      - Add a safe scheduled/external-cron runner for `php artisan big5:result-page-v2-agent audit --strict --json --no-ansi`.
+      - Persist redacted audit artifacts only.
+      - Ensure the scheduler does not change production rollout, CMS writes, frontend writes, release snapshots, production import gates, or rollout gates.
+      - Add tests proving the scheduled audit is strict, redacted, staging/not_runtime only, and fails closed.
+    allowed_paths:
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add fap-web copy, generate final frontend payloads, make big5_report_engine_v2 primary, enable production rollout, or touch release/import/rollout gates.
+      - Add auto PR, CI inspector, mechanical fixer, auto merge, cleanup, or weekly ops runner behavior in this PR.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi
+      - cd backend && php artisan schedule:list --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
     repo: fap-api
     branch: codex/riasec-result-asset-agent-runbook-01


### PR DESCRIPTION
## What changed
- Registers the Big Five V2 result-page asset agent strict audit in the Laravel scheduler at `04:40`.
- Adds focused automation tests proving the scheduled command is strict/redacted and that malformed source-ledger input fails closed while preserving staging-only artifacts.
- Registers the authorized PR-train item and reconciles the already-merged M8 dependency state.

## Why
This is PR1 of the Big Five V2 result-page asset agent full-auto train. It gives the agent a safe nightly audit entrypoint without enabling candidate generation, production import, rollout, or frontend copy changes.

## Validation
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit --strict --json --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi`
- `cd backend && php artisan schedule:list --no-ansi`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy or `fap-web` changes.
- No final frontend `big5_result_page_v2` payload generation.
- No production/runtime gate, release snapshot, production import gate, or rollout gate changes.
- No auto PR orchestration, CI inspector/mechanical fixer, auto-merge cleanup, or weekly Ops runner behavior in this PR.
- Legacy `big5_report_engine_v2` remains fallback only.

Repository rule impact: backend remains the authority for Big Five V2 result-page content assets; this PR only schedules a read-only strict audit and keeps artifacts staging/not-runtime only.
