### PR TITLE
Enneagram: add small-batch result page content automation harness

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageContentBatchCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageContentBatchCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageContentBatchAutomation;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageContentBatchCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-content-batch
+        {action=evaluate : Only evaluate is supported in this small-batch automation PR}
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/enneagram_result_page_content_batch_automation}
+        {--contract-path= : Optional content-batch automation contract path}
+        {--source-ledger-path= : Optional source ledger JSON path}
+        {--source-id=batch_1r_a_asset_stream : Source ledger source id}
+        {--module-key=pilot_baseline_reflection : Target module key}
+        {--result-type=type_1 : Target result type}
+        {--scope=pilot : Target scope}
+        {--public-payload-json= : Optional public payload JSON; defaults to a one-payload pilot fixture}
+        {--strict : Return non-zero when validation errors are present}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Evaluate a tiny Enneagram result page content batch input through source mapping and safety gates.';
+
+    public function handle(EnneagramResultPageContentBatchAutomation $automation): int
+    {
+        try {
+            if ($this->argument('action') !== 'evaluate') {
+                $this->error('Unsupported action. This PR supports only: evaluate');
+
+                return self::FAILURE;
+            }
+
+            $payloadJson = trim((string) $this->option('public-payload-json'));
+            $publicPayload = $payloadJson === '' ? null : json_decode($payloadJson, true);
+            if ($payloadJson !== '' && ! is_array($publicPayload)) {
+                $this->error('public-payload-json must decode to an object');
+
+                return self::FAILURE;
+            }
+
+            $summary = $automation->evaluate([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'source_ledger_path' => trim((string) $this->option('source-ledger-path')),
+                'source_id' => trim((string) $this->option('source-id')),
+                'module_key' => trim((string) $this->option('module-key')),
+                'result_type' => trim((string) $this->option('result-type')),
+                'scope' => trim((string) $this->option('scope')),
+                'public_payload' => $publicPayload,
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('artifact_dir='.(string) ($summary['artifact_dir'] ?? ''));
+        $this->line('payload_count='.(string) data_get($summary, 'summary.payload_count', 0));
+        $this->line('bulk_generation_allowed='.(((bool) data_get($summary, 'summary.bulk_generation_allowed', true)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -113,6 +113,7 @@ use App\Console\Commands\EnneagramActivateInactiveCandidateRelease;
 use App\Console\Commands\EnneagramActivateRegistryRelease;
 use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
+use App\Console\Commands\EnneagramResultPageContentBatchCommand;
 use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
@@ -246,6 +247,7 @@ class Kernel extends ConsoleKernel
         EnneagramActivateInactiveCandidateRelease::class,
         EnneagramActivateRegistryRelease::class,
         EnneagramImportInactiveCandidateRelease::class,
+        EnneagramResultPageContentBatchCommand::class,
         EnneagramResultPageAgentReadinessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramResultPageOpsRunnerCommand::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageContentBatchAutomation.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageContentBatchAutomation.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageContentBatchAutomation
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.content_batch_automation.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_content_batch_automation';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/content_batch_automation/content_batch_automation_contract_v0_1.json';
+
+    public const DEFAULT_SOURCE_LEDGER_RELATIVE_PATH = 'content_assets/enneagram/result_page/source_ledger/source_ledger.json';
+
+    private const FORBIDDEN_CLAIM_FAMILIES = [
+        'diagnosis_clinical_treatment',
+        'hiring_employment_screening',
+        'final_typing_you_are_this_type',
+        'fixed_type_certainty',
+        'e105_fc144_score_comparison',
+        'fc144_more_accurate_or_replacement_result',
+        'success_salary_performance_prediction',
+        'private_result_identifier_path_or_vector_leakage',
+    ];
+
+    public function __construct(private readonly EnneagramResultPageAgentBatchRunner $runner) {}
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     source_ledger_path?:string,
+     *     source_id?:string,
+     *     module_key?:string,
+     *     result_type?:string,
+     *     scope?:string,
+     *     public_payload?:array<string,mixed>,
+     *     previous_payload?:array<string,mixed>|null,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function evaluate(array $options = []): array
+    {
+        $runId = $this->runId((string) ($options['run_id'] ?? ''), $options);
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $sourceLedgerPath = $this->sourceLedgerPath((string) ($options['source_ledger_path'] ?? ''));
+        $sourceId = trim((string) ($options['source_id'] ?? 'batch_1r_a_asset_stream'));
+        $moduleKey = trim((string) ($options['module_key'] ?? 'pilot_baseline_reflection'));
+        $resultType = trim((string) ($options['result_type'] ?? 'type_1'));
+        $scope = trim((string) ($options['scope'] ?? 'pilot'));
+        $publicPayload = is_array($options['public_payload'] ?? null)
+            ? (array) $options['public_payload']
+            : $this->defaultPilotPayload();
+        $previousPayload = is_array($options['previous_payload'] ?? null) ? (array) $options['previous_payload'] : null;
+        $strict = ($options['strict'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readJson($contractPath, 'Content batch automation contract');
+        $contractErrors = $this->contractErrors($contract);
+        $sourceLedgerRow = $this->sourceLedgerRow($sourceLedgerPath, $sourceId);
+
+        $runnerResult = $this->runner->run([
+            'source_ledger_row' => $sourceLedgerRow,
+            'target_module' => [
+                'module_key' => $moduleKey,
+                'result_type' => $resultType,
+                'scope' => $scope,
+                'additional_source_ids' => [
+                    'phase8b_candidate_baseline_a9fd',
+                    'forbidden_claim_policy',
+                ],
+            ],
+            'public_payload' => $publicPayload,
+            'previous_payload' => $previousPayload,
+            'forbidden_claim_policy' => [
+                'families' => self::FORBIDDEN_CLAIM_FAMILIES,
+            ],
+        ]);
+
+        $errors = array_values(array_unique(array_merge(
+            $contractErrors,
+            (array) ($runnerResult['errors'] ?? [])
+        )));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'content_batch_automation_evaluate',
+            'run_id' => $runId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'input' => [
+                'source_id' => $sourceId,
+                'module_key' => $moduleKey,
+                'result_type' => $resultType,
+                'scope' => $scope,
+                'payload_count' => 1,
+                'bulk_generation_allowed' => false,
+            ],
+            'runner_status' => [
+                'ok' => (bool) ($runnerResult['ok'] ?? false),
+                'status' => (string) ($runnerResult['status'] ?? 'unknown'),
+                'payload_hash_sha256' => (string) ($runnerResult['payload_hash_sha256'] ?? ''),
+            ],
+            'output_files' => [
+                'payload.json',
+                'source_mapping_report.json',
+                'safety_report.json',
+                'diff_report.json',
+                'rollback_report.json',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'payload.json' => $this->writeJson($artifactDir.'/payload.json', (array) ($runnerResult['payload'] ?? [])),
+            'source_mapping_report.json' => $this->writeJson($artifactDir.'/source_mapping_report.json', (array) ($runnerResult['source_mapping_report'] ?? [])),
+            'safety_report.json' => $this->writeJson($artifactDir.'/safety_report.json', (array) ($runnerResult['safety_report'] ?? [])),
+            'diff_report.json' => $this->writeJson($artifactDir.'/diff_report.json', (array) ($runnerResult['diff_report'] ?? [])),
+            'rollback_report.json' => $this->writeJson($artifactDir.'/rollback_report.json', (array) ($runnerResult['rollback_report'] ?? [])),
+            'batch_automation_report.json' => $this->writeJson($artifactDir.'/batch_automation_report.json', $report),
+        ];
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'summary' => [
+                'payload_count' => 1,
+                'bulk_generation_allowed' => false,
+                'source_mapping_zero_failures' => (int) data_get($runnerResult, 'source_mapping_report.source_mapping_failure_count', 1) === 0,
+                'metadata_leakage_zero' => (int) data_get($runnerResult, 'safety_report.metadata_leakage_hit_count', 1) === 0,
+                'forbidden_claim_zero' => (int) data_get($runnerResult, 'safety_report.forbidden_claim_hit_count', 1) === 0,
+                'fc144_boundary_zero' => (int) data_get($runnerResult, 'safety_report.fc144_boundary_violation_count', 1) === 0,
+                'production_execution_allowed_for_agent' => false,
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function defaultPilotPayload(): array
+    {
+        return [
+            'heading' => 'Turn one observation into a next step',
+            'body' => 'Name one situation to review, then choose one small action that can be completed today.',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['runner_schema_version'] ?? null) !== EnneagramResultPageAgentBatchRunner::SCHEMA_VERSION) {
+            $errors[] = 'runner_schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+        if (data_get($contract, 'batch_size_policy.bulk_generation_allowed') !== false) {
+            $errors[] = 'bulk_generation_must_be_false';
+        }
+        if ((int) data_get($contract, 'batch_size_policy.max_fixture_payloads_in_this_pr') > 1) {
+            $errors[] = 'max_fixture_payloads_exceeds_one';
+        }
+        if (data_get($contract, 'production_guard.agent_may_import_candidate') !== false) {
+            $errors[] = 'agent_import_candidate_must_be_false';
+        }
+        if (data_get($contract, 'production_guard.agent_may_execute_production_rollout') !== false) {
+            $errors[] = 'agent_production_rollout_must_be_false';
+        }
+
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sourceLedgerRow(string $sourceLedgerPath, string $sourceId): array
+    {
+        $ledger = $this->readJson($sourceLedgerPath, 'Source ledger');
+        foreach ((array) ($ledger['sources'] ?? []) as $source) {
+            if (is_array($source) && ($source['source_id'] ?? null) === $sourceId) {
+                return $source;
+            }
+        }
+
+        throw new RuntimeException('Missing source ledger row: '.$sourceId);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        if (! is_file($path)) {
+            throw new RuntimeException($label.' does not exist: '.$path);
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException($label.' is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bulk_content_generation_happened' => false,
+            'candidate_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function sourceLedgerPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_SOURCE_LEDGER_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function runId(string $provided, array $options): string
+    {
+        $provided = trim($provided);
+        if ($provided !== '') {
+            return $this->sanitizeSlug($provided);
+        }
+
+        $seed = implode('|', [
+            (string) ($options['source_id'] ?? 'batch_1r_a_asset_stream'),
+            (string) ($options['module_key'] ?? 'pilot_baseline_reflection'),
+            (string) ($options['result_type'] ?? 'type_1'),
+            (string) ($options['scope'] ?? 'pilot'),
+        ]);
+
+        return 'enneagram-batch-'.substr(hash('sha256', $seed), 0, 12);
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'content-batch';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/content_batch_automation/README.md
+++ b/backend/content_assets/enneagram/result_page/content_batch_automation/README.md
@@ -1,0 +1,16 @@
+# Enneagram Result Page Content Batch Automation
+
+This directory defines the small-batch automation harness for Enneagram result page content assets.
+
+The harness evaluates a tiny run-scoped input against:
+
+- a source ledger row,
+- a target module,
+- result type and scope,
+- forbidden claim policy,
+- public payload schema,
+- source mapping,
+- safety checks,
+- diff and rollback reports.
+
+It writes artifacts only under caller-provided artifact directories. It does not generate bulk content, import candidates, activate runtime, write production data, or touch frontend code.

--- a/backend/content_assets/enneagram/result_page/content_batch_automation/content_batch_automation_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/content_batch_automation/content_batch_automation_contract_v0_1.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "fap.enneagram.result_page.content_batch_automation.v0.1",
+  "runner_schema_version": "fap.enneagram.result_page.agent_batch_runner.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "batch_size_policy": {
+    "bulk_generation_allowed": false,
+    "max_fixture_payloads_in_this_pr": 1,
+    "one_batch_per_future_pr": true
+  },
+  "input_contract": {
+    "requires_source_ledger_row": true,
+    "requires_target_module": true,
+    "requires_type_or_scope": true,
+    "requires_forbidden_claim_policy": true,
+    "requires_public_payload": true
+  },
+  "output_contract": {
+    "writes_payload_json": true,
+    "writes_source_mapping_report": true,
+    "writes_safety_report": true,
+    "writes_diff_report": true,
+    "writes_rollback_report": true
+  },
+  "production_guard": {
+    "agent_may_import_candidate": false,
+    "agent_may_execute_production_rollout": false,
+    "production_requires_manual_gate": true
+  },
+  "negative_guarantees": {
+    "bulk_content_generation_happened": false,
+    "candidate_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageContentBatchCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageContentBatchCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageContentBatchCommandTest extends TestCase
+{
+    public function test_content_batch_command_writes_run_scoped_artifacts(): void
+    {
+        $root = $this->tempDir('enneagram-content-batch-command');
+
+        try {
+            $this->artisan('enneagram:result-page-content-batch', [
+                'action' => 'evaluate',
+                '--run-id' => 'command-run',
+                '--artifact-dir' => $root,
+                '--source-id' => 'batch_1r_a_asset_stream',
+                '--module-key' => 'pilot_baseline_reflection',
+                '--result-type' => 'type_1',
+                '--scope' => 'pilot',
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/command-run/batch_automation_report.json');
+            $this->assertSame(1, (int) data_get($report, 'input.payload_count'));
+            $this->assertFalse((bool) data_get($report, 'input.bulk_generation_allowed', true));
+            $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_activation_happened', true));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_content_batch_command_rejects_bad_payload_json(): void
+    {
+        $this->artisan('enneagram:result-page-content-batch', [
+            'action' => 'evaluate',
+            '--public-payload-json' => '{bad',
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2851,6 +2851,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_content_batch_automation_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageContentBatchCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageContentBatchAutomation.php',
+            'backend/content_assets/enneagram/result_page/content_batch_automation/README.md',
+            'backend/content_assets/enneagram/result_page/content_batch_automation/content_batch_automation_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageContentBatchCommand;',
+            '+        EnneagramResultPageContentBatchCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4725,6 +4748,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageContentBatchAutomationFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4833,6 +4860,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageAgentReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageOpsControlPlaneOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6715,6 +6743,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageContentBatchAutomationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageContentBatchCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageContentBatchAutomation.php',
+            'backend/content_assets/enneagram/result_page/content_batch_automation/README.md',
+            'backend/content_assets/enneagram/result_page/content_batch_automation/content_batch_automation_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -7845,6 +7883,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageOpsRunnerCommand;',
             '        EnneagramResultPageOpsRunnerCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageContentBatchAutomationOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageContentBatchCommand;',
+            '        EnneagramResultPageContentBatchCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentBatchAutomationTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentBatchAutomationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageContentBatchAutomation;
+use Tests\TestCase;
+
+final class EnneagramResultPageContentBatchAutomationTest extends TestCase
+{
+    public function test_content_batch_automation_writes_one_payload_and_reports_without_production_permissions(): void
+    {
+        $root = $this->tempDir('enneagram-content-batch');
+
+        try {
+            $summary = app(EnneagramResultPageContentBatchAutomation::class)->evaluate([
+                'run_id' => 'unit-run',
+                'artifact_dir' => $root,
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertSame(1, (int) data_get($summary, 'summary.payload_count'));
+            $this->assertFalse((bool) data_get($summary, 'summary.bulk_generation_allowed', true));
+            $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+
+            foreach ([
+                'payload.json',
+                'source_mapping_report.json',
+                'safety_report.json',
+                'diff_report.json',
+                'rollback_report.json',
+                'batch_automation_report.json',
+            ] as $file) {
+                $this->assertFileExists($root.'/unit-run/'.$file);
+            }
+
+            $payload = $this->readJson($root.'/unit-run/payload.json');
+            $this->assertSame('not_runtime', $payload['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($payload['production_use_allowed'] ?? true));
+            $this->assertSame('batch_1r_a_asset_stream', data_get($payload, 'source_trace.primary_source_id'));
+
+            $sourceMapping = $this->readJson($root.'/unit-run/source_mapping_report.json');
+            $this->assertSame(0, (int) ($sourceMapping['source_mapping_failure_count'] ?? -1));
+
+            $safety = $this->readJson($root.'/unit-run/safety_report.json');
+            $this->assertSame(0, (int) ($safety['metadata_leakage_hit_count'] ?? -1));
+            $this->assertSame(0, (int) ($safety['forbidden_claim_hit_count'] ?? -1));
+            $this->assertSame(0, (int) ($safety['fc144_boundary_violation_count'] ?? -1));
+
+            $report = (string) file_get_contents($root.'/unit-run/batch_automation_report.json');
+            $this->assertStringNotContainsString('/Users/rainie/', $report);
+            $this->assertStringNotContainsString('/private/tmp/', $report);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_content_batch_automation_fails_closed_on_forbidden_claim(): void
+    {
+        $root = $this->tempDir('enneagram-content-batch-forbidden');
+
+        try {
+            $summary = app(EnneagramResultPageContentBatchAutomation::class)->evaluate([
+                'run_id' => 'forbidden-run',
+                'artifact_dir' => $root,
+                'public_payload' => [
+                    'heading' => 'Unsafe claim',
+                    'body' => 'FC144 is more accurate and replaces your result.',
+                ],
+                'module_key' => 'fc144_second_lens',
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('safety_scan_failed', $summary['errors'] ?? []);
+
+            $safety = $this->readJson($root.'/forbidden-run/safety_report.json');
+            $this->assertGreaterThan(0, (int) ($safety['forbidden_claim_hit_count'] ?? 0));
+            $this->assertGreaterThan(0, (int) ($safety['fc144_boundary_violation_count'] ?? 0));
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_content_batch_automation_rejects_malformed_contract(): void
+    {
+        $root = $this->tempDir('enneagram-content-batch-contract');
+        $contractPath = $root.'/bad_contract.json';
+        file_put_contents($contractPath, json_encode([
+            'schema_version' => 'bad',
+            'production_use_allowed' => true,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        try {
+            $summary = app(EnneagramResultPageContentBatchAutomation::class)->evaluate([
+                'run_id' => 'bad-contract-run',
+                'artifact_dir' => $root.'/artifacts',
+                'contract_path' => $contractPath,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertContains('schema_version_mismatch', $summary['errors'] ?? []);
+            $this->assertContains('production_use_allowed_must_be_false', $summary['errors'] ?? []);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a small-batch Enneagram result page content automation contract.
- Added `EnneagramResultPageContentBatchAutomation`, a thin harness over the existing agent batch runner.
- Added `enneagram:result-page-content-batch evaluate` to write run-scoped payload, source mapping, safety, diff, rollback, and batch automation reports.
- Added tests for one-payload output, forbidden-claim fail-closed behavior, malformed contract fail-closed behavior, and command smoke.
- Added a narrow Big Five freeze-guard allowlist for this Enneagram-only scaffold.

## Why
This is the third guardrail PR for the Enneagram result page operations agent. It proves the agent input/output shape for tiny batches before any larger content batch is attempted.

## Validation
- `php -l app/Services/Enneagram/Assets/Agent/EnneagramResultPageContentBatchAutomation.php`
- `php -l app/Console/Commands/EnneagramResultPageContentBatchCommand.php`
- `php -l app/Console/Kernel.php`
- `php -l tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentBatchAutomationTest.php`
- `php -l tests/Feature/Console/EnneagramResultPageContentBatchCommandTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageContentBatchAutomationTest.php tests/Feature/Console/EnneagramResultPageContentBatchCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_content_batch_automation_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan enneagram:result-page-content-batch evaluate --run-id=smoke-rebase --artifact-dir=$(mktemp -d) --source-id=batch_1r_a_asset_stream --module-key=pilot_baseline_reflection --result-type=type_1 --scope=pilot --strict --json`
- `php artisan list --no-ansi | rg "enneagram:result-page-(content-batch|ops-runner|ops-control-plane|agent)"`
- `git diff --check`

## Intentionally deferred
- No bulk content generation.
- No candidate import.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.
- Future content batches remain one batch per PR.
