### PR TITLE
SEO-AGENT-L5A-CMS-DRAFT-WRITE-CANARY1-01 follow-up: resolve pathless source package

### DIFF
--- a/backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php
@@ -6,8 +6,11 @@ namespace App\Console\Commands;
 
 use App\Models\CmsTranslationRevision;
 use App\Models\ContentPage;
+use FilesystemIterator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -250,11 +253,45 @@ final class SeoAgentL5aCmsDraftWriteCanaryCommand extends Command
     private function sourcePackagePath(array $candidateReview): ?string
     {
         $path = trim((string) data_get($candidateReview, 'input_artifacts.cms_draft_package_dry_run.path'));
-        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+        if ($path !== '' && ! str_contains($path, "\0") && is_file($path) && is_readable($path)) {
+            return $path;
+        }
+
+        $sha = strtolower(trim((string) data_get($candidateReview, 'input_artifacts.cms_draft_package_dry_run.sha256')));
+        if (preg_match('/\A[a-f0-9]{64}\z/', $sha) !== 1) {
             return null;
         }
 
-        return $path;
+        return $this->sourcePackagePathBySha($sha);
+    }
+
+    private function sourcePackagePathBySha(string $sha): ?string
+    {
+        $root = storage_path('app/seo-agent');
+        if (! is_dir($root) || ! is_readable($root)) {
+            return null;
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if (! $file->isFile() || $file->getExtension() !== 'json') {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            if (! is_readable($path)) {
+                continue;
+            }
+
+            if ((hash_file('sha256', $path) ?: '') === $sha) {
+                return $path;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -353,7 +390,7 @@ final class SeoAgentL5aCmsDraftWriteCanaryCommand extends Command
             $input['--execute'] = true;
         }
 
-        $buffer = new BufferedOutput();
+        $buffer = new BufferedOutput;
         $exitCode = $command->run(new ArrayInput($input), $buffer);
         $summary = json_decode(trim($buffer->fetch()), true);
         if (! is_array($summary)) {

--- a/backend/tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php
@@ -51,6 +51,35 @@ final class SeoAgentL5aCmsDraftWriteCanaryTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_resolves_pathless_candidate_review_package_by_sha(): void
+    {
+        $page = $this->createContentPage();
+        [$candidateReviewPath, $packagePath, $candidateReview] = $this->writeCandidateReview($page);
+        $seoAgentDir = storage_path('app/seo-agent/l5a-pathless-package-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($seoAgentDir);
+        $resolvedPackagePath = $seoAgentDir.'/source-package.json';
+        File::copy($packagePath, $resolvedPackagePath);
+
+        unset($candidateReview['input_artifacts']['cms_draft_package_dry_run']['path']);
+        $candidateReview['input_artifacts']['cms_draft_package_dry_run']['sha256'] = hash_file('sha256', $resolvedPackagePath) ?: '';
+        $candidateReview['input_artifacts']['cms_draft_package_dry_run']['size'] = filesize($resolvedPackagePath) ?: 0;
+        File::put($candidateReviewPath, json_encode($candidateReview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        $exitCode = Artisan::call('seo-agent:l5a-cms-draft-write-canary', [
+            '--candidate-review' => $candidateReviewPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['planned_count'] ?? null);
+        $this->assertSame(0, CmsTranslationRevision::query()->count());
+        $this->assertNoForbiddenStrings($summary);
+    }
+
+    #[Test]
     public function execute_fails_closed_without_matching_candidate_review_sha(): void
     {
         $page = $this->createContentPage();


### PR DESCRIPTION
## What changed
- Fixed `seo-agent:l5a-cms-draft-write-canary` so it can consume the real sanitized PR1 candidate-review artifact when `input_artifacts.cms_draft_package_dry_run.path` is absent.
- The command now falls back to resolving the source draft package by sha256 under the controlled `storage/app/seo-agent` artifact tree.
- Added a regression test for pathless candidate-review evidence.

## Why
The production PR2 dry-run was blocked with `source_draft_package_missing` because PR1 intentionally sanitized source artifact paths to `path_hash` + `sha256`, while PR2 expected a readable `path`. This follow-up keeps PR1 output sanitized and lets PR2 resolve the already-recorded package by hash.

## Validation commands
- `cd backend && php -l app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php && php -l tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php`
- `cd backend && php artisan test --filter SeoAgentL5aCmsDraftWriteCanaryTest`
- `cd backend && php artisan test --filter SeoAgentControlledCmsDraftWriterTest`
- `cd backend && php artisan test --filter 'BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_agent_l5a_cms_draft_write_canary_files'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentL5aCmsDraftWriteCanaryCommand.php tests/Feature/SeoIntel/SeoAgentL5aCmsDraftWriteCanaryTest.php`
- `git diff --check`

## Intentionally deferred items
- No production CMS draft write in this PR.
- No ContentPage publish canary.
- No Search Channel enqueue or IndexNow submit.
- No scheduler or cron activation.
- No PR3 implementation.

## Negative guarantees
- No CMS publish.
- No Search Channel queue write or submit.
- No IndexNow live submit.
- No Google Indexing API call.
- No Laravel scheduler or queue worker activation.
- No fap-web/frontend mutation.
- No raw URL, raw body, token, cookie, private key, or client email in artifacts.

## Repository rule impact
No content authority change. Backend remains the authority for CMS draft write evidence; this only repairs pathless sanitized artifact consumption for the existing L5-A canary command.