### PR TITLE
Enneagram: add automated candidate export and staging inactive import harness

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageCandidateStagingHarnessCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageCandidateStagingHarnessCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageCandidateStagingHarness;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageCandidateStagingHarnessCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-candidate-staging-harness
+        {action=audit : Only audit is supported in this harness PR}
+        {--run-id=candidate-staging-harness : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root}
+        {--contract-path= : Optional harness contract path}
+        {--candidate-dir= : Candidate package directory}
+        {--output-dir= : Output directory for export/import reports}
+        {--expected-candidate-manifest-sha256= : Expected candidate manifest hash}
+        {--expected-runtime-registry-sha256= : Expected runtime registry hash}
+        {--run-export : Run the existing candidate payload exporter}
+        {--run-staging-import : Run the existing inactive candidate importer}
+        {--strict : Return non-zero when validation errors are present}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Validate Enneagram candidate export and staging-only inactive import gates without activation.';
+
+    public function handle(EnneagramResultPageCandidateStagingHarness $harness): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $harness->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'candidate_dir' => trim((string) $this->option('candidate-dir')),
+                'output_dir' => trim((string) $this->option('output-dir')),
+                'expected_candidate_manifest_sha256' => trim((string) $this->option('expected-candidate-manifest-sha256')),
+                'expected_runtime_registry_sha256' => trim((string) $this->option('expected-runtime-registry-sha256')),
+                'run_export' => (bool) $this->option('run-export'),
+                'run_staging_import' => (bool) $this->option('run-staging-import'),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('candidate_contract_valid='.(((bool) data_get($summary, 'summary.candidate_contract_valid', false)) ? 'true' : 'false'));
+        $this->line('candidate_payload_count='.(string) data_get($summary, 'summary.candidate_payload_count', 0));
+        $this->line('run_export='.(((bool) data_get($summary, 'summary.run_export', false)) ? 'true' : 'false'));
+        $this->line('run_staging_import='.(((bool) data_get($summary, 'summary.run_staging_import', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -115,6 +115,7 @@ use App\Console\Commands\EnneagramExportProductionEquivalentCandidatePayloads;
 use App\Console\Commands\EnneagramImportInactiveCandidateRelease;
 use App\Console\Commands\EnneagramResultPageContentBatchCommand;
 use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
+use App\Console\Commands\EnneagramResultPageCandidateStagingHarnessCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
@@ -249,6 +250,7 @@ class Kernel extends ConsoleKernel
         EnneagramImportInactiveCandidateRelease::class,
         EnneagramResultPageContentBatchCommand::class,
         EnneagramResultPageAgentReadinessCommand::class,
+        EnneagramResultPageCandidateStagingHarnessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramResultPageOpsRunnerCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageCandidateStagingHarness.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageCandidateStagingHarness.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
+use App\Services\Enneagram\Assets\EnneagramProductionEquivalentCandidatePayloadExporter;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageCandidateStagingHarness
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.candidate_staging_harness.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_candidate_staging_harness';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/candidate_staging_harness/candidate_staging_harness_contract_v0_1.json';
+
+    private const DEFAULT_EXPECTED_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
+
+    private const DEFAULT_EXPECTED_RUNTIME_REGISTRY_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
+
+    private const EXPECTED_PAYLOAD_COUNT = 630;
+
+    private const LAUNCH_SCOPE = ['1R-A', '1R-B', '1R-C', '1R-D', '1R-E', '1R-F', '1R-G', '1R-H'];
+
+    private const OUT_OF_LAUNCH_SCOPE = ['1R-I', '1R-J'];
+
+    public function __construct(
+        private readonly EnneagramProductionEquivalentCandidatePayloadExporter $exporter,
+        private readonly EnneagramInactiveCandidateReleaseImporter $importer,
+    ) {}
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     candidate_dir?:string,
+     *     output_dir?:string,
+     *     expected_candidate_manifest_sha256?:string,
+     *     expected_runtime_registry_sha256?:string,
+     *     run_export?:bool,
+     *     run_staging_import?:bool,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'candidate-staging-harness'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $candidateDir = rtrim(trim((string) ($options['candidate_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $outputDir = rtrim(trim((string) ($options['output_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $expectedCandidateHash = trim((string) ($options['expected_candidate_manifest_sha256'] ?? self::DEFAULT_EXPECTED_CANDIDATE_MANIFEST_SHA256));
+        $expectedRuntimeHash = trim((string) ($options['expected_runtime_registry_sha256'] ?? self::DEFAULT_EXPECTED_RUNTIME_REGISTRY_SHA256));
+        $runExport = ($options['run_export'] ?? false) === true;
+        $runStagingImport = ($options['run_staging_import'] ?? false) === true;
+        $strict = ($options['strict'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readJson($contractPath, 'Candidate staging harness contract');
+        $contractErrors = $this->contractErrors($contract);
+        $candidateReport = $this->candidateReport($candidateDir, $expectedCandidateHash, $expectedRuntimeHash);
+
+        $exportSummary = null;
+        $stagingImportSummary = null;
+        $executionErrors = [];
+
+        if ($runExport) {
+            try {
+                $exportSummary = $this->exporter->export($candidateDir, $outputDir);
+            } catch (RuntimeException $exception) {
+                $executionErrors[] = 'export_failed:'.$exception->getMessage();
+            }
+        }
+
+        if ($runStagingImport) {
+            try {
+                $stagingImportSummary = $this->importer->import($candidateDir, $outputDir, [
+                    'candidate_manifest_sha256' => $expectedCandidateHash,
+                    'runtime_registry_manifest_sha256' => $expectedRuntimeHash,
+                ]);
+            } catch (RuntimeException $exception) {
+                $executionErrors[] = 'staging_import_failed:'.$exception->getMessage();
+            }
+        }
+
+        $errors = array_values(array_unique(array_merge(
+            $contractErrors,
+            (array) ($candidateReport['errors'] ?? []),
+            $executionErrors
+        )));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'candidate_export_staging_import_harness',
+            'run_id' => $runId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'candidate_dir' => [
+                'provided' => $candidateDir !== '',
+                'path' => $candidateDir === '' ? null : $this->redactPath($candidateDir),
+            ],
+            'candidate_contract' => $candidateReport,
+            'execution' => [
+                'run_export' => $runExport,
+                'run_staging_import' => $runStagingImport,
+                'export_summary' => $exportSummary,
+                'staging_import_summary' => $stagingImportSummary,
+                'activation_allowed' => false,
+                'production_import_allowed' => false,
+                'runtime_switch_allowed' => false,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'candidate_export_staging_import_report.json' => $this->writeJson($artifactDir.'/candidate_export_staging_import_report.json', $report),
+        ];
+        if (is_array($stagingImportSummary)) {
+            $artifacts['staging_import_summary.json'] = $this->writeJson($artifactDir.'/staging_import_summary.json', $stagingImportSummary);
+        }
+        if (is_array($exportSummary)) {
+            $artifacts['candidate_export_summary.json'] = $this->writeJson($artifactDir.'/candidate_export_summary.json', $exportSummary);
+        }
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'summary' => [
+                'candidate_contract_valid' => (bool) ($candidateReport['valid'] ?? false),
+                'candidate_payload_count' => (int) ($candidateReport['payload_count'] ?? 0),
+                'run_export' => $runExport,
+                'run_staging_import' => $runStagingImport,
+                'inactive_release_id' => is_array($stagingImportSummary) ? (string) ($stagingImportSummary['inactive_release_id'] ?? '') : null,
+                'activation_allowed' => false,
+                'production_import_allowed' => false,
+                'production_execution_allowed_for_agent' => false,
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function candidateReport(string $candidateDir, string $expectedCandidateHash, string $expectedRuntimeHash): array
+    {
+        $errors = [];
+        if ($candidateDir === '' || ! is_dir($candidateDir)) {
+            return [
+                'valid' => false,
+                'payload_count' => 0,
+                'errors' => ['candidate_dir_missing'],
+            ];
+        }
+
+        $manifestPath = $candidateDir.'/candidate_manifest.json';
+        $hashesPath = $candidateDir.'/candidate_hashes.json';
+        $payloadDir = $candidateDir.'/candidate_payloads';
+        $manifest = is_file($manifestPath) ? $this->readJson($manifestPath, 'Candidate manifest') : null;
+        $hashes = is_file($hashesPath) ? $this->readJson($hashesPath, 'Candidate hashes') : null;
+
+        if (! is_array($manifest)) {
+            $errors[] = 'candidate_manifest_missing';
+        }
+        if (! is_array($hashes)) {
+            $errors[] = 'candidate_hashes_missing';
+        }
+
+        $actualManifestHash = is_file($manifestPath) ? (hash_file('sha256', $manifestPath) ?: '') : '';
+        if ($actualManifestHash !== $expectedCandidateHash) {
+            $errors[] = 'candidate_manifest_hash_mismatch';
+        }
+        if ((string) data_get($hashes, 'candidate_manifest_sha256') !== $expectedCandidateHash) {
+            $errors[] = 'candidate_hashes_manifest_hash_mismatch';
+        }
+        if ((string) data_get($hashes, 'runtime_registry_manifest_sha256') !== $expectedRuntimeHash) {
+            $errors[] = 'runtime_registry_hash_mismatch';
+        }
+
+        $payloadFiles = is_dir($payloadDir) ? (File::glob($payloadDir.'/*.json') ?: []) : [];
+        if (count($payloadFiles) !== self::EXPECTED_PAYLOAD_COUNT) {
+            $errors[] = 'candidate_payload_count_mismatch';
+        }
+
+        $launchScope = array_values((array) data_get($manifest, 'launch_scope', []));
+        if ($launchScope === []) {
+            $launchScope = array_keys((array) data_get($manifest, 'candidate_items_by_batch', []));
+        }
+        sort($launchScope);
+        $expectedLaunch = self::LAUNCH_SCOPE;
+        sort($expectedLaunch);
+        if ($launchScope !== $expectedLaunch) {
+            $errors[] = 'launch_scope_mismatch';
+        }
+
+        $outOfLaunchScope = array_values((array) data_get($manifest, 'out_of_launch_scope', []));
+        sort($outOfLaunchScope);
+        $expectedOut = self::OUT_OF_LAUNCH_SCOPE;
+        sort($expectedOut);
+        if ($outOfLaunchScope !== $expectedOut) {
+            $errors[] = 'out_of_launch_scope_mismatch';
+        }
+
+        foreach ([
+            'source_mapping_report.json' => ['source_mapping_failure_count', 'missing_count', 'fallback_count', 'blocked_count', 'duplicate_selection_count', 'metadata_leak_count'],
+            'legacy_residual_scan.json' => ['legacy_deep_core_residual_count', 'legacy_residual_count', 'residual_count'],
+            'fc144_boundary_report.json' => ['violation_count', 'fc144_boundary_violation_count'],
+            'forbidden_claim_report.json' => ['violation_count', 'forbidden_claim_violation_count', 'failure_count'],
+        ] as $file => $counters) {
+            $path = $candidateDir.'/'.$file;
+            if (! is_file($path) && $file === 'forbidden_claim_report.json') {
+                continue;
+            }
+            if (! is_file($path)) {
+                $errors[] = 'candidate_report_missing:'.$file;
+                continue;
+            }
+            $report = $this->readJson($path, $file);
+            foreach ($counters as $counter) {
+                $value = data_get($report, $counter);
+                if ($value !== null && (int) $value !== 0) {
+                    $errors[] = $counter.'_nonzero';
+                }
+            }
+        }
+
+        return [
+            'valid' => $errors === [],
+            'expected_candidate_manifest_sha256' => $expectedCandidateHash,
+            'actual_candidate_manifest_sha256' => $actualManifestHash,
+            'expected_runtime_registry_sha256' => $expectedRuntimeHash,
+            'recorded_runtime_registry_sha256' => (string) data_get($hashes, 'runtime_registry_manifest_sha256', ''),
+            'expected_payload_count' => self::EXPECTED_PAYLOAD_COUNT,
+            'payload_count' => count($payloadFiles),
+            'launch_scope' => self::LAUNCH_SCOPE,
+            'actual_launch_scope' => $launchScope,
+            'out_of_launch_scope' => $outOfLaunchScope,
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+        if ((int) ($contract['expected_payload_count'] ?? 0) !== self::EXPECTED_PAYLOAD_COUNT) {
+            $errors[] = 'expected_payload_count_mismatch';
+        }
+        if (data_get($contract, 'staging_import_policy.inactive_import_allowed') !== true) {
+            $errors[] = 'inactive_import_must_be_allowed';
+        }
+        if (data_get($contract, 'staging_import_policy.activation_allowed') !== false) {
+            $errors[] = 'activation_allowed_must_be_false';
+        }
+        if (data_get($contract, 'staging_import_policy.production_import_allowed') !== false) {
+            $errors[] = 'production_import_allowed_must_be_false';
+        }
+
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bulk_content_generation_happened' => false,
+            'production_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException($label.' is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'candidate-staging-harness';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/candidate_staging_harness/README.md
+++ b/backend/content_assets/enneagram/result_page/candidate_staging_harness/README.md
@@ -1,0 +1,7 @@
+# Enneagram Candidate Export + Staging Import Harness
+
+This directory defines the automation harness contract for Enneagram result page candidate export and staging-only inactive import validation.
+
+The harness can validate a provided candidate directory, optionally run the existing production-equivalent candidate payload exporter, and optionally run the existing inactive candidate release importer. It is staging/inactive only.
+
+It does not run production import, production activation, runtime switching, production writes, or frontend changes.

--- a/backend/content_assets/enneagram/result_page/candidate_staging_harness/candidate_staging_harness_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/candidate_staging_harness/candidate_staging_harness_contract_v0_1.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "fap.enneagram.result_page.candidate_staging_harness.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "expected_payload_count": 630,
+  "launch_scope": ["1R-A", "1R-B", "1R-C", "1R-D", "1R-E", "1R-F", "1R-G", "1R-H"],
+  "out_of_launch_scope": ["1R-I", "1R-J"],
+  "checks": [
+    "candidate_manifest_hash",
+    "runtime_registry_hash",
+    "payload_count",
+    "scope",
+    "source_mapping_zero",
+    "metadata_leakage_zero",
+    "forbidden_claim_zero",
+    "legacy_residual_zero",
+    "fc144_boundary_zero"
+  ],
+  "staging_import_policy": {
+    "inactive_import_allowed": true,
+    "activation_allowed": false,
+    "production_import_allowed": false,
+    "runtime_switch_allowed": false
+  },
+  "negative_guarantees": {
+    "bulk_content_generation_happened": false,
+    "production_import_happened": false,
+    "production_activation_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageCandidateStagingHarnessCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageCandidateStagingHarnessCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageCandidateStagingHarnessCommandTest extends TestCase
+{
+    public function test_candidate_staging_harness_command_fails_closed_without_candidate_dir(): void
+    {
+        $this->artisan('enneagram:result-page-candidate-staging-harness', [
+            'action' => 'audit',
+            '--run-id' => 'missing-candidate',
+            '--artifact-dir' => sys_get_temp_dir().'/enneagram-candidate-staging-command',
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2874,6 +2874,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_candidate_staging_harness_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageCandidateStagingHarnessCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageCandidateStagingHarness.php',
+            'backend/content_assets/enneagram/result_page/candidate_staging_harness/README.md',
+            'backend/content_assets/enneagram/result_page/candidate_staging_harness/candidate_staging_harness_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageCandidateStagingHarnessCommand;',
+            '+        EnneagramResultPageCandidateStagingHarnessCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4786,6 +4809,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageCandidateStagingHarnessFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4895,6 +4922,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageOpsControlPlaneOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6798,6 +6826,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageCandidateStagingHarnessFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageCandidateStagingHarnessCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageCandidateStagingHarness.php',
+            'backend/content_assets/enneagram/result_page/candidate_staging_harness/README.md',
+            'backend/content_assets/enneagram/result_page/candidate_staging_harness/candidate_staging_harness_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -7945,6 +7983,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageContentBatchCommand;',
             '        EnneagramResultPageContentBatchCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageCandidateStagingHarnessCommand;',
+            '        EnneagramResultPageCandidateStagingHarnessCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageCandidateStagingHarnessTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageCandidateStagingHarnessTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Content\EnneagramRegistryReleaseResolver;
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageCandidateStagingHarness;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramResultPageCandidateStagingHarnessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_harness_validates_candidate_and_runs_inactive_staging_import_without_activation(): void
+    {
+        $fixture = $this->makeCandidateFixture('harness_inactive_import');
+        $artifactRoot = storage_path('framework/testing/enneagram_candidate_staging_harness_artifacts/import');
+
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageCandidateStagingHarness::class)->run([
+            'run_id' => 'unit-run',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $fixture['candidate_dir'],
+            'output_dir' => $fixture['output_dir'],
+            'expected_candidate_manifest_sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            'expected_runtime_registry_sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            'run_staging_import' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.candidate_contract_valid', false));
+        $this->assertSame(630, (int) data_get($summary, 'summary.candidate_payload_count'));
+        $this->assertTrue((bool) data_get($summary, 'summary.run_staging_import', false));
+        $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+        $this->assertNotEmpty(data_get($summary, 'summary.inactive_release_id'));
+        $this->assertFalse(DB::table('content_pack_activations')
+            ->where('pack_id', 'ENNEAGRAM')
+            ->where('pack_version', 'v2')
+            ->exists());
+
+        $resolver = app(EnneagramRegistryReleaseResolver::class);
+        $this->assertSame(base_path('content_packs/ENNEAGRAM/v2/registry'), $resolver->runtimeRegistryRoot());
+
+        $report = $this->readJson($artifactRoot.'/unit-run/candidate_export_staging_import_report.json');
+        $this->assertFalse((bool) data_get($report, 'execution.activation_allowed', true));
+        $this->assertFalse((bool) data_get($report, 'execution.production_import_allowed', true));
+        $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_activation_happened', true));
+        $this->assertFileExists($artifactRoot.'/unit-run/staging_import_summary.json');
+    }
+
+    public function test_harness_fails_closed_on_hash_mismatch(): void
+    {
+        $fixture = $this->makeCandidateFixture('harness_hash_mismatch');
+        $artifactRoot = storage_path('framework/testing/enneagram_candidate_staging_harness_artifacts/hash');
+
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageCandidateStagingHarness::class)->run([
+            'run_id' => 'hash-run',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $fixture['candidate_dir'],
+            'output_dir' => $fixture['output_dir'],
+            'expected_candidate_manifest_sha256' => str_repeat('0', 64),
+            'expected_runtime_registry_sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('candidate_manifest_hash_mismatch', $summary['errors'] ?? []);
+    }
+
+    public function test_harness_fails_closed_on_payload_count_mismatch(): void
+    {
+        $fixture = $this->makeCandidateFixture('harness_count_mismatch');
+        unlink($fixture['candidate_dir'].'/candidate_payloads/payload_000.json');
+        $artifactRoot = storage_path('framework/testing/enneagram_candidate_staging_harness_artifacts/count');
+
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageCandidateStagingHarness::class)->run([
+            'run_id' => 'count-run',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $fixture['candidate_dir'],
+            'output_dir' => $fixture['output_dir'],
+            'expected_candidate_manifest_sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            'expected_runtime_registry_sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('candidate_payload_count_mismatch', $summary['errors'] ?? []);
+    }
+
+    public function test_harness_fails_closed_on_launch_scope_mismatch(): void
+    {
+        $fixture = $this->makeCandidateFixture('harness_scope_mismatch');
+        $manifest = $this->readJson($fixture['candidate_dir'].'/candidate_manifest.json');
+        unset($manifest['candidate_items_by_batch']['1R-H']);
+        $contracts = $this->rewriteManifestAndHashes($fixture['candidate_dir'], $manifest);
+        $artifactRoot = storage_path('framework/testing/enneagram_candidate_staging_harness_artifacts/scope');
+
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageCandidateStagingHarness::class)->run([
+            'run_id' => 'scope-run',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $fixture['candidate_dir'],
+            'output_dir' => $fixture['output_dir'],
+            'expected_candidate_manifest_sha256' => $contracts['candidate_manifest_sha256'],
+            'expected_runtime_registry_sha256' => $contracts['runtime_registry_manifest_sha256'],
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('launch_scope_mismatch', $summary['errors'] ?? []);
+    }
+
+    public function test_harness_fails_closed_on_metadata_leakage_count(): void
+    {
+        $fixture = $this->makeCandidateFixture('harness_metadata_leakage');
+        $sourceMapping = $this->readJson($fixture['candidate_dir'].'/source_mapping_report.json');
+        $sourceMapping['metadata_leak_count'] = 1;
+        File::put($fixture['candidate_dir'].'/source_mapping_report.json', json_encode($sourceMapping, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $artifactRoot = storage_path('framework/testing/enneagram_candidate_staging_harness_artifacts/leakage');
+
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageCandidateStagingHarness::class)->run([
+            'run_id' => 'leakage-run',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $fixture['candidate_dir'],
+            'output_dir' => $fixture['output_dir'],
+            'expected_candidate_manifest_sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            'expected_runtime_registry_sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('metadata_leak_count_nonzero', $summary['errors'] ?? []);
+    }
+
+    /**
+     * @return array{candidate_dir:string,output_dir:string,contracts:array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}}
+     */
+    private function makeCandidateFixture(string $suffix): array
+    {
+        $candidateDir = storage_path('framework/testing/enneagram_candidate_staging_harness/'.$suffix);
+        $outputDir = storage_path('framework/testing/enneagram_candidate_staging_harness_output/'.$suffix);
+        File::deleteDirectory($candidateDir);
+        File::deleteDirectory($outputDir);
+        File::ensureDirectoryExists($candidateDir);
+        File::ensureDirectoryExists($candidateDir.'/candidate_payloads');
+
+        $runtimeHash = hash_file('sha256', base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json')) ?: '';
+        $manifest = [
+            'schema_version' => 'enneagram.production_import_candidate.v1',
+            'generated_at' => now()->toIso8601String(),
+            'mode' => 'dry_run_candidate_only',
+            'production_import_happened' => false,
+            'full_replacement_happened' => false,
+            'out_of_launch_scope' => ['1R-I', '1R-J'],
+            'source_assets' => ['1R-A' => '/tmp/a.json'],
+            'source_versions' => [
+                'batch_1r_a' => 'enneagram_content_expansion_batch_1R_A.v6',
+                'batch_1r_b' => 'enneagram_content_expansion_batch_1R_B_legacy_core_rewrite.v3',
+                'batch_1r_c' => 'enneagram_content_expansion_batch_1R_C_low_resonance_objection_handling.v1',
+                'batch_1r_d' => 'enneagram_content_expansion_batch_1R_D_partial_resonance_deep_branch.v1',
+                'batch_1r_e' => 'enneagram_content_expansion_batch_1R_E_diffuse_top3_convergence.v1',
+                'batch_1r_f' => 'enneagram_content_expansion_batch_1R_F_close_call_36_pair_completion.v1',
+                'batch_1r_g' => 'enneagram_content_expansion_batch_1R_G_scene_localization.v1',
+                'batch_1r_h' => 'enneagram_content_expansion_batch_1R_H_fc144_recommendation.v1',
+            ],
+            'replacement_coverage' => [
+                'batch_1r_a_replaces' => ['page1_summary', 'type_summary', 'deep_dive_intro'],
+                'batch_1r_b_replaces' => [
+                    'core_motivation', 'core_fear', 'core_desire', 'self_image', 'attention_pattern',
+                    'strength', 'blindspot', 'stress_pattern', 'relationship_pattern', 'work_pattern',
+                    'growth_direction', 'daily_observation', 'boundary',
+                ],
+                'batch_1r_c_adds' => ['low_resonance_response'],
+                'batch_1r_d_adds' => ['partial_resonance_response'],
+                'batch_1r_e_adds' => ['diffuse_convergence_response'],
+                'batch_1r_f_adds' => ['close_call_pair'],
+                'batch_1r_g_adds' => ['scene_localization_response'],
+                'batch_1r_h_adds' => ['fc144_recommendation_response'],
+            ],
+            'candidate_item_count' => 1332,
+            'candidate_items_by_batch' => [
+                '1R-A' => 315, '1R-B' => 423, '1R-C' => 108, '1R-D' => 90,
+                '1R-E' => 108, '1R-F' => 36, '1R-G' => 162, '1R-H' => 90,
+            ],
+            'payload_counts' => [
+                'baseline' => 36, 'low_resonance' => 108, 'partial_resonance' => 90,
+                'diffuse_convergence' => 108, 'close_call_pair' => 36, 'scene_localization' => 162,
+                'fc144_recommendation' => 90,
+            ],
+            'runtime_registry_manifest' => [
+                'path' => base_path('content_packs/ENNEAGRAM/v2/registry/manifest.json'),
+                'sha256' => $runtimeHash,
+            ],
+        ];
+
+        File::put($candidateDir.'/candidate_manifest.json', json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $manifestHash = hash_file('sha256', $candidateDir.'/candidate_manifest.json') ?: '';
+
+        foreach ([
+            'candidate_hashes.json' => ['candidate_manifest_sha256' => $manifestHash, 'runtime_registry_manifest_sha256' => $runtimeHash],
+            'import_diff_summary.json' => ['no_full_replacement' => true, 'no_production_registry_write' => true],
+            'replacement_additive_map.json' => $manifest['replacement_coverage'],
+            'source_mapping_report.json' => ['source_mapping_failure_count' => 0, 'missing_count' => 0, 'fallback_count' => 0, 'blocked_count' => 0, 'duplicate_selection_count' => 0, 'metadata_leak_count' => 0],
+            'legacy_residual_scan.json' => ['legacy_deep_core_residual_count' => 0],
+            'fc144_boundary_report.json' => ['violation_count' => 0],
+            'forbidden_claim_report.json' => ['violation_count' => 0],
+            'phase8b_summary.json' => ['verdict' => 'PASS_FOR_PRODUCTION_EQUIVALENT_E2E_QA'],
+            'candidate_payloads_manifest.json' => ['total_payload_count' => 630],
+            'candidate_payload_hashes.json' => ['candidate_payloads_manifest_sha256' => 'fixture'],
+            'candidate_payload_source_mapping.json' => ['source_mapping_failure_count' => 0],
+        ] as $file => $payload) {
+            File::put($candidateDir.'/'.$file, json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        }
+        File::put($candidateDir.'/rollback_plan.md', "# rollback\n");
+
+        for ($i = 0; $i < 630; $i++) {
+            File::put($candidateDir.'/candidate_payloads/payload_'.str_pad((string) $i, 3, '0', STR_PAD_LEFT).'.json', json_encode([
+                'fixture_index' => $i,
+                'enneagram_report_v2' => ['schema_version' => 'enneagram.report.v2'],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        }
+
+        return [
+            'candidate_dir' => $candidateDir,
+            'output_dir' => $outputDir,
+            'contracts' => [
+                'candidate_manifest_sha256' => $manifestHash,
+                'runtime_registry_manifest_sha256' => $runtimeHash,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @return array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}
+     */
+    private function rewriteManifestAndHashes(string $candidateDir, array $manifest): array
+    {
+        File::put($candidateDir.'/candidate_manifest.json', json_encode($manifest, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        $manifestHash = hash_file('sha256', $candidateDir.'/candidate_manifest.json') ?: '';
+        $hashes = $this->readJson($candidateDir.'/candidate_hashes.json');
+        $hashes['candidate_manifest_sha256'] = $manifestHash;
+        File::put($candidateDir.'/candidate_hashes.json', json_encode($hashes, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        return [
+            'candidate_manifest_sha256' => $manifestHash,
+            'runtime_registry_manifest_sha256' => (string) ($hashes['runtime_registry_manifest_sha256'] ?? ''),
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- Added an Enneagram result page candidate export + staging inactive import harness contract.
- Added `enneagram:result-page-candidate-staging-harness audit` to validate candidate gates and optionally call the existing exporter/importer in staging/inactive mode.
- Added unit and command tests for candidate hash, runtime hash, 630 payload count, launch scope, metadata leakage, and inactive import without activation.
- Added a narrow BigFive runtime freeze allowlist entry for this Enneagram-only scaffold.

## Why
This is the automation layer for dry-run candidate export and staging-only inactive import evidence before any rendered QA or production gate. It keeps candidate validation reproducible while preserving the manual production approval boundary.

## Validation
- `php -l backend/app/Console/Kernel.php && php -l backend/app/Console/Commands/EnneagramResultPageCandidateStagingHarnessCommand.php && php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageCandidateStagingHarness.php && php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageCandidateStagingHarnessTest.php && php -l backend/tests/Feature/Console/EnneagramResultPageCandidateStagingHarnessCommandTest.php && php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageCandidateStagingHarnessTest.php tests/Feature/Console/EnneagramResultPageCandidateStagingHarnessCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_candidate_staging_harness_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan list --no-ansi | rg "enneagram:result-page-(candidate-staging-harness|content-batch|ops-runner|ops-control-plane|agent)"`
- `git diff --check`
- Scoped changed-file validation passed.

## Intentionally deferred
- No bulk content generation.
- No production import.
- No activation.
- No runtime switch.
- No production writes.
- No frontend changes.
