### PR TITLE
B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,13 +11,17 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates, stage-candidates}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
         {--source-ledger-dir= : Optional source ledger directory for tests}
         {--candidate-dir= : Candidate artifact directory for stage-candidates}
         {--staging-output-dir= : Optional staging package output directory for stage-candidates}
+        {--source-run-dir= : Existing agent artifact run directory for plan-pr}
+        {--pr-id= : Planned PR id for plan-pr}
+        {--branch= : Planned branch for plan-pr}
+        {--title= : Planned PR title for plan-pr}
         {--allow-staging-write : Permit stage-candidates to write the reviewed staging package}
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
         {--json : Emit machine-readable summary}';
@@ -48,11 +52,19 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'staging_output_dir' => trim((string) $this->option('staging-output-dir')),
                     'allow_staging_write' => (bool) $this->option('allow-staging-write'),
                 ]),
+                'plan-pr' => $agent->planPr([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'source_run_dir' => trim((string) $this->option('source-run-dir')),
+                    'pr_id' => trim((string) $this->option('pr-id')),
+                    'branch' => trim((string) $this->option('branch')),
+                    'title' => trim((string) $this->option('title')),
+                ]),
                 default => null,
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -389,6 +389,88 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   source_run_dir?:string,
+     *   pr_id?:string,
+     *   branch?:string,
+     *   title?:string
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function planPr(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $sourceRunDir = trim((string) ($options['source_run_dir'] ?? '')) === ''
+            ? ''
+            : $this->absolutePath((string) ($options['source_run_dir'] ?? ''));
+        $prId = $this->sanitizePrId((string) ($options['pr_id'] ?? ''));
+        $branch = $this->sanitizeBranch((string) ($options['branch'] ?? ''), $prId);
+        $title = trim((string) ($options['title'] ?? '')) !== ''
+            ? trim((string) ($options['title'] ?? ''))
+            : $prId.': Big Five V2 agent artifact handoff';
+
+        $this->ensureDirectory($artifactDir);
+
+        $sourceSummary = $this->sourceRunSummary($sourceRunDir);
+        $plannedFiles = $this->plannedChangedFiles((array) ($sourceSummary['files'] ?? []));
+        $scopeValidation = $this->orchestratorScopeValidation($plannedFiles);
+        $prBody = $this->buildAutoPrBody($prId, $sourceSummary, $scopeValidation);
+        $ok = (bool) ($sourceSummary['valid'] ?? false) && (bool) ($scopeValidation['valid'] ?? false);
+
+        $plan = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'auto_pr_orchestrator_plan',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'ok' => $ok,
+            'status' => $ok ? 'ready_for_operator_orchestrator' : 'blocked',
+            'execution_mode' => 'dry_run_artifact_only',
+            'run_id' => $runId,
+            'pr' => [
+                'id' => $prId,
+                'branch' => $branch,
+                'title' => $title,
+                'commit_message' => $title,
+                'body_artifact' => 'auto_pr_body.md',
+            ],
+            'source_run' => $sourceSummary,
+            'planned_changed_files' => $plannedFiles,
+            'scope_validation' => $scopeValidation,
+            'negative_guarantees' => $this->orchestratorNegativeGuarantees(),
+        ];
+
+        $artifacts = [
+            'auto_pr_orchestration_plan.json' => $this->writeJson($artifactDir.'/auto_pr_orchestration_plan.json', $plan),
+            'auto_pr_scope_validation.json' => $this->writeJson($artifactDir.'/auto_pr_scope_validation.json', $scopeValidation),
+            'auto_pr_body.md' => $this->writeText($artifactDir.'/auto_pr_body.md', $prBody),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'source_run_valid' => (bool) ($sourceSummary['valid'] ?? false),
+                'planned_changed_file_count' => count($plannedFiles),
+                'scope_validation_valid' => (bool) ($scopeValidation['valid'] ?? false),
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->orchestratorNegativeGuarantees(),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function buildInventory(string $contentAssetRoot, string $sourceLedgerDir): array
@@ -1477,6 +1559,203 @@ final class BigFiveResultPageV2AssetAgent
         return trim($runId, '.-') !== '' ? $runId : gmdate('Ymd\THis\Z');
     }
 
