### PR TITLE
RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/governance/ops_agent_permission_model.v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/ops_agent_permission_model.v0_1.json
@@ -1,0 +1,98 @@
+{
+  "schema": "fap.riasec.result_page_v2.ops_agent_permission_model.v0.1",
+  "status": "staging_governance",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_allowed": false,
+  "production_rollout_allowed": false,
+  "production_gate_auto_enable_allowed": false,
+  "permission_tiers": [
+    {
+      "id": "auto_to_pr",
+      "allowed_actions": [
+        "read_pr_train_manifest",
+        "read_pr_train_state",
+        "verify_dependency_merged_to_main",
+        "create_scoped_branch_from_latest_main",
+        "edit_manifest_allowed_paths",
+        "run_manifest_local_checks",
+        "run_scope_validation",
+        "commit_push_open_pr",
+        "poll_github_checks",
+        "inspect_failed_checks"
+      ],
+      "denied_actions": [
+        "modify_files_outside_current_scope",
+        "combine_adjacent_pr_scopes",
+        "skip_unmerged_dependency",
+        "bypass_required_github_checks",
+        "merge_when_policy_blocks"
+      ]
+    },
+    {
+      "id": "auto_to_staging",
+      "allowed_actions": [
+        "run_staging_dry_run",
+        "run_staging_preview",
+        "run_staging_smoke",
+        "write_staging_artifacts",
+        "write_staging_reports",
+        "run_checksum_inventory_leak_scan"
+      ],
+      "denied_actions": [
+        "write_production_cms",
+        "import_production_content",
+        "mutate_production_environment",
+        "mark_assets_production_ready",
+        "enable_runtime_without_runtime_wrapper_pr"
+      ]
+    },
+    {
+      "id": "auto_to_report",
+      "allowed_actions": [
+        "write_go_no_go_report",
+        "write_sidecar_blocker_record",
+        "classify_failure_source",
+        "recommend_next_step"
+      ],
+      "denied_actions": [
+        "treat_report_as_production_approval",
+        "suppress_current_pr_failure",
+        "hide_required_check_failure",
+        "convert_sidecar_to_production_action"
+      ]
+    }
+  ],
+  "always_denied_capabilities": [
+    "production_rollout_execution",
+    "production_cms_write",
+    "production_import",
+    "production_gate_enablement",
+    "production_environment_flag_mutation",
+    "frontend_authored_result_copy_fallback",
+    "private_score_or_trace_public_leak",
+    "cross_surface_runtime_side_effect"
+  ],
+  "required_stage_gates": [
+    "dependency_merged",
+    "branch_created_from_latest_main",
+    "manifest_scope_loaded",
+    "local_checks_passed",
+    "scope_validation_passed",
+    "pull_request_opened",
+    "github_required_checks_green",
+    "merge_policy_satisfied",
+    "merged_to_main",
+    "main_synced",
+    "task_branch_deleted",
+    "post_merge_revalidated"
+  ],
+  "sidecar_policy": {
+    "continue_when_external_blocker": true,
+    "requires_current_pr_checks_green": true,
+    "requires_scope_validation_green": true,
+    "current_pr_blocker_stops_train": true
+  }
+}

