### PR TITLE
B5-RESULT-WEEKLY-OPS-RUNNER-01: Schedule Big Five V2 weekly ops report

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup, weekly-ops}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -24,6 +24,7 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
         {--title= : Planned PR title for plan-pr}
         {--checks-json= : Exported GitHub statusCheckRollup JSON for inspect-ci}
         {--pr-state-json= : Exported GitHub PR state JSON for plan-merge-cleanup}
+        {--production-ops-dir= : Production ops contract directory for weekly-ops}
         {--apply-mechanical-fixes : Permit inspect-ci to apply supported mechanical fixes}
         {--allow-staging-write : Permit stage-candidates to write the reviewed staging package}
         {--strict : Return non-zero when validator, inventory, source-ledger, or leak checks fail}
@@ -74,11 +75,16 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'artifact_dir' => trim((string) $this->option('artifact-dir')),
                     'pr_state_json' => trim((string) $this->option('pr-state-json')),
                 ]),
+                'weekly-ops' => $agent->weeklyOps([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'production_ops_dir' => trim((string) $this->option('production-ops-dir')),
+                ]),
                 default => null,
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup, weekly-ops');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -46,6 +46,8 @@ final class BigFiveResultPageV2AssetAgent
 
     private const CONTENT_ASSET_SCHEMA_RELATIVE_PATH = 'content_assets/big5/result_page_v2/governance/content_asset_factory_spec/big5_content_asset_schema_v0_1.json';
 
+    private const PRODUCTION_OPS_RELATIVE_PATH = 'content_assets/big5/result_page_v2/qa/production_ops/v0_1';
+
     private const FORBIDDEN_PUBLIC_FIELDS = [
         'attempt_id',
         'private_url',
@@ -670,6 +672,87 @@ final class BigFiveResultPageV2AssetAgent
                 'ready_for_production' => false,
             ],
             'negative_guarantees' => $this->mergeCleanupNegativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   production_ops_dir?:string
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function weeklyOps(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $productionOpsDir = $this->optionalPath(
+            (string) ($options['production_ops_dir'] ?? ''),
+            base_path(self::PRODUCTION_OPS_RELATIVE_PATH)
+        );
+
+        $this->ensureDirectory($artifactDir);
+
+        $opsReport = $this->readOptionalJson($productionOpsDir.'/big5_v2_production_ops_report_v0_1.json') ?? [];
+        $smoke = $this->readOptionalJson($productionOpsDir.'/big5_v2_production_ops_smoke_v0_1.json') ?? [];
+        $metrics = (array) ($opsReport['metrics'] ?? []);
+        $smokeContract = (array) ($smoke['smoke_contract'] ?? []);
+        $forbiddenTokens = array_values(array_map('strval', (array) ($smoke['forbidden_public_text_tokens'] ?? [])));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'weekly_ops_runner',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'run_id' => $runId,
+            'reporting_window_days' => (int) ($opsReport['reporting_window_days'] ?? 45),
+            'production_ops_reporting_ready' => (bool) ($opsReport['production_ops_reporting_ready'] ?? false),
+            'production_rollout_enabled' => (bool) ($opsReport['production_rollout_enabled'] ?? true),
+            'metrics_contract' => [
+                'v2_payload_coverage_rate' => $metrics['v2_payload_coverage_rate'] ?? null,
+                'fallback_hit_rate' => $metrics['fallback_hit_rate'] ?? null,
+                'malformed_rejection_reasons' => $metrics['malformed_rejection_reasons'] ?? null,
+                'validation_error_count' => $metrics['validation_error_count'] ?? null,
+                'audited_at_freshness' => $metrics['audited_at_freshness'] ?? null,
+            ],
+            'smoke_contract' => [
+                'pdf_private_link_check' => $smokeContract['pdf_private_link_check'] ?? null,
+                'footer_check' => $smokeContract['footer_check'] ?? null,
+                'legacy_engine_label_check' => $smokeContract['legacy_engine_label_check'] ?? null,
+                'controller_name_check' => $smokeContract['controller_name_check'] ?? null,
+                'payload_word_check' => $smokeContract['payload_word_check'] ?? null,
+                'registry_word_check' => $smokeContract['registry_word_check'] ?? null,
+                'forbidden_public_text_token_count' => count($forbiddenTokens),
+            ],
+            'evidence_output_policy' => $smoke['evidence_output_policy'] ?? [],
+            'negative_guarantees' => $this->weeklyOpsNegativeGuarantees(),
+        ];
+
+        $artifacts = [
+            'weekly_ops_report.json' => $this->writeJson($artifactDir.'/weekly_ops_report.json', $report),
+            'weekly_ops_report.md' => $this->writeText($artifactDir.'/weekly_ops_report.md', $this->buildWeeklyOpsMarkdown($report)),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) ($report['production_ops_reporting_ready'] ?? false) && ! (bool) ($report['production_rollout_enabled'] ?? true),
+            'status' => ((bool) ($report['production_ops_reporting_ready'] ?? false) && ! (bool) ($report['production_rollout_enabled'] ?? true)) ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'production_ops_reporting_ready' => (bool) ($report['production_ops_reporting_ready'] ?? false),
+                'production_rollout_enabled' => (bool) ($report['production_rollout_enabled'] ?? true),
+                'forbidden_public_text_token_count' => count($forbiddenTokens),
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->weeklyOpsNegativeGuarantees(),
         ];
     }
 