+    private function sanitizePrId(string $prId): string
+    {
+        $prId = strtoupper(trim($prId));
+        $prId = preg_replace('/[^A-Z0-9_.-]/', '-', $prId) ?: 'B5-RESULT-AGENT-ARTIFACT-PR';
+
+        return trim($prId, '.-') !== '' ? $prId : 'B5-RESULT-AGENT-ARTIFACT-PR';
+    }
+
+    private function sanitizeBranch(string $branch, string $prId): string
+    {
+        $branch = trim($branch) !== '' ? trim($branch) : 'codex/'.strtolower(str_replace('_', '-', $prId));
+        $branch = preg_replace('/[^A-Za-z0-9_\\/.:-]/', '-', $branch) ?: 'codex/big5-v2-agent-artifact-pr';
+
+        return trim($branch, '.-/') !== '' ? $branch : 'codex/big5-v2-agent-artifact-pr';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sourceRunSummary(string $sourceRunDir): array
+    {
+        if ($sourceRunDir === '' || ! is_dir($sourceRunDir)) {
+            return [
+                'valid' => false,
+                'source_run_dir' => null,
+                'artifact_kind' => 'missing',
+                'files' => [],
+                'errors' => ['source_run_dir missing'],
+            ];
+        }
+
+        $files = [];
+        foreach ($this->filesUnder($sourceRunDir) as $file) {
+            $files[] = [
+                'relative_path' => $this->redactPath($file->getPathname()),
+                'sha256' => hash_file('sha256', $file->getPathname()) ?: '',
+                'size' => filesize($file->getPathname()) ?: 0,
+            ];
+        }
+
+        $errors = [];
+        $kind = $this->sourceArtifactKind($sourceRunDir);
+        if ($kind === 'unknown') {
+            $errors[] = 'source artifact kind unsupported';
+        }
+
+        return [
+            'valid' => $errors === [] && $files !== [],
+            'source_run_dir' => $this->redactPath($sourceRunDir),
+            'artifact_kind' => $kind,
+            'file_count' => count($files),
+            'files' => $files,
+            'summary' => $this->sourceArtifactSummary($sourceRunDir, $kind),
+            'errors' => $errors,
+        ];
+    }
+
+    private function sourceArtifactKind(string $sourceRunDir): string
+    {
+        foreach ([
+            'candidate_generation_summary.json' => 'candidate_generation',
+            'staging_import_summary.json' => 'staging_import',
+            'ops_report_summary.json' => 'audit_ops_report',
+            'qa_eval_summary.json' => 'audit_qa_report',
+        ] as $filename => $kind) {
+            if (is_file(rtrim($sourceRunDir, '/').'/'.$filename)) {
+                return $kind;
+            }
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sourceArtifactSummary(string $sourceRunDir, string $kind): array
+    {
+        $filename = match ($kind) {
+            'candidate_generation' => 'candidate_generation_summary.json',
+            'staging_import' => 'staging_import_summary.json',
+            'audit_ops_report' => 'ops_report_summary.json',
+            'audit_qa_report' => 'qa_eval_summary.json',
+            default => '',
+        };
+
+        if ($filename === '') {
+            return [];
+        }
+
+        $payload = $this->readOptionalJson(rtrim($sourceRunDir, '/').'/'.$filename);
+        if (! is_array($payload)) {
+            return [];
+        }
+
+        return [
+            'status' => (string) ($payload['status'] ?? ($payload['task'] ?? '')),
+            'runtime_use' => (string) ($payload['runtime_use'] ?? ''),
+            'production_use_allowed' => (bool) ($payload['production_use_allowed'] ?? false),
+            'ready_for_pilot' => (bool) ($payload['ready_for_pilot'] ?? false),
+            'ready_for_runtime' => (bool) ($payload['ready_for_runtime'] ?? false),
+            'ready_for_production' => (bool) ($payload['ready_for_production'] ?? false),
+            'validation_error_count' => (int) data_get($payload, 'validation.error_count', data_get($payload, 'metrics.validation_error_count', 0)),
+            'leak_hit_count' => (int) data_get($payload, 'leak_scan.hit_count', data_get($payload, 'metrics.forbidden_leak_hit_count', 0)),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $files
+     * @return list<string>
+     */
+    private function plannedChangedFiles(array $files): array
+    {
+        $planned = [];
+        foreach ($files as $file) {
+            $relativePath = (string) ($file['relative_path'] ?? '');
+            if ($relativePath === '') {
+                continue;
+            }
+            $planned[] = str_starts_with($relativePath, 'backend/')
+                ? $relativePath
+                : 'backend/'.$relativePath;
+        }
+
+        sort($planned);
+
+        return array_values(array_unique($planned));
+    }
+
+    /**
+     * @param  list<string>  $plannedFiles
+     * @return array<string,mixed>
+     */
+    private function orchestratorScopeValidation(array $plannedFiles): array
+    {
+        $allowedPrefixes = [
+            'backend/artifacts/big5_result_page_v2_agent/',
+            'backend/content_assets/big5/result_page_v2/agent_runs/',
+            'backend/content_assets/big5/result_page_v2/staging_candidate_imports/',
+            'docs/codex/',
+        ];
+        $violations = [];
+        foreach ($plannedFiles as $file) {
+            $allowed = false;
+            foreach ($allowedPrefixes as $prefix) {
+                if (str_starts_with($file, $prefix)) {
+                    $allowed = true;
+                    break;
+                }
+            }
+            if (! $allowed) {
+                $violations[] = $file;
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'auto_pr_scope_validation',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'valid' => $plannedFiles !== [] && $violations === [],
+            'allowed_prefixes' => $allowedPrefixes,
+            'planned_changed_file_count' => count($plannedFiles),
+            'violations' => $violations,
+            'negative_guarantees' => $this->orchestratorNegativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $sourceSummary
+     * @param  array<string,mixed>  $scopeValidation
+     */
+    private function buildAutoPrBody(string $prId, array $sourceSummary, array $scopeValidation): string
+    {
+        $lines = [
+            '## What changed',
+            '- Adds reviewed Big Five V2 result-page asset agent artifacts for `'.$prId.'`.',
+            '- Includes generated scope validation evidence for the artifact-only change set.',
+            '',
+            '## Why',
+            '- Keeps backend as the content asset authority while preserving staging/not-runtime defaults.',
+            '',
+            '## Validation',
+            '- `php artisan big5:result-page-v2-agent plan-pr --run-id=<run> --source-run-dir=<artifact-run> --json --no-ansi`',
+            '- Scope validation: '.$this->markdownScalar($scopeValidation['valid'] ?? false),
+            '- Source artifact kind: '.(string) ($sourceSummary['artifact_kind'] ?? 'unknown'),
+            '',
+            '## Intentionally deferred',
+            '- No frontend copy added.',
+            '- No final Big Five result page runtime payload generated.',
+            '- No production import, release snapshot, rollout gate, or runtime flag changed.',
+            '- Legacy `big5_report_engine_v2` remains fallback only.',
+        ];
+
+        return implode(PHP_EOL, $lines).PHP_EOL;
+    }
+
     private function ensureDirectory(string $path): void
     {
         if (! is_dir($path) && ! mkdir($path, 0775, true) && ! is_dir($path)) {
@@ -1620,6 +1899,29 @@ final class BigFiveResultPageV2AssetAgent
             'release_snapshot_change' => false,
             'production_import_gate_change' => false,
             'rollout_gate_change' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function orchestratorNegativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+            'git_branch_created' => false,
+            'git_commit_created' => false,
+            'github_pr_created' => false,
+            'github_checks_polled' => false,
+            'auto_merge_performed' => false,
         ];
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -265,6 +265,86 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_plan_pr_writes_dry_run_orchestration_artifacts_without_git_or_github_mutation(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-orchestrator');
+
+        $this->deleteDirectory($artifactRoot);
+
+        try {
+            app(BigFiveResultPageV2AssetAgent::class)->generateCandidates([
+                'run_id' => 'candidate-source',
+                'artifact_dir' => $artifactRoot,
+            ]);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'plan-pr',
+                '--run-id' => 'orchestrator-plan',
+                '--artifact-dir' => $artifactRoot,
+                '--source-run-dir' => $artifactRoot.'/candidate-source',
+                '--pr-id' => 'B5-RESULT-CANDIDATE-BATCH-DRY-RUN-01',
+                '--branch' => 'codex/big5-v2-candidate-batch-dry-run',
+                '--title' => 'B5-RESULT-CANDIDATE-BATCH-DRY-RUN-01: Big Five V2 candidate batch dry run',
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/orchestrator-plan';
+            foreach ([
+                'auto_pr_orchestration_plan.json',
+                'auto_pr_scope_validation.json',
+                'auto_pr_body.md',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $plan = $this->readJson($runDir.'/auto_pr_orchestration_plan.json');
+            $scope = $this->readJson($runDir.'/auto_pr_scope_validation.json');
+            $body = (string) file_get_contents($runDir.'/auto_pr_body.md');
+
+            $this->assertSame('auto_pr_orchestrator_plan', $plan['task'] ?? null);
+            $this->assertSame('not_runtime', $plan['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($plan['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($plan['ready_for_pilot'] ?? true));
+            $this->assertFalse((bool) ($plan['ready_for_runtime'] ?? true));
+            $this->assertFalse((bool) ($plan['ready_for_production'] ?? true));
+            $this->assertSame('dry_run_artifact_only', $plan['execution_mode'] ?? null);
+            $this->assertSame('codex/big5-v2-candidate-batch-dry-run', data_get($plan, 'pr.branch'));
+            $this->assertSame('candidate_generation', data_get($plan, 'source_run.artifact_kind'));
+            $this->assertTrue((bool) data_get($plan, 'source_run.valid'));
+            $this->assertGreaterThan(0, (int) data_get($plan, 'scope_validation.planned_changed_file_count'));
+            $this->assertTrue((bool) data_get($plan, 'scope_validation.valid'));
+            $this->assertTrue((bool) ($scope['valid'] ?? false));
+
+            foreach ([
+                'git_branch_created',
+                'git_commit_created',
+                'github_pr_created',
+                'github_checks_polled',
+                'auto_merge_performed',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($plan, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+
+            $this->assertStringContainsString('No frontend copy added.', $body);
+            $this->assertStringContainsString('No production import, release snapshot, rollout gate, or runtime flag changed.', $body);
+            $this->assertStringContainsString('Legacy `big5_report_engine_v2` remains fallback only.', $body);
+
+            $allArtifacts = implode("\n", [
+                (string) file_get_contents($runDir.'/auto_pr_orchestration_plan.json'),
+                (string) file_get_contents($runDir.'/auto_pr_scope_validation.json'),
+                $body,
+            ]);
+            foreach (['private_url', 'attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_stage_candidates_fails_closed_without_human_review_manifest(): void
     {
         $artifactRoot = $this->tempDir('big5-v2-agent-stage-missing-review');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:44:54+08:00",
+  "updated_at": "2026-06-22T08:42:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -55942,7 +55942,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-nightly-audit-scheduler",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01: Schedule Big Five V2 nightly audit",
     "depends_on": [
@@ -55976,15 +55976,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2239 checks completed successfully on head 85841992376a4c5419901cf672ed6f1584a4b1be; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
+        "evidence": "PR #2239 merged with merge commit c3165a95d0f7647b5a3cc083d415d97f7c7e10d8 after required GitHub checks passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "85841992376a4c5419901cf672ed6f1584a4b1be",
+    "commit_sha": "c3165a95d0f7647b5a3cc083d415d97f7c7e10d8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2239",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T23:25:42Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T07:10:00+08:00",
@@ -57213,6 +57213,61 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      }
+    ]
+  },
+  "B5-RESULT-AUTO-PR-ORCHESTRATOR-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-auto-pr-orchestrator",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big5_result_page_v2_asset_agent_automation",
+    "title": "B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs",
+    "depends_on": [
+      "B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the Big Five V2 result-page asset agent full-auto PR train and authorized manifest/state updates for this PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR #2239 for B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01 is merged and origin/main contains merge commit c3165a95d0f7647b5a3cc083d415d97f7c7e10d8."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=candidate-source --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --json --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=orchestrator-plan --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --source-run-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator/candidate-source --pr-id=B5-RESULT-CANDIDATE-BATCH-DRY-RUN-01 --branch=codex/big5-v2-candidate-batch-dry-run --json --no-ansi",
+          "rm -rf backend/artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed 9 tests/237 assertions; generate-candidates smoke succeeded; plan-pr smoke succeeded with source_run_valid=true, planned_changed_file_count=3, scope_validation_valid=true, and git/GitHub/merge negative guarantees false; YAML/JSON/diff checks passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed PR2 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, CI inspector, mechanical fixer, auto merge, or weekly ops behavior changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T08:42:00+08:00",
+        "status": "local_validated",
+        "note": "Local validation and scope validation passed for dry-run artifact-only auto PR orchestrator planning after rebase."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T08:42:00+08:00",
+  "updated_at": "2026-06-22T08:44:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57220,7 +57220,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-pr-orchestrator",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs",
     "depends_on": [
@@ -57254,12 +57254,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2242 open; waiting for GitHub checks after second rebase onto latest origin/main."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "244f2c0b4c7803fada3417503052743ce93881a7",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2242",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57268,6 +57268,11 @@
         "at": "2026-06-22T08:42:00+08:00",
         "status": "local_validated",
         "note": "Local validation and scope validation passed for dry-run artifact-only auto PR orchestrator planning after rebase."
+      },
+      {
+        "at": "2026-06-22T08:44:00+08:00",
+        "status": "pr_open",
+        "note": "PR #2242 remains open after second rebase onto latest origin/main; waiting for required GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T08:44:00+08:00",
+  "updated_at": "2026-06-22T08:45:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57220,7 +57220,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-pr-orchestrator",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs",
     "depends_on": [
@@ -57253,12 +57253,12 @@
         "evidence": "Changed files are limited to allowed PR2 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, CI inspector, mechanical fixer, auto merge, or weekly ops behavior changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2242 open; waiting for GitHub checks after second rebase onto latest origin/main."
+        "status": "pass",
+        "evidence": "PR #2242 checks had completed successfully before the latest rebase; waiting for required checks on the rebased ready-to-merge head."
       }
     },
     "failure_reason": null,
-    "commit_sha": "244f2c0b4c7803fada3417503052743ce93881a7",
+    "commit_sha": "ad5d5d65fd44d63a2e9b9d10c7fae538c7fadcda",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2242",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57273,6 +57273,11 @@
         "at": "2026-06-22T08:44:00+08:00",
         "status": "pr_open",
         "note": "PR #2242 remains open after second rebase onto latest origin/main; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T08:45:00+08:00",
+        "status": "ready_to_merge",
+        "note": "Ready-to-merge state replayed during second rebase; required checks must pass on the rebased head before merge."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24465,6 +24465,46 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: B5-RESULT-AUTO-PR-ORCHESTRATOR-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-AUTO-NIGHTLY-SCHEDULER-01
+    branch: codex/big5-v2-auto-pr-orchestrator
+    title: "B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs"
+    train_scope: big5_result_page_v2_asset_agent_automation
+    status: user_authorized
+    scope:
+      - Add an artifact-only auto PR orchestration plan action for Big Five V2 agent runs.
+      - Generate scoped branch, commit message, PR title/body, planned changed files, and scope validation artifacts from an existing agent artifact run.
+      - Keep the first orchestrator version dry-run/artifact-only: no git branch creation, no commit, no push, no GitHub PR creation, no check polling, and no merge.
+      - Preserve backend authority and staging/not-runtime defaults.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add fap-web copy, generate final frontend payloads, make big5_report_engine_v2 primary, enable production rollout, or touch release/import/rollout gates.
+      - Add CI inspector, mechanical fixer, auto merge, cleanup, or weekly ops runner behavior in this PR.
+      - Execute git or GitHub mutations from the orchestrator action.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=candidate-source --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --json --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=orchestrator-plan --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --source-run-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator/candidate-source --pr-id=B5-RESULT-CANDIDATE-BATCH-DRY-RUN-01 --branch=codex/big5-v2-candidate-batch-dry-run --json --no-ansi
+      - rm -rf backend/artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
     repo: fap-api
     branch: codex/riasec-result-asset-agent-runbook-01


### PR DESCRIPTION
## What changed
- Adds a `plan-pr` action to the Big Five V2 result-page asset agent.
- The action reads an existing agent artifact run and writes dry-run orchestration artifacts: PR plan JSON, scope validation JSON, and PR body Markdown.
- Adds tests proving the orchestrator stays artifact-only and does not create branches, commits, GitHub PRs, check polling, or merges.
- Registers the authorized PR-train item and reconciles the already-merged nightly scheduler dependency.

## Why
This is PR2 of the Big Five V2 result-page asset agent full-auto train. It standardizes the PR planning contract before later PRs add CI inspection or merge automation.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=candidate-source --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --json --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=orchestrator-plan --artifact-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator --source-run-dir=artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator/candidate-source --pr-id=B5-RESULT-CANDIDATE-BATCH-DRY-RUN-01 --branch=codex/big5-v2-candidate-batch-dry-run --json --no-ansi`
- `rm -rf backend/artifacts/big5_result_page_v2_agent/testing-auto-pr-orchestrator`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy or `fap-web` changes.
- No final frontend `big5_result_page_v2` payload generation.
- No production/runtime gate, release snapshot, production import gate, or rollout gate changes.
- No CI inspector, mechanical fixer, auto-merge cleanup, or weekly Ops runner behavior in this PR.
- The orchestrator action does not execute git or GitHub mutations.
- Legacy `big5_report_engine_v2` remains fallback only.

Repository rule impact: backend remains the authority for Big Five V2 result-page content assets; this PR only adds a dry-run artifact planning contract for future scoped backend PRs.
