### PR TITLE
RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook

### DIFF
--- a/backend/docs/riasec/result-ops-agent-runbook.md
+++ b/backend/docs/riasec/result-ops-agent-runbook.md
@@ -1,0 +1,101 @@
+# RIASEC Result Page Ops Agent Runbook
+
+Status: `RIASEC-OPS-AGENT-RUNBOOK-01`
+
+This runbook defines the operating contract for the Holland/RIASEC result page ops agent. It authorizes auto-to-PR, auto-to-staging, and auto-to-report workflows. It does not authorize automatic production rollout, production CMS writes, production import, or production gate enablement.
+
+## Operating Boundary
+
+The ops agent may automate:
+
+- creating scoped PR branches from latest `main`;
+- validating PR-train manifest and state entries;
+- running local checks and scope validation;
+- opening pull requests and polling required GitHub checks;
+- producing staging-only dry-run artifacts and preview reports;
+- writing go/no-go reports and sidecar issues for blockers not introduced by the current PR.
+
+The ops agent must not automate:
+
+- production rollout execution;
+- production CMS writes or imports;
+- production gate enablement;
+- production environment flag mutation;
+- frontend-authored RIASEC interpretation fallback;
+- public release of private score, raw score, vector, percentile, selector trace, source, QA, or editor metadata.
+
+Production may be prepared only as a manual approval gate with validation evidence, rollback or kill-switch instructions, and post-deploy smoke procedures.
+
+## Required Sequence
+
+The program is split into fourteen PR-train tasks:
+
+1. `RIASEC-OPS-AGENT-RUNBOOK-01`: document the ops-agent boundary, stage gates, and forbidden actions.
+2. `RIASEC-OPS-AGENT-PERMISSION-MODEL-01`: define the permission model for auto-to-PR, auto-to-staging, and auto-to-report.
+3. `RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01`: implement the PR-train orchestration wrapper.
+4. `RIASEC-OPS-AGENT-STAGING-RUNNER-01`: implement staging dry-run, preview, and smoke runner support.
+5. `RIASEC-OPS-AGENT-REPORTING-SIDECAR-01`: implement go/no-go and sidecar issue reporting.
+6. `RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01`: hand backend fixtures to fap-web rendered preview QA.
+7. `RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01`: create backend staging import handoff governance.
+8. `RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01`: fill route-specific selector coverage gaps.
+9. `RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01`: run staging import dry-run validation.
+10. `RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01`: add staging-gated runtime wrapper wiring.
+11. `RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01`: add pilot allowlist and kill-switch controls.
+12. `RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01`: validate all pilot surfaces.
+13. `RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01`: define production import gate and release evidence.
+14. `RIASEC-RESULT-PRODUCTION-ROLLOUT-GATE-01`: define manual production rollout gate, rollback, and smoke procedures.
+
+Each task is one PR scope. A task must not implement future PR behavior before its dependency has merged into `main`.
+
+## Stage Gates
+
+The allowed stage progression is:
+
+1. `manifest_authorized`
+2. `branch_created`
+3. `local_checks_passed`
+4. `scope_validation_passed`
+5. `pull_request_open`
+6. `github_required_checks_green`
+7. `merged`
+8. `main_synced`
+9. `branch_cleaned`
+10. `post_merge_revalidated`
+
+Staging dry-runs may produce reports and artifacts only under staging paths. A staging artifact must keep:
+
+- `runtime_use=staging_only`;
+- `production_use_allowed=false`;
+- `ready_for_runtime=false` until an explicit runtime PR changes only the staging wrapper;
+- `ready_for_production=false`;
+- `cms_write_performed=false`;
+- `runtime_change_performed=false` unless the current runtime-wrapper PR explicitly permits it.
+
+## Sidecar Policy
+
+If a blocker is not introduced by the current PR and the current PR has green required checks plus clean scope validation, the ops agent records the blocker as a sidecar issue and continues the train. Sidecar records must include:
+
+- blocker title;
+- introduced-by-current-PR flag;
+- evidence path or command output summary;
+- severity;
+- whether it blocks current merge;
+- recommended follow-up PR or manual action.
+
+Current-PR failures still block progression.
+
+## Stop Conditions
+
+Stop immediately when:
+
+- local checks for the current PR fail;
+- GitHub required checks fail;
+- changed files drift outside the manifest scope;
+- a dependency is not merged into `main`;
+- the worktree cannot isolate the current scope;
+- production rollout, production CMS write, or production gate enablement would be required to proceed;
+- any public payload contains private score, raw score, vector, percentile, selector trace, source, QA, editor, internal metadata, attempt id, user id, or private URL fields.
+
+## Production Rule
+
+Production rollout remains manual. The final production rollout gate may verify configuration, approval evidence, rollback readiness, kill-switch behavior, and post-deploy smoke procedures, but it must not execute the production rollout or mutate production configuration automatically.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56750,5 +56750,420 @@
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2223 for FREE-FULL-REPORT-MODE-FEATURE-FLAG-01 after local checks passed."
       }
     ]
