### PR TITLE
B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -23,6 +23,7 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
         {--branch= : Planned branch for plan-pr}
         {--title= : Planned PR title for plan-pr}
         {--checks-json= : Exported GitHub statusCheckRollup JSON for inspect-ci}
+        {--pr-state-json= : Exported GitHub PR state JSON for plan-merge-cleanup}
         {--apply-mechanical-fixes : Permit inspect-ci to apply supported mechanical fixes}
         {--allow-staging-write : Permit stage-candidates to write the reviewed staging package}
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
@@ -68,11 +69,16 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'checks_json' => trim((string) $this->option('checks-json')),
                     'apply_mechanical_fixes' => (bool) $this->option('apply-mechanical-fixes'),
                 ]),
+                'plan-merge-cleanup' => $agent->planMergeCleanup([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'pr_state_json' => trim((string) $this->option('pr-state-json')),
+                ]),
                 default => null,
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -568,6 +568,112 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   pr_state_json?:string
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function planMergeCleanup(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $prStateJson = trim((string) ($options['pr_state_json'] ?? '')) === ''
+            ? ''
+            : $this->absolutePath((string) ($options['pr_state_json'] ?? ''));
+
+        $this->ensureDirectory($artifactDir);
+
+        $state = $this->readOptionalJson($prStateJson) ?? [];
+        $checks = $this->readCheckRollupFromPayload($state);
+        $pending = array_values(array_filter($checks, static fn (array $check): bool => ($check['state'] ?? '') === 'pending'));
+        $failed = array_values(array_filter($checks, static fn (array $check): bool => ($check['state'] ?? '') === 'failed'));
+        $mergeState = strtoupper((string) ($state['mergeStateStatus'] ?? ''));
+        $reviewDecision = strtoupper((string) ($state['reviewDecision'] ?? ''));
+        $isDraft = (bool) ($state['isDraft'] ?? false);
+        $headRef = (string) ($state['headRefName'] ?? '');
+        $prNumber = (string) ($state['number'] ?? '');
+        $canMerge = $state !== []
+            && ! $isDraft
+            && $mergeState === 'CLEAN'
+            && $pending === []
+            && $failed === []
+            && in_array($reviewDecision, ['', 'APPROVED'], true);
+
+        $blockers = array_values(array_filter([
+            $state === [] ? 'pr_state_json_missing_or_invalid' : null,
+            $isDraft ? 'draft_pr' : null,
+            $mergeState !== 'CLEAN' ? 'merge_state_not_clean' : null,
+            $pending !== [] ? 'checks_pending' : null,
+            $failed !== [] ? 'checks_failed' : null,
+            ! in_array($reviewDecision, ['', 'APPROVED'], true) ? 'review_not_approved' : null,
+        ]));
+
+        $plan = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'auto_merge_cleanup_plan',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'execution_mode' => 'dry_run_artifact_only',
+            'pr_state_json' => $prStateJson === '' ? null : $this->redactPath($prStateJson),
+            'gate' => [
+                'can_merge' => $canMerge,
+                'blockers' => $blockers,
+                'merge_state' => $mergeState,
+                'review_decision' => $reviewDecision,
+                'is_draft' => $isDraft,
+                'pending_check_count' => count($pending),
+                'failed_check_count' => count($failed),
+            ],
+            'planned_commands' => $canMerge ? [
+                'gh pr merge '.$prNumber.' --squash --delete-branch',
+                'git fetch origin main --prune',
+                'git checkout main',
+                'git pull --ff-only origin main',
+                'git branch -d '.$headRef,
+            ] : [],
+            'negative_guarantees' => $this->mergeCleanupNegativeGuarantees(),
+        ];
+
+        $artifacts = [
+            'auto_merge_cleanup_plan.json' => $this->writeJson($artifactDir.'/auto_merge_cleanup_plan.json', $plan),
+            'repair_log.json' => $this->writeJson($artifactDir.'/repair_log.json', [
+                'schema_version' => self::SCHEMA_VERSION,
+                'task' => 'auto_merge_cleanup_repair_log',
+                'runtime_use' => 'not_runtime',
+                'production_use_allowed' => false,
+                'repair_required' => ! $canMerge,
+                'entries' => $blockers,
+            ]),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $state !== [],
+            'status' => $state === [] ? 'blocked' : 'success',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'can_merge' => $canMerge,
+                'blocker_count' => count($blockers),
+                'pending_check_count' => count($pending),
+                'failed_check_count' => count($failed),
+                'merge_performed' => false,
+                'cleanup_performed' => false,
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->mergeCleanupNegativeGuarantees(),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function buildInventory(string $contentAssetRoot, string $sourceLedgerDir): array
@@ -1882,6 +1988,25 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @param  array<string,mixed>  $payload
+     * @return list<array<string,mixed>>
+     */
+    private function readCheckRollupFromPayload(array $payload): array
+    {
+        $rollup = is_array($payload['statusCheckRollup'] ?? null)
+            ? (array) $payload['statusCheckRollup']
+            : [];
+        $checks = [];
+        foreach ($rollup as $row) {
+            if (is_array($row)) {
+                $checks[] = $this->classifyCheckRun($row);
+            }
+        }
+
+        return $checks;
+    }
+
+    /**
      * @param  array<string,mixed>  $check
      * @return array<string,mixed>
      */
@@ -2124,6 +2249,30 @@ final class BigFiveResultPageV2AssetAgent
             'github_pr_created' => false,
             'mechanical_fix_apply_requested' => $applyRequested,
             'mechanical_fix_apply_performed' => false,
+            'auto_merge_performed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function mergeCleanupNegativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+            'github_merge_performed' => false,
+            'remote_branch_deleted' => false,
+            'local_branch_deleted' => false,
+            'local_main_synced' => false,
+            'post_merge_revalidation_run' => false,
             'auto_merge_performed' => false,
         ];
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -441,6 +441,76 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_plan_merge_cleanup_requires_clean_green_pr_and_does_not_execute_merge(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-merge-cleanup');
+
+        $this->deleteDirectory($artifactRoot);
+        mkdir($artifactRoot, 0777, true);
+
+        try {
+            $statePath = $artifactRoot.'/pr-state.json';
+            file_put_contents($statePath, json_encode([
+                'number' => 2250,
+                'headRefName' => 'codex/big5-v2-ci-inspector-mechanical-fixer',
+                'state' => 'OPEN',
+                'isDraft' => false,
+                'mergeStateStatus' => 'CLEAN',
+                'reviewDecision' => '',
+                'statusCheckRollup' => [
+                    [
+                        'name' => 'hygiene',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'SUCCESS',
+                    ],
+                    [
+                        'name' => 'verify-bigfive',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'SUCCESS',
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'plan-merge-cleanup',
+                '--run-id' => 'merge-cleanup',
+                '--artifact-dir' => $artifactRoot,
+                '--pr-state-json' => $statePath,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/merge-cleanup';
+            $this->assertFileExists($runDir.'/auto_merge_cleanup_plan.json');
+            $this->assertFileExists($runDir.'/repair_log.json');
+
+            $plan = $this->readJson($runDir.'/auto_merge_cleanup_plan.json');
+            $this->assertSame('auto_merge_cleanup_plan', $plan['task'] ?? null);
+            $this->assertSame('not_runtime', $plan['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($plan['production_use_allowed'] ?? true));
+            $this->assertTrue((bool) data_get($plan, 'gate.can_merge'));
+            $this->assertSame([], data_get($plan, 'gate.blockers'));
+            $this->assertSame(0, (int) data_get($plan, 'gate.pending_check_count', -1));
+            $this->assertSame(0, (int) data_get($plan, 'gate.failed_check_count', -1));
+            $this->assertContains('gh pr merge 2250 --squash --delete-branch', (array) ($plan['planned_commands'] ?? []));
+
+            foreach ([
+                'github_merge_performed',
+                'remote_branch_deleted',
+                'local_branch_deleted',
+                'local_main_synced',
+                'post_merge_revalidation_run',
+                'auto_merge_performed',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($plan, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_stage_candidates_fails_closed_without_human_review_manifest(): void
     {
         $artifactRoot = $this->tempDir('big5-v2-agent-stage-missing-review');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:22:00+08:00",
+  "updated_at": "2026-06-22T09:33:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57290,7 +57290,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-ci-inspector-mechanical-fixer",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01: Inspect Big Five V2 agent PR checks",
     "depends_on": [
@@ -57322,15 +57322,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2250 checks completed successfully on head 3c07528c8f615919d4ece45c1517c97104f3baf0; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
+        "evidence": "PR #2250 merged with merge commit af20b19af64cb4aac2e71155a48a42f4dff2e948 after required GitHub checks passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "3c07528c8f615919d4ece45c1517c97104f3baf0",
+    "commit_sha": "af20b19af64cb4aac2e71155a48a42f4dff2e948",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2250",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T00:15:09Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T09:03:00+08:00",
@@ -57346,6 +57346,64 @@
         "at": "2026-06-22T09:22:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
+      },
+      {
+        "at": "2026-06-22T09:33:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during B5-RESULT-AUTO-MERGE-CLEANUP-01: PR #2250 is merged, origin/main contains af20b19af64cb4aac2e71155a48a42f4dff2e948, local main was fast-forwarded, task branch is absent locally/remotely, and post-merge AssetAgentTest plus inspect-ci smoke passed."
+      }
+    ]
+  },
+  "B5-RESULT-AUTO-MERGE-CLEANUP-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-auto-merge-cleanup",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big5_result_page_v2_asset_agent_automation",
+    "title": "B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup",
+    "depends_on": [
+      "B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the Big Five V2 result-page asset agent full-auto PR train and authorized manifest/state updates for this PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR #2250 for B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01 is merged and origin/main contains merge commit af20b19af64cb4aac2e71155a48a42f4dff2e948."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-merge-cleanup && printf ... pr-state.json && APP_ENV=testing php artisan big5:result-page-v2-agent plan-merge-cleanup --run-id=merge-cleanup --artifact-dir=artifacts/big5_result_page_v2_agent/testing-merge-cleanup --pr-state-json=artifacts/big5_result_page_v2_agent/testing-merge-cleanup/pr-state.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-merge-cleanup",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed 11 tests/293 assertions; plan-merge-cleanup smoke succeeded with can_merge=true, blocker_count=0, merge_performed=false, cleanup_performed=false; diff check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed PR4 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, or weekly ops behavior changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T09:33:00+08:00",
+        "status": "local_validated",
+        "note": "Started PR4 from synced main after PR3 merge/cleanup. Local validation and scope validation passed for dry-run merge cleanup gate planning."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:41:00+08:00",
+  "updated_at": "2026-06-22T09:52:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57358,7 +57358,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-merge-cleanup",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup",
     "depends_on": [
@@ -57389,12 +57389,12 @@
         "evidence": "Changed files are limited to allowed PR4 scope: BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, runtime flag, or weekly ops behavior changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2253 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2253 checks completed successfully on head 21826e51140d54199b8405ec8ce6df81a51f4c93; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "1e70634add11c549e1da1a1a76c2532771fcc72a",
+    "commit_sha": "21826e51140d54199b8405ec8ce6df81a51f4c93",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2253",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57409,6 +57409,11 @@
         "at": "2026-06-22T09:41:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2253 after local validation and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T09:52:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:33:00+08:00",
+  "updated_at": "2026-06-22T09:41:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57358,7 +57358,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-merge-cleanup",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup",
     "depends_on": [
@@ -57390,12 +57390,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2253 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "1e70634add11c549e1da1a1a76c2532771fcc72a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2253",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57404,6 +57404,11 @@
         "at": "2026-06-22T09:33:00+08:00",
         "status": "local_validated",
         "note": "Started PR4 from synced main after PR3 merge/cleanup. Local validation and scope validation passed for dry-run merge cleanup gate planning."
+      },
+      {
+        "at": "2026-06-22T09:41:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2253 after local validation and scope validation passed; waiting for required GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24543,6 +24543,43 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: B5-RESULT-AUTO-MERGE-CLEANUP-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-CI-INSPECTOR-MECHANICAL-FIXER-01
+    branch: codex/big5-v2-auto-merge-cleanup
+    title: "B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup"
+    train_scope: big5_result_page_v2_asset_agent_automation
+    status: user_authorized
+    scope:
+      - Add an artifact-only merge/cleanup gate plan for exported GitHub PR state JSON.
+      - Require clean merge state, green completed checks, non-draft PR, and acceptable review state before planning squash merge and cleanup commands.
+      - Keep first version dry-run/artifact-only; no merge, branch deletion, local main sync, or post-merge command execution from the agent.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add fap-web copy, generate final frontend payloads, make big5_report_engine_v2 primary, enable production rollout, or touch release/import/rollout gates.
+      - Add weekly ops runner behavior in this PR.
+      - Execute merge, branch deletion, local main sync, or post-merge validation from plan-merge-cleanup.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-merge-cleanup && printf '%s\n' '{"number":2250,"headRefName":"codex/big5-v2-ci-inspector-mechanical-fixer","state":"OPEN","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"","statusCheckRollup":[{"name":"hygiene","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"verify-bigfive","status":"COMPLETED","conclusion":"SUCCESS"}]}' > artifacts/big5_result_page_v2_agent/testing-merge-cleanup/pr-state.json && APP_ENV=testing php artisan big5:result-page-v2-agent plan-merge-cleanup --run-id=merge-cleanup --artifact-dir=artifacts/big5_result_page_v2_agent/testing-merge-cleanup --pr-state-json=artifacts/big5_result_page_v2_agent/testing-merge-cleanup/pr-state.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-merge-cleanup
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
     repo: fap-api
     branch: codex/riasec-result-asset-agent-runbook-01


### PR DESCRIPTION
## What changed
- Adds a `plan-merge-cleanup` action to the Big Five V2 result-page asset agent.
- Reads exported GitHub PR state JSON and requires CLEAN merge state, green completed checks, non-draft status, and acceptable review state before planning squash merge/cleanup commands.
- Writes redacted `auto_merge_cleanup_plan.json` and `repair_log.json` artifacts.
- Adds tests proving merge/cleanup is only planned and not executed.
- Registers the authorized PR-train item and reconciles the already-merged CI inspector dependency.

## Why
This is PR4 of the Big Five V2 result-page asset agent full-auto train. It establishes the merge/cleanup gate contract before the final weekly Ops runner PR.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && mkdir -p artifacts/big5_result_page_v2_agent/testing-merge-cleanup && printf '%s\n' '{"number":2250,"headRefName":"codex/big5-v2-ci-inspector-mechanical-fixer","state":"OPEN","isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"","statusCheckRollup":[{"name":"hygiene","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"verify-bigfive","status":"COMPLETED","conclusion":"SUCCESS"}]}' > artifacts/big5_result_page_v2_agent/testing-merge-cleanup/pr-state.json && APP_ENV=testing php artisan big5:result-page-v2-agent plan-merge-cleanup --run-id=merge-cleanup --artifact-dir=artifacts/big5_result_page_v2_agent/testing-merge-cleanup --pr-state-json=artifacts/big5_result_page_v2_agent/testing-merge-cleanup/pr-state.json --json --no-ansi && rm -rf artifacts/big5_result_page_v2_agent/testing-merge-cleanup`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy or `fap-web` changes.
- No final frontend `big5_result_page_v2` payload generation.
- No production/runtime gate, release snapshot, production import gate, or rollout gate changes.
- No weekly Ops runner behavior in this PR.
- `plan-merge-cleanup` does not execute merge, branch deletion, local main sync, or post-merge validation.
- Legacy `big5_report_engine_v2` remains fallback only.

Repository rule impact: backend remains the authority for Big Five V2 result-page content assets; this PR only adds dry-run merge cleanup gate artifacts for the backend agent train.
