### PR TITLE
Enneagram: add result page ops agent control plane

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageOpsControlPlaneCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageOpsControlPlaneCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageOpsControlPlane;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageOpsControlPlaneCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-ops-control-plane
+        {action=audit : Only audit is supported in this control-plane PR}
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/enneagram_result_page_ops_control_plane}
+        {--contract-path= : Optional control-plane contract path; defaults to backend/content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json}
+        {--mode=auto-to-report : Requested mode: auto-to-pr, auto-to-staging, auto-to-report, production-manual-gate}
+        {--simulate-production-rollout : Prove automatic production rollout is blocked}
+        {--release-id= : Prepared manual approval release id}
+        {--confirm-release-id= : Prepared manual approval confirm release id}
+        {--candidate-manifest-sha256= : Prepared manual approval candidate manifest hash}
+        {--runtime-registry-sha256= : Prepared manual approval runtime registry hash}
+        {--rollback-window= : Prepared manual approval rollback window}
+        {--post-activation-smoke-plan= : Prepared manual approval smoke plan}
+        {--strict : Return non-zero when any control-plane validation error is present}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Read-only Enneagram result page ops agent control-plane audit.';
+
+    public function handle(EnneagramResultPageOpsControlPlane $controlPlane): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $controlPlane->audit([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'mode' => trim((string) $this->option('mode')),
+                'strict' => (bool) $this->option('strict'),
+                'simulate_production_rollout' => (bool) $this->option('simulate-production-rollout'),
+                'approval' => [
+                    'release_id' => trim((string) $this->option('release-id')),
+                    'confirm_release_id' => trim((string) $this->option('confirm-release-id')),
+                    'candidate_manifest_sha256' => trim((string) $this->option('candidate-manifest-sha256')),
+                    'runtime_registry_sha256' => trim((string) $this->option('runtime-registry-sha256')),
+                    'rollback_window' => trim((string) $this->option('rollback-window')),
+                    'post_activation_smoke_plan' => trim((string) $this->option('post-activation-smoke-plan')),
+                ],
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('mode='.(string) ($summary['mode'] ?? ''));
+        $this->line('artifact_dir='.(string) ($summary['artifact_dir'] ?? ''));
+        $this->line('contract_valid='.(((bool) data_get($summary, 'summary.contract_valid', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+        $this->line('manual_approval_required_for_production='.(((bool) data_get($summary, 'summary.manual_approval_required_for_production', false)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -114,6 +114,7 @@ use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
 use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
+use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
@@ -245,6 +246,7 @@ class Kernel extends ConsoleKernel
         EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
         EnneagramResultPageAgentReadinessCommand::class,
+        EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,
         BigFiveExportProductionEquivalentCandidatePayloads::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsControlPlane.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsControlPlane.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageOpsControlPlane
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.ops_agent_control_plane.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_ops_control_plane';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json';
+
+    public const EXACT_RELEASE_ID = 'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4';
+
+    public const EXACT_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
+
+    public const EXACT_RUNTIME_REGISTRY_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
+
+    private const ALLOWED_MODES = [
+        'auto-to-pr',
+        'auto-to-staging',
+        'auto-to-report',
+        'production-manual-gate',
+    ];
+
+    private const AUTO_MODES = [
+        'auto-to-pr',
+        'auto-to-staging',
+        'auto-to-report',
+    ];
+
+    private const REQUIRED_APPROVAL_FIELDS = [
+        'release_id',
+        'confirm_release_id',
+        'candidate_manifest_sha256',
+        'runtime_registry_sha256',
+        'rollback_window',
+        'post_activation_smoke_plan',
+    ];
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     mode?:string,
+     *     strict?:bool,
+     *     simulate_production_rollout?:bool,
+     *     approval?:array<string,mixed>
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function audit(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $mode = trim((string) ($options['mode'] ?? 'auto-to-report'));
+        $strict = ($options['strict'] ?? false) === true;
+        $simulateProductionRollout = ($options['simulate_production_rollout'] ?? false) === true;
+        $approval = is_array($options['approval'] ?? null) ? $options['approval'] : [];
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readContract($contractPath);
+        $contractErrors = $this->contractErrors($contract);
+        $modeDecision = $this->modeDecision($mode, $simulateProductionRollout, $approval, $contract);
+        $errors = array_values(array_merge($contractErrors, $modeDecision['errors']));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ops_agent_control_plane_audit',
+            'run_id' => $runId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'mode_decision' => $modeDecision,
+            'allowed_modes' => self::ALLOWED_MODES,
+            'auto_modes' => self::AUTO_MODES,
+            'production_manual_gate' => [
+                'execution_allowed_for_agent' => false,
+                'manual_approval_required' => true,
+                'exact_release_id' => self::EXACT_RELEASE_ID,
+                'candidate_manifest_sha256' => self::EXACT_CANDIDATE_MANIFEST_SHA256,
+                'runtime_registry_sha256' => self::EXACT_RUNTIME_REGISTRY_SHA256,
+                'required_approval_fields' => self::REQUIRED_APPROVAL_FIELDS,
+                'prepared_command_template' => (string) data_get($contract, 'production_manual_gate.prepared_command_template', ''),
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifact = $this->writeJson($artifactDir.'/ops_agent_control_plane_report.json', $report);
+        $ok = $errors === [] || (! $strict && $modeDecision['status'] === 'manual_approval_required');
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => [
+                'ops_agent_control_plane_report.json' => $artifact,
+            ],
+            'mode' => $mode,
+            'strict' => $strict,
+            'summary' => [
+                'contract_valid' => $contractErrors === [],
+                'mode_allowed' => (bool) $modeDecision['mode_allowed'],
+                'production_execution_allowed_for_agent' => false,
+                'manual_approval_required_for_production' => true,
+                'production_rollout_simulated' => $simulateProductionRollout,
+                'production_rollout_blocked' => (bool) $modeDecision['production_rollout_blocked'],
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function modeDecision(string $mode, bool $simulateProductionRollout, array $approval, array $contract): array
+    {
+        $errors = [];
+        $modeAllowed = in_array($mode, self::ALLOWED_MODES, true);
+        $productionBlocked = false;
+
+        if (! $modeAllowed) {
+            $errors[] = 'mode_not_allowed:'.$mode;
+        }
+
+        if ($simulateProductionRollout && in_array($mode, self::AUTO_MODES, true)) {
+            $productionBlocked = true;
+            $errors[] = 'automatic_production_rollout_blocked';
+        }
+
+        $approvalErrors = [];
+        $approvalValid = false;
+        if ($mode === 'production-manual-gate') {
+            $approvalErrors = $this->approvalErrors($approval);
+            $approvalValid = $approvalErrors === [];
+            $errors = array_merge($errors, $approvalErrors);
+        }
+
+        $modeRows = collect((array) ($contract['allowed_modes'] ?? []))
+            ->filter(static fn ($row): bool => is_array($row))
+            ->keyBy(static fn (array $row): string => (string) ($row['mode'] ?? ''));
+        $contractMode = $modeRows->get($mode, []);
+
+        return [
+            'mode' => $mode,
+            'mode_allowed' => $modeAllowed,
+            'status' => $mode === 'production-manual-gate' ? 'manual_approval_required' : ($errors === [] ? 'allowed' : 'blocked'),
+            'may_create_pull_request' => (bool) data_get($contractMode, 'may_create_pull_request', false),
+            'may_write_staging' => (bool) data_get($contractMode, 'may_write_staging', false),
+            'may_write_production' => false,
+            'may_activate_production' => false,
+            'production_rollout_blocked' => $productionBlocked || $mode === 'production-manual-gate',
+            'approval_contract_valid' => $mode === 'production-manual-gate' ? $approvalValid : null,
+            'approval_errors' => $approvalErrors,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function approvalErrors(array $approval): array
+    {
+        $errors = [];
+        foreach (self::REQUIRED_APPROVAL_FIELDS as $field) {
+            if (! array_key_exists($field, $approval) || trim((string) $approval[$field]) === '') {
+                $errors[] = 'missing_approval_field:'.$field;
+            }
+        }
+
+        if (($approval['release_id'] ?? null) !== self::EXACT_RELEASE_ID) {
+            $errors[] = 'release_id_mismatch';
+        }
+        if (($approval['confirm_release_id'] ?? null) !== self::EXACT_RELEASE_ID) {
+            $errors[] = 'confirm_release_id_mismatch';
+        }
+        if (($approval['candidate_manifest_sha256'] ?? null) !== self::EXACT_CANDIDATE_MANIFEST_SHA256) {
+            $errors[] = 'candidate_manifest_sha256_mismatch';
+        }
+        if (($approval['runtime_registry_sha256'] ?? null) !== self::EXACT_RUNTIME_REGISTRY_SHA256) {
+            $errors[] = 'runtime_registry_sha256_mismatch';
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+
+        $modes = array_map(
+            static fn (array $row): string => (string) ($row['mode'] ?? ''),
+            array_filter((array) ($contract['allowed_modes'] ?? []), 'is_array')
+        );
+        sort($modes);
+        $expectedModes = self::ALLOWED_MODES;
+        sort($expectedModes);
+        if ($modes !== $expectedModes) {
+            $errors[] = 'allowed_modes_mismatch';
+        }
+
+        foreach ((array) ($contract['allowed_modes'] ?? []) as $modeRow) {
+            if (! is_array($modeRow)) {
+                $errors[] = 'allowed_mode_row_malformed';
+                continue;
+            }
+
+            if (($modeRow['may_write_production'] ?? null) !== false) {
+                $errors[] = 'mode_may_write_production_not_false:'.(string) ($modeRow['mode'] ?? '');
+            }
+            if (($modeRow['may_activate_production'] ?? null) !== false) {
+                $errors[] = 'mode_may_activate_production_not_false:'.(string) ($modeRow['mode'] ?? '');
+            }
+        }
+
+        if (data_get($contract, 'production_manual_gate.execution_allowed_for_agent') !== false) {
+            $errors[] = 'production_execution_allowed_for_agent_must_be_false';
+        }
+        if (data_get($contract, 'production_manual_gate.manual_approval_required') !== true) {
+            $errors[] = 'production_manual_approval_required_must_be_true';
+        }
+        if (data_get($contract, 'production_manual_gate.exact_release_id') !== self::EXACT_RELEASE_ID) {
+            $errors[] = 'production_gate_release_id_mismatch';
+        }
+        if (data_get($contract, 'production_manual_gate.candidate_manifest_sha256') !== self::EXACT_CANDIDATE_MANIFEST_SHA256) {
+            $errors[] = 'production_gate_candidate_hash_mismatch';
+        }
+        if (data_get($contract, 'production_manual_gate.runtime_registry_sha256') !== self::EXACT_RUNTIME_REGISTRY_SHA256) {
+            $errors[] = 'production_gate_runtime_hash_mismatch';
+        }
+        if ((array) data_get($contract, 'production_manual_gate.required_approval_fields', []) !== self::REQUIRED_APPROVAL_FIELDS) {
+            $errors[] = 'production_gate_required_approval_fields_mismatch';
+        }
+
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bulk_content_generation_happened' => false,
+            'candidate_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readContract(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('Control plane contract does not exist: '.$path);
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Control plane contract is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        if ($path !== '') {
+            return $path;
+        }
+
+        return base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sanitizeRunId(string $runId): string
+    {
+        $trimmed = trim($runId);
+        if ($trimmed === '') {
+            return 'ops-control-plane-'.gmdate('Ymd\THis\Z');
+        }
+
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', $trimmed) ?: '';
+
+        return trim($sanitized, '-') ?: 'ops-control-plane';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/ops_agent_control_plane/README.md
+++ b/backend/content_assets/enneagram/result_page/ops_agent_control_plane/README.md
@@ -1,0 +1,14 @@
+# Enneagram Result Page Ops Agent Control Plane
+
+This directory defines the read-only operations contract for the Enneagram result page agent.
+
+The control plane allows the agent to automate:
+
+- `auto-to-pr`: prepare scoped branches, validation evidence, and pull requests.
+- `auto-to-staging`: prepare staging-only candidate validation and inactive import plans.
+- `auto-to-report`: prepare evidence bundles, failure reports, and sidecar issue payloads.
+- `production-manual-gate`: prepare the exact production approval packet.
+
+Production rollout is never automatic. A production activation command may only be prepared after a human provides the exact release id, candidate manifest hash, runtime registry hash, rollback window, and post-activation smoke plan required by `control_plane_v0_1.json`.
+
+This scaffold does not generate content, import candidates, switch runtime, write production data, or touch frontend code.

--- a/backend/content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "fap.enneagram.result_page.ops_agent_control_plane.v0.1",
+  "scale": "ENNEAGRAM",
+  "surface": "private_result_page",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "allowed_modes": [
+    {
+      "mode": "auto-to-pr",
+      "description": "Agent may prepare scoped branches, run local validation, open PRs, and poll checks.",
+      "may_write_repo_files": true,
+      "may_create_pull_request": true,
+      "may_write_staging": false,
+      "may_write_production": false,
+      "may_activate_production": false,
+      "requires_manual_approval": false
+    },
+    {
+      "mode": "auto-to-staging",
+      "description": "Agent may prepare staging-only dry runs and inactive import validation evidence.",
+      "may_write_repo_files": true,
+      "may_create_pull_request": true,
+      "may_write_staging": true,
+      "may_write_production": false,
+      "may_activate_production": false,
+      "requires_manual_approval": false
+    },
+    {
+      "mode": "auto-to-report",
+      "description": "Agent may prepare evidence bundles, readiness reports, and sidecar issue payloads.",
+      "may_write_repo_files": true,
+      "may_create_pull_request": true,
+      "may_write_staging": false,
+      "may_write_production": false,
+      "may_activate_production": false,
+      "requires_manual_approval": false
+    },
+    {
+      "mode": "production-manual-gate",
+      "description": "Agent may prepare the production activation command packet, but execution requires human approval.",
+      "may_write_repo_files": false,
+      "may_create_pull_request": false,
+      "may_write_staging": false,
+      "may_write_production": false,
+      "may_activate_production": false,
+      "requires_manual_approval": true
+    }
+  ],
+  "production_manual_gate": {
+    "execution_allowed_for_agent": false,
+    "manual_approval_required": true,
+    "exact_release_id": "enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4",
+    "candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "runtime_registry_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+    "required_approval_fields": [
+      "release_id",
+      "confirm_release_id",
+      "candidate_manifest_sha256",
+      "runtime_registry_sha256",
+      "rollback_window",
+      "post_activation_smoke_plan"
+    ],
+    "prepared_command_template": "php artisan enneagram:activate-inactive-candidate-release --release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 --confirm-release-id=enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4 --candidate-manifest-sha256=a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0 --runtime-registry-sha256=ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f --json"
+  },
+  "negative_guarantees": {
+    "bulk_content_generation_happened": false,
+    "candidate_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageOpsControlPlaneCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageOpsControlPlaneCommandTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageOpsControlPlaneCommandTest extends TestCase
+{
+    public function test_control_plane_command_writes_read_only_report(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-command');
+
+        try {
+            $this->artisan('enneagram:result-page-ops-control-plane', [
+                'action' => 'audit',
+                '--run-id' => 'command-run',
+                '--artifact-dir' => $root,
+                '--mode' => 'auto-to-pr',
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/command-run/ops_agent_control_plane_report.json');
+            $this->assertSame('auto-to-pr', data_get($report, 'mode_decision.mode'));
+            $this->assertTrue((bool) data_get($report, 'mode_decision.may_create_pull_request', false));
+            $this->assertFalse((bool) data_get($report, 'mode_decision.may_write_production', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_control_plane_command_fails_closed_for_automatic_production_rollout(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-command-block');
+
+        try {
+            $this->artisan('enneagram:result-page-ops-control-plane', [
+                'action' => 'audit',
+                '--run-id' => 'command-block',
+                '--artifact-dir' => $root,
+                '--mode' => 'auto-to-staging',
+                '--simulate-production-rollout' => true,
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(1);
+
+            $report = $this->readJson($root.'/command-block/ops_agent_control_plane_report.json');
+            $this->assertContains('automatic_production_rollout_blocked', $report['errors'] ?? []);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2805,6 +2805,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_ops_control_plane_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageOpsControlPlaneCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsControlPlane.php',
+            'backend/content_assets/enneagram/result_page/ops_agent_control_plane/README.md',
+            'backend/content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageOpsControlPlaneCommand;',
+            '+        EnneagramResultPageOpsControlPlaneCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4671,6 +4694,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageOpsControlPlaneFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4777,6 +4804,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsBigFiveV2AssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsRiasecResultPageAssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageAgentReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageOpsControlPlaneOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6639,6 +6667,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageOpsControlPlaneFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageOpsControlPlaneCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsControlPlane.php',
+            'backend/content_assets/enneagram/result_page/ops_agent_control_plane/README.md',
+            'backend/content_assets/enneagram/result_page/ops_agent_control_plane/control_plane_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -7735,6 +7773,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageAgentReadinessCommand;',
             '        EnneagramResultPageAgentReadinessCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageOpsControlPlaneOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageOpsControlPlaneCommand;',
+            '        EnneagramResultPageOpsControlPlaneCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsControlPlaneTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsControlPlaneTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageOpsControlPlane;
+use Tests\TestCase;
+
+final class EnneagramResultPageOpsControlPlaneTest extends TestCase
+{
+    public function test_control_plane_audit_writes_report_for_auto_to_report_without_production_permissions(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane');
+
+        try {
+            $summary = app(EnneagramResultPageOpsControlPlane::class)->audit([
+                'run_id' => 'unit-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-report',
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertSame('success', $summary['status'] ?? null);
+            $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+            $this->assertTrue((bool) data_get($summary, 'summary.manual_approval_required_for_production', false));
+
+            $reportPath = $root.'/unit-run/ops_agent_control_plane_report.json';
+            $this->assertFileExists($reportPath);
+            $report = $this->readJson($reportPath);
+
+            $this->assertSame(EnneagramResultPageOpsControlPlane::SCHEMA_VERSION, $report['schema_version'] ?? null);
+            $this->assertSame(['auto-to-pr', 'auto-to-staging', 'auto-to-report', 'production-manual-gate'], $report['allowed_modes'] ?? []);
+            $this->assertSame('allowed', data_get($report, 'mode_decision.status'));
+            $this->assertFalse((bool) data_get($report, 'mode_decision.may_write_production', true));
+            $this->assertFalse((bool) data_get($report, 'mode_decision.may_activate_production', true));
+            $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_activation_happened', true));
+            $this->assertArtifactsDoNotLeakPrivatePaths((string) file_get_contents($reportPath));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_auto_modes_reject_simulated_production_rollout(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-prod-block');
+
+        try {
+            $summary = app(EnneagramResultPageOpsControlPlane::class)->audit([
+                'run_id' => 'blocked-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-staging',
+                'simulate_production_rollout' => true,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('automatic_production_rollout_blocked', $summary['errors'] ?? []);
+            $this->assertTrue((bool) data_get($summary, 'summary.production_rollout_blocked', false));
+
+            $report = $this->readJson($root.'/blocked-run/ops_agent_control_plane_report.json');
+            $this->assertFalse((bool) data_get($report, 'mode_decision.may_write_production', true));
+            $this->assertFalse((bool) data_get($report, 'mode_decision.may_activate_production', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_production_manual_gate_validates_exact_approval_but_never_allows_agent_execution(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-manual');
+
+        try {
+            $summary = app(EnneagramResultPageOpsControlPlane::class)->audit([
+                'run_id' => 'manual-run',
+                'artifact_dir' => $root,
+                'mode' => 'production-manual-gate',
+                'strict' => true,
+                'approval' => [
+                    'release_id' => EnneagramResultPageOpsControlPlane::EXACT_RELEASE_ID,
+                    'confirm_release_id' => EnneagramResultPageOpsControlPlane::EXACT_RELEASE_ID,
+                    'candidate_manifest_sha256' => EnneagramResultPageOpsControlPlane::EXACT_CANDIDATE_MANIFEST_SHA256,
+                    'runtime_registry_sha256' => EnneagramResultPageOpsControlPlane::EXACT_RUNTIME_REGISTRY_SHA256,
+                    'rollback_window' => '2026-06-22T00:00:00Z/2026-06-22T02:00:00Z',
+                    'post_activation_smoke_plan' => 'Run API result smoke and rollback simulation.',
+                ],
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+
+            $report = $this->readJson($root.'/manual-run/ops_agent_control_plane_report.json');
+            $this->assertSame('manual_approval_required', data_get($report, 'mode_decision.status'));
+            $this->assertTrue((bool) data_get($report, 'mode_decision.approval_contract_valid', false));
+            $this->assertFalse((bool) data_get($report, 'production_manual_gate.execution_allowed_for_agent', true));
+            $this->assertSame(EnneagramResultPageOpsControlPlane::EXACT_RELEASE_ID, data_get($report, 'production_manual_gate.exact_release_id'));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_production_manual_gate_rejects_missing_or_mismatched_approval_fields(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-manual-bad');
+
+        try {
+            $summary = app(EnneagramResultPageOpsControlPlane::class)->audit([
+                'run_id' => 'manual-bad-run',
+                'artifact_dir' => $root,
+                'mode' => 'production-manual-gate',
+                'strict' => true,
+                'approval' => [
+                    'release_id' => 'wrong',
+                ],
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('release_id_mismatch', $summary['errors'] ?? []);
+            $this->assertContains('confirm_release_id_mismatch', $summary['errors'] ?? []);
+            $this->assertContains('missing_approval_field:rollback_window', $summary['errors'] ?? []);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_strict_mode_rejects_malformed_control_plane_contract(): void
+    {
+        $root = $this->tempDir('enneagram-ops-control-plane-contract-bad');
+        $contractPath = $root.'/bad_contract.json';
+        file_put_contents($contractPath, json_encode([
+            'schema_version' => 'bad',
+            'runtime_use' => 'runtime',
+            'production_use_allowed' => true,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        try {
+            $summary = app(EnneagramResultPageOpsControlPlane::class)->audit([
+                'run_id' => 'bad-contract-run',
+                'artifact_dir' => $root.'/artifacts',
+                'contract_path' => $contractPath,
+                'mode' => 'auto-to-report',
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('schema_version_mismatch', $summary['errors'] ?? []);
+            $this->assertContains('production_use_allowed_must_be_false', $summary['errors'] ?? []);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function assertArtifactsDoNotLeakPrivatePaths(string $artifact): void
+    {
+        foreach ([
+            '/Users/rainie/',
+            '/private/tmp/',
+            'content_pack_activations write happened',
+            'production_activation_happened": true',
+        ] as $blocked) {
+            $this->assertStringNotContainsString($blocked, $artifact);
+        }
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a repo-owned Enneagram result page ops agent control-plane contract for `auto-to-pr`, `auto-to-staging`, `auto-to-report`, and `production-manual-gate`.
- Added a read-only `EnneagramResultPageOpsControlPlane` validator/report service.
- Added `enneagram:result-page-ops-control-plane audit` for read-only control-plane evidence generation.
- Added tests proving automatic production rollout is blocked and production gate preparation still never allows agent execution.
- Added a narrow Big Five freeze-guard allowlist for this Enneagram-only scaffold.

## Why
This is the first guardrail PR for the Enneagram result page operations agent. It lets the agent automate PR/staging/report preparation while keeping production rollout behind an exact human approval gate.

## Validation
- `php -l app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsControlPlane.php`
- `php -l app/Console/Commands/EnneagramResultPageOpsControlPlaneCommand.php`
- `php -l app/Console/Kernel.php`
- `php -l tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsControlPlaneTest.php`
- `php -l tests/Feature/Console/EnneagramResultPageOpsControlPlaneCommandTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsControlPlaneTest.php tests/Feature/Console/EnneagramResultPageOpsControlPlaneCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "EnneagramResultPageOpsControlPlane|runtime_freeze_classifier_ignores_enneagram_result_page_ops_control_plane_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan enneagram:result-page-ops-control-plane audit --run-id=smoke-rebase --artifact-dir=$(mktemp -d) --mode=auto-to-report --strict --json`
- `php artisan list --no-ansi | rg "enneagram:result-page-(agent|ops-control-plane)|enneagram:activate-inactive"`
- `git diff --check`

## Intentionally deferred
- No content generation.
- No candidate import.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.
- Production requires manual approval with exact release id, candidate hash, runtime hash, rollback window, and post-activation smoke plan.
