### PR TITLE
B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -22,6 +22,8 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
         {--pr-id= : Planned PR id for plan-pr}
         {--branch= : Planned branch for plan-pr}
         {--title= : Planned PR title for plan-pr}
+        {--checks-json= : Exported GitHub statusCheckRollup JSON for inspect-ci}
+        {--apply-mechanical-fixes : Permit inspect-ci to apply supported mechanical fixes}
         {--allow-staging-write : Permit stage-candidates to write the reviewed staging package}
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
         {--json : Emit machine-readable summary}';
@@ -60,11 +62,17 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'branch' => trim((string) $this->option('branch')),
                     'title' => trim((string) $this->option('title')),
                 ]),
+                'inspect-ci' => $agent->inspectCi([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'checks_json' => trim((string) $this->option('checks-json')),
+                    'apply_mechanical_fixes' => (bool) $this->option('apply-mechanical-fixes'),
+                ]),
                 default => null,
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -471,6 +471,103 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   checks_json?:string,
+     *   apply_mechanical_fixes?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function inspectCi(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $checksJson = trim((string) ($options['checks_json'] ?? '')) === ''
+            ? ''
+            : $this->absolutePath((string) ($options['checks_json'] ?? ''));
+        $applyMechanicalFixes = ($options['apply_mechanical_fixes'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $checks = $this->readCheckRollup($checksJson);
+        $classifications = array_map(
+            fn (array $check): array => $this->classifyCheckRun($check),
+            $checks
+        );
+        $failed = array_values(array_filter($classifications, static fn (array $check): bool => ($check['state'] ?? '') === 'failed'));
+        $repairable = array_values(array_filter($failed, static fn (array $check): bool => ($check['mechanical_fix_allowed'] ?? false) === true));
+        $blocked = array_values(array_filter($failed, static fn (array $check): bool => ($check['mechanical_fix_allowed'] ?? false) !== true));
+        $repairLogEntries = array_map(
+            static fn (array $check): string => (string) ($check['name'] ?? 'unknown').': '.(string) ($check['failure_class'] ?? 'unknown'),
+            $failed
+        );
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ci_inspector',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'checks_json' => $checksJson === '' ? null : $this->redactPath($checksJson),
+            'check_count' => count($classifications),
+            'failed_check_count' => count($failed),
+            'mechanical_fix_candidate_count' => count($repairable),
+            'blocked_failure_count' => count($blocked),
+            'checks' => $classifications,
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+        ];
+        $fixPlan = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'mechanical_fix_plan',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'apply_requested' => $applyMechanicalFixes,
+            'apply_performed' => false,
+            'allowed_failure_classes' => ['schema', 'checksum', 'format', 'scope'],
+            'candidates' => $repairable,
+            'blocked_failures' => $blocked,
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+        ];
+        $repairLog = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ci_inspector_repair_log',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'repair_required' => $failed !== [],
+            'entries' => $repairLogEntries,
+        ];
+
+        $artifacts = [
+            'ci_inspection_report.json' => $this->writeJson($artifactDir.'/ci_inspection_report.json', $report),
+            'mechanical_fix_plan.json' => $this->writeJson($artifactDir.'/mechanical_fix_plan.json', $fixPlan),
+            'repair_log.json' => $this->writeJson($artifactDir.'/repair_log.json', $repairLog),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $checks !== [],
+            'status' => $checks === [] ? 'blocked' : 'success',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'check_count' => count($classifications),
+                'failed_check_count' => count($failed),
+                'mechanical_fix_candidate_count' => count($repairable),
+                'blocked_failure_count' => count($blocked),
+                'apply_performed' => false,
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function buildInventory(string $contentAssetRoot, string $sourceLedgerDir): array
@@ -1756,6 +1853,87 @@ final class BigFiveResultPageV2AssetAgent
         return implode(PHP_EOL, $lines).PHP_EOL;
     }
 
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function readCheckRollup(string $checksJson): array
+    {
+        if ($checksJson === '' || ! is_file($checksJson)) {
+            return [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($checksJson), true);
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        $rollup = is_array($decoded['statusCheckRollup'] ?? null)
+            ? (array) $decoded['statusCheckRollup']
+            : $decoded;
+
+        $checks = [];
+        foreach ($rollup as $row) {
+            if (is_array($row)) {
+                $checks[] = $row;
+            }
+        }
+
+        return $checks;
+    }
+
+    /**
+     * @param  array<string,mixed>  $check
+     * @return array<string,mixed>
+     */
+    private function classifyCheckRun(array $check): array
+    {
+        $name = (string) ($check['name'] ?? $check['context'] ?? 'unknown');
+        $status = strtoupper((string) ($check['status'] ?? ''));
+        $conclusion = strtoupper((string) ($check['conclusion'] ?? ''));
+        $state = ($status === 'COMPLETED' && in_array($conclusion, ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED'], true))
+            ? 'failed'
+            : (($status === 'COMPLETED' && in_array($conclusion, ['SUCCESS', 'SKIPPED', 'NEUTRAL'], true)) ? 'passed' : 'pending');
+        $failureClass = $state === 'failed' ? $this->failureClassForCheck($name) : 'none';
+
+        return [
+            'name' => $name,
+            'status' => $status,
+            'conclusion' => $conclusion,
+            'state' => $state,
+            'failure_class' => $failureClass,
+            'mechanical_fix_allowed' => in_array($failureClass, ['schema', 'checksum', 'format', 'scope'], true),
+            'mechanical_fix_policy' => $this->mechanicalFixPolicy($failureClass),
+        ];
+    }
+
+    private function failureClassForCheck(string $name): string
+    {
+        $normalized = strtolower($name);
+
+        return match (true) {
+            str_contains($normalized, 'schema') => 'schema',
+            str_contains($normalized, 'checksum') || str_contains($normalized, 'hash') => 'checksum',
+            str_contains($normalized, 'format') || str_contains($normalized, 'hygiene') => 'format',
+            str_contains($normalized, 'scope') || str_contains($normalized, 'content-pack') => 'scope',
+            str_contains($normalized, 'semgrep') || str_contains($normalized, 'secret') => 'security',
+            str_contains($normalized, 'supply-chain') => 'supply_chain',
+            str_contains($normalized, 'verify') || str_contains($normalized, 'test') => 'test',
+            default => 'unknown',
+        };
+    }
+
+    private function mechanicalFixPolicy(string $failureClass): string
+    {
+        return match ($failureClass) {
+            'schema' => 'mechanical_schema_regeneration_only',
+            'checksum' => 'mechanical_checksum_refresh_only',
+            'format' => 'mechanical_formatting_only',
+            'scope' => 'mechanical_scope_manifest_or_artifact_list_only',
+            'none' => 'not_needed',
+            default => 'manual_inspection_required',
+        };
+    }
+
     private function ensureDirectory(string $path): void
     {
         if (! is_dir($path) && ! mkdir($path, 0775, true) && ! is_dir($path)) {
@@ -1921,6 +2099,31 @@ final class BigFiveResultPageV2AssetAgent
             'git_commit_created' => false,
             'github_pr_created' => false,
             'github_checks_polled' => false,
+            'auto_merge_performed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function ciInspectorNegativeGuarantees(bool $applyRequested): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+            'github_checks_read_live' => false,
+            'git_branch_created' => false,
+            'git_commit_created' => false,
+            'github_pr_created' => false,
+            'mechanical_fix_apply_requested' => $applyRequested,
+            'mechanical_fix_apply_performed' => false,
             'auto_merge_performed' => false,
         ];
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -345,6 +345,102 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_inspect_ci_classifies_failures_and_only_plans_mechanical_fixes(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-ci-inspector');
+
+        $this->deleteDirectory($artifactRoot);
+        mkdir($artifactRoot, 0777, true);
+
+        try {
+            $checksPath = $artifactRoot.'/checks.json';
+            file_put_contents($checksPath, json_encode([
+                'statusCheckRollup' => [
+                    [
+                        'name' => 'hygiene',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                    ],
+                    [
+                        'name' => 'content-pack-build-validate',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                    ],
+                    [
+                        'name' => 'Semgrep blocking secrets',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                    ],
+                    [
+                        'name' => 'verify-bigfive',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'SUCCESS',
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'inspect-ci',
+                '--run-id' => 'ci-inspection',
+                '--artifact-dir' => $artifactRoot,
+                '--checks-json' => $checksPath,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/ci-inspection';
+            foreach ([
+                'ci_inspection_report.json',
+                'mechanical_fix_plan.json',
+                'repair_log.json',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $report = $this->readJson($runDir.'/ci_inspection_report.json');
+            $fixPlan = $this->readJson($runDir.'/mechanical_fix_plan.json');
+
+            $this->assertSame('ci_inspector', $report['task'] ?? null);
+            $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertSame(4, (int) ($report['check_count'] ?? 0));
+            $this->assertSame(3, (int) ($report['failed_check_count'] ?? 0));
+            $this->assertSame(2, (int) ($report['mechanical_fix_candidate_count'] ?? 0));
+            $this->assertSame(1, (int) ($report['blocked_failure_count'] ?? 0));
+
+            $this->assertSame('mechanical_fix_plan', $fixPlan['task'] ?? null);
+            $this->assertFalse((bool) ($fixPlan['apply_requested'] ?? true));
+            $this->assertFalse((bool) ($fixPlan['apply_performed'] ?? true));
+            $this->assertCount(2, (array) ($fixPlan['candidates'] ?? []));
+            $this->assertCount(1, (array) ($fixPlan['blocked_failures'] ?? []));
+            $this->assertSame('security', data_get($fixPlan, 'blocked_failures.0.failure_class'));
+
+            foreach ([
+                'github_checks_read_live',
+                'git_branch_created',
+                'git_commit_created',
+                'github_pr_created',
+                'mechanical_fix_apply_performed',
+                'auto_merge_performed',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+
+            $allArtifacts = implode("\n", [
+                (string) file_get_contents($runDir.'/ci_inspection_report.json'),
+                (string) file_get_contents($runDir.'/mechanical_fix_plan.json'),
+                (string) file_get_contents($runDir.'/repair_log.json'),
+            ]);
+            foreach (['private_url', 'attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_stage_candidates_fails_closed_without_human_review_manifest(): void
     {
         $artifactRoot = $this->tempDir('big5-v2-agent-stage-missing-review');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:03:00+08:00",
+  "updated_at": "2026-06-22T09:10:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57290,7 +57290,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-ci-inspector-mechanical-fixer",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks",
     "depends_on": [
@@ -57322,12 +57322,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2250 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "4622292c1a9d46a2f9c590a0f4ced8cdc8f77ae2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2250",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57336,6 +57336,11 @@
         "at": "2026-06-22T09:03:00+08:00",
         "status": "local_validated",
         "note": "Started PR3 from synced main after PR2 merge/cleanup. Local validation and scope validation passed for artifact-only CI check inspection and mechanical fix planning."
+      },
+      {
+        "at": "2026-06-22T09:10:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2250 after local validation and scope validation passed; waiting for required GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:10:00+08:00",
+  "updated_at": "2026-06-22T09:22:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57290,7 +57290,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-ci-inspector-mechanical-fixer",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks",
     "depends_on": [
@@ -57321,12 +57321,12 @@
         "evidence": "Changed files are limited to allowed PR3 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, auto merge, cleanup, or weekly ops behavior changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2250 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2250 checks completed successfully on head 3c07528c8f615919d4ece45c1517c97104f3baf0; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "4622292c1a9d46a2f9c590a0f4ced8cdc8f77ae2",
+    "commit_sha": "3c07528c8f615919d4ece45c1517c97104f3baf0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2250",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57341,6 +57341,11 @@
         "at": "2026-06-22T09:10:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2250 after local validation and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T09:22:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T08:45:00+08:00",
+  "updated_at": "2026-06-22T09:03:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57220,7 +57220,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-pr-orchestrator",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-PR-ORCHESTRATOR-01: Plan Big Five V2 agent artifact PRs",
     "depends_on": [
@@ -57254,15 +57254,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2242 checks had completed successfully before the latest rebase; waiting for required checks on the rebased ready-to-merge head."
+        "evidence": "PR #2242 merged with merge commit adc05a56e73b15366bb0665780dcf0a82d994a43 after required GitHub checks passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "ad5d5d65fd44d63a2e9b9d10c7fae538c7fadcda",
+    "commit_sha": "adc05a56e73b15366bb0665780dcf0a82d994a43",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2242",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-21T23:59:31Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T08:42:00+08:00",
@@ -57278,6 +57278,64 @@
         "at": "2026-06-22T08:45:00+08:00",
         "status": "ready_to_merge",
         "note": "Ready-to-merge state replayed during second rebase; required checks must pass on the rebased head before merge."
+      },
+      {
+        "at": "2026-06-22T09:03:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: PR #2242 is merged, origin/main contains adc05a56e73b15366bb0665780dcf0a82d994a43, local main was fast-forwarded, remote task branch is absent, local task branch is absent, and post-merge AssetAgentTest plus plan-pr smoke passed."
+      }
+    ]
+  },
+  "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-ci-inspector-mechanical-fixer",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big5_result_page_v2_asset_agent_automation",
+    "title": "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks",
+    "depends_on": [
+      "B5-RESULT-AUTO-PR-ORCHESTRATOR-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the Big Five V2 result-page asset agent full-auto PR train and authorized manifest/state updates for this PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR #2242 for B5-RESULT-AUTO-PR-ORCHESTRATOR-01 is merged and origin/main contains merge commit adc05a56e73b15366bb0665780dcf0a82d994a43."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-ci-inspector && printf ... checks.json && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=ci-inspection --artifact-dir=artifacts/big5_result_page_v2_agent/testing-ci-inspector --checks-json=artifacts/big5_result_page_v2_agent/testing-ci-inspector/checks.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-ci-inspector",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed 10 tests/272 assertions; inspect-ci smoke succeeded with failed_check_count=2, mechanical_fix_candidate_count=1, blocked_failure_count=1, apply_performed=false; diff check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed PR3 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, auto merge, cleanup, or weekly ops behavior changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T09:03:00+08:00",
+        "status": "local_validated",
+        "note": "Started PR3 from synced main after PR2 merge/cleanup. Local validation and scope validation passed for artifact-only CI check inspection and mechanical fix planning."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24505,6 +24505,44 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-AUTO-PR-ORCHESTRATOR-01
+    branch: codex/big5-v2-ci-inspector-mechanical-fixer
+    title: "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks"
+    train_scope: big5_result_page_v2_asset_agent_automation
+    status: user_authorized
+    scope:
+      - Add an artifact-only CI inspector for exported GitHub check rollup JSON.
+      - Classify failures into schema, checksum, format, scope, security, supply-chain, test, or unknown buckets.
+      - Generate a mechanical fix plan that only marks schema/checksum/format/scope failures as mechanically repairable.
+      - Keep first version dry-run/artifact-only; no live GitHub reads and no source mutation or auto merge.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add fap-web copy, generate final frontend payloads, make big5_report_engine_v2 primary, enable production rollout, or touch release/import/rollout gates.
+      - Add auto merge, cleanup, or weekly ops runner behavior in this PR.
+      - Apply non-mechanical fixes, inspect secrets beyond check names/statuses, or mutate source files from inspect-ci.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-ci-inspector && printf '%s\n' '{"statusCheckRollup":[{"name":"hygiene","status":"COMPLETED","conclusion":"FAILURE"},{"name":"Semgrep blocking secrets","status":"COMPLETED","conclusion":"FAILURE"},{"name":"verify-bigfive","status":"COMPLETED","conclusion":"SUCCESS"}]}' > artifacts/big5_result_page_v2_agent/testing-ci-inspector/checks.json && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=ci-inspection --artifact-dir=artifacts/big5_result_page_v2_agent/testing-ci-inspector --checks-json=artifacts/big5_result_page_v2_agent/testing-ci-inspector/checks.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-ci-inspector
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
     repo: fap-api
     branch: codex/riasec-result-asset-agent-runbook-01


### PR DESCRIPTION
## What changed
- Adds an `inspect-ci` action to the Big Five V2 result-page asset agent.
- Reads exported GitHub check rollup JSON and classifies failures into mechanical buckets or blocked/manual buckets.
- Generates redacted `ci_inspection_report.json`, `mechanical_fix_plan.json`, and `repair_log.json` artifacts.
- Adds tests proving only schema/checksum/format/scope-style failures are marked mechanically repairable and that no git/GitHub/source mutation is performed.
- Registers the authorized PR-train item and reconciles the already-merged auto PR orchestrator dependency.

## Why
This is PR3 of the Big Five V2 result-page asset agent full-auto train. It establishes the safe CI inspection and mechanical-fix planning contract before later PRs add merge/cleanup automation.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-ci-inspector && printf '%s\n' '{"statusCheckRollup":[{"name":"hygiene","status":"COMPLETED","conclusion":"FAILURE"},{"name":"Semgrep blocking secrets","status":"COMPLETED","conclusion":"FAILURE"},{"name":"verify-bigfive","status":"COMPLETED","conclusion":"SUCCESS"}]}' > artifacts/big5_result_page_v2_agent/testing-ci-inspector/checks.json && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=ci-inspection --artifact-dir=artifacts/big5_result_page_v2_agent/testing-ci-inspector --checks-json=artifacts/big5_result_page_v2_agent/testing-ci-inspector/checks.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-ci-inspector`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy or `fap-web` changes.
- No final frontend `big5_result_page_v2` payload generation.
- No production/runtime gate, release snapshot, production import gate, or rollout gate changes.
- No auto-merge cleanup or weekly Ops runner behavior in this PR.
- `inspect-ci` reads exported check JSON only; it does not call GitHub live or mutate source files.
- Legacy `big5_report_engine_v2` remains fallback only.

Repository rule impact: backend remains the authority for Big Five V2 result-page content assets; this PR only adds CI inspection and mechanical-fix planning artifacts for the backend agent train.
