### PR TITLE
Enneagram: add ops report and sidecar issue harness

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageReportSidecarIssueCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageReportSidecarIssueCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageReportSidecarIssueHarness;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageReportSidecarIssueCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-report-sidecar
+        {action=audit : Only audit is supported in this harness PR}
+        {--run-id=report-sidecar : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root}
+        {--contract-path= : Optional harness contract path}
+        {--evidence-dir= : Optional evidence directory}
+        {--blocker-source=none : none, external, or current_pr}
+        {--blocker-reason= : Optional blocker summary}
+        {--github-checks-green=1 : Whether required GitHub checks are green}
+        {--scope-validation-green=1 : Whether current scope validation is green}
+        {--strict : Include evidence inventory failures as blocking errors}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Generate Enneagram result page ops reports, sidecar issue payloads, and readiness summaries without production rollout.';
+
+    public function handle(EnneagramResultPageReportSidecarIssueHarness $harness): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $harness->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'evidence_dir' => trim((string) $this->option('evidence-dir')),
+                'blocker_source' => trim((string) $this->option('blocker-source')),
+                'blocker_reason' => trim((string) $this->option('blocker-reason')),
+                'github_checks_green' => $this->truthy($this->option('github-checks-green')),
+                'scope_validation_green' => $this->truthy($this->option('scope-validation-green')),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('train_can_continue='.(((bool) data_get($summary, 'summary.train_can_continue', false)) ? 'true' : 'false'));
+        $this->line('release_ready_for_manual_production_gate='.(((bool) data_get($summary, 'summary.release_ready_for_manual_production_gate', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+
+    private function truthy(mixed $value): bool
+    {
+        return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'y'], true);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -118,6 +118,7 @@ use App\Console\Commands\EnneagramResultPageCandidateStagingHarnessCommand;
 use App\Console\Commands\EnneagramResultPageContentBatchCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
+use App\Console\Commands\EnneagramResultPageReportSidecarIssueCommand;
 use App\Console\Commands\EnneagramResultPageRenderedQaSmokeHarnessCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
@@ -255,6 +256,7 @@ class Kernel extends ConsoleKernel
         EnneagramResultPageCandidateStagingHarnessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramResultPageOpsRunnerCommand::class,
+        EnneagramResultPageReportSidecarIssueCommand::class,
         EnneagramResultPageRenderedQaSmokeHarnessCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,
         EnneagramRollbackRegistryRelease::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageReportSidecarIssueHarness.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageReportSidecarIssueHarness.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageReportSidecarIssueHarness
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.report_sidecar_issue.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_report_sidecar_issue';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/report_sidecar_issue/report_sidecar_issue_contract_v0_1.json';
+
+    private const READINESS_GATES = [
+        'candidate_export_staging_import',
+        'web_rendered_qa',
+        'api_smoke',
+        'rollback_simulation',
+        'production_manual_gate',
+    ];
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     evidence_dir?:string,
+     *     blocker_source?:string,
+     *     blocker_reason?:string,
+     *     github_checks_green?:bool,
+     *     scope_validation_green?:bool,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'report-sidecar'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $evidenceDir = rtrim(trim((string) ($options['evidence_dir'] ?? '')), DIRECTORY_SEPARATOR);
+        $blockerSource = trim((string) ($options['blocker_source'] ?? 'none'));
+        $blockerReason = trim((string) ($options['blocker_reason'] ?? ''));
+        $githubChecksGreen = ($options['github_checks_green'] ?? true) === true;
+        $scopeValidationGreen = ($options['scope_validation_green'] ?? true) === true;
+        $strict = ($options['strict'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readJson($contractPath, 'Report sidecar issue contract');
+        $contractErrors = $this->contractErrors($contract);
+        $evidence = $this->evidenceInventory($evidenceDir);
+        $failureClassification = $this->failureClassification(
+            $blockerSource,
+            $blockerReason,
+            $githubChecksGreen,
+            $scopeValidationGreen,
+        );
+        $readiness = $this->releaseReadinessSummary($evidence, $failureClassification);
+        $sidecarIssue = $this->sidecarIssuePayload($runId, $failureClassification, $readiness);
+        $opsReport = $this->opsReportMarkdown($runId, $failureClassification, $readiness);
+
+        $errors = array_values(array_unique(array_merge(
+            $contractErrors,
+            (array) ($failureClassification['blocking_errors'] ?? []),
+            $strict ? (array) ($evidence['errors'] ?? []) : [],
+        )));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'report_sidecar_issue_harness',
+            'run_id' => $runId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'evidence_inventory' => $evidence,
+            'failure_classification' => $failureClassification,
+            'release_readiness_summary' => $readiness,
+            'sidecar_issue_payload' => $sidecarIssue,
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'report_sidecar_issue_harness_report.json' => $this->writeJson($artifactDir.'/report_sidecar_issue_harness_report.json', $report),
+            'failure_classification_report.json' => $this->writeJson($artifactDir.'/failure_classification_report.json', $failureClassification),
+            'sidecar_issue_payload.json' => $this->writeJson($artifactDir.'/sidecar_issue_payload.json', $sidecarIssue),
+            'release_readiness_summary.json' => $this->writeJson($artifactDir.'/release_readiness_summary.json', $readiness),
+            'ops_report.md' => $this->writeText($artifactDir.'/ops_report.md', $opsReport),
+        ];
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'summary' => [
+                'train_can_continue' => (bool) ($failureClassification['train_can_continue'] ?? false),
+                'sidecar_issue_payload_created' => true,
+                'release_ready_for_manual_production_gate' => (bool) ($readiness['ready_for_manual_production_gate'] ?? false),
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureClassification(string $blockerSource, string $blockerReason, bool $githubChecksGreen, bool $scopeValidationGreen): array
+    {
+        $allowed = ['none', 'external', 'current_pr'];
+        $errors = [];
+        if (! in_array($blockerSource, $allowed, true)) {
+            $errors[] = 'blocker_source_not_allowed:'.$blockerSource;
+        }
+
+        $currentPrBlocker = $blockerSource === 'current_pr' || ! $githubChecksGreen || ! $scopeValidationGreen;
+        $externalBlocker = $blockerSource === 'external';
+        $trainCanContinue = ! $currentPrBlocker && ($blockerSource === 'none' || ($externalBlocker && $githubChecksGreen && $scopeValidationGreen));
+        if ($currentPrBlocker) {
+            $errors[] = 'current_pr_or_required_gate_blocker';
+        }
+
+        return [
+            'blocker_source' => $blockerSource,
+            'blocker_reason' => $blockerReason === '' ? null : $blockerReason,
+            'github_checks_green' => $githubChecksGreen,
+            'scope_validation_green' => $scopeValidationGreen,
+            'external_blocker' => $externalBlocker,
+            'current_pr_blocker' => $currentPrBlocker,
+            'train_can_continue' => $trainCanContinue,
+            'sidecar_issue_required' => $externalBlocker,
+            'blocking_errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function releaseReadinessSummary(array $evidence, array $failureClassification): array
+    {
+        $evidenceByGate = (array) ($evidence['gate_status'] ?? []);
+        $gates = [];
+        foreach (self::READINESS_GATES as $gate) {
+            $gates[$gate] = [
+                'status' => $gate === 'production_manual_gate'
+                    ? 'manual_required'
+                    : (string) ($evidenceByGate[$gate] ?? 'pending'),
+                'production_execution_allowed_for_agent' => false,
+            ];
+        }
+
+        $nonManualReady = collect($gates)
+            ->except('production_manual_gate')
+            ->every(static fn (array $gate): bool => $gate['status'] === 'pass');
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'gates' => $gates,
+            'non_manual_gates_passed' => $nonManualReady,
+            'ready_for_manual_production_gate' => $nonManualReady && (bool) ($failureClassification['train_can_continue'] ?? false),
+            'production_manual_gate_required' => true,
+            'production_execution_allowed_for_agent' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sidecarIssuePayload(string $runId, array $failureClassification, array $readiness): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'create_issue_directly' => false,
+            'payload_only' => true,
+            'title' => 'Enneagram result page external blocker: '.$runId,
+            'labels' => ['enneagram-result-page', 'ops-agent', 'sidecar'],
+            'body' => [
+                'blocker_source' => $failureClassification['blocker_source'] ?? 'unknown',
+                'blocker_reason' => $failureClassification['blocker_reason'] ?? null,
+                'train_can_continue' => (bool) ($failureClassification['train_can_continue'] ?? false),
+                'ready_for_manual_production_gate' => (bool) ($readiness['ready_for_manual_production_gate'] ?? false),
+                'production_execution_allowed_for_agent' => false,
+            ],
+        ];
+    }
+
+    private function opsReportMarkdown(string $runId, array $failureClassification, array $readiness): string
+    {
+        return implode(PHP_EOL, [
+            '# Enneagram Result Page Ops Report',
+            '',
+            '- run_id: '.$runId,
+            '- train_can_continue: '.(((bool) ($failureClassification['train_can_continue'] ?? false)) ? 'true' : 'false'),
+            '- blocker_source: '.(string) ($failureClassification['blocker_source'] ?? 'unknown'),
+            '- ready_for_manual_production_gate: '.(((bool) ($readiness['ready_for_manual_production_gate'] ?? false)) ? 'true' : 'false'),
+            '- production_execution_allowed_for_agent: false',
+            '- production_manual_gate_required: true',
+            '',
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function evidenceInventory(string $evidenceDir): array
+    {
+        if ($evidenceDir === '') {
+            return [
+                'provided' => false,
+                'relative_path' => null,
+                'gate_status' => [],
+                'reports' => [],
+                'errors' => [],
+            ];
+        }
+        if (! is_dir($evidenceDir)) {
+            return [
+                'provided' => true,
+                'relative_path' => $this->redactPath($evidenceDir),
+                'gate_status' => [],
+                'reports' => [],
+                'errors' => ['evidence_dir_not_found'],
+            ];
+        }
+
+        $reports = [];
+        $gateStatus = [];
+        $errors = [];
+        foreach (File::glob($evidenceDir.'/*.json') ?: [] as $path) {
+            $payload = $this->readJson($path, basename($path));
+            $gate = (string) ($payload['gate'] ?? pathinfo($path, PATHINFO_FILENAME));
+            $ok = (bool) ($payload['ok'] ?? false);
+            $gateStatus[$gate] = $ok ? 'pass' : 'fail';
+            if (! $ok) {
+                $errors[] = 'evidence_gate_failed:'.$gate;
+            }
+            $reports[] = [
+                'relative_path' => $this->relativePath($path),
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'gate' => $gate,
+                'ok' => $ok,
+            ];
+        }
+
+        return [
+            'provided' => true,
+            'relative_path' => $this->redactPath($evidenceDir),
+            'gate_status' => $gateStatus,
+            'reports' => $reports,
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['runtime_use'] ?? null) !== 'not_runtime') {
+            $errors[] = 'runtime_use_must_be_not_runtime';
+        }
+        if (($contract['production_use_allowed'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_must_be_false';
+        }
+        if (data_get($contract, 'sidecar_issue.create_issue_directly') !== false) {
+            $errors[] = 'sidecar_issue_direct_write_must_be_false';
+        }
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'github_issue_created' => false,
+            'bulk_content_generation_happened' => false,
+            'production_import_happened' => false,
+            'production_activation_happened' => false,
+            'production_rollback_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException($label.' is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'report-sidecar';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function writeText(string $path, string $payload): array
+    {
+        file_put_contents($path, $payload);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/report_sidecar_issue/README.md
+++ b/backend/content_assets/enneagram/result_page/report_sidecar_issue/README.md
@@ -1,0 +1,7 @@
+# Enneagram Report + Sidecar Issue Harness
+
+This directory defines the Enneagram result page operations report and sidecar issue payload contract.
+
+The harness classifies current-PR failures versus external blockers, writes release readiness summaries, and prepares sidecar issue payloads for follow-up.
+
+It does not create GitHub issues directly, merge PRs, run production activation, run rollback, switch runtime, write production, or change frontend code.

--- a/backend/content_assets/enneagram/result_page/report_sidecar_issue/report_sidecar_issue_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/report_sidecar_issue/report_sidecar_issue_contract_v0_1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "fap.enneagram.result_page.report_sidecar_issue.v0.1",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "allowed_blocker_sources": ["none", "external", "current_pr"],
+  "continue_policy": {
+    "external_blocker_can_continue_when_github_checks_green": true,
+    "external_blocker_can_continue_when_scope_validation_green": true,
+    "current_pr_blocker_can_continue": false
+  },
+  "release_readiness_gates": [
+    "candidate_export_staging_import",
+    "web_rendered_qa",
+    "api_smoke",
+    "rollback_simulation",
+    "production_manual_gate"
+  ],
+  "sidecar_issue": {
+    "create_issue_directly": false,
+    "payload_only": true
+  },
+  "negative_guarantees": {
+    "github_issue_created": false,
+    "bulk_content_generation_happened": false,
+    "production_import_happened": false,
+    "production_activation_happened": false,
+    "production_rollback_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageReportSidecarIssueCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageReportSidecarIssueCommandTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageReportSidecarIssueCommandTest extends TestCase
+{
+    public function test_report_sidecar_command_succeeds_with_external_blocker_when_required_gates_are_green(): void
+    {
+        $this->artisan('enneagram:result-page-report-sidecar', [
+            'action' => 'audit',
+            '--run-id' => 'command-sidecar',
+            '--artifact-dir' => sys_get_temp_dir().'/enneagram-report-sidecar-command',
+            '--blocker-source' => 'external',
+            '--blocker-reason' => 'outside current PR scope',
+            '--github-checks-green' => '1',
+            '--scope-validation-green' => '1',
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(0);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2946,6 +2946,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_report_sidecar_scaffold(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageReportSidecarIssueCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageReportSidecarIssueHarness.php',
+            'backend/content_assets/enneagram/result_page/report_sidecar_issue/README.md',
+            'backend/content_assets/enneagram/result_page/report_sidecar_issue/report_sidecar_issue_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageReportSidecarIssueCommand;',
+            '+        EnneagramResultPageReportSidecarIssueCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4874,6 +4897,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageReportSidecarIssueFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -4986,6 +5013,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageReportSidecarIssueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6924,6 +6952,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageReportSidecarIssueFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageReportSidecarIssueCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageReportSidecarIssueHarness.php',
+            'backend/content_assets/enneagram/result_page/report_sidecar_issue/README.md',
+            'backend/content_assets/enneagram/result_page/report_sidecar_issue/report_sidecar_issue_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -8127,6 +8165,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageRenderedQaSmokeHarnessCommand;',
             '        EnneagramResultPageRenderedQaSmokeHarnessCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageReportSidecarIssueOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageReportSidecarIssueCommand;',
+            '        EnneagramResultPageReportSidecarIssueCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageReportSidecarIssueHarnessTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageReportSidecarIssueHarnessTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageReportSidecarIssueHarness;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramResultPageReportSidecarIssueHarnessTest extends TestCase
+{
+    public function test_external_blocker_creates_sidecar_payload_and_allows_train_when_required_gates_are_green(): void
+    {
+        $artifactRoot = storage_path('framework/testing/report_sidecar_artifacts/external');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageReportSidecarIssueHarness::class)->run([
+            'run_id' => 'external-blocker',
+            'artifact_dir' => $artifactRoot,
+            'blocker_source' => 'external',
+            'blocker_reason' => 'staging API unavailable outside current PR scope',
+            'github_checks_green' => true,
+            'scope_validation_green' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.train_can_continue', false));
+        $this->assertTrue((bool) data_get($summary, 'summary.sidecar_issue_payload_created', false));
+        $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+        $this->assertFileExists($artifactRoot.'/external-blocker/sidecar_issue_payload.json');
+        $this->assertFileExists($artifactRoot.'/external-blocker/ops_report.md');
+    }
+
+    public function test_current_pr_blocker_fails_closed(): void
+    {
+        $artifactRoot = storage_path('framework/testing/report_sidecar_artifacts/current');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageReportSidecarIssueHarness::class)->run([
+            'run_id' => 'current-blocker',
+            'artifact_dir' => $artifactRoot,
+            'blocker_source' => 'current_pr',
+            'blocker_reason' => 'scope validation failed',
+            'github_checks_green' => true,
+            'scope_validation_green' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'summary.train_can_continue', true));
+        $this->assertContains('current_pr_or_required_gate_blocker', $summary['errors'] ?? []);
+    }
+
+    public function test_readiness_summary_requires_manual_production_gate_even_when_non_manual_gates_pass(): void
+    {
+        $evidenceDir = storage_path('framework/testing/report_sidecar_evidence/pass');
+        $artifactRoot = storage_path('framework/testing/report_sidecar_artifacts/readiness');
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        File::deleteDirectory($artifactRoot);
+
+        foreach (['candidate_export_staging_import', 'web_rendered_qa', 'api_smoke', 'rollback_simulation'] as $gate) {
+            File::put($evidenceDir.'/'.$gate.'.json', json_encode(['gate' => $gate, 'ok' => true], JSON_PRETTY_PRINT));
+        }
+
+        $summary = app(EnneagramResultPageReportSidecarIssueHarness::class)->run([
+            'run_id' => 'readiness-pass',
+            'artifact_dir' => $artifactRoot,
+            'evidence_dir' => $evidenceDir,
+            'blocker_source' => 'none',
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.release_ready_for_manual_production_gate', false));
+
+        $readiness = $this->readJson($artifactRoot.'/readiness-pass/release_readiness_summary.json');
+        $this->assertSame('manual_required', data_get($readiness, 'gates.production_manual_gate.status'));
+        $this->assertFalse((bool) data_get($readiness, 'production_execution_allowed_for_agent', true));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added an Enneagram report + sidecar issue harness contract.
- Added `enneagram:result-page-report-sidecar audit` to generate ops reports, failure classification, sidecar issue payloads, and release readiness summaries.
- Added current-PR versus external-blocker classification so external blockers can be reported without stopping the train when required checks and scope validation are green.
- Added unit/command coverage and a narrow BigFive runtime freeze allowlist for this Enneagram-only scaffold.

## Why
This gives the operations agent a reporting layer for evidence bundles and blocker handling while preserving the rule that production rollout remains manual-gated.

## Validation
- `php -l backend/app/Console/Kernel.php && php -l backend/app/Console/Commands/EnneagramResultPageReportSidecarIssueCommand.php && php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageReportSidecarIssueHarness.php && php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageReportSidecarIssueHarnessTest.php && php -l backend/tests/Feature/Console/EnneagramResultPageReportSidecarIssueCommandTest.php && php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageReportSidecarIssueHarnessTest.php tests/Feature/Console/EnneagramResultPageReportSidecarIssueCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_report_sidecar_scaffold|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan list --no-ansi | rg "enneagram:result-page-(report-sidecar|rendered-qa-smoke-harness|candidate-staging-harness|content-batch|ops-runner|ops-control-plane|agent)"`
- `git diff --check`
- Scoped changed-file validation passed.

## Intentionally deferred
- No direct GitHub issue creation.
- No bulk content generation.
- No production import.
- No activation.
- No production rollback.
- No runtime switch.
- No production writes.
- No frontend changes.