--- a/backend/docs/riasec/result-ops-agent-permission-model.md
+++ b/backend/docs/riasec/result-ops-agent-permission-model.md
@@ -1,0 +1,104 @@
+# RIASEC Result Page Ops Agent Permission Model
+
+Status: `RIASEC-OPS-AGENT-PERMISSION-MODEL-01`
+
+This document defines the permission model for the Holland/RIASEC result page ops agent. It is a governance contract for automation boundaries only. It does not authorize production rollout, production CMS writes, production import, runtime enablement, or frontend fallback content.
+
+## Permission Tiers
+
+### Auto-To-PR
+
+The ops agent may:
+
+- read `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json`;
+- verify that dependencies are merged into `main`;
+- create a scoped branch from latest `main`;
+- edit files allowed by the current manifest entry;
+- run local checks declared by the current manifest entry;
+- run changed-file scope validation;
+- commit, push, and open one pull request for the current task;
+- poll GitHub checks and inspect failures.
+
+The ops agent may not:
+
+- modify files outside the current manifest scope;
+- merge multiple PR scopes into one branch;
+- skip a dependency that is not merged into `main`;
+- bypass required GitHub checks;
+- merge when review or repository policy blocks the PR.
+
+### Auto-To-Staging
+
+The ops agent may:
+
+- run dry-run import, preview, smoke, checksum, inventory, and leak-scan commands against staging-only artifacts;
+- write staging reports and staging artifact manifests;
+- mark staging outputs with `runtime_use=staging_only`;
+- record `production_use_allowed=false`, `ready_for_production=false`, and `cms_write_performed=false`.
+
+The ops agent may not:
+
+- write production CMS data;
+- import content into production;
+- mutate production environment flags;
+- mark generated content as production-ready;
+- use staging output as runtime authority before a specific runtime-wrapper PR allows it.
+
+### Auto-To-Report
+
+The ops agent may:
+
+- write go/no-go reports;
+- write sidecar blocker records for issues not introduced by the current PR;
+- classify failures as current-PR, external dependency, environment, repository policy, or manual approval;
+- continue to the next PR only when the current PR has green required checks, clean scope validation, and no current-PR blocker.
+
+The ops agent may not:
+
+- treat a report as production approval;
+- suppress a current-PR failure as an external blocker;
+- hide required check failures;
+- convert sidecar records into production actions.
+
+## Forbidden Capabilities
+
+The following capabilities are always denied unless a later human-approved production SOP explicitly changes the repository policy:
+
+- production rollout execution;
+- production CMS write or import;
+- production gate enablement;
+- production environment or feature-flag mutation;
+- frontend-authored RIASEC interpretation fallback;
+- publication of private score, raw score, vector, percentile, selector trace, source, QA, editor metadata, attempt id, user id, or private URL fields;
+- changing MBTI, Big Five, Enneagram, payment, or account runtime behavior as a side effect of RIASEC ops work.
+
+## Stage Gate Requirements
+
+Every automated task must pass these gates in order:
+
+1. `dependency_merged`
+2. `branch_created_from_latest_main`
+3. `manifest_scope_loaded`
+4. `local_checks_passed`
+5. `scope_validation_passed`
+6. `pull_request_opened`
+7. `github_required_checks_green`
+8. `merge_policy_satisfied`
+9. `merged_to_main`
+10. `main_synced`
+11. `task_branch_deleted`
+12. `post_merge_revalidated`
+
+The ops agent stops when a current-PR gate fails. If a blocker is external to the current PR, it may be recorded as a sidecar issue only after the current PR has passed required checks and scope validation.
+
+## Audit Evidence
+
+Each PR must preserve enough evidence for review:
+
+- manifest entry and current state entry;
+- changed-file allowlist result;
+- local command names and pass/fail state;
+- GitHub check names and conclusions;
+- PR URL and merge commit when available;
+- sidecar blocker record when applicable;
+- explicit statement that production rollout, production CMS write, and production gate enablement were not performed.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:36:54+08:00",
+  "updated_at": "2026-06-22T07:37:55+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -56816,7 +56816,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-permission-model-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model",
     "depends_on": [
@@ -56827,11 +56827,12 @@
       "json_tool_pr_train_state": "passed",
       "yaml_parse_pr_train_manifest": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "ca5f218c52e721df675fb9cd5730cd50bcf38b6f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2244",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -56850,6 +56851,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed",
         "notes": "Permission-model docs and staging governance JSON passed local validation and manifest scope validation."
+      },
+      {
+        "at": "2026-06-22T07:37:55+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2244 after local checks and path scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:37:55+08:00",
+  "updated_at": "2026-06-22T07:44:54+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -56816,7 +56816,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-permission-model-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model",
     "depends_on": [
@@ -56828,10 +56828,12 @@
       "yaml_parse_pr_train_manifest": "passed",
       "git_diff_check": "passed",
       "scope_validation": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "merge_state": "clean"
     },
     "failure_reason": null,
-    "commit_sha": "ca5f218c52e721df675fb9cd5730cd50bcf38b6f",
+    "commit_sha": "2c55e2d08555af5a7c9373c80401a87613902b03",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2244",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -56857,6 +56859,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2244 after local checks and path scope validation passed."
+      },
+      {
+        "at": "2026-06-22T07:44:54+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks passed and PR merge state was CLEAN before merge."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T07:39:00+08:00",
+  "updated_at": "2026-06-22T07:36:54+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -56755,7 +56755,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-runbook-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-RUNBOOK-01: docs(riasec): solidify ops agent runbook",
     "depends_on": [],
@@ -56766,14 +56766,15 @@
       "scope_validation": "passed",
       "pr_created": "passed",
       "github_required_checks": "passed",
-      "merge_state": "clean"
+      "merge_state": "clean",
+      "post_merge_revalidation": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "23a536e7fcf45d0d9359ccf349884b166792290a",
+    "commit_sha": "03ecc9ad1f037e05206d319c0051629a98053664",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2240",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T23:33:46Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -56801,20 +56802,33 @@
         "from": "pull_request_open",
         "to": "ready_to_merge",
         "notes": "GitHub required checks passed and PR merge state was CLEAN before merge."
+      },
+      {
+        "at": "2026-06-22T07:36:54+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled PR #2240 after GitHub reported MERGED, origin/main contained merge commit fa0333b68ff4cb261e01be6658c73b4f9a82c7d0, local main was fast-forwarded, and task branches were cleaned."
       }
-    ]
+    ],
+    "merge_commit": "fa0333b68ff4cb261e01be6658c73b4f9a82c7d0"
   },
   "RIASEC-OPS-AGENT-PERMISSION-MODEL-01": {
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-permission-model-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-PERMISSION-MODEL-01: docs(riasec): define ops agent permission model",
     "depends_on": [
       "RIASEC-OPS-AGENT-RUNBOOK-01"
     ],
-    "checks": {},
+    "checks": {
+      "json_tool_permission_model": "passed",
+      "json_tool_pr_train_state": "passed",
+      "yaml_parse_pr_train_manifest": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -56830,6 +56844,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T07:36:54+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "Permission-model docs and staging governance JSON passed local validation and manifest scope validation."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added the RIASEC result page ops agent permission model document.
- Added a staging-only machine-readable governance JSON permission model.
- Reconciled the prior runbook PR state after PR #2240 merged and local cleanup completed.

## Why
The train needs an explicit permission boundary before automation code is introduced. This PR defines what the agent may automate for auto-to-PR, auto-to-staging, and auto-to-report, and what remains forbidden.

## Validation
- `python3 -m json.tool backend/content_assets/riasec/result_page_v2/governance/ops_agent_permission_model.v0_1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- path scope validation against the current PR allowlist

## Intentionally deferred
- No orchestration command or service implementation.
- No staging runner implementation.
- No asset generation.
- No CMS import or write.
- No runtime wrapper changes.
- No production gate enablement or rollout execution.

## Repository rule impact
This PR adds RIASEC ops governance only. RIASEC result content remains backend-authoritative, and production rollout remains a manual approval gate.