@@ -2059,6 +2142,54 @@ final class BigFiveResultPageV2AssetAgent
         };
     }
 
+    /**
+     * @param  array<string,mixed>  $report
+     */
+    private function buildWeeklyOpsMarkdown(array $report): string
+    {
+        $lines = [
+            '# Big Five V2 Weekly Ops Report',
+            '',
+            '- runtime_use: not_runtime',
+            '- production_use_allowed: false',
+            '- ready_for_runtime: false',
+            '- ready_for_production: false',
+            '- production_rollout_enabled: '.$this->markdownScalar($report['production_rollout_enabled'] ?? null),
+            '- reporting_window_days: '.$this->markdownScalar($report['reporting_window_days'] ?? null),
+            '',
+            '## Metrics',
+            '',
+        ];
+
+        foreach ([
+            'v2_payload_coverage_rate',
+            'fallback_hit_rate',
+            'malformed_rejection_reasons',
+            'validation_error_count',
+            'audited_at_freshness',
+        ] as $metricKey) {
+            $lines[] = '- '.$metricKey.': '.(string) data_get($report, "metrics_contract.{$metricKey}.redaction", 'redacted_contract');
+        }
+
+        $lines = array_merge($lines, [
+            '',
+            '## Smoke',
+            '',
+            '- pdf_private_link_check: '.$this->markdownScalar(data_get($report, 'smoke_contract.pdf_private_link_check')),
+            '- footer_check: '.$this->markdownScalar(data_get($report, 'smoke_contract.footer_check')),
+            '- legacy_engine_label_check: '.$this->markdownScalar(data_get($report, 'smoke_contract.legacy_engine_label_check')),
+            '- controller_name_check: '.$this->markdownScalar(data_get($report, 'smoke_contract.controller_name_check')),
+            '- forbidden_public_text_token_count: '.$this->markdownScalar(data_get($report, 'smoke_contract.forbidden_public_text_token_count')),
+            '',
+            '## Deferred',
+            '',
+            '- No production rollout is enabled by this runner.',
+            '- No raw report bodies, private links, PDF files, attempt identifiers, or user score values are stored.',
+        ]);
+
+        return implode(PHP_EOL, $lines).PHP_EOL;
+    }
+
     private function ensureDirectory(string $path): void
     {
         if (! is_dir($path) && ! mkdir($path, 0775, true) && ! is_dir($path)) {
@@ -2274,6 +2405,29 @@ final class BigFiveResultPageV2AssetAgent
             'local_main_synced' => false,
             'post_merge_revalidation_run' => false,
             'auto_merge_performed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function weeklyOpsNegativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+            'stores_real_attempt_identifier' => false,
+            'stores_private_link' => false,
+            'stores_pdf_file' => false,
+            'stores_raw_report_body' => false,
+            'stores_user_score_values' => false,
         ];
     }
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -47,6 +47,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('eq60:psychometrics --window=last_90_days')->weeklyOn(1, '04:20')->withoutOverlapping();
         $schedule->command('big5:result-page-v2-agent audit --strict --json --no-ansi')->dailyAt('04:40')->withoutOverlapping();
