### PR TITLE
RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner

### DIFF
--- a/backend/app/Console/Commands/RiasecResultPageOpsRunnerCommand.php
+++ b/backend/app/Console/Commands/RiasecResultPageOpsRunnerCommand.php
@@ -11,9 +11,9 @@ use Throwable;
 final class RiasecResultPageOpsRunnerCommand extends Command
 {
     protected $signature = 'riasec:result-page-ops-runner
-        {action=plan : Only plan is supported in this orchestrator PR}
+        {action=plan : Supported actions: plan, staging-dry-run}
         {--run-id= : Stable run identifier for the artifact directory}
-        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/riasec_result_page_ops_agent_runner}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/riasec_result_page_v2_agent}
         {--permission-model-path= : Optional permission model path}
         {--mode=auto-to-pr : Requested mode: auto-to-pr, auto-to-staging, auto-to-report}
         {--scope-id=ops-agent-pr-train-orchestrator : Stable scope id for deterministic run and branch naming}
@@ -30,13 +30,7 @@ final class RiasecResultPageOpsRunnerCommand extends Command
     public function handle(RiasecResultPageOpsAgentRunOrchestrator $orchestrator): int
     {
         try {
-            if ($this->argument('action') !== 'plan') {
-                $this->error('Unsupported action. This PR supports only: plan');
-
-                return self::FAILURE;
-            }
-
-            $summary = $orchestrator->plan([
+            $options = [
                 'run_id' => trim((string) $this->option('run-id')),
                 'artifact_dir' => trim((string) $this->option('artifact-dir')),
                 'permission_model_path' => trim((string) $this->option('permission-model-path')),
@@ -48,7 +42,19 @@ final class RiasecResultPageOpsRunnerCommand extends Command
                 'simulate_external_blocker' => (bool) $this->option('simulate-external-blocker'),
                 'simulate_current_scope_failure' => (bool) $this->option('simulate-current-scope-failure'),
                 'strict' => (bool) $this->option('strict'),
-            ]);
+            ];
+
+            $summary = match ($this->argument('action')) {
+                'plan' => $orchestrator->plan($options),
+                'staging-dry-run' => $orchestrator->stagingDryRun($options),
+                default => null,
+            };
+
+            if (! is_array($summary)) {
+                $this->error('Unsupported action. Supported actions: plan, staging-dry-run');
+
+                return self::FAILURE;
+            }
 
             $this->render($summary);
 

--- a/backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php
+++ b/backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php
@@ -11,7 +11,7 @@ final class RiasecResultPageOpsAgentRunOrchestrator
 {
     public const SCHEMA_VERSION = 'fap.riasec.result_page_v2.ops_pr_train_orchestrator.v0.1';
 
-    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/riasec_result_page_ops_agent_runner';
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/riasec_result_page_v2_agent';
 
     public const DEFAULT_PERMISSION_MODEL_RELATIVE_PATH = 'content_assets/riasec/result_page_v2/governance/ops_agent_permission_model.v0_1.json';
 
@@ -139,6 +139,110 @@ final class RiasecResultPageOpsAgentRunOrchestrator
                 'production_execution_allowed_for_agent' => false,
                 'production_manual_gate_required' => true,
             ],
+            'errors' => array_values(array_unique($errors)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     permission_model_path?:string,
+     *     mode?:string,
+     *     scope_id?:string,
+     *     pr_title?:string,
+     *     base_branch?:string,
+     *     changed_files?:list<string>,
+     *     strict?:bool,
+     *     simulate_external_blocker?:bool,
+     *     simulate_current_scope_failure?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function stagingDryRun(array $options = []): array
+    {
+        $options['mode'] = $options['mode'] ?? 'auto-to-staging';
+        $plan = $this->plan($options);
+        $runId = (string) ($plan['run_id'] ?? $this->runId('', 'auto-to-staging', 'ops-agent-staging-runner', 'main', 'RIASEC staging dry-run'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $this->ensureDirectory($artifactDir);
+
+        $dryRunReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_dry_run',
+            'run_id' => $runId,
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'checks' => [
+                'permission_model_valid' => (bool) data_get($plan, 'summary.permission_model_valid', false),
+                'scope_valid' => (bool) data_get($plan, 'summary.scope_valid', false),
+                'checksum_inventory_planned' => true,
+                'public_leak_scan_planned' => true,
+                'fail_closed_policy_present' => true,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $previewReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'render_preview_smoke',
+            'run_id' => $runId,
+            'runtime_use' => 'staging_only',
+            'surfaces' => ['result_page', 'pdf', 'share', 'history', 'compare'],
+            'locked_free_redaction_required' => true,
+            'frontend_fallback_allowed' => false,
+            'production_use_allowed' => false,
+        ];
+        $apiSmokeReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'api_smoke',
+            'run_id' => $runId,
+            'runtime_use' => 'staging_only',
+            'routes_smoked' => [],
+            'dry_run_only' => true,
+            'cms_write_performed' => false,
+            'production_rollout_performed' => false,
+        ];
+
+        $artifacts = [
+            'ops_agent_pr_train_orchestrator_plan.json' => (array) data_get($plan, 'artifacts.ops_agent_pr_train_orchestrator_plan.json', []),
+            'staging_dry_run_report.json' => $this->writeJson($artifactDir.'/staging_dry_run_report.json', $dryRunReport),
+            'render_preview_smoke_report.json' => $this->writeJson($artifactDir.'/render_preview_smoke_report.json', $previewReport),
+            'api_smoke_report.json' => $this->writeJson($artifactDir.'/api_smoke_report.json', $apiSmokeReport),
+        ];
+
+        $errors = (array) ($plan['errors'] ?? []);
+        if (($dryRunReport['checks']['permission_model_valid'] ?? false) !== true) {
+            $errors[] = 'permission_model_invalid';
+        }
+        if (($dryRunReport['checks']['scope_valid'] ?? false) !== true) {
+            $errors[] = 'scope_validation_failed';
+        }
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'mode' => 'auto-to-staging',
+            'scope_id' => (string) ($plan['scope_id'] ?? ''),
+            'summary' => [
+                'staging_dry_run_report_created' => true,
+                'render_preview_smoke_report_created' => true,
+                'api_smoke_report_created' => true,
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+                'cms_write_performed' => false,
+                'runtime_change_performed' => false,
+            ],
+            'artifacts' => $artifacts,
             'errors' => array_values(array_unique($errors)),
             'negative_guarantees' => $this->negativeGuarantees(),
         ];

--- a/backend/tests/Feature/Console/RiasecOpsAgentRunnerCommandTest.php
+++ b/backend/tests/Feature/Console/RiasecOpsAgentRunnerCommandTest.php
@@ -58,6 +58,35 @@ final class RiasecOpsAgentRunnerCommandTest extends TestCase
         }
     }
 
+    public function test_ops_runner_command_writes_staging_dry_run_reports_without_production_actions(): void
+    {
+        $root = $this->tempDir('riasec-ops-runner-command-staging');
+
+        try {
+            $this->artisan('riasec:result-page-ops-runner', [
+                'action' => 'staging-dry-run',
+                '--run-id' => 'command-staging',
+                '--artifact-dir' => $root,
+                '--mode' => 'auto-to-staging',
+                '--scope-id' => 'ops-agent-staging-runner',
+                '--changed-file' => [
+                    'backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php',
+                ],
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/command-staging/staging_dry_run_report.json');
+            $this->assertSame('staging_only', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($report['cms_write_performed'] ?? true));
+            $this->assertFileExists($root.'/command-staging/render_preview_smoke_report.json');
+            $this->assertFileExists($root.'/command-staging/api_smoke_report.json');
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
     private function tempDir(string $prefix): string
     {
         $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));

--- a/backend/tests/Unit/Services/Riasec/Ops/RiasecOpsAgentRunOrchestratorTest.php
+++ b/backend/tests/Unit/Services/Riasec/Ops/RiasecOpsAgentRunOrchestratorTest.php
@@ -121,6 +121,37 @@ final class RiasecOpsAgentRunOrchestratorTest extends TestCase
         }
     }
 
+    public function test_staging_dry_run_writes_staging_only_reports_without_runtime_or_cms_writes(): void
+    {
+        $root = $this->tempDir('riasec-ops-runner-staging');
+
+        try {
+            $summary = app(RiasecResultPageOpsAgentRunOrchestrator::class)->stagingDryRun([
+                'run_id' => 'staging-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-staging',
+                'scope_id' => 'ops-agent-staging-runner',
+                'changed_files' => [
+                    'backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php',
+                ],
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertFalse((bool) data_get($summary, 'summary.cms_write_performed', true));
+            $this->assertFalse((bool) data_get($summary, 'summary.runtime_change_performed', true));
+
+            $report = $this->readJson($root.'/staging-run/staging_dry_run_report.json');
+            $this->assertSame('staging_only', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+            $this->assertFalse((bool) ($report['runtime_change_performed'] ?? true));
+            $this->assertFileExists($root.'/staging-run/render_preview_smoke_report.json');
+            $this->assertFileExists($root.'/staging-run/api_smoke_report.json');
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
     private function tempDir(string $prefix): string
     {
         $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56880,7 +56880,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-pr-train-orchestrator-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01: feat(riasec): add ops PR train orchestrator",
     "depends_on": [
@@ -56902,14 +56902,15 @@
       "git_diff_check_after_repair": "passed",
       "github_required_checks_after_repair": "passed",
       "verify_bigfive_after_repair": "passed",
-      "merge_state": "clean"
+      "merge_state": "clean",
+      "post_merge_revalidation": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "3a8c45d8408c9905bcc2c68856311d7fffb2b444",
+    "commit_sha": "d55037d3fdcd08222457c034c17d90064e6cc3d4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2249",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T00:24:20Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -56955,20 +56956,35 @@
         "from": "local_checks_passed_after_repair",
         "to": "ready_to_merge",
         "notes": "GitHub required checks passed after the freeze-guard repair and PR merge state was CLEAN before merge."
+      },
+      {
+        "at": "2026-06-22T08:27:35+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled PR #2249 after GitHub reported MERGED, origin/main contained merge commit d45ffac138bc8d417673e189a712ea417099e804, local main was fast-forwarded, and task branches were cleaned."
       }
-    ]
+    ],
+    "merge_commit": "d45ffac138bc8d417673e189a712ea417099e804"
   },
   "RIASEC-OPS-AGENT-STAGING-RUNNER-01": {
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-staging-runner-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner",
     "depends_on": [
       "RIASEC-OPS-AGENT-PR-TRAIN-ORCHESTRATOR-01"
     ],
-    "checks": {},
+    "checks": {
+      "php_lint_orchestrator": "passed",
+      "php_lint_command": "passed",
+      "php_artisan_test_filter_RiasecOpsAgent": "passed",
+      "php_artisan_test_filter_RiasecResultPage": "passed",
+      "staging_dry_run_command_smoke": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -56984,6 +57000,18 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T08:27:35+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "Staging dry-run action wrote staging-only reports with cms_write_performed=false, runtime_change_performed=false, and production execution disabled."
+      },
+      {
+        "at": "2026-06-22T08:27:46+08:00",
+        "from": "local_checks_passed",
+        "to": "scope_validation_passed",
+        "notes": "Changed files were limited to Riasec ops command/service/tests and PR train state."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56970,7 +56970,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-staging-runner-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner",
     "depends_on": [
@@ -56983,11 +56983,12 @@
       "php_artisan_test_filter_RiasecResultPage": "passed",
       "staging_dry_run_command_smoke": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "98be3aaf571ce533ae4af0ed4706ed078464ae57",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2255",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57012,6 +57013,12 @@
         "from": "local_checks_passed",
         "to": "scope_validation_passed",
         "notes": "Changed files were limited to Riasec ops command/service/tests and PR train state."
+      },
+      {
+        "at": "2026-06-22T08:28:34+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2255 after local checks and path scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -56970,7 +56970,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-staging-runner-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-STAGING-RUNNER-01: feat(riasec): add ops staging runner",
     "depends_on": [
@@ -56984,10 +56984,12 @@
       "staging_dry_run_command_smoke": "passed",
       "git_diff_check": "passed",
       "scope_validation": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_recheck": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "98be3aaf571ce533ae4af0ed4706ed078464ae57",
+    "commit_sha": "07a361200f3021088cac9333ef1a6c10287e67f8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2255",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57019,6 +57021,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2255 after local checks and path scope validation passed."
+      },
+      {
+        "at": "2026-06-22T08:40:31+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks passed after rebasing onto origin/main; pre-merge scope recheck stayed within PR4 allowed files."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added `riasec:result-page-ops-runner staging-dry-run`.
- Extended the RIASEC ops orchestrator to write staging-only dry-run, render-preview smoke, and API smoke reports.
- Added unit and feature coverage for staging-only reports, no CMS writes, no runtime changes, and no production execution.
- Reconciled PR #2249 state after the PR train orchestrator merged and cleanup completed.

## Why
The ops agent needs an automated staging dry-run/reporting step before any staging import or runtime-wrapper work. This PR keeps the runner dry-run only and fail-closed.

## Validation
- `php -l app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php`
- `php -l app/Console/Commands/RiasecResultPageOpsRunnerCommand.php`
- `php artisan test --filter=RiasecOpsAgent --no-ansi`
- `php artisan test --filter=RiasecResultPage --no-ansi`
- `php artisan riasec:result-page-ops-runner staging-dry-run --run-id=local-pr4-staging --artifact-dir=<tmp> --mode=auto-to-staging --scope-id=ops-agent-staging-runner --changed-file=backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php --strict --json`
- `git diff --check`
- path scope validation against the current PR allowlist

## Intentionally deferred
- No CMS import or write.
- No runtime wrapper changes.
- No asset generation.
- No production gate enablement or rollout execution.
- No frontend fallback behavior.

## Repository rule impact
This PR adds backend-only staging dry-run reporting for the RIASEC ops agent. RIASEC content remains backend-authoritative, and production rollout remains manual-gated.
