### PR TITLE
Enneagram: add result page ops agent runner orchestrator

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageOpsAgentRunOrchestrator;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageOpsRunnerCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-ops-runner
+        {action=plan : Only plan is supported in this runner/orchestrator PR}
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/enneagram_result_page_ops_agent_runner}
+        {--contract-path= : Optional run-orchestrator contract path}
+        {--mode=auto-to-pr : Requested mode: auto-to-pr, auto-to-staging, auto-to-report}
+        {--scope-id=ops-agent-runner : Stable scope id for deterministic run and branch naming}
+        {--pr-title=Enneagram: add result page ops agent runner orchestrator : Planned PR title}
+        {--base-branch=main : Planned base branch}
+        {--changed-file=* : Planned changed file for scope validation}
+        {--simulate-external-blocker : Record an external blocker as a non-blocking sidecar payload}
+        {--simulate-current-scope-failure : Prove current PR scope failures block the train}
+        {--strict : Return non-zero when validation errors are present}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Prepare a read-only Enneagram result page ops agent runner/orchestrator plan.';
+
+    public function handle(EnneagramResultPageOpsAgentRunOrchestrator $orchestrator): int
+    {
+        try {
+            if ($this->argument('action') !== 'plan') {
+                $this->error('Unsupported action. This PR supports only: plan');
+
+                return self::FAILURE;
+            }
+
+            $summary = $orchestrator->plan([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'mode' => trim((string) $this->option('mode')),
+                'scope_id' => trim((string) $this->option('scope-id')),
+                'pr_title' => trim((string) $this->option('pr-title')),
+                'base_branch' => trim((string) $this->option('base-branch')),
+                'changed_files' => array_map('strval', (array) $this->option('changed-file')),
+                'simulate_external_blocker' => (bool) $this->option('simulate-external-blocker'),
+                'simulate_current_scope_failure' => (bool) $this->option('simulate-current-scope-failure'),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('mode='.(string) ($summary['mode'] ?? ''));
+        $this->line('scope_id='.(string) ($summary['scope_id'] ?? ''));
+        $this->line('train_can_continue='.(((bool) data_get($summary, 'summary.train_can_continue', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -115,6 +115,7 @@ use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
 use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
+use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
@@ -247,6 +248,7 @@ class Kernel extends ConsoleKernel
         EnneagramImportInactiveCandidateRelease::class,
         EnneagramResultPageAgentReadinessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
+        EnneagramResultPageOpsRunnerCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,
         BigFiveExportProductionEquivalentCandidatePayloads::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php
@@ -1,0 +1,504 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageOpsAgentRunOrchestrator
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.ops_agent_runner.v0.1';
+
+    public const CONTROL_PLANE_SCHEMA_VERSION = EnneagramResultPageOpsControlPlane::SCHEMA_VERSION;
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_ops_agent_runner';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/ops_agent_runner/run_orchestrator_contract_v0_1.json';
+
+    private const ALLOWED_MODES = [
+        'auto-to-pr',
+        'auto-to-staging',
+        'auto-to-report',
+    ];
+
+    private const RUN_STATES = [
+        'planned',
+        'branch_prepared',
+        'local_validation',
+        'scope_validation',
+        'pr_created',
+        'checks_polling',
+        'ready_to_merge',
+        'merged',
+        'post_merge_revalidated',
+    ];
+
+    private const ALLOWED_CHANGED_FILE_PREFIXES = [
+        'backend/app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php',
+        'backend/app/Console/Kernel.php',
+        'backend/app/Services/Enneagram/Assets/Agent/',
+        'backend/content_assets/enneagram/result_page/ops_agent_runner/',
+        'backend/tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php',
+        'backend/tests/Unit/Services/Enneagram/Assets/',
+        'backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php',
+    ];
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     mode?:string,
+     *     scope_id?:string,
+     *     pr_title?:string,
+     *     base_branch?:string,
+     *     changed_files?:list<string>,
+     *     strict?:bool,
+     *     simulate_external_blocker?:bool,
+     *     simulate_current_scope_failure?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function plan(array $options = []): array
+    {
+        $mode = trim((string) ($options['mode'] ?? 'auto-to-pr'));
+        $scopeId = $this->sanitizeSlug((string) ($options['scope_id'] ?? 'ops-agent-runner'));
+        $baseBranch = $this->sanitizeBranchSegment((string) ($options['base_branch'] ?? 'main'));
+        $prTitle = trim((string) ($options['pr_title'] ?? 'Enneagram: add result page ops agent runner orchestrator'));
+        $runId = $this->runId((string) ($options['run_id'] ?? ''), $mode, $scopeId, $baseBranch, $prTitle);
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $strict = ($options['strict'] ?? false) === true;
+        $changedFiles = $this->normalizeChangedFiles((array) ($options['changed_files'] ?? []));
+        $simulateExternalBlocker = ($options['simulate_external_blocker'] ?? false) === true;
+        $simulateCurrentScopeFailure = ($options['simulate_current_scope_failure'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readContract($contractPath);
+        $contractErrors = $this->contractErrors($contract);
+        $scopeReport = $this->scopeValidationReport($changedFiles, $simulateCurrentScopeFailure);
+        $failureReport = $this->failureClassificationReport($simulateExternalBlocker, $simulateCurrentScopeFailure);
+        $queueItem = $this->queueItem($runId, $mode, $scopeId, $baseBranch, $prTitle);
+        $branchPlan = $this->branchPlan($scopeId, $baseBranch);
+        $validationPlan = $this->validationPlan();
+        $prContract = $this->pullRequestContract($prTitle, $branchPlan['branch_name'], $baseBranch);
+        $checksContract = $this->githubChecksContract();
+        $sidecarPayload = $this->sidecarIssuePayload($runId, $scopeId, $failureReport);
+
+        $errors = array_merge($contractErrors, (array) $scopeReport['errors'], (array) $failureReport['blocking_errors']);
+        if (! in_array($mode, self::ALLOWED_MODES, true)) {
+            $errors[] = 'mode_not_allowed:'.$mode;
+        }
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ops_agent_run_orchestrator_plan',
+            'run_id' => $runId,
+            'mode' => $mode,
+            'scope_id' => $scopeId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'queue_item' => $queueItem,
+            'branch_plan' => $branchPlan,
+            'scope_validation' => $scopeReport,
+            'local_validation_plan' => $validationPlan,
+            'pull_request_contract' => $prContract,
+            'github_checks_contract' => $checksContract,
+            'failure_classification' => $failureReport,
+            'sidecar_issue_payload' => $sidecarPayload,
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count(array_unique($errors)),
+            'errors' => array_values(array_unique($errors)),
+        ];
+
+        $artifacts = [
+            'ops_agent_run_orchestrator_plan.json' => $this->writeJson($artifactDir.'/ops_agent_run_orchestrator_plan.json', $report),
+            'sidecar_issue_payload.json' => $this->writeJson($artifactDir.'/sidecar_issue_payload.json', $sidecarPayload),
+        ];
+
+        $ok = $errors === [] || (! $strict && $failureReport['train_can_continue'] === true && $scopeReport['valid'] === true);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'mode' => $mode,
+            'scope_id' => $scopeId,
+            'strict' => $strict,
+            'summary' => [
+                'contract_valid' => $contractErrors === [],
+                'scope_valid' => (bool) $scopeReport['valid'],
+                'train_can_continue' => (bool) $failureReport['train_can_continue'] && $scopeReport['valid'] === true,
+                'sidecar_issue_payload_created' => true,
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+            ],
+            'errors' => array_values(array_unique($errors)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function queueItem(string $runId, string $mode, string $scopeId, string $baseBranch, string $prTitle): array
+    {
+        return [
+            'queue_backend' => 'file_backed_manifest',
+            'run_id' => $runId,
+            'mode' => $mode,
+            'scope_id' => $scopeId,
+            'base_branch' => $baseBranch,
+            'pr_title' => $prTitle,
+            'current_state' => 'planned',
+            'allowed_states' => self::RUN_STATES,
+            'state_transitions' => [
+                ['from' => 'planned', 'to' => 'branch_prepared'],
+                ['from' => 'branch_prepared', 'to' => 'local_validation'],
+                ['from' => 'local_validation', 'to' => 'scope_validation'],
+                ['from' => 'scope_validation', 'to' => 'pr_created'],
+                ['from' => 'pr_created', 'to' => 'checks_polling'],
+                ['from' => 'checks_polling', 'to' => 'ready_to_merge'],
+                ['from' => 'ready_to_merge', 'to' => 'merged'],
+                ['from' => 'merged', 'to' => 'post_merge_revalidated'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function branchPlan(string $scopeId, string $baseBranch): array
+    {
+        $branchName = 'codex/enneagram-'.$scopeId.'-01';
+        $branchSlug = str_replace('/', '-', $branchName);
+
+        return [
+            'base_branch' => $baseBranch,
+            'branch_name' => $branchName,
+            'worktree_path_template' => '<tmp>/fap-api-'.$branchSlug,
+            'start_from_latest_origin_main' => true,
+            'requires_clean_worktree' => true,
+            'delete_branch_after_merge' => true,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function scopeValidationReport(array $changedFiles, bool $simulateCurrentScopeFailure): array
+    {
+        $outOfScope = [];
+        foreach ($changedFiles as $file) {
+            if (! $this->fileIsAllowed($file)) {
+                $outOfScope[] = $file;
+            }
+        }
+
+        if ($simulateCurrentScopeFailure) {
+            $outOfScope[] = 'backend/routes/api.php';
+        }
+
+        return [
+            'valid' => $outOfScope === [],
+            'changed_files' => $changedFiles,
+            'allowed_prefixes' => self::ALLOWED_CHANGED_FILE_PREFIXES,
+            'out_of_scope_files' => array_values(array_unique($outOfScope)),
+            'errors' => $outOfScope === [] ? [] : ['scope_validation_failed'],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validationPlan(): array
+    {
+        return [
+            'commands' => [
+                'php -l app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php',
+                'php -l app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php',
+                'php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsAgentRunOrchestratorTest.php tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php --no-ansi',
+                'php artisan enneagram:result-page-ops-runner plan --run-id=<run-id> --scope-id=<scope-id> --mode=auto-to-pr --strict --json',
+                'git diff --check',
+            ],
+            'scope_validation_required' => true,
+            'github_required_checks_required' => true,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function pullRequestContract(string $title, string $headBranch, string $baseBranch): array
+    {
+        return [
+            'auto_create_pr_allowed' => true,
+            'title' => $title,
+            'head_branch' => $headBranch,
+            'base_branch' => $baseBranch,
+            'body_required_sections' => [
+                'What changed',
+                'Why',
+                'Validation',
+                'Intentionally deferred',
+            ],
+            'must_state_no_production_activation' => true,
+            'must_state_no_production_writes' => true,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function githubChecksContract(): array
+    {
+        return [
+            'poll_checks_allowed' => true,
+            'required_checks_must_be_green_before_merge' => true,
+            'inspect_logs_before_fixing_failures' => true,
+            'fix_only_current_pr_scope' => true,
+            'auto_merge_when_repo_policy_allows' => true,
+            'squash_merge_default' => true,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureClassificationReport(bool $simulateExternalBlocker, bool $simulateCurrentScopeFailure): array
+    {
+        $events = [];
+        $blockingErrors = [];
+        if ($simulateExternalBlocker) {
+            $events[] = [
+                'class' => 'external_ci_flaky',
+                'train_blocking' => false,
+                'sidecar_issue_required' => true,
+            ];
+        }
+
+        if ($simulateCurrentScopeFailure) {
+            $events[] = [
+                'class' => 'current_pr_scope',
+                'train_blocking' => true,
+                'sidecar_issue_required' => false,
+            ];
+            $blockingErrors[] = 'current_pr_scope_failure';
+        }
+
+        return [
+            'events' => $events,
+            'blocking_errors' => $blockingErrors,
+            'external_blockers_recorded_as_sidecar' => $simulateExternalBlocker,
+            'train_can_continue' => $blockingErrors === [],
+            'policy' => [
+                'external_blocker_does_not_stop_train_when_required_checks_green' => true,
+                'current_pr_scope_failure_stops_train' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sidecarIssuePayload(string $runId, string $scopeId, array $failureReport): array
+    {
+        return [
+            'dry_run' => true,
+            'run_id' => $runId,
+            'scope_id' => $scopeId,
+            'title' => 'Enneagram ops agent external blocker: '.$scopeId,
+            'labels' => ['ops-agent', 'enneagram', 'external-blocker'],
+            'body' => [
+                'external_blockers_recorded' => (bool) $failureReport['external_blockers_recorded_as_sidecar'],
+                'train_can_continue' => (bool) $failureReport['train_can_continue'],
+                'production_activation_executed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['control_plane_schema_version'] ?? null) !== self::CONTROL_PLANE_SCHEMA_VERSION) {
+            $errors[] = 'control_plane_schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+        if ((array) ($contract['allowed_modes'] ?? []) !== self::ALLOWED_MODES) {
+            $errors[] = 'allowed_modes_mismatch';
+        }
+        if (data_get($contract, 'production_guard.agent_may_execute_production_rollout') !== false) {
+            $errors[] = 'production_agent_execution_must_be_false';
+        }
+        if (data_get($contract, 'production_guard.production_requires_manual_gate') !== true) {
+            $errors[] = 'production_manual_gate_required_must_be_true';
+        }
+
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bulk_content_generation_happened' => false,
+            'candidate_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    private function fileIsAllowed(string $file): bool
+    {
+        foreach (self::ALLOWED_CHANGED_FILE_PREFIXES as $allowed) {
+            if ($file === $allowed || str_starts_with($file, $allowed)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeChangedFiles(array $changedFiles): array
+    {
+        $normalized = [];
+        foreach ($changedFiles as $file) {
+            $file = trim((string) $file);
+            if ($file !== '') {
+                $normalized[] = $file;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readContract(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException('Run orchestrator contract does not exist: '.$path);
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Run orchestrator contract is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function runId(string $provided, string $mode, string $scopeId, string $baseBranch, string $prTitle): string
+    {
+        $provided = trim($provided);
+        if ($provided !== '') {
+            return $this->sanitizeSlug($provided);
+        }
+
+        $seed = implode('|', [$mode, $scopeId, $baseBranch, $prTitle]);
+
+        return 'enneagram-ops-'.substr(hash('sha256', $seed), 0, 12);
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'ops-agent-runner';
+    }
+
+    private function sanitizeBranchSegment(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.\\/-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'main';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/ops_agent_runner/README.md
+++ b/backend/content_assets/enneagram/result_page/ops_agent_runner/README.md
@@ -1,0 +1,15 @@
+# Enneagram Result Page Ops Agent Runner
+
+This directory defines the file-backed run-orchestrator scaffold for the Enneagram result page operations agent.
+
+The runner prepares deterministic run plans for:
+
+- scoped branch and worktree naming,
+- local validation command plans,
+- scope validation,
+- pull request creation contracts,
+- GitHub required-check polling,
+- failure classification,
+- dry-run sidecar issue payloads for external blockers.
+
+This scaffold does not create production releases, import candidates, activate runtime, write production data, generate content, or touch frontend code.

--- a/backend/content_assets/enneagram/result_page/ops_agent_runner/run_orchestrator_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/ops_agent_runner/run_orchestrator_contract_v0_1.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "fap.enneagram.result_page.ops_agent_runner.v0.1",
+  "control_plane_schema_version": "fap.enneagram.result_page.ops_agent_control_plane.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "queue_backend": "file_backed_manifest",
+  "default_base_branch": "main",
+  "branch_prefix": "codex/",
+  "worktree_root_template": "<tmp>/fap-api-{branch_slug}",
+  "allowed_modes": [
+    "auto-to-pr",
+    "auto-to-staging",
+    "auto-to-report"
+  ],
+  "run_states": [
+    "planned",
+    "branch_prepared",
+    "local_validation",
+    "scope_validation",
+    "pr_created",
+    "checks_polling",
+    "ready_to_merge",
+    "merged",
+    "post_merge_revalidated"
+  ],
+  "failure_classes": [
+    "current_pr_scope",
+    "external_ci_flaky",
+    "external_dependency",
+    "merge_policy_block",
+    "manual_review_required"
+  ],
+  "external_blocker_policy": {
+    "continue_when_required_checks_green": true,
+    "continue_when_scope_validation_green": true,
+    "record_sidecar_issue_payload": true,
+    "sidecar_issue_dry_run_by_default": true
+  },
+  "production_guard": {
+    "agent_may_execute_production_rollout": false,
+    "production_requires_manual_gate": true
+  },
+  "negative_guarantees": {
+    "bulk_content_generation_happened": false,
+    "candidate_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageOpsRunnerCommandTest extends TestCase
+{
+    public function test_ops_runner_command_writes_plan_artifacts(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner-command');
+
+        try {
+            $this->artisan('enneagram:result-page-ops-runner', [
+                'action' => 'plan',
+                '--run-id' => 'command-run',
+                '--artifact-dir' => $root,
+                '--mode' => 'auto-to-pr',
+                '--scope-id' => 'ops-agent-runner',
+                '--changed-file' => [
+                    'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php',
+                ],
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/command-run/ops_agent_run_orchestrator_plan.json');
+            $this->assertSame('auto-to-pr', $report['mode'] ?? null);
+            $this->assertTrue((bool) data_get($report, 'scope_validation.valid', false));
+            $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_write_happened', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_ops_runner_command_blocks_current_scope_failure(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner-command-block');
+
+        try {
+            $this->artisan('enneagram:result-page-ops-runner', [
+                'action' => 'plan',
+                '--run-id' => 'command-block',
+                '--artifact-dir' => $root,
+                '--mode' => 'auto-to-pr',
+                '--scope-id' => 'ops-agent-runner',
+                '--simulate-current-scope-failure' => true,
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(1);
+
+            $report = $this->readJson($root.'/command-block/ops_agent_run_orchestrator_plan.json');
+            $this->assertContains('current_pr_scope_failure', $report['errors'] ?? []);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2828,6 +2828,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_ops_runner_orchestrator_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php',
+            'backend/content_assets/enneagram/result_page/ops_agent_runner/README.md',
+            'backend/content_assets/enneagram/result_page/ops_agent_runner/run_orchestrator_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageOpsRunnerCommand;',
+            '+        EnneagramResultPageOpsRunnerCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4698,6 +4721,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageOpsRunnerOrchestratorFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4805,6 +4832,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsRiasecResultPageAssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageAgentReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageOpsControlPlaneOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6677,6 +6705,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageOpsRunnerOrchestratorFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php',
+            'backend/content_assets/enneagram/result_page/ops_agent_runner/README.md',
+            'backend/content_assets/enneagram/result_page/ops_agent_runner/run_orchestrator_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -7790,6 +7828,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageOpsControlPlaneCommand;',
             '        EnneagramResultPageOpsControlPlaneCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageOpsRunnerCommand;',
+            '        EnneagramResultPageOpsRunnerCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsAgentRunOrchestratorTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsAgentRunOrchestratorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageOpsAgentRunOrchestrator;
+use Tests\TestCase;
+
+final class EnneagramResultPageOpsAgentRunOrchestratorTest extends TestCase
+{
+    public function test_orchestrator_writes_deterministic_run_plan_without_production_permissions(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner');
+
+        try {
+            $options = [
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-pr',
+                'scope_id' => 'ops-agent-runner',
+                'changed_files' => [
+                    'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php',
+                ],
+                'strict' => true,
+            ];
+            $first = app(EnneagramResultPageOpsAgentRunOrchestrator::class)->plan($options);
+            $second = app(EnneagramResultPageOpsAgentRunOrchestrator::class)->plan($options);
+
+            $this->assertTrue((bool) ($first['ok'] ?? false));
+            $this->assertSame($first['run_id'] ?? null, $second['run_id'] ?? null);
+            $this->assertFalse((bool) data_get($first, 'summary.production_execution_allowed_for_agent', true));
+            $this->assertTrue((bool) data_get($first, 'summary.production_manual_gate_required', false));
+
+            $report = $this->readJson($root.'/'.$first['run_id'].'/ops_agent_run_orchestrator_plan.json');
+            $this->assertSame(EnneagramResultPageOpsAgentRunOrchestrator::SCHEMA_VERSION, $report['schema_version'] ?? null);
+            $this->assertSame('file_backed_manifest', data_get($report, 'queue_item.queue_backend'));
+            $this->assertSame('planned', data_get($report, 'queue_item.current_state'));
+            $this->assertStringStartsWith('codex/enneagram-ops-agent-runner', (string) data_get($report, 'branch_plan.branch_name'));
+            $this->assertTrue((bool) data_get($report, 'pull_request_contract.auto_create_pr_allowed', false));
+            $this->assertTrue((bool) data_get($report, 'github_checks_contract.required_checks_must_be_green_before_merge', false));
+            $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_activation_happened', true));
+            $this->assertArtifactsDoNotLeakPrivatePaths((string) file_get_contents($root.'/'.$first['run_id'].'/ops_agent_run_orchestrator_plan.json'));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_external_blocker_is_recorded_as_non_blocking_sidecar_payload(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner-external');
+
+        try {
+            $summary = app(EnneagramResultPageOpsAgentRunOrchestrator::class)->plan([
+                'run_id' => 'external-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-report',
+                'scope_id' => 'ops-agent-runner',
+                'simulate_external_blocker' => true,
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertTrue((bool) data_get($summary, 'summary.train_can_continue', false));
+
+            $sidecar = $this->readJson($root.'/external-run/sidecar_issue_payload.json');
+            $this->assertTrue((bool) ($sidecar['dry_run'] ?? false));
+            $this->assertTrue((bool) data_get($sidecar, 'body.external_blockers_recorded', false));
+            $this->assertFalse((bool) data_get($sidecar, 'body.production_activation_executed', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_current_pr_scope_failure_blocks_train(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner-scope-failure');
+
+        try {
+            $summary = app(EnneagramResultPageOpsAgentRunOrchestrator::class)->plan([
+                'run_id' => 'scope-failure-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-pr',
+                'scope_id' => 'ops-agent-runner',
+                'simulate_current_scope_failure' => true,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('scope_validation_failed', $summary['errors'] ?? []);
+            $this->assertContains('current_pr_scope_failure', $summary['errors'] ?? []);
+            $this->assertFalse((bool) data_get($summary, 'summary.train_can_continue', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_scope_validation_rejects_out_of_scope_changed_files(): void
+    {
+        $root = $this->tempDir('enneagram-ops-runner-out-of-scope');
+
+        try {
+            $summary = app(EnneagramResultPageOpsAgentRunOrchestrator::class)->plan([
+                'run_id' => 'out-of-scope-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-pr',
+                'scope_id' => 'ops-agent-runner',
+                'changed_files' => [
+                    'backend/routes/api.php',
+                ],
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('scope_validation_failed', $summary['errors'] ?? []);
+
+            $report = $this->readJson($root.'/out-of-scope-run/ops_agent_run_orchestrator_plan.json');
+            $this->assertContains('backend/routes/api.php', data_get($report, 'scope_validation.out_of_scope_files'));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function assertArtifactsDoNotLeakPrivatePaths(string $artifact): void
+    {
+        foreach ([
+            '/Users/rainie/',
+            '/private/tmp/',
+            'production_activation_happened": true',
+            'production_write_happened": true',
+        ] as $blocked) {
+            $this->assertStringNotContainsString($blocked, $artifact);
+        }
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a file-backed Enneagram result page ops agent runner/orchestrator contract.
- Added `EnneagramResultPageOpsAgentRunOrchestrator` for deterministic run ids, queue-state planning, branch/worktree plans, local validation plans, scope validation, PR creation contracts, GitHub checks polling contracts, and failure classification.
- Added `enneagram:result-page-ops-runner plan` as a read-only planning command.
- Added dry-run sidecar issue payload generation for external blockers.
- Added tests proving current PR scope failures block the train while external blockers can be recorded as sidecar payloads.
- Added a narrow Big Five freeze-guard allowlist for this Enneagram-only runner scaffold.

## Why
This is the second guardrail PR for the Enneagram result page operations agent. It prepares auto-to-PR/report/staging orchestration while preserving the production manual gate established by the control-plane PR.

## Validation
- `php -l app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php`
- `php -l app/Console/Commands/EnneagramResultPageOpsRunnerCommand.php`
- `php -l app/Console/Kernel.php`
- `php -l tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsAgentRunOrchestratorTest.php`
- `php -l tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageOpsAgentRunOrchestratorTest.php tests/Feature/Console/EnneagramResultPageOpsRunnerCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_ops_runner_orchestrator_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan enneagram:result-page-ops-runner plan --run-id=smoke --artifact-dir=$(mktemp -d) --scope-id=ops-agent-runner --mode=auto-to-pr --changed-file=backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageOpsAgentRunOrchestrator.php --strict --json`
- `php artisan list --no-ansi | rg "enneagram:result-page-(ops-control-plane|ops-runner|agent)"`
- `git diff --check`

## Intentionally deferred
- No content generation.
- No candidate import.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.
- No actual PR creation from the runner in this scaffold.
- Production remains manual-gated and cannot be executed automatically by the agent.
