### PR TITLE
MBTI64-COMPARISON-AGENT-PROJECTION-LIVE-READ-CONTRACT-01

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -320,10 +320,13 @@ class PersonalityController extends Controller
     private function comparisonMeta(string $baseTypeCode, string $locale, ?array $comparisonOverlay = null): array
     {
         $overlaySeo = is_array($comparisonOverlay['seo'] ?? null) ? $comparisonOverlay['seo'] : [];
-        $title = $this->normalizedString($overlaySeo['seo_title'] ?? null) ?? ($locale === 'zh-CN'
+        $title = $this->normalizedString($overlaySeo['seo_title'] ?? null)
+            ?? $this->normalizedString($overlaySeo['title'] ?? null)
+            ?? ($locale === 'zh-CN'
             ? $baseTypeCode.'-A 和 '.$baseTypeCode.'-T 区别：特点、职业、爱情与稀有度'
             : $baseTypeCode.'-A vs '.$baseTypeCode.'-T: Traits, Careers, Love & Rarity');
         $description = $this->normalizedString($overlaySeo['seo_description'] ?? null)
+            ?? $this->normalizedString($overlaySeo['description'] ?? null)
             ?? $this->normalizedString($overlaySeo['quick_answer_summary'] ?? null)
             ?? ($locale === 'zh-CN'
             ? '对比 '.$baseTypeCode.'-A 与 '.$baseTypeCode.'-T 的 A/T 区别、核心特点、爱情关系、适合职业、优势盲点、稀有度，并通过 MBTI 测试确认自己的类型。'
@@ -498,6 +501,7 @@ class PersonalityController extends Controller
             'faq' => is_array($payload['faq'] ?? null) ? array_values((array) $payload['faq']) : [],
             'internal_links' => is_array($payload['internal_links'] ?? null) ? array_values((array) $payload['internal_links']) : [],
             'source' => $this->normalizedString($payload['source'] ?? null) ?? 'mbti64_comparison_a_vs_t',
+            'snapshot_key' => $this->normalizedString($payload['snapshot_key'] ?? null),
         ];
     }
 
@@ -518,31 +522,42 @@ class PersonalityController extends Controller
         $seo = is_array($comparisonOverlay['seo'] ?? null) ? $comparisonOverlay['seo'] : [];
         $content = is_array($comparisonOverlay['content'] ?? null) ? $comparisonOverlay['content'] : [];
         $blocks = $this->mbti64PromotedComparisonBlocks($content);
-        if ($blocks === []) {
+        $title = $this->normalizedString($seo['h1'] ?? null)
+            ?? $this->normalizedString($seo['seo_title'] ?? null)
+            ?? $this->normalizedString($seo['title'] ?? null);
+        $description = $this->normalizedString($seo['quick_answer_summary'] ?? null)
+            ?? $this->normalizedString($content['quick_answer'] ?? null)
+            ?? $this->normalizedString($seo['seo_description'] ?? null)
+            ?? $this->normalizedString($seo['description'] ?? null);
+        $faq = $this->mbti64PromotedComparisonFaq($comparisonOverlay);
+        $internalLinks = $this->mbti64PromotedComparisonInternalLinks($comparisonOverlay, $locale);
+
+        if ($blocks === [] && $title === null && $description === null && $faq === [] && $internalLinks === []) {
             return $projection;
         }
 
+        $snapshotKey = $this->normalizedString($comparisonOverlay['snapshot_key'] ?? null)
+            ?? 'mbti64_comparison_draft_v2_1';
+
         $projection['comparison_contract_version'] = 'mbti.at_comparison.v1.mbti64_overlay';
-        $projection['title'] = $this->normalizedString($seo['h1'] ?? null)
-            ?? $this->normalizedString($seo['seo_title'] ?? null)
-            ?? ($projection['title'] ?? null);
-        $projection['description'] = $this->normalizedString($seo['quick_answer_summary'] ?? null)
-            ?? $this->normalizedString($content['quick_answer'] ?? null)
-            ?? $this->normalizedString($seo['seo_description'] ?? null)
-            ?? ($projection['description'] ?? null);
-        $projection['comparison_blocks'] = $blocks;
+        $projection['title'] = $title ?? ($projection['title'] ?? null);
+        $projection['description'] = $description ?? ($projection['description'] ?? null);
+        if ($blocks !== []) {
+            $projection['comparison_blocks'] = $blocks;
+        }
         $projection['source_refs'] = array_values(array_unique(array_merge(
             (array) ($projection['source_refs'] ?? []),
             [
                 'personality_profile_sections.mbti64_comparison_a_vs_t',
-                'mbti64_comparison_draft_v2_1',
+                $snapshotKey,
             ]
         )));
-        $projection['faq'] = $this->mbti64PromotedComparisonFaq($comparisonOverlay);
-        $projection['internal_links'] = $this->mbti64PromotedComparisonInternalLinks($comparisonOverlay, $locale);
+        $projection['faq'] = $faq;
+        $projection['internal_links'] = $internalLinks;
         $projection['overlay_source'] = [
             'section_key' => 'mbti64_comparison_a_vs_t',
             'source' => $comparisonOverlay['source'] ?? 'mbti64_comparison_a_vs_t',
+            'snapshot_key' => $snapshotKey,
             'base_type_code' => $baseTypeCode,
         ];
 

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -885,6 +885,139 @@ final class PersonalityPublicApiTest extends TestCase
         self::assertStringNotContainsString('Old generated assertive difference.', (string) $response->getContent());
     }
 
+    public function test_personality_comparison_endpoint_reads_agent_projection_overlay_without_comparison_blocks(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'type_name' => 'Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'INTJ Personality Type',
+            'seo_description' => 'Explore INTJ traits.',
+            'robots' => 'index,follow',
+        ]);
+
+        $assertive = $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($assertive, [
+            'seo_title' => 'Old INTJ-A title',
+            'seo_description' => 'Old INTJ-A description.',
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $assertive->id,
+            'section_key' => 'traits.at_difference',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Old generated assertive difference kept as fallback.',
+            'sort_order' => 31,
+            'is_enabled' => true,
+        ]);
+
+        $turbulent = $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect Turbulent',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($turbulent, [
+            'seo_title' => 'Old INTJ-T title',
+            'seo_description' => 'Old INTJ-T description.',
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $turbulent->id,
+            'section_key' => 'traits.at_difference',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Old generated turbulent difference kept as fallback.',
+            'sort_order' => 31,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'mbti64_comparison_a_vs_t',
+            'title' => 'INTJ-A vs INTJ-T: Agent Projection',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ-A and INTJ-T share the Architect core.',
+            'payload_json' => [
+                'snapshot_key' => 'mbti64_agent_projection_draft_v1',
+                'source' => 'mbti64_agent_projection_draft_v1',
+                'seo' => [
+                    'title' => 'INTJ-A vs INTJ-T: Confidence, Stress and Work Style | FermatMind',
+                    'description' => 'Compare INTJ-A and INTJ-T through strategy, independence, confidence, stress recovery and feedback style.',
+                ],
+                'content' => [
+                    'quick_answer' => 'INTJ-A and INTJ-T share the same Architect core. The useful difference is how each style handles confidence, pressure, feedback and self-correction.',
+                ],
+                'faq' => [
+                    [
+                        'id' => 'intj-a-vs-intj-t-main-difference',
+                        'question' => 'What is the main INTJ-A vs INTJ-T difference?',
+                        'answer' => 'The main difference is confidence style and pressure recovery, not a better or worse INTJ type.',
+                    ],
+                ],
+                'internal_links' => [
+                    [
+                        'href' => '/en/personality/intj-a',
+                        'anchor_text' => 'INTJ-A profile',
+                        'role' => 'assertive_detail',
+                        'safe_public_route' => true,
+                    ],
+                    [
+                        'href' => '/en/results/lookup',
+                        'anchor_text' => 'Private result lookup',
+                        'role' => 'unsafe_result_lookup',
+                        'safe_public_route' => true,
+                    ],
+                ],
+            ],
+            'sort_order' => 920,
+            'is_enabled' => true,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/comparisons/intj-a-vs-intj-t?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('seo_meta.seo_title', 'INTJ-A vs INTJ-T: Confidence, Stress and Work Style | FermatMind')
+            ->assertJsonPath('seo_meta.seo_description', 'Compare INTJ-A and INTJ-T through strategy, independence, confidence, stress recovery and feedback style.')
+            ->assertJsonPath('seo_surface_v1.title', 'INTJ-A vs INTJ-T: Confidence, Stress and Work Style | FermatMind')
+            ->assertJsonPath('seo_surface_v1.description', 'Compare INTJ-A and INTJ-T through strategy, independence, confidence, stress recovery and feedback style.')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_contract_version', 'mbti.at_comparison.v1.mbti64_overlay')
+            ->assertJsonPath('comparison_public_projection_v1.title', 'INTJ-A vs INTJ-T: Confidence, Stress and Work Style | FermatMind')
+            ->assertJsonPath('comparison_public_projection_v1.description', 'INTJ-A and INTJ-T share the same Architect core. The useful difference is how each style handles confidence, pressure, feedback and self-correction.')
+            ->assertJsonPath('comparison_public_projection_v1.comparison_blocks.0.key', 'at_difference')
+            ->assertJsonPath('comparison_public_projection_v1.faq.0.question', 'What is the main INTJ-A vs INTJ-T difference?')
+            ->assertJsonPath('comparison_public_projection_v1.internal_links.0.href', '/en/personality/intj-a')
+            ->assertJsonPath('comparison_public_projection_v1.overlay_source.snapshot_key', 'mbti64_agent_projection_draft_v1')
+            ->assertJsonPath('answer_surface_v1.summary_blocks.0.body', 'INTJ-A and INTJ-T share the same Architect core. The useful difference is how each style handles confidence, pressure, feedback and self-correction.')
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.question', 'What is the main INTJ-A vs INTJ-T difference?')
+            ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/personality/intj-a');
+
+        self::assertContains('mbti64_agent_projection_draft_v1', (array) $response->json('comparison_public_projection_v1.source_refs'));
+        self::assertStringContainsString(
+            'Old generated assertive difference kept as fallback.',
+            (string) $response->getContent(),
+        );
+        self::assertStringNotContainsString('/en/results/lookup', (string) $response->getContent());
+    }
+
     public function test_personality_comparison_endpoint_requires_complete_published_pair(): void
     {
         $profile = $this->createProfile([


### PR DESCRIPTION
## What changed
- Updated the MBTI64 comparison API overlay reader to consume `mbti64_agent_projection_draft_v1` comparison payloads.
- `seo.title` and `seo.description` now feed comparison SEO metadata when present.
- `content.quick_answer` now feeds the public comparison answer surface even when the overlay has no `comparison_blocks`.
- Existing V2.1 promoted block behavior and generated fallback blocks remain intact.
- Added a focused API contract test for an agent projection overlay with safe internal-link filtering.

## Why
The 88-page MBTI64 agent projection promotion uses `mbti64_agent_projection_draft_v1`; comparison pages need to read that live overlay contract instead of only the earlier 8-page V2.1 pilot shape.

## Validation
- `php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter=comparison --display-warnings`
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No CMS write or promotion.
- No frontend change.
- No sitemap, llms, URL Truth, Search Queue, approve, or submit action.