+  },
+  "RIASEC-OPS-AGENT-RUNBOOK-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-ops-agent-runbook-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook",
+    "depends_on": [],
+    "checks": {
+      "json_tool_pr_train_state": "passed",
+      "yaml_parse_pr_train_manifest": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T07:15:40+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Docs-only runbook, manifest/state parse, git diff check, and path scope validation passed before commit."
+      }
+    ]
+  },
+  "RIASEC-OPS-AGENT-PERMISSION-MODEL-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-ops-agent-permission-model-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model",
+    "depends_on": [
+      "RIASEC-OPS-AGENT-RUNBOOK-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-ops-agent-pr-train-orchestrator-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01: feat(riasec): add ops PR train orchestrator",
+    "depends_on": [
+      "RIASEC-OPS-AGENT-PERMISSION-MODEL-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-OPS-AGENT-STAGING-RUNNER-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-ops-agent-staging-runner-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner",
+    "depends_on": [
+      "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-ops-agent-reporting-sidecar-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar",
+    "depends_on": [
+      "RIASEC-OPS-AGENT-STAGING-RUNNER-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01": {
+    "repo": "fap-web",
+    "branch": "codex/riasec-result-fapweb-rendered-preview-qa-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01: test(riasec): add rendered preview QA",
+    "depends_on": [
+      "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-backend-staging-import-handoff-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff",
+    "depends_on": [
+      "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-selector-coverage-batch-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01: content(riasec): fill selector coverage gaps",
+    "depends_on": [
+      "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-staging-import-dry-run-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run",
+    "depends_on": [
+      "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-runtime-wrapper-staging-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01: feat(riasec): add staging runtime wrapper gate",
+    "depends_on": [
+      "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-pilot-allowlist-gate-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate",
+    "depends_on": [
+      "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-all-surface-pilot-qa-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA",
+    "depends_on": [
+      "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-production-import-gate-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01: test(riasec): add production import gate",
+    "depends_on": [
+      "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "RIASEC-RESULT-PRODUCTION-ROLLOUT-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/riasec-result-production-rollout-gate-01",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "riasec_result_ops_agent_release_chain",
+    "title": "RIASEC-RESULT-PRODUCTION-ROLLOUT-GATE-01: test(riasec): add production rollout gate",
+    "depends_on": [
+      "RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01"
+    ],
+    "checks": {},
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "production_auto_rollout_allowed": false,
+    "production_cms_write_allowed": false,
+    "production_gate_auto_enable_allowed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T07:12:59+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56755,7 +56755,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-runbook-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook",
     "depends_on": [],
@@ -56763,11 +56763,12 @@
       "json_tool_pr_train_state": "passed",
       "yaml_parse_pr_train_manifest": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "3af8b1ab6ea62140c1ae2a631f23533990f3920e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2240",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56786,6 +56787,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Docs-only runbook, manifest/state parse, git diff check, and path scope validation passed before commit."
+      },
+      {
+        "at": "2026-06-22T07:17:03+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2240 after local checks and path scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56755,7 +56755,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-runbook-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook",
     "depends_on": [],
@@ -56764,10 +56764,12 @@
       "yaml_parse_pr_train_manifest": "passed",
       "git_diff_check": "passed",
       "scope_validation": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "merge_state": "clean"
     },
     "failure_reason": null,
-    "commit_sha": "3af8b1ab6ea62140c1ae2a631f23533990f3920e",
+    "commit_sha": "23a536e7fcf45d0d9359ccf349884b166792290a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2240",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56793,6 +56795,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2240 after local checks and path scope validation passed."
+      },
+      {
+        "at": "2026-06-22T07:22:17+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks passed and PR merge state was CLEAN before merge."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26019,3 +26019,435 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: RIASEC-OPS-AGENT-RUNBOOK-01
+    repo: fap-api
+    branch: codex/riasec-ops-agent-runbook-01
+    title: "RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Document auto-to-PR, auto-to-staging, and auto-to-report boundaries for the RIASEC result page ops agent.
+      - Document production as a manual approval gate only.
+      - Document forbidden production rollout, CMS write, runtime enablement, and frontend fallback actions.
+    allowed_paths:
+      - backend/docs/riasec/result-ops-agent-runbook.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate assets.
+      - Modify runtime code.
+      - Import CMS content.
+      - Open production gates.
+    validation:
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-OPS-AGENT-PERMISSION-MODEL-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-OPS-AGENT-RUNBOOK-01
+    branch: codex/riasec-ops-agent-permission-model-01
+    title: "RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Define allowed and forbidden permissions for branch, validation, PR, staging dry-run, and reporting automation.
+      - Forbid production CMS writes and production rollout execution.
+    allowed_paths:
+      - backend/docs/riasec/**
+      - backend/content_assets/riasec/result_page_v2/governance/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - git diff --check
+      - jq empty on touched JSON files
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-OPS-AGENT-PERMISSION-MODEL-01
+    branch: codex/riasec-ops-agent-pr-train-orchestrator-01
+    title: "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01: feat(riasec): add ops PR train orchestrator"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add backend ops command, service, and tests for manifest/state driven PR train orchestration status.
+      - Model branch, scope validation, push, PR, and check polling states without bypassing repository policy.
+    allowed_paths:
+      - backend/app/Console/Commands/*Riasec*Ops*
+      - backend/app/Services/Riasec/Ops/**
+      - backend/tests/**/RiasecOpsAgent*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecOpsAgent
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-OPS-AGENT-STAGING-RUNNER-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01
+    branch: codex/riasec-ops-agent-staging-runner-01
+    title: "RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add staging dry-run, preview, and smoke runner support.
+      - Write only staging artifacts and reports.
+    allowed_paths:
+      - backend/app/Console/Commands/*Riasec*Ops*
+      - backend/app/Services/Riasec/Ops/**
+      - backend/artifacts/riasec_result_page_v2_agent/**
+      - backend/tests/**/RiasecOpsAgent*
+      - backend/tests/**/RiasecResultPage*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecOpsAgent
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-OPS-AGENT-REPORTING-SIDECAR-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-OPS-AGENT-STAGING-RUNNER-01
+    branch: codex/riasec-ops-agent-reporting-sidecar-01
+    title: "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add go/no-go, sidecar issue, failure attribution, and next-step report support.
+      - Allow external blockers to be recorded without stopping the train when current PR checks and scope are clean.
+    allowed_paths:
+      - backend/docs/riasec/**
+      - backend/app/Services/Riasec/Ops/**
+      - backend/tests/**/RiasecOpsAgent*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecOpsAgent
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01
+    repo: fap-web
+    depends_on:
+      - RIASEC-OPS-AGENT-REPORTING-SIDECAR-01
+    branch: codex/riasec-result-fapweb-rendered-preview-qa-01
+    title: "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01: test(riasec): add rendered preview QA"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Consume backend handoff fixtures and expected assertions in fap-web contract tests.
+      - Cover result page, PDF, share, history, compare, locked/free redaction, low-quality, and fallback.
+      - Preserve backend authority and no frontend fallback copy.
+    allowed_paths:
+      - tests/contracts/**
+      - tests/fixtures/riasec/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - pnpm test:contract -- riasec
+      - pnpm typecheck
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01
+    branch: codex/riasec-result-backend-staging-import-handoff-01
+    title: "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add staging import handoff governance, import package list, checksum, acceptance matrix, and runtime no-touch policy.
+      - Do not write CMS data.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/governance/**
+      - backend/docs/riasec/**
+      - backend/tests/**/RiasecResultPage*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - jq empty on touched JSON files
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01
+    branch: codex/riasec-result-selector-coverage-batch-01
+    title: "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01: content(riasec): fill selector coverage gaps"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add staging-only selector assets for clear primary, near tie, top3, low-quality, and norm-unavailable route groups.
+      - Preserve raw draft, repaired draft, final assets, QA report, and safety report.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/**
+      - backend/tests/**/RiasecResultPage*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan riasec:result-page-v2-agent audit --strict --json
+      - cd backend && php artisan test --filter=RiasecResultPageAssetAgent
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - jq empty on touched JSON files
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01
+    branch: codex/riasec-result-staging-import-dry-run-01
+    title: "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add staging import dry-run report, checksum, inventory, leak scan, and fail-closed report support.
+      - Do not write CMS data.
+    allowed_paths:
+      - backend/app/Console/Commands/*Riasec*
+      - backend/app/Services/Riasec/**
+      - backend/content_assets/riasec/result_page_v2/**
+      - backend/tests/**/RiasecResultPage*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan riasec:result-page-v2-agent audit --strict --json
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01
+    branch: codex/riasec-result-runtime-wrapper-staging-01
+    title: "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01: feat(riasec): add staging runtime wrapper gate"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add RIASEC result_page_v2 runtime wrapper with default-off staging and pilot gate behavior.
+      - Omit invalid payloads and fail closed for locked/free redaction states.
+    allowed_paths:
+      - backend/config/**
+      - backend/app/Services/Riasec/**
+      - backend/app/Services/Report/**
+      - backend/app/Http/Controllers/API/V0_3/**
+      - backend/tests/**/RiasecResultPage*
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan test --filter=RiasecAssessmentFlowTest
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01
+    branch: codex/riasec-result-pilot-allowlist-gate-01
+    title: "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add attempt, user, anon, org, form, locale, and environment allowlist gates.
+      - Add kill switch and pilot observability.
+      - Keep production default denied.
+    allowed_paths:
+      - backend/config/**
+      - backend/app/Services/Riasec/**
+      - backend/tests/**/RiasecPilot*
+      - backend/tests/**/RiasecResultPage*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan test --filter=RiasecPilot
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01
+    branch: codex/riasec-result-all-surface-pilot-qa-01
+    title: "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add all-surface pilot QA evidence for result, PDF, share, history, compare, locked/free, low-quality, and fallback surfaces.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/tests/**/RiasecResultPage*
+      - backend/tests/Feature/V0_3/RiasecAssessmentFlowTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan test --filter=RiasecAssessmentFlowTest
+      - jq empty on touched JSON files
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01
+    branch: codex/riasec-result-production-import-gate-01
+    title: "RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01: test(riasec): add production import gate"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add production import gate policy, release snapshot, and approval evidence.
+      - Reject staging-only artifacts and keep production disabled.
+    allowed_paths:
+      - backend/content_assets/riasec/result_page_v2/governance/**
+      - backend/content_assets/riasec/result_page_v2/releases/**
+      - backend/tests/**/RiasecResultPage*
+      - backend/tests/**/ImportGate*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan test --filter=ImportGate
+      - jq empty on touched JSON files
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: RIASEC-RESULT-PRODUCTION-ROLLOUT-GATE-01
+    repo: fap-api
+    depends_on:
+      - RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01
+    branch: codex/riasec-result-production-rollout-gate-01
+    title: "RIASEC-RESULT-PRODUCTION-ROLLOUT-GATE-01: test(riasec): add production rollout gate"
+    train_scope: riasec_result_ops_agent_release_chain
+    status: user_authorized
+    scope:
+      - Add manual approval gate, configuration validation, tenant/form/locale scope, percentage max, rollback and kill-switch checks, and post-deploy smoke procedures.
+      - Do not execute production rollout automatically.
+    allowed_paths:
+      - backend/config/**
+      - backend/app/Services/Riasec/**
+      - backend/content_assets/riasec/result_page_v2/governance/**
+      - backend/content_assets/riasec/result_page_v2/qa/**
+      - backend/tests/**/RiasecResultPage*
+      - backend/tests/**/ProductionRuntime*
+      - backend/tests/**/RolloutGate*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=RiasecResultPage
+      - cd backend && php artisan test --filter=ProductionRuntime
+      - cd backend && php artisan test --filter=RolloutGate
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added the RIASEC result page ops agent runbook for auto-to-PR, auto-to-staging, and auto-to-report workflows.
- Registered the 14-item RIASEC ops agent and release-chain PR train in `docs/codex/pr-train.yaml`.
- Initialized `docs/codex/pr-train-state.json` entries for the train from the explicit `/goal` authorization.

## Why
This fixes the operating boundary before any automation or release-chain implementation starts. Production rollout remains a manual approval gate and is not automated by this train.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- path scope validation against the current PR allowlist

## Intentionally deferred
- No runtime code changes.
- No asset generation.
- No CMS import or write.
- No staging import execution.
- No production gate enablement.
- No production rollout execution.

## Repository rule impact
This PR updates RIASEC ops governance only. It keeps RIASEC result content backend-authoritative and does not introduce frontend fallback content or production publishing behavior.
