### PR TITLE
Add career page assembly staging preview importer

### DIFF
--- a/backend/app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerJobPageAssemblyAsset;
+use App\Services\Career\PageAssemblyAssets\CareerPageAssemblyImportService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class CareerImportPageAssemblyAssetsPreview extends Command
+{
+    protected $signature = 'career:page-assembly-assets-import-preview
+        {--file= : Absolute path to PASS career_page_assembly_v1 JSONL}
+        {--expected-sha256= : Optional expected SHA-256 for the input JSONL artifact}
+        {--slugs= : Optional comma-separated preview slug subset}
+        {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
+        {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
+        {--dry-run : Validate only; do not write staging rows}
+        {--force : Write rows only when --status=staging_preview}
+        {--status=staging_preview : Target import status; only staging_preview is supported}
+        {--json : Emit machine-readable JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Dry-run or staging-preview import of PASS v1 career page assembly asset rows.';
+
+    public function __construct(
+        private readonly CareerPageAssemblyImportService $importService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $file = trim((string) $this->option('file'));
+            if ($file === '') {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--file is required.'],
+                ], false);
+            }
+
+            $force = (bool) $this->option('force');
+            $dryRun = (bool) $this->option('dry-run');
+            $status = trim((string) $this->option('status')) ?: CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW;
+
+            if ($force && $dryRun) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--force cannot be combined with --dry-run.'],
+                ], false);
+            }
+
+            if ($status !== CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['Only --status=staging_preview is supported.'],
+                ], false);
+            }
+
+            if (
+                $force
+                && (bool) $this->option('all-slugs-from-file')
+                && ! (bool) $this->option('confirm-full-staging-preview')
+            ) {
+                return $this->finish([
+                    'decision' => 'fail',
+                    'errors' => ['--force --all-slugs-from-file requires --confirm-full-staging-preview.'],
+                ], false);
+            }
+
+            $report = $force
+                ? $this->importService->importStagingPreview(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                    $status,
+                )
+                : $this->importService->validateFile(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                );
+
+            return $this->finish($report, ($report['decision'] ?? null) === 'pass');
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'decision' => 'fail',
+                'errors' => [$throwable->getMessage()],
+            ], false);
+        }
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function requestedSlugs(): ?array
+    {
+        $raw = trim((string) $this->option('slugs'));
+        if ($raw === '') {
+            return null;
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (string $slug): string => strtolower(trim($slug)), explode(',', $raw)),
+            static fn (string $slug): bool => $slug !== ''
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $outputPath = trim((string) $this->option('output'));
+        if ($outputPath !== '') {
+            $directory = dirname($outputPath);
+            if (! is_dir($directory)) {
+                mkdir($directory, 0775, true);
+            }
+
+            file_put_contents($outputPath, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif ($success) {
+            $this->info('career page assembly asset preview import validation passed.');
+        } else {
+            $this->error('career page assembly asset preview import validation failed.');
+            foreach ((array) ($report['errors'] ?? []) as $error) {
+                $this->line('- '.(string) $error);
+            }
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerPageAssemblyAssetPreviewController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerPageAssemblyAssetPreviewController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Career;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\CareerJobPageAssemblyAsset;
+use App\Services\Career\PageAssemblyAssets\CareerPageAssemblyPreviewService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class CareerPageAssemblyAssetPreviewController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerPageAssemblyPreviewService $previewService,
+    ) {}
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $locale = is_string($request->query('locale')) ? (string) $request->query('locale') : 'zh-CN';
+        $asset = $this->previewService->previewAsset($slug, $locale);
+
+        if (! $asset instanceof CareerJobPageAssemblyAsset) {
+            return $this->notFoundResponse('career page assembly asset preview unavailable.');
+        }
+
+        return response()->json($this->previewService->publicPayload($asset));
+    }
+}

--- a/backend/app/Models/CareerJobPageAssemblyAsset.php
+++ b/backend/app/Models/CareerJobPageAssemblyAsset.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerJobPageAssemblyAsset extends CareerFoundationModel
+{
+    public const ASSET_VERSION_V1 = 'career_page_assembly_v1';
+
+    public const STATUS_STAGING_PREVIEW = 'staging_preview';
+
+    protected $table = 'career_job_page_assembly_assets';
+
+    protected $casts = [
+        'preview_allowlisted' => 'boolean',
+        'asset_payload_json' => 'array',
+        'block_refs_json' => 'array',
+        'audit_fields_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function occupation(): BelongsTo
+    {
+        return $this->belongsTo(Occupation::class, 'occupation_id', 'id');
+    }
+}

--- a/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
+++ b/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
@@ -1,0 +1,516 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\PageAssemblyAssets;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobPageAssemblyAsset;
+use App\Models\Occupation;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+final class CareerPageAssemblyImportService
+{
+    public const IMPORTER_VERSION = 'career_page_assembly_v1_staging_preview_importer_v0.1';
+
+    public function __construct(
+        private readonly CareerPageAssemblyPreviewService $previewService,
+        private readonly CareerRuntimePublishProjectionVisibility $runtimeProjection,
+        private readonly PublicCareerAuthorityResponseCache $authorityResponseCache,
+    ) {}
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function validateFile(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        bool $enforcePreviewAllowlist = true,
+    ): array {
+        $report = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile, $enforcePreviewAllowlist);
+        $errors = [];
+
+        if (! is_file($file) || ! is_readable($file)) {
+            return array_merge($report, [
+                'decision' => 'fail',
+                'errors' => ['Source JSONL file is missing or unreadable.'],
+            ]);
+        }
+
+        $sourceSha = hash_file('sha256', $file) ?: null;
+        if ($expectedSha256 !== null && $this->normalizeSha256($expectedSha256) !== $sourceSha) {
+            $errors[] = 'Source JSONL SHA-256 does not match --expected-sha256.';
+        }
+
+        [$rowsByKey, $slugsFromFile, $parseErrors, $duplicateKeys, $totalLines] = $this->readRowsByKey($file);
+        foreach ($parseErrors as $parseError) {
+            $errors[] = $parseError;
+        }
+        foreach ($duplicateKeys as $duplicateKey) {
+            $errors[] = "Duplicate slug/locale row: {$duplicateKey}.";
+        }
+
+        $targetSlugs = $allSlugsFromFile
+            ? array_values(array_unique($slugsFromFile))
+            : $this->targetSlugs($requestedSlugs, $errors, $enforcePreviewAllowlist);
+
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            $targetKeys[] = $slug.'|zh-CN';
+            $targetKeys[] = $slug.'|en';
+        }
+
+        $validatedRows = [];
+        foreach ($targetKeys as $targetKey) {
+            $row = $rowsByKey[$targetKey] ?? null;
+            if (! is_array($row)) {
+                $errors[] = "{$targetKey}: required preview row missing.";
+
+                continue;
+            }
+
+            [$slug, $locale] = explode('|', $targetKey, 2);
+            foreach ($this->rowErrors($row, $slug, $locale) as $rowError) {
+                $errors[] = "{$targetKey}: {$rowError}";
+            }
+            $validatedRows[] = $row;
+        }
+
+        $authorityReport = $this->careerJobBundleAuthorityReport($targetSlugs);
+        foreach ($authorityReport['rows'] as $authorityRow) {
+            foreach ((array) ($authorityRow['errors'] ?? []) as $authorityError) {
+                $errors[] = ((string) ($authorityRow['slug'] ?? 'unknown')).': missing_career_job_bundle_authority: '.(string) $authorityError;
+            }
+        }
+
+        $projectionSafety = $this->projectionSafetyReport($validatedRows);
+        foreach ($projectionSafety['rows'] as $projectionRow) {
+            foreach ((array) ($projectionRow['errors'] ?? []) as $projectionError) {
+                $errors[] = ((string) ($projectionRow['slug'] ?? 'unknown')).'/'.((string) ($projectionRow['locale'] ?? 'unknown')).': reader_safe_projection: '.(string) $projectionError;
+            }
+        }
+
+        return array_merge($report, [
+            'mode' => 'dry_run',
+            'decision' => $errors === [] ? 'pass' : 'fail',
+            'source_file_sha256' => $sourceSha,
+            'source_file_sha256_match' => $expectedSha256 === null || $this->normalizeSha256($expectedSha256) === $sourceSha,
+            'target_slugs' => $targetSlugs,
+            'target_slug_count' => count($targetSlugs),
+            'total_jsonl_rows' => $totalLines,
+            'validated_preview_rows' => count($validatedRows),
+            'expected_preview_rows' => count($targetSlugs) * 2,
+            'duplicate_key_count' => count($duplicateKeys),
+            'career_job_bundle_authority' => $authorityReport,
+            'reader_safe_projection' => $projectionSafety,
+            'idempotency' => $this->idempotencyReport($sourceSha, $targetSlugs),
+            'rollback_policy' => $this->rollbackPolicy(),
+            'staging_write_performed' => false,
+            'production_import_allowed' => false,
+            'production_rows_touched' => 0,
+            'runtime_modified' => false,
+            'seo_runtime_modified' => false,
+            'search_projection_activated' => false,
+            'errors' => array_values(array_unique($errors)),
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    public function importStagingPreview(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        string $status = CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+    ): array {
+        if ($status !== CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW) {
+            return [
+                'mode' => 'invalid',
+                'decision' => 'fail',
+                'errors' => ['Only staging_preview status is supported by this command.'],
+                'production_import_allowed' => false,
+            ];
+        }
+
+        $validation = $this->validateFile(
+            $file,
+            $requestedSlugs,
+            $expectedSha256,
+            $allSlugsFromFile,
+            ! $allSlugsFromFile,
+        );
+        if (($validation['decision'] ?? null) !== 'pass') {
+            return array_merge($validation, [
+                'mode' => 'write',
+                'staging_write_performed' => false,
+                'written_count' => 0,
+            ]);
+        }
+
+        $sourceSha = (string) ($validation['source_file_sha256'] ?? '');
+        $targetSlugs = (array) ($validation['target_slugs'] ?? []);
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            $targetKeys[] = (string) $slug.'|zh-CN';
+            $targetKeys[] = (string) $slug.'|en';
+        }
+        $rowsByKey = $this->targetRowsFromFile($file, $targetKeys);
+        $importRunId = (string) Str::uuid();
+
+        $writtenRows = DB::transaction(function () use ($rowsByKey, $sourceSha, $importRunId): array {
+            $written = [];
+            foreach ($rowsByKey as $key => $row) {
+                $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+                $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+                $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
+                $asset = CareerJobPageAssemblyAsset::query()->updateOrCreate(
+                    [
+                        'career_job_slug' => $slug,
+                        'locale' => $locale,
+                        'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+                        'preview_allowlisted' => true,
+                        'asset_payload_json' => $row,
+                        'block_refs_json' => is_array($row['block_refs'] ?? null) ? $row['block_refs'] : null,
+                        'audit_fields_json' => is_array($row['audit_fields'] ?? null) ? $row['audit_fields'] : null,
+                        'asset_row_hash' => (string) data_get($row, 'audit_fields.row_hash'),
+                        'source_artifact_sha256' => $sourceSha,
+                        'import_run_id' => $importRunId,
+                    ],
+                );
+                $written[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'row_id' => $asset->id,
+                    'created' => $asset->wasRecentlyCreated,
+                ];
+            }
+
+            return $written;
+        });
+
+        $expectedRows = (int) ($validation['expected_preview_rows'] ?? 0);
+        $decision = count($writtenRows) === $expectedRows ? 'pass' : 'fail';
+
+        return array_merge($validation, [
+            'mode' => 'write',
+            'decision' => $decision,
+            'status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+            'staging_write_performed' => true,
+            'production_import_allowed' => false,
+            'production_rows_touched' => 0,
+            'cms_rows_touched' => 0,
+            'runtime_modified' => false,
+            'seo_runtime_modified' => false,
+            'search_projection_activated' => false,
+            'import_run_id' => $importRunId,
+            'written_count' => count($writtenRows),
+            'expected_written_count' => $expectedRows,
+            'created_count' => count(array_filter($writtenRows, static fn (array $row): bool => ($row['created'] ?? false) === true)),
+            'updated_count' => count(array_filter($writtenRows, static fn (array $row): bool => ($row['created'] ?? false) !== true)),
+            'written_rows' => $writtenRows,
+            'errors' => $decision === 'pass' ? [] : ['Staging preview write count invariant failed.'],
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
+    private function baseReport(string $file, ?array $requestedSlugs, bool $allSlugsFromFile, bool $enforcePreviewAllowlist): array
+    {
+        return [
+            'importer_version' => self::IMPORTER_VERSION,
+            'source_file' => $file,
+            'requested_slugs' => $requestedSlugs,
+            'all_slugs_from_file' => $allSlugsFromFile,
+            'preview_allowlist_enforced' => $enforcePreviewAllowlist,
+            'status_policy' => 'staging_preview_only',
+        ];
+    }
+
+    /**
+     * @return array{0: array<string, array<string, mixed>>, 1: list<string>, 2: list<string>, 3: list<string>, 4: int}
+     */
+    private function readRowsByKey(string $file): array
+    {
+        $rowsByKey = [];
+        $slugsFromFile = [];
+        $parseErrors = [];
+        $duplicateKeys = [];
+        $totalLines = 0;
+        $lineNumber = 0;
+        $handle = fopen($file, 'rb');
+        if ($handle === false) {
+            return [$rowsByKey, $slugsFromFile, ['Source JSONL file could not be opened.'], $duplicateKeys, $totalLines];
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $lineNumber++;
+            if (trim($line) === '') {
+                continue;
+            }
+            $totalLines++;
+            try {
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                $parseErrors[] = "Line {$lineNumber}: invalid JSON.";
+
+                continue;
+            }
+            if (! is_array($row)) {
+                $parseErrors[] = "Line {$lineNumber}: row must be an object.";
+
+                continue;
+            }
+            $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+            $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+            if ($slug === '' || ! in_array($locale, ['zh-CN', 'en'], true)) {
+                $parseErrors[] = "Line {$lineNumber}: slug and locale are required.";
+
+                continue;
+            }
+            $key = $slug.'|'.$locale;
+            if (isset($rowsByKey[$key])) {
+                $duplicateKeys[] = $key;
+
+                continue;
+            }
+            $rowsByKey[$key] = $row;
+            $slugsFromFile[] = $slug;
+        }
+        fclose($handle);
+
+        return [$rowsByKey, array_values(array_unique($slugsFromFile)), $parseErrors, array_values(array_unique($duplicateKeys)), $totalLines];
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @param  list<string>  $errors
+     * @return list<string>
+     */
+    private function targetSlugs(?array $requestedSlugs, array &$errors, bool $enforcePreviewAllowlist): array
+    {
+        $allowlist = $this->previewService->previewSlugs();
+        $target = $requestedSlugs === null || $requestedSlugs === []
+            ? $allowlist
+            : array_values(array_unique(array_map(
+                fn (string $slug): string => $this->previewService->normalizeSlug($slug),
+                $requestedSlugs
+            )));
+
+        if ($enforcePreviewAllowlist) {
+            foreach ($target as $slug) {
+                if (! in_array($slug, $allowlist, true)) {
+                    $errors[] = "{$slug}: slug is not in the career content page assembly staging preview allowlist.";
+                }
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array<string, mixed>
+     */
+    private function careerJobBundleAuthorityReport(array $targetSlugs): array
+    {
+        $rows = [];
+        $readyCount = 0;
+
+        foreach ($targetSlugs as $slug) {
+            $occupationExists = Occupation::query()->where('canonical_slug', $slug)->exists();
+            $enItem = $this->runtimeProjection->itemForSlug($slug, 'en');
+            $zhItem = $this->runtimeProjection->itemForSlug($slug, 'zh-CN');
+            $projectionItem = is_array($enItem) ? $enItem : (is_array($zhItem) ? $zhItem : null);
+            $projectionExists = is_array($projectionItem);
+            $publicResolutionType = $projectionExists ? (string) ($projectionItem['public_resolution_type'] ?? '') : null;
+            $detailRouteEnabled = $projectionExists ? (($projectionItem['detail_route_enabled'] ?? false) === true) : false;
+            $releaseGatePass = $projectionExists ? (($projectionItem['release_gate_pass'] ?? false) === true) : false;
+            $detailApiZh = $this->authorityResponseCache->jobDetailPayload($slug, 'zh-CN') !== null;
+            $detailApiEn = $this->authorityResponseCache->jobDetailPayload($slug, 'en') !== null;
+            $errors = [];
+
+            if (! $occupationExists) {
+                $errors[] = 'occupation row is missing.';
+            }
+            if (! $projectionExists) {
+                $errors[] = 'runtime publish projection item is missing.';
+            }
+            if ($projectionExists && $publicResolutionType !== CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB) {
+                $errors[] = 'public_resolution_type must be public_canonical_job.';
+            }
+            if ($projectionExists && ! $detailRouteEnabled) {
+                $errors[] = 'detail_route_enabled must be true.';
+            }
+            if ($projectionExists && ! $releaseGatePass) {
+                $errors[] = 'release_gate_pass must be true.';
+            }
+            if (! $detailApiZh) {
+                $errors[] = 'zh-CN career job detail API is not ready.';
+            }
+            if (! $detailApiEn) {
+                $errors[] = 'en career job detail API is not ready.';
+            }
+
+            if ($errors === []) {
+                $readyCount++;
+            }
+
+            $rows[] = [
+                'slug' => $slug,
+                'occupation_row_exists' => $occupationExists,
+                'runtime_publish_projection_item_exists' => $projectionExists,
+                'public_resolution_type' => $publicResolutionType,
+                'detail_route_enabled' => $detailRouteEnabled,
+                'release_gate_pass' => $releaseGatePass,
+                'detail_api_zh_CN_200' => $detailApiZh,
+                'detail_api_en_200' => $detailApiEn,
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_slug_count' => count($targetSlugs),
+            'ready_slug_count' => $readyCount,
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return array{checked_row_count: int, ready_row_count: int, rows: list<array<string, mixed>>}
+     */
+    private function projectionSafetyReport(array $rows): array
+    {
+        $reportRows = [];
+        $readyCount = 0;
+        foreach ($rows as $row) {
+            $errors = [];
+            $safePayload = $this->previewService->readerSafePayload($row);
+            $safeText = json_encode($safePayload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '';
+            foreach (['audit_fields', 'source_row_hash', 'row_hash', 'block_refs', 'search_projection', 'candidate_only', 'runtime seo', 'json-ld', 'canonical', 'noindex'] as $fragment) {
+                if (str_contains(strtolower($safeText), strtolower($fragment))) {
+                    $errors[] = "reader-safe projection must not leak {$fragment}.";
+                }
+            }
+            if ($errors === []) {
+                $readyCount++;
+            }
+            $reportRows[] = [
+                'slug' => $this->previewService->normalizeSlug((string) ($row['slug'] ?? '')),
+                'locale' => $this->previewService->normalizeLocale((string) ($row['locale'] ?? '')),
+                'ready' => $errors === [],
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'checked_row_count' => count($rows),
+            'ready_row_count' => $readyCount,
+            'rows' => $reportRows,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return list<string>
+     */
+    private function rowErrors(array $row, string $slug, string $locale): array
+    {
+        $errors = [];
+        if (($row['asset_version'] ?? null) !== CareerJobPageAssemblyAsset::ASSET_VERSION_V1) {
+            $errors[] = 'asset_version must be career_page_assembly_v1.';
+        }
+        if (($row['block_type'] ?? null) !== 'career-page-assembly') {
+            $errors[] = 'block_type must be career-page-assembly.';
+        }
+        if (($row['ledger_type'] ?? null) !== 'career-page-assembly') {
+            $errors[] = 'ledger_type must be career-page-assembly.';
+        }
+        if ($this->previewService->normalizeSlug((string) ($row['slug'] ?? '')) !== $slug) {
+            $errors[] = 'slug does not match target slug.';
+        }
+        if ($this->previewService->normalizeLocale((string) ($row['locale'] ?? '')) !== $locale) {
+            $errors[] = 'locale does not match target locale.';
+        }
+        if (! is_array($row['occupation'] ?? null)) {
+            $errors[] = 'occupation object is required.';
+        }
+        if (! is_array($row['section_order'] ?? null) || $row['section_order'] === []) {
+            $errors[] = 'section_order must be a non-empty array.';
+        }
+        if (! is_array($row['page_sections'] ?? null) || $row['page_sections'] === []) {
+            $errors[] = 'page_sections must be a non-empty array.';
+        }
+        if (! is_array($row['audit_fields'] ?? null) || ! $this->normalizeSha256((string) data_get($row, 'audit_fields.row_hash'))) {
+            $errors[] = 'audit_fields.row_hash must be present.';
+        }
+        if (array_key_exists('search_projection', $row)) {
+            $errors[] = 'search_projection must not be embedded in reader asset rows.';
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>  $targetSlugs
+     * @return array<string, mixed>
+     */
+    private function idempotencyReport(?string $sourceFileSha256, array $targetSlugs): array
+    {
+        return [
+            'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+            'source_file_sha256' => $sourceFileSha256,
+            'target_slug_count' => count($targetSlugs),
+            'expected_row_count' => count($targetSlugs) * 2,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function rollbackPolicy(): array
+    {
+        return [
+            'dry_run_writes_database' => false,
+            'staging_preview_write_supported_in_this_pr' => true,
+            'production_import_supported_in_this_pr' => false,
+            'rollback_boundary' => 'Rows written by staging_preview are scoped by import_run_id and target key.',
+        ];
+    }
+
+    /**
+     * @param  list<string>  $targetKeys
+     * @return array<string, array<string, mixed>>
+     */
+    private function targetRowsFromFile(string $file, array $targetKeys): array
+    {
+        [$rowsByKey] = $this->readRowsByKey($file);
+        $targetKeyMap = array_fill_keys($targetKeys, true);
+
+        return array_intersect_key($rowsByKey, $targetKeyMap);
+    }
+
+    private function normalizeSha256(?string $value): ?string
+    {
+        $normalized = strtolower(trim((string) $value));
+
+        return preg_match('/^[a-f0-9]{64}$/', $normalized) === 1 ? $normalized : null;
+    }
+}

--- a/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php
+++ b/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\PageAssemblyAssets;
+
+use App\Models\CareerJobPageAssemblyAsset;
+
+final class CareerPageAssemblyPreviewService
+{
+    private const FORBIDDEN_READER_KEYS = [
+        'audit_fields',
+        'block_refs',
+        'source_row_hash',
+        'row_hash',
+        'search_projection',
+        'internal_lineage',
+        'lineage',
+    ];
+
+    public function previewEnabled(): bool
+    {
+        return (bool) config('career_content_page_assembly_assets.staging_preview_enabled', false);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function previewSlugs(): array
+    {
+        $slugs = config('career_content_page_assembly_assets.preview_slugs', []);
+        if (! is_array($slugs)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            array_map(fn (mixed $slug): string => $this->normalizeSlug((string) $slug), $slugs),
+            static fn (string $slug): bool => $slug !== ''
+        )));
+    }
+
+    public function previewAsset(string $slug, string $locale): ?CareerJobPageAssemblyAsset
+    {
+        $normalizedLocale = $this->normalizePreviewLocale($locale);
+        if ($normalizedLocale === null || ! $this->previewEnabled()) {
+            return null;
+        }
+
+        return CareerJobPageAssemblyAsset::query()
+            ->where('career_job_slug', $this->normalizeSlug($slug))
+            ->where('locale', $normalizedLocale)
+            ->where('asset_version', CareerJobPageAssemblyAsset::ASSET_VERSION_V1)
+            ->where('status', CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW)
+            ->where('preview_allowlisted', true)
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function publicPayload(CareerJobPageAssemblyAsset $asset): array
+    {
+        $payload = is_array($asset->asset_payload_json) ? $asset->asset_payload_json : [];
+
+        return [
+            'ok' => true,
+            'preview' => true,
+            'status' => $asset->status,
+            'career_page_assembly_v1' => $this->readerSafePayload($payload),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function readerSafePayload(array $payload): array
+    {
+        $safePayload = [];
+        foreach ([
+            'slug',
+            'locale',
+            'asset_version',
+            'occupation',
+            'section_order',
+            'page_sections',
+            'reader_boundary',
+        ] as $readerKey) {
+            if (array_key_exists($readerKey, $payload)) {
+                $safePayload[$readerKey] = $this->sanitizeReaderValue($payload[$readerKey]);
+            }
+        }
+
+        $safePayload['preview'] = true;
+
+        return $safePayload;
+    }
+
+    public function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    public function normalizeLocale(string $locale): string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            default => 'zh-CN',
+        };
+    }
+
+    private function normalizePreviewLocale(string $locale): ?string
+    {
+        return match (strtolower(trim($locale))) {
+            'en', 'en-us', 'en_us' => 'en',
+            'zh', 'zh-cn', 'zh_cn' => 'zh-CN',
+            default => null,
+        };
+    }
+
+    private function sanitizeReaderValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $sanitized = [];
+        foreach ($value as $key => $nestedValue) {
+            if (is_string($key) && in_array($key, self::FORBIDDEN_READER_KEYS, true)) {
+                continue;
+            }
+
+            $sanitized[$key] = $this->sanitizeReaderValue($nestedValue);
+        }
+
+        return $sanitized;
+    }
+}

--- a/backend/config/career_content_page_assembly_assets.php
+++ b/backend/config/career_content_page_assembly_assets.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+$resolvePreviewSlugs = static function (): array {
+    $raw = trim((string) env('CAREER_CONTENT_PAGE_ASSEMBLY_PREVIEW_SLUGS', ''));
+    if ($raw !== '') {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded)) {
+            return array_values(array_unique(array_map(
+                static fn (mixed $slug): string => strtolower(trim((string) $slug)),
+                $decoded
+            )));
+        }
+
+        return array_values(array_unique(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            preg_split('/\s*,\s*/', $raw, -1, PREG_SPLIT_NO_EMPTY) ?: []
+        )));
+    }
+
+    return [
+        'accountants-and-auditors',
+        'actuaries',
+        'computer-programmers',
+        'agents-and-business-managers-of-artists-performers-and-athletes',
+        'writers-and-authors',
+        'zoologists-and-wildlife-biologists',
+        'wind-turbine-technicians',
+        'woodworking-machine-setters-operators-and-tenders-except-sawing',
+        'air-traffic-controllers',
+        'athletes-and-sports-competitors',
+        'acute-care-nurses',
+        'emergency-medicine-physicians',
+        'nurse-anesthetists',
+        'pharmacists',
+        'diagnostic-medical-sonographers',
+        'medical-and-clinical-laboratory-technologists',
+        'genetic-counselors',
+        'physicians-and-surgeons',
+        'airline-pilots-copilots-and-flight-engineers',
+        'aviation-inspectors',
+        'aircraft-and-avionics-equipment-mechanics-and-technicians',
+        'commercial-pilots',
+        'administrative-law-judges-adjudicators-and-hearing-officers',
+        'judges-magistrate-judges-and-magistrates',
+        'lawyers',
+        'judicial-law-clerks',
+        'military-careers',
+        'first-line-supervisors-of-air-crew-members',
+        'first-line-supervisors-of-weapons-specialists-crew-members',
+        'command-and-control-center-officers',
+        'elementary-school-teachers-except-special-education',
+        'school-and-career-counselors',
+        'adult-literacy-and-ged-teachers',
+        'special-education-teachers-elementary-school',
+        'actors',
+        'poets-lyricists-and-creative-writers',
+        'multimedia-artists-and-animators',
+        'dancers-and-choreographers',
+        'electricians',
+        'plumbers-pipefitters-and-steamfitters',
+        'firefighters',
+        'police-and-sheriff-s-patrol-officers',
+        'heavy-and-tractor-trailer-truck-drivers',
+        'construction-and-building-inspectors',
+        'web-developers',
+        'data-scientists',
+        'information-security-analysts',
+        'civil-engineers',
+        'biomedical-engineers',
+        'computer-systems-engineers-architects',
+    ];
+};
+
+return [
+    'staging_preview_enabled' => env('CAREER_CONTENT_PAGE_ASSEMBLY_PREVIEW_ENABLED', false),
+    'preview_slugs' => $resolvePreviewSlugs(),
+];

--- a/backend/database/migrations/2026_06_22_000100_create_career_job_page_assembly_assets_table.php
+++ b/backend/database/migrations/2026_06_22_000100_create_career_job_page_assembly_assets_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('career_job_page_assembly_assets')) {
+            return;
+        }
+
+        Schema::create('career_job_page_assembly_assets', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('occupation_id');
+            $table->string('career_job_slug', 160);
+            $table->string('locale', 16);
+            $table->string('asset_version', 96);
+            $table->string('status', 64);
+            $table->boolean('preview_allowlisted')->default(false);
+            $table->json('asset_payload_json');
+            $table->json('block_refs_json')->nullable();
+            $table->json('audit_fields_json')->nullable();
+            $table->string('asset_row_hash', 64);
+            $table->string('source_artifact_sha256', 64)->nullable();
+            $table->uuid('import_run_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['career_job_slug', 'locale', 'asset_version'], 'career_page_assembly_slug_locale_version_unique');
+            $table->index(['status', 'preview_allowlisted'], 'career_page_assembly_status_preview_idx');
+            $table->index('asset_version', 'career_page_assembly_version_idx');
+            $table->index('import_run_id', 'career_page_assembly_import_run_idx');
+            $table->index('occupation_id', 'career_page_assembly_occupation_idx');
+
+            $table->foreign('occupation_id')
+                ->references('id')
+                ->on('occupations')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // Forward-only migration: rollback is intentionally disabled to avoid
+        // deleting preview/import ledgers in shared environments.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -2889,6 +2889,23 @@
                 ]
             }
         },
+        "/api/v0.5/career/jobs/{slug}/page-assembly-asset": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_page_assembly_asset",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Career\\CareerPageAssemblyAssetPreviewController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career/jobs/{slug}/salary-asset": {
             "get": {
                 "operationId": "get_api_v0_5_career_jobs_slug_salary_asset",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -52,6 +52,7 @@ use App\Http\Controllers\API\V0_5\Career\CareerJobExplainabilityController;
 use App\Http\Controllers\API\V0_5\Career\CareerJobListController;
 use App\Http\Controllers\API\V0_5\Career\CareerLaunchGovernanceClosureController;
 use App\Http\Controllers\API\V0_5\Career\CareerLifecycleOperationalSummaryController;
+use App\Http\Controllers\API\V0_5\Career\CareerPageAssemblyAssetPreviewController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationDetailController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationExplainabilityController;
 use App\Http\Controllers\API\V0_5\Career\CareerRecommendationFeedbackController;
@@ -508,6 +509,7 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/jobs', [CareerJobListController::class, 'index']);
     Route::get('/career/cn-proxy/{slug}', [CareerCnProxyPublicOwnerController::class, 'show']);
     Route::get('/career/jobs/{slug}/ai-impact-asset', [CareerAiImpactAssetPreviewController::class, 'show']);
+    Route::get('/career/jobs/{slug}/page-assembly-asset', [CareerPageAssemblyAssetPreviewController::class, 'show']);
     Route::get('/career/jobs/{slug}/salary-asset', [CareerSalaryAssetPreviewController::class, 'show']);
     Route::get('/career/jobs/{slug}', [CareerJobDetailController::class, 'show']);
     Route::get('/career/jobs/{slug}/explainability', [CareerJobExplainabilityController::class, 'show']);

--- a/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Career;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobPageAssemblyAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Services\Career\PageAssemblyAssets\CareerPageAssemblyImportService;
+use App\Services\Career\PageAssemblyAssets\CareerPageAssemblyPreviewService;
+use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class CareerPageAssemblyAssetPreviewImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        $this->seedRuntimeProjectionAuthority([]);
+    }
+
+    public function test_page_assembly_asset_sidecar_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('career_job_page_assembly_assets'));
+        $this->assertTrue(Schema::hasColumn('career_job_page_assembly_assets', 'asset_payload_json'));
+        $this->assertTrue(Schema::hasColumn('career_job_page_assembly_assets', 'asset_row_hash'));
+        $this->assertTrue(Schema::hasColumn('career_job_page_assembly_assets', 'preview_allowlisted'));
+    }
+
+    public function test_importer_dry_run_validates_page_assembly_rows_without_writing(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/page-assembly-preview-dry-run.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--dry-run' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_page_assembly_assets', 0);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame(2, $decoded['validated_preview_rows']);
+        $this->assertSame(1, $decoded['career_job_bundle_authority']['ready_slug_count']);
+        $this->assertFalse((bool) ($decoded['production_import_allowed'] ?? true));
+        $this->assertFalse((bool) ($decoded['staging_write_performed'] ?? true));
+        $this->assertFalse((bool) ($decoded['search_projection_activated'] ?? true));
+    }
+
+    public function test_importer_force_writes_staging_preview_rows_after_validation_passes(): void
+    {
+        Config::set('career_content_page_assembly_assets.staging_preview_enabled', true);
+        Config::set('career_content_page_assembly_assets.preview_slugs', ['accountants-and-auditors']);
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $sha = hash_file('sha256', $file);
+        $report = storage_path('framework/testing/page-assembly-preview-force-write.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $sha,
+            '--force' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('career_job_page_assembly_assets', 2);
+        $this->assertDatabaseHas('career_job_page_assembly_assets', [
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+            'status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'source_artifact_sha256' => $sha,
+        ]);
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('write', $decoded['mode']);
+        $this->assertSame(2, $decoded['written_count']);
+        $this->assertTrue((bool) $decoded['staging_write_performed']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['runtime_modified']);
+        $this->assertFalse((bool) $decoded['seo_runtime_modified']);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/page-assembly-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('preview', true)
+            ->assertJsonPath('status', CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW)
+            ->assertJsonPath('career_page_assembly_v1.slug', 'accountants-and-auditors')
+            ->assertJsonPath('career_page_assembly_v1.locale', 'en')
+            ->assertJsonMissingPath('career_page_assembly_v1.block_refs')
+            ->assertJsonMissingPath('career_page_assembly_v1.audit_fields')
+            ->assertJsonMissingPath('career_page_assembly_v1.page_sections.0.source_row_hash')
+            ->assertJsonMissingPath('career_page_assembly_v1.search_projection');
+    }
+
+    public function test_preview_api_fails_closed_when_flag_off_or_locale_is_invalid(): void
+    {
+        Config::set('career_content_page_assembly_assets.staging_preview_enabled', false);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        CareerJobPageAssemblyAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+            'status' => CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            'block_refs_json' => [],
+            'audit_fields_json' => ['row_hash' => str_repeat('a', 64)],
+            'asset_row_hash' => str_repeat('a', 64),
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/page-assembly-asset?locale=zh-CN')
+            ->assertNotFound()
+            ->assertJsonPath('ok', false);
+
+        Config::set('career_content_page_assembly_assets.staging_preview_enabled', true);
+
+        $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/page-assembly-asset?locale=fr')
+            ->assertNotFound()
+            ->assertJsonPath('ok', false);
+    }
+
+    public function test_force_all_slugs_from_file_requires_explicit_confirmation(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/page-assembly-preview-force-missing-confirmation.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--all-slugs-from-file' => true,
+            '--force' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertDatabaseCount('career_job_page_assembly_assets', 0);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertContains('--force --all-slugs-from-file requires --confirm-full-staging-preview.', $decoded['errors']);
+    }
+
+    private function seedCareerJobBundleAuthority(string $slug): void
+    {
+        $this->seedRuntimeProjectionAuthority([$slug]);
+
+        if (! Occupation::query()->where('canonical_slug', $slug)->exists()) {
+            $this->seedOccupation($slug);
+        }
+
+        $authorityCache = app(PublicCareerAuthorityResponseCache::class);
+        Cache::forever($authorityCache->jobDetailCacheKey($slug, 'zh-CN'), [
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'sections' => [['key' => 'identity']],
+        ]);
+        Cache::forever($authorityCache->jobDetailCacheKey($slug, 'en'), [
+            'slug' => $slug,
+            'locale' => 'en',
+            'sections' => [['key' => 'identity']],
+        ]);
+
+        $this->app->forgetInstance(CareerPageAssemblyImportService::class);
+        $this->app->forgetInstance(CareerPageAssemblyPreviewService::class);
+        $this->app->forgetInstance('App\\Console\\Commands\\CareerImportPageAssemblyAssetsPreview');
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function seedRuntimeProjectionAuthority(array $slugs): void
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            $normalizedSlug = strtolower(trim($slug));
+            foreach (['en', 'zh', 'zh-CN'] as $locale) {
+                $items[$normalizedSlug.'|'.$locale] = [
+                    'slug' => $normalizedSlug,
+                    'locale' => $locale,
+                    'public_resolution_type' => 'public_canonical_job',
+                    'dataset_visible' => true,
+                    'search_visible' => true,
+                    'detail_route_enabled' => true,
+                    'robots_indexable' => true,
+                    'release_gate_pass' => true,
+                    'runtime_publish_state' => 'published',
+                ];
+            }
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                items: $items,
+            ),
+        );
+    }
+
+    private function seedOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'page-assembly-preview-'.$slug,
+            'title_en' => 'Page Assembly Preview',
+            'title_zh' => '页面组装预览',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Accountants and Auditors',
+            'canonical_title_zh' => '会计师和审计师',
+            'search_h1_zh' => '会计师和审计师',
+            'structural_stability' => 0.9,
+            'task_prototype_signature' => ['analysis' => 0.8],
+            'market_semantics_gap' => 0.1,
+            'regulatory_divergence' => 0.1,
+            'toolchain_divergence' => 0.1,
+            'skill_gap_threshold' => 0.4,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function writeJsonl(array $rows): string
+    {
+        $path = storage_path('framework/testing/page-assembly-preview-'.bin2hex(random_bytes(4)).'.jsonl');
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        file_put_contents($path, implode('', array_map(
+            static fn (array $row): string => json_encode($row, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL,
+            $rows
+        )));
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assemblyRow(string $slug, string $locale): array
+    {
+        return [
+            'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+            'audit_fields' => [
+                'row_hash' => hash('sha256', $slug.'|'.$locale),
+                'source_block_count' => 7,
+            ],
+            'block_refs' => [
+                'career-identity' => [
+                    'status' => 'available',
+                    'source_row_hash' => str_repeat('b', 64),
+                ],
+            ],
+            'block_type' => 'career-page-assembly',
+            'ledger_type' => 'career-page-assembly',
+            'locale' => $locale,
+            'missing_blocks' => [],
+            'occupation' => [
+                'title_en' => 'Accountants and Auditors',
+                'title_zh' => '会计师和审计师',
+                'soc_code' => '13-2011',
+                'onet_code' => '13-2011.00',
+            ],
+            'page_sections' => [
+                [
+                    'section_key' => 'hero_identity',
+                    'display_priority' => 10,
+                    'availability_status' => 'available',
+                    'source_block' => 'career-identity',
+                    'source_row_hash' => str_repeat('c', 64),
+                ],
+                [
+                    'section_key' => 'work_activities',
+                    'display_priority' => 20,
+                    'availability_status' => 'available',
+                    'source_block' => 'career-work-activities',
+                    'source_row_hash' => str_repeat('d', 64),
+                ],
+            ],
+            'reader_boundary' => 'Preview payload is assembled from PASS or mature registered blocks and contains no new career facts.',
+            'runtime_boundary' => 'Preview-only page assembly; not a runtime SEO instruction.',
+            'section_order' => ['hero_identity', 'work_activities'],
+            'seed_ordinal' => 1,
+            'slug' => $slug,
+            'source_coverage' => [
+                'available_block_count' => 7,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3025,6 +3025,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_career_page_assembly_asset_preview_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerPageAssemblyAssetPreviewController.php',
+            'backend/app/Models/CareerJobPageAssemblyAsset.php',
+            'backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php',
+            'backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php',
+            'backend/database/migrations/2026_06_22_000100_create_career_job_page_assembly_assets_table.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerPageAssemblyAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/page-assembly-asset', [CareerPageAssemblyAssetPreviewController::class, 'show']);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_asset_backed_bundle_changes(): void
     {
         $changed = [
@@ -4345,6 +4368,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerPageAssemblyAssetPreviewContractFile($file)) {
+                continue;
+            }
+
             if (
                 $file === 'backend/app/Services/Content/ContentPacksIndex.php'
                 && $this->contentPacksIndexDiffIsStreamingScanOnly(
@@ -4407,6 +4434,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsCareerAiImpactAssetPreviewContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsCareerPageAssemblyAssetPreviewContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -6331,6 +6365,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isCareerPageAssemblyAssetPreviewContractFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerPageAssemblyAssetPreviewController.php',
+            'backend/app/Models/CareerJobPageAssemblyAsset.php',
+            'backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php',
+            'backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php',
+            'backend/database/migrations/2026_06_22_000100_create_career_job_page_assembly_assets_table.php',
+        ], true);
+    }
+
     private function isCareerPublicDistributionFile(string $file): bool
     {
         return in_array($file, [
@@ -8109,6 +8154,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowedLines = [
             '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerAiImpactAssetPreviewController;',
             "+    Route::get('/career/jobs/{slug}/ai-impact-asset', [CareerAiImpactAssetPreviewController::class, 'show']);",
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsCareerPageAssemblyAssetPreviewContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Career\\CareerPageAssemblyAssetPreviewController;',
+            "+    Route::get('/career/jobs/{slug}/page-assembly-asset', [CareerPageAssemblyAssetPreviewController::class, 'show']);",
         ];
 
         foreach ($changedLines as $line) {


### PR DESCRIPTION
## Summary
- add a dedicated `career_job_page_assembly_assets` staging-preview sidecar table/model for career page assembly assets
- add a dry-run/`--force staging_preview` importer with career job bundle authority and reader-safe projection gates
- expose a fail-closed preview API at `/api/v0.5/career/jobs/{slug}/page-assembly-asset?locale={locale}`
- add feature coverage for dry-run, staging-preview writes, API projection safety, allowlist/flag fail-closed behavior, and full-preview confirmation

## Why
The completed career page assembly baseline needs the same staged handoff pattern as salary and AI Impact before any CMS/runtime integration: dry-run first, then explicit staging-preview write, then API smoke. This PR only adds the backend harness required for that path.

## Validation
- `php artisan test tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php`
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `./vendor/bin/pint --test app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php app/Http/Controllers/API/V0_5/Career/CareerPageAssemblyAssetPreviewController.php app/Models/CareerJobPageAssemblyAsset.php app/Services/Career/PageAssemblyAssets config/career_content_page_assembly_assets.php database/migrations/2026_06_22_000100_create_career_job_page_assembly_assets_table.php tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php routes/api.php`
- `php artisan route:list --path=career/jobs --no-ansi | rg "page-assembly|ai-impact|salary"`
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --pretend --no-ansi`
- `git diff --check`

## Intentionally deferred
- no production import
- no CMS import
- no staging-preview write performed by this PR
- no fap-web runtime/page changes
- no SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, or search_projection activation
- 50-slug/full 1046 dry-run and `--force staging_preview` execution after this PR is merged and deployed

## Repository rule impact
This adds a backend-authoritative preview/import harness for career page assembly content assets. Runtime page rendering remains API-authoritative; no frontend fallback content or SEO enumeration changes are introduced.