+        $schedule->command('big5:result-page-v2-agent weekly-ops --json --no-ansi')->weeklyOn(1, '05:20')->withoutOverlapping();
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();
         $schedule->command('norms:eq60:drift-check --from=active --to=candidate')->monthlyOn(1, '05:00')->withoutOverlapping();

--- a/backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
+++ b/backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
@@ -31,6 +31,22 @@ final class BigFiveResultPageV2AgentAutomationTest extends TestCase
         $this->assertStringContainsString('--no-ansi', (string) $event['command']);
     }
 
+    public function test_weekly_ops_runner_is_registered_as_redacted_schedule(): void
+    {
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains(
+                (string) ($event['command'] ?? ''),
+                'big5:result-page-v2-agent weekly-ops --json --no-ansi'
+            )
+        );
+
+        $this->assertNotNull($event, 'schedule:list did not include the Big Five V2 weekly ops command.');
+        $this->assertSame('20 5 * * 1', $event['expression']);
+        $this->assertStringContainsString('--json', (string) $event['command']);
+        $this->assertStringContainsString('--no-ansi', (string) $event['command']);
+    }
+
     public function test_strict_nightly_audit_fails_closed_and_keeps_artifacts_redacted(): void
     {
         $root = base_path('artifacts/testing/big5-v2-nightly-audit');

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -511,6 +511,54 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_weekly_ops_writes_redacted_ops_and_smoke_report(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-weekly-ops');
+
+        $this->deleteDirectory($artifactRoot);
+
+        try {
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'weekly-ops',
+                '--run-id' => 'weekly',
+                '--artifact-dir' => $artifactRoot,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/weekly';
+            $this->assertFileExists($runDir.'/weekly_ops_report.json');
+            $this->assertFileExists($runDir.'/weekly_ops_report.md');
+
+            $report = $this->readJson($runDir.'/weekly_ops_report.json');
+            $this->assertSame('weekly_ops_runner', $report['task'] ?? null);
+            $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertTrue((bool) ($report['production_ops_reporting_ready'] ?? false));
+            $this->assertFalse((bool) ($report['production_rollout_enabled'] ?? true));
+            $this->assertSame('count_and_rate_only', data_get($report, 'metrics_contract.v2_payload_coverage_rate.redaction'));
+            $this->assertSame('count_and_rate_only', data_get($report, 'metrics_contract.fallback_hit_rate.redaction'));
+            $this->assertSame('enum_counts_only', data_get($report, 'metrics_contract.malformed_rejection_reasons.redaction'));
+            $this->assertSame('must_not_appear', data_get($report, 'smoke_contract.pdf_private_link_check'));
+            $this->assertSame('must_not_expose_internal_tokens', data_get($report, 'smoke_contract.footer_check'));
+            $this->assertGreaterThanOrEqual(10, (int) data_get($report, 'smoke_contract.forbidden_public_text_token_count', 0));
+
+            foreach ([
+                'stores_real_attempt_identifier',
+                'stores_private_link',
+                'stores_pdf_file',
+                'stores_raw_report_body',
+                'stores_user_score_values',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_stage_candidates_fails_closed_without_human_review_manifest(): void
     {
         $artifactRoot = $this->tempDir('big5-v2-agent-stage-missing-review');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T09:52:00+08:00",
+  "updated_at": "2026-06-22T10:06:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57419,7 +57419,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-merge-cleanup",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-AUTO-MERGE-CLEANUP-01: Plan Big Five V2 agent merge cleanup",
     "depends_on": [
@@ -57451,15 +57451,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2253 checks completed successfully on head 21826e51140d54199b8405ec8ce6df81a51f4c93; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
+        "evidence": "PR #2253 merged with merge commit cc86ec454af272b860f5ebfe7a9549b6659d5312 after required GitHub checks passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "21826e51140d54199b8405ec8ce6df81a51f4c93",
+    "commit_sha": "cc86ec454af272b860f5ebfe7a9549b6659d5312",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2253",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T00:30:24Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T09:33:00+08:00",
@@ -57475,6 +57475,66 @@
         "at": "2026-06-22T09:52:00+08:00",
         "status": "ready_to_merge",
         "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
+      },
+      {
+        "at": "2026-06-22T10:06:00+08:00",
+        "status": "merged",
+        "note": "Reconciled during B5-RESULT-WEEKLY-OPS-RUNNER-01: PR #2253 is merged, origin/main contains cc86ec454af272b860f5ebfe7a9549b6659d5312, local main was fast-forwarded, task branch is absent locally/remotely, and post-merge AssetAgentTest plus plan-merge-cleanup smoke passed."
+      }
+    ]
+  },
+  "B5-RESULT-WEEKLY-OPS-RUNNER-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-weekly-ops-runner",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big5_result_page_v2_asset_agent_automation",
+    "title": "B5-RESULT-WEEKLY-OPS-RUNNER-01: Schedule Big Five V2 weekly ops report",
+    "depends_on": [
+      "B5-RESULT-AUTO-MERGE-CLEANUP-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the Big Five V2 result-page asset agent full-auto PR train and authorized manifest/state updates for this PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR #2253 for B5-RESULT-AUTO-MERGE-CLEANUP-01 is merged and origin/main contains merge commit cc86ec454af272b860f5ebfe7a9549b6659d5312."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent weekly-ops --run-id=weekly-ops --artifact-dir=artifacts/big5_result_page_v2_agent/testing-weekly-ops --json --no-ansi && rm -rf backend/artifacts/big5_result_page_v2_agent/testing-weekly-ops",
+          "cd backend && php artisan schedule:list --no-ansi",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed 12 tests/317 assertions; AgentAutomationTest passed 3 tests/40 assertions; weekly-ops smoke succeeded with production_ops_reporting_ready=true, production_rollout_enabled=false, forbidden_public_text_token_count=11; schedule:list includes weekly-ops at 20 5 * * 1; diff check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to allowed PR5 scope: backend/bootstrap/app.php, BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AgentAutomationTest.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, or runtime production enablement changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T10:06:00+08:00",
+        "status": "local_validated",
+        "note": "Started PR5 from synced main after PR4 merge/cleanup. Local validation and scope validation passed for weekly redacted ops report runner."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T10:13:00+08:00",
+  "updated_at": "2026-06-22T10:25:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57487,7 +57487,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-weekly-ops-runner",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-WEEKLY-OPS-RUNNER-01: Schedule Big Five V2 weekly ops report",
     "depends_on": [
@@ -57520,12 +57520,12 @@
         "evidence": "Changed files are limited to allowed PR5 scope: backend/bootstrap/app.php, BigFiveResultPageV2AssetAgentAuditCommand.php, BigFiveResultPageV2AssetAgent.php, BigFiveResultPageV2AgentAutomationTest.php, BigFiveResultPageV2AssetAgentTest.php, docs/codex/pr-train.yaml, docs/codex/pr-train-state.json. No fap-web copy, production import gate, rollout gate, release snapshot, or runtime production enablement changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2256 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2256 checks completed successfully on head 6f22501abada13f2f4fd9c9d8c9d5f9aa614042f; mergeStateStatus CLEAN; PR title/body and changed-file scope re-reviewed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "af516daaa404ab4fc718880d918d94048ec0ff7a",
+    "commit_sha": "6f22501abada13f2f4fd9c9d8c9d5f9aa614042f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2256",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57540,6 +57540,11 @@
         "at": "2026-06-22T10:13:00+08:00",
         "status": "pr_open",
         "note": "Opened PR #2256 after local validation and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T10:25:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T10:06:00+08:00",
+  "updated_at": "2026-06-22T10:13:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57487,7 +57487,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-weekly-ops-runner",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_automation",
     "title": "B5-RESULT-WEEKLY-OPS-RUNNER-01: Schedule Big Five V2 weekly ops report",
     "depends_on": [
@@ -57521,12 +57521,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2256 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "af516daaa404ab4fc718880d918d94048ec0ff7a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2256",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57535,6 +57535,11 @@
         "at": "2026-06-22T10:06:00+08:00",
         "status": "local_validated",
         "note": "Started PR5 from synced main after PR4 merge/cleanup. Local validation and scope validation passed for weekly redacted ops report runner."
+      },
+      {
+        "at": "2026-06-22T10:13:00+08:00",
+        "status": "pr_open",
+        "note": "Opened PR #2256 after local validation and scope validation passed; waiting for required GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24580,6 +24580,46 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: B5-RESULT-WEEKLY-OPS-RUNNER-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-AUTO-MERGE-CLEANUP-01
+    branch: codex/big5-v2-weekly-ops-runner
+    title: "B5-RESULT-WEEKLY-OPS-RUNNER-01: Schedule Big Five V2 weekly ops report"
+    train_scope: big5_result_page_v2_asset_agent_automation
+    status: user_authorized
+    scope:
+      - Add a weekly Big Five V2 ops report action that emits redacted artifact-only JSON and Markdown reports.
+      - Schedule the weekly ops runner without enabling production rollout, release snapshots, production imports, or frontend copy.
+      - Include V2 coverage, fallback, malformed reason, validation count, audit freshness, and PDF/private URL/footer/token smoke contract fields.
+    allowed_paths:
+      - backend/bootstrap/app.php
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add fap-web copy, generate final frontend payloads, make big5_report_engine_v2 primary, enable production rollout, or touch release/import/rollout gates.
+      - Store private URLs, attempt ids, PDF files, raw report bodies, user score values, or raw payloads in weekly ops artifacts.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent weekly-ops --run-id=weekly-ops --artifact-dir=artifacts/big5_result_page_v2_agent/testing-weekly-ops --json --no-ansi && rm -rf backend/artifacts/big5_result_page_v2_agent/testing-weekly-ops
+      - cd backend && php artisan schedule:list --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: RIASEC-RESULT-ASSET-AGENT-RUNBOOK-01
     repo: fap-api
     branch: codex/riasec-result-asset-agent-runbook-01


### PR DESCRIPTION
## What changed
- Adds a `weekly-ops` action to the Big Five V2 result-page asset agent.
- Emits redacted weekly Ops JSON and Markdown artifacts from the existing production Ops reporting/smoke contracts.
- Registers the weekly scheduler entry at `20 5 * * 1`.
- Adds tests for weekly report content and scheduler registration.
- Registers the authorized final PR-train item and reconciles the already-merged merge cleanup dependency.

## Why
This is PR5 of the Big Five V2 result-page asset agent full-auto train. It makes weekly redacted Ops reporting a scheduled backend artifact without enabling production rollout or adding frontend copy.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AgentAutomationTest --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent weekly-ops --run-id=weekly-ops --artifact-dir=artifacts/big5_result_page_v2_agent/testing-weekly-ops --json --no-ansi && rm -rf backend/artifacts/big5_result_page_v2_agent/testing-weekly-ops`
- `cd backend && php artisan schedule:list --no-ansi`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy or `fap-web` changes.
- No final frontend `big5_result_page_v2` payload generation.
- No production/runtime gate, release snapshot, production import gate, or rollout gate changes.
- Weekly artifacts do not store private URLs, attempt ids, PDF files, raw report bodies, user score values, or raw payloads.
- Legacy `big5_report_engine_v2` remains fallback only.

Repository rule impact: backend remains the authority for Big Five V2 result-page content assets; this PR only schedules redacted backend Ops report artifacts.
