### PR TITLE
Enneagram: add rendered QA and smoke evidence harness

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageRenderedQaSmokeHarnessCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageRenderedQaSmokeHarnessCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageRenderedQaSmokeHarness;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageRenderedQaSmokeHarnessCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-rendered-qa-smoke-harness
+        {action=audit : Only audit is supported in this harness PR}
+        {--run-id=rendered-qa-smoke : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root}
+        {--contract-path= : Optional harness contract path}
+        {--candidate-dir= : Candidate package directory}
+        {--web-repo-dir= : fap-web checkout path used for rendered QA command rendering}
+        {--evidence-dir= : Optional directory containing *_report.json evidence files}
+        {--release-id= : Inactive release id used for rollback simulation planning}
+        {--mode=auto-to-report : auto-to-staging or auto-to-report}
+        {--strict : Return non-zero when validation errors are present}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Prepare Enneagram rendered QA, API smoke, and rollback simulation evidence bundles without production rollout.';
+
+    public function handle(EnneagramResultPageRenderedQaSmokeHarness $harness): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $harness->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'candidate_dir' => trim((string) $this->option('candidate-dir')),
+                'web_repo_dir' => trim((string) $this->option('web-repo-dir')),
+                'evidence_dir' => trim((string) $this->option('evidence-dir')),
+                'release_id' => trim((string) $this->option('release-id')),
+                'mode' => trim((string) $this->option('mode')),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('mode='.(string) ($summary['mode'] ?? ''));
+        $this->line('candidate_dir_valid='.(((bool) data_get($summary, 'summary.candidate_dir_valid', false)) ? 'true' : 'false'));
+        $this->line('evidence_valid='.(((bool) data_get($summary, 'summary.evidence_valid', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -118,6 +118,7 @@ use App\Console\Commands\EnneagramResultPageAgentReadinessCommand;
 use App\Console\Commands\EnneagramResultPageCandidateStagingHarnessCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
+use App\Console\Commands\EnneagramResultPageRenderedQaSmokeHarnessCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
@@ -253,6 +254,7 @@ class Kernel extends ConsoleKernel
         EnneagramResultPageCandidateStagingHarnessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramResultPageOpsRunnerCommand::class,
+        EnneagramResultPageRenderedQaSmokeHarnessCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,
         BigFiveExportProductionEquivalentCandidatePayloads::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageRenderedQaSmokeHarness.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageRenderedQaSmokeHarness.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageRenderedQaSmokeHarness
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.rendered_qa_smoke_harness.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_rendered_qa_smoke_harness';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/rendered_qa_smoke_harness/rendered_qa_smoke_harness_contract_v0_1.json';
+
+    private const REQUIRED_EVIDENCE = [
+        'web_rendered_qa',
+        'api_smoke',
+        'rollback_simulation',
+    ];
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     candidate_dir?:string,
+     *     web_repo_dir?:string,
+     *     evidence_dir?:string,
+     *     release_id?:string,
+     *     mode?:string,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'rendered-qa-smoke'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $candidateDir = rtrim(trim((string) ($options['candidate_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $webRepoDir = rtrim(trim((string) ($options['web_repo_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $evidenceDir = rtrim(trim((string) ($options['evidence_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $releaseId = trim((string) ($options['release_id'] ?? ''));
+        $mode = trim((string) ($options['mode'] ?? 'auto-to-report'));
+        $strict = ($options['strict'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readJson($contractPath, 'Rendered QA smoke harness contract');
+        $contractErrors = $this->contractErrors($contract);
+        $candidateReport = $this->candidateReport($candidateDir);
+        $evidenceReport = $this->evidenceReport($evidenceDir);
+        $webCommand = $this->webRenderedQaCommand($webRepoDir, $candidateDir);
+        $apiCommand = $this->apiSmokeCommand($candidateDir, $artifactDir);
+        $rollbackPlan = $this->rollbackSimulationPlan($releaseId, $artifactDir);
+
+        $errors = array_values(array_unique(array_merge(
+            $contractErrors,
+            $strict ? (array) ($candidateReport['errors'] ?? []) : [],
+            (array) ($evidenceReport['errors'] ?? []),
+        )));
+
+        if (! in_array($mode, ['auto-to-staging', 'auto-to-report'], true)) {
+            $errors[] = 'mode_not_allowed:'.$mode;
+        }
+
+        $bundle = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'rendered_qa_smoke_evidence_bundle',
+            'run_id' => $runId,
+            'mode' => $mode,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'candidate_dir' => $candidateReport,
+            'web_rendered_qa' => $webCommand,
+            'api_smoke' => $apiCommand,
+            'rollback_simulation' => $rollbackPlan,
+            'evidence' => $evidenceReport,
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'rendered_qa_smoke_harness_report.json' => $this->writeJson($artifactDir.'/rendered_qa_smoke_harness_report.json', $bundle),
+            'web_rendered_qa_command.json' => $this->writeJson($artifactDir.'/web_rendered_qa_command.json', $webCommand),
+            'api_smoke_command.json' => $this->writeJson($artifactDir.'/api_smoke_command.json', $apiCommand),
+            'rollback_simulation_plan.json' => $this->writeJson($artifactDir.'/rollback_simulation_plan.json', $rollbackPlan),
+            'evidence_bundle_manifest.json' => $this->writeJson($artifactDir.'/evidence_bundle_manifest.json', [
+                'schema_version' => self::SCHEMA_VERSION,
+                'run_id' => $runId,
+                'required_evidence' => self::REQUIRED_EVIDENCE,
+                'evidence_dir_provided' => $evidenceDir !== '',
+                'evidence_valid' => (bool) ($evidenceReport['valid'] ?? false),
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+            ]),
+        ];
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'mode' => $mode,
+            'strict' => $strict,
+            'summary' => [
+                'contract_valid' => $contractErrors === [],
+                'candidate_dir_valid' => (bool) ($candidateReport['valid'] ?? false),
+                'evidence_valid' => (bool) ($evidenceReport['valid'] ?? false),
+                'web_rendered_qa_command_ready' => true,
+                'api_smoke_command_ready' => true,
+                'rollback_simulation_plan_ready' => true,
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function candidateReport(string $candidateDir): array
+    {
+        $errors = [];
+        if ($candidateDir === '') {
+            $errors[] = 'candidate_dir_missing';
+        } elseif (! is_dir($candidateDir)) {
+            $errors[] = 'candidate_dir_not_found';
+        }
+
+        return [
+            'provided' => $candidateDir !== '',
+            'path' => $candidateDir === '' ? null : $this->redactPath($candidateDir),
+            'valid' => $errors === [],
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function webRenderedQaCommand(string $webRepoDir, string $candidateDir): array
+    {
+        return [
+            'task' => 'web_rendered_qa',
+            'repo' => 'fap-web',
+            'working_directory' => $webRepoDir === '' ? '<fap-web-repo>' : $this->redactPath($webRepoDir),
+            'environment' => [
+                'PHASE8B_CANDIDATE_DIR' => $candidateDir === '' ? '<candidate-dir>' : $this->redactPath($candidateDir),
+            ],
+            'command' => 'pnpm exec playwright test tests/e2e/enneagram-phase8c-production-equivalent-candidate-e2e.spec.ts',
+            'execution_allowed_for_agent' => true,
+            'production_execution_allowed_for_agent' => false,
+            'frontend_change_allowed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function apiSmokeCommand(string $candidateDir, string $artifactDir): array
+    {
+        return [
+            'task' => 'api_smoke',
+            'repo' => 'fap-api',
+            'working_directory' => 'backend',
+            'environment' => [
+                'PHASE8B_CANDIDATE_DIR' => $candidateDir === '' ? '<candidate-dir>' : $this->redactPath($candidateDir),
+            ],
+            'command' => 'php artisan enneagram:result-page-candidate-staging-harness audit --candidate-dir=<candidate-dir> --artifact-dir=<artifact-dir> --strict --json',
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'execution_allowed_for_agent' => true,
+            'production_execution_allowed_for_agent' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function rollbackSimulationPlan(string $releaseId, string $artifactDir): array
+    {
+        return [
+            'task' => 'rollback_simulation',
+            'release_id' => $releaseId === '' ? '<inactive-release-id>' : $releaseId,
+            'simulation_policy' => 'plan_only_until_manual_production_gate',
+            'manual_gate_required_before_production_rollback' => true,
+            'command_template' => 'php artisan enneagram:rollback-inactive-candidate-release --release-id=<release-id> --confirm-release-id=<release-id> --output-dir=<output-dir> --json',
+            'output_dir' => $this->redactPath($artifactDir.'/rollback_simulation'),
+            'execution_allowed_for_agent' => false,
+            'production_rollback_allowed_for_agent' => false,
+            'production_execution_allowed_for_agent' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function evidenceReport(string $evidenceDir): array
+    {
+        if ($evidenceDir === '') {
+            return [
+                'provided' => false,
+                'valid' => true,
+                'reports' => [],
+                'errors' => [],
+            ];
+        }
+
+        if (! is_dir($evidenceDir)) {
+            return [
+                'provided' => true,
+                'valid' => false,
+                'reports' => [],
+                'errors' => ['evidence_dir_not_found'],
+            ];
+        }
+
+        $reports = [];
+        $errors = [];
+        foreach (self::REQUIRED_EVIDENCE as $evidenceKey) {
+            $path = $evidenceDir.'/'.$evidenceKey.'_report.json';
+            if (! is_file($path)) {
+                $errors[] = 'evidence_report_missing:'.$evidenceKey;
+                continue;
+            }
+
+            $payload = $this->readJson($path, $evidenceKey.' evidence report');
+            $status = strtolower((string) ($payload['status'] ?? $payload['verdict'] ?? ''));
+            $ok = (bool) ($payload['ok'] ?? in_array($status, ['pass', 'passed', 'success'], true));
+            if (! $ok) {
+                $errors[] = 'evidence_report_failed:'.$evidenceKey;
+            }
+
+            $reports[$evidenceKey] = [
+                'relative_path' => $this->relativePath($path),
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'ok' => $ok,
+            ];
+        }
+
+        return [
+            'provided' => true,
+            'valid' => $errors === [],
+            'reports' => $reports,
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+        foreach (self::REQUIRED_EVIDENCE as $key) {
+            if (! in_array($key, (array) ($contract['required_evidence'] ?? []), true)) {
+                $errors[] = 'required_evidence_missing:'.$key;
+            }
+        }
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bulk_content_generation_happened' => false,
+            'production_import_happened' => false,
+            'production_activation_happened' => false,
+            'production_rollback_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException($label.' is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'rendered-qa-smoke';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/README.md
+++ b/backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/README.md
@@ -1,0 +1,7 @@
+# Enneagram Rendered QA + Smoke Harness
+
+This directory defines the Enneagram result page rendered QA, API smoke, and rollback simulation evidence-bundle contract.
+
+The harness prepares deterministic commands and validates returned evidence reports. It is safe for auto-to-staging and auto-to-report workflows.
+
+It does not run production activation, production rollback, production writes, runtime switching, bulk content generation, or frontend changes.

--- a/backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/rendered_qa_smoke_harness_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/rendered_qa_smoke_harness_contract_v0_1.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "fap.enneagram.result_page.rendered_qa_smoke_harness.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "allowed_modes": ["auto-to-staging", "auto-to-report"],
+  "required_evidence": [
+    "web_rendered_qa",
+    "api_smoke",
+    "rollback_simulation"
+  ],
+  "web_rendered_qa": {
+    "repo": "fap-web",
+    "command_template": "PHASE8B_CANDIDATE_DIR=<candidate-dir> pnpm exec playwright test tests/e2e/enneagram-phase8c-production-equivalent-candidate-e2e.spec.ts",
+    "production_execution_allowed": false
+  },
+  "api_smoke": {
+    "repo": "fap-api",
+    "command_template": "php artisan enneagram:result-page-candidate-staging-harness audit --candidate-dir=<candidate-dir> --strict --json",
+    "production_execution_allowed": false
+  },
+  "rollback_simulation": {
+    "execution_policy": "plan_only_until_manual_production_gate",
+    "production_rollback_allowed_for_agent": false
+  },
+  "negative_guarantees": {
+    "bulk_content_generation_happened": false,
+    "production_import_happened": false,
+    "production_activation_happened": false,
+    "production_rollback_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageRenderedQaSmokeHarnessCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageRenderedQaSmokeHarnessCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramResultPageRenderedQaSmokeHarnessCommandTest extends TestCase
+{
+    public function test_rendered_qa_smoke_harness_command_succeeds_with_candidate_dir(): void
+    {
+        $candidateDir = storage_path('framework/testing/rendered_qa_smoke_command_candidate');
+        File::ensureDirectoryExists($candidateDir);
+
+        $this->artisan('enneagram:result-page-rendered-qa-smoke-harness', [
+            'action' => 'audit',
+            '--run-id' => 'command-smoke',
+            '--artifact-dir' => sys_get_temp_dir().'/enneagram-rendered-qa-smoke-command',
+            '--candidate-dir' => $candidateDir,
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(0);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2907,6 +2907,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_rendered_qa_smoke_harness_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageRenderedQaSmokeHarnessCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageRenderedQaSmokeHarness.php',
+            'backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/README.md',
+            'backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/rendered_qa_smoke_harness_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageRenderedQaSmokeHarnessCommand;',
+            '+        EnneagramResultPageRenderedQaSmokeHarnessCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4827,6 +4850,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageRenderedQaSmokeHarnessFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4937,6 +4964,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6858,6 +6886,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageRenderedQaSmokeHarnessFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageRenderedQaSmokeHarnessCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageRenderedQaSmokeHarness.php',
+            'backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/README.md',
+            'backend/content_assets/enneagram/result_page/rendered_qa_smoke_harness/rendered_qa_smoke_harness_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -8022,6 +8060,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageCandidateStagingHarnessCommand;',
             '        EnneagramResultPageCandidateStagingHarnessCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageRenderedQaSmokeHarnessCommand;',
+            '        EnneagramResultPageRenderedQaSmokeHarnessCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageRenderedQaSmokeHarnessTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageRenderedQaSmokeHarnessTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageRenderedQaSmokeHarness;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramResultPageRenderedQaSmokeHarnessTest extends TestCase
+{
+    public function test_harness_writes_evidence_bundle_plan_without_production_execution(): void
+    {
+        $candidateDir = storage_path('framework/testing/rendered_qa_smoke_candidate');
+        $artifactRoot = storage_path('framework/testing/rendered_qa_smoke_artifacts/plan');
+        File::ensureDirectoryExists($candidateDir);
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageRenderedQaSmokeHarness::class)->run([
+            'run_id' => 'unit-plan',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $candidateDir,
+            'web_repo_dir' => base_path('../fap-web'),
+            'release_id' => 'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4',
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.web_rendered_qa_command_ready', false));
+        $this->assertTrue((bool) data_get($summary, 'summary.api_smoke_command_ready', false));
+        $this->assertTrue((bool) data_get($summary, 'summary.rollback_simulation_plan_ready', false));
+        $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+        $this->assertTrue((bool) data_get($summary, 'summary.production_manual_gate_required', false));
+
+        $report = $this->readJson($artifactRoot.'/unit-plan/rendered_qa_smoke_harness_report.json');
+        $this->assertFalse((bool) data_get($report, 'rollback_simulation.production_rollback_allowed_for_agent', true));
+        $this->assertFalse((bool) data_get($report, 'negative_guarantees.production_activation_happened', true));
+        $this->assertFalse((bool) data_get($report, 'negative_guarantees.frontend_change_happened', true));
+        $this->assertStringNotContainsString('/Users/rainie/', json_encode($report, JSON_UNESCAPED_SLASHES) ?: '');
+        $this->assertStringNotContainsString('/private/tmp/', json_encode($report, JSON_UNESCAPED_SLASHES) ?: '');
+    }
+
+    public function test_strict_harness_fails_without_candidate_dir(): void
+    {
+        $artifactRoot = storage_path('framework/testing/rendered_qa_smoke_artifacts/missing');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageRenderedQaSmokeHarness::class)->run([
+            'run_id' => 'missing-candidate',
+            'artifact_dir' => $artifactRoot,
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('candidate_dir_missing', $summary['errors'] ?? []);
+    }
+
+    public function test_harness_validates_supplied_evidence_reports(): void
+    {
+        $candidateDir = storage_path('framework/testing/rendered_qa_smoke_candidate_evidence');
+        $evidenceDir = storage_path('framework/testing/rendered_qa_smoke_evidence/pass');
+        $artifactRoot = storage_path('framework/testing/rendered_qa_smoke_artifacts/evidence');
+        File::ensureDirectoryExists($candidateDir);
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        File::deleteDirectory($artifactRoot);
+
+        foreach (['web_rendered_qa', 'api_smoke', 'rollback_simulation'] as $key) {
+            File::put($evidenceDir.'/'.$key.'_report.json', json_encode(['ok' => true, 'status' => 'success'], JSON_PRETTY_PRINT));
+        }
+
+        $summary = app(EnneagramResultPageRenderedQaSmokeHarness::class)->run([
+            'run_id' => 'evidence-pass',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $candidateDir,
+            'evidence_dir' => $evidenceDir,
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.evidence_valid', false));
+    }
+
+    public function test_harness_fails_closed_on_failed_evidence_report(): void
+    {
+        $candidateDir = storage_path('framework/testing/rendered_qa_smoke_candidate_failed_evidence');
+        $evidenceDir = storage_path('framework/testing/rendered_qa_smoke_evidence/fail');
+        $artifactRoot = storage_path('framework/testing/rendered_qa_smoke_artifacts/failed');
+        File::ensureDirectoryExists($candidateDir);
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        File::deleteDirectory($artifactRoot);
+
+        File::put($evidenceDir.'/web_rendered_qa_report.json', json_encode(['ok' => false, 'status' => 'failed'], JSON_PRETTY_PRINT));
+        File::put($evidenceDir.'/api_smoke_report.json', json_encode(['ok' => true, 'status' => 'success'], JSON_PRETTY_PRINT));
+        File::put($evidenceDir.'/rollback_simulation_report.json', json_encode(['ok' => true, 'status' => 'success'], JSON_PRETTY_PRINT));
+
+        $summary = app(EnneagramResultPageRenderedQaSmokeHarness::class)->run([
+            'run_id' => 'evidence-fail',
+            'artifact_dir' => $artifactRoot,
+            'candidate_dir' => $candidateDir,
+            'evidence_dir' => $evidenceDir,
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('evidence_report_failed:web_rendered_qa', $summary['errors'] ?? []);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added an Enneagram rendered QA + API smoke + rollback simulation harness contract.
- Added `enneagram:result-page-rendered-qa-smoke-harness audit` to prepare deterministic web rendered QA/API smoke commands and rollback simulation plans.
- Added evidence bundle validation for web rendered QA, API smoke, and rollback simulation report files.
- Added unit/command coverage and a narrow BigFive runtime freeze allowlist for this Enneagram-only scaffold.

## Why
This creates the evidence-bundle layer after candidate export/staging import. It lets the operations agent prepare auto-to-staging and auto-to-report validation, while keeping production rollout behind a manual approval gate.

## Validation
- `php -l backend/app/Console/Kernel.php && php -l backend/app/Console/Commands/EnneagramResultPageRenderedQaSmokeHarnessCommand.php && php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageRenderedQaSmokeHarness.php && php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageRenderedQaSmokeHarnessTest.php && php -l backend/tests/Feature/Console/EnneagramResultPageRenderedQaSmokeHarnessCommandTest.php && php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageRenderedQaSmokeHarnessTest.php tests/Feature/Console/EnneagramResultPageRenderedQaSmokeHarnessCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_rendered_qa_smoke_harness_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan list --no-ansi | rg "enneagram:result-page-(rendered-qa-smoke-harness|candidate-staging-harness|content-batch|ops-runner|ops-control-plane|agent)"`
- `git diff --check`
- Scoped changed-file validation passed.

## Intentionally deferred
- No bulk content generation.
- No production import.
- No activation.
- No production rollback.
- No runtime switch.
- No production writes.
- No frontend changes.
