### PR TITLE
Enneagram: add production manual gate runbook

### DIFF
--- a/backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageProductionManualGateRunbook;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnneagramResultPageProductionManualGateCommand extends Command
+{
+    protected $signature = 'enneagram:result-page-production-manual-gate
+        {action=audit : Only audit is supported in this runbook PR}
+        {--run-id=production-manual-gate : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root}
+        {--contract-path= : Optional runbook contract path}
+        {--release-id= : Exact inactive release id}
+        {--confirm-release-id= : Repeat exact inactive release id}
+        {--candidate-manifest-sha256= : Exact candidate manifest SHA256}
+        {--runtime-registry-sha256= : Exact runtime registry SHA256}
+        {--rollback-window= : Human-approved rollback window}
+        {--post-activation-smoke-acknowledged : Acknowledge post-activation smoke plan}
+        {--strict : Return non-zero when manual approval packet is incomplete or mismatched}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Prepare Enneagram production manual approval packets without executing production rollout.';
+
+    public function handle(EnneagramResultPageProductionManualGateRunbook $runbook): int
+    {
+        try {
+            if ($this->argument('action') !== 'audit') {
+                $this->error('Unsupported action. This PR supports only: audit');
+
+                return self::FAILURE;
+            }
+
+            $summary = $runbook->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'contract_path' => trim((string) $this->option('contract-path')),
+                'release_id' => trim((string) $this->option('release-id')),
+                'confirm_release_id' => trim((string) $this->option('confirm-release-id')),
+                'candidate_manifest_sha256' => trim((string) $this->option('candidate-manifest-sha256')),
+                'runtime_registry_sha256' => trim((string) $this->option('runtime-registry-sha256')),
+                'rollback_window' => trim((string) $this->option('rollback-window')),
+                'post_activation_smoke_acknowledged' => (bool) $this->option('post-activation-smoke-acknowledged'),
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('release_id='.(string) data_get($summary, 'summary.release_id', ''));
+        $this->line('manual_approval_packet_valid='.(((bool) data_get($summary, 'summary.manual_approval_packet_valid', false)) ? 'true' : 'false'));
+        $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -118,6 +118,7 @@ use App\Console\Commands\EnneagramResultPageCandidateStagingHarnessCommand;
 use App\Console\Commands\EnneagramResultPageContentBatchCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
+use App\Console\Commands\EnneagramResultPageProductionManualGateCommand;
 use App\Console\Commands\EnneagramResultPageReportSidecarIssueCommand;
 use App\Console\Commands\EnneagramResultPageRenderedQaSmokeHarnessCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
@@ -256,6 +257,7 @@ class Kernel extends ConsoleKernel
         EnneagramResultPageCandidateStagingHarnessCommand::class,
         EnneagramResultPageOpsControlPlaneCommand::class,
         EnneagramResultPageOpsRunnerCommand::class,
+        EnneagramResultPageProductionManualGateCommand::class,
         EnneagramResultPageReportSidecarIssueCommand::class,
         EnneagramResultPageRenderedQaSmokeHarnessCommand::class,
         EnneagramRollbackInactiveCandidateRelease::class,

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPageProductionManualGateRunbook
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.production_manual_gate.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/enneagram_result_page_production_manual_gate';
+
+    public const DEFAULT_CONTRACT_RELATIVE_PATH = 'content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json';
+
+    public const EXPECTED_RELEASE_ID = 'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4';
+
+    public const EXPECTED_CANDIDATE_MANIFEST_SHA256 = 'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0';
+
+    public const EXPECTED_RUNTIME_REGISTRY_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     contract_path?:string,
+     *     release_id?:string,
+     *     confirm_release_id?:string,
+     *     candidate_manifest_sha256?:string,
+     *     runtime_registry_sha256?:string,
+     *     rollback_window?:string,
+     *     post_activation_smoke_acknowledged?:bool,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'production-manual-gate'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $releaseId = trim((string) ($options['release_id'] ?? ''));
+        $confirmReleaseId = trim((string) ($options['confirm_release_id'] ?? ''));
+        $candidateManifestSha256 = trim((string) ($options['candidate_manifest_sha256'] ?? ''));
+        $runtimeRegistrySha256 = trim((string) ($options['runtime_registry_sha256'] ?? ''));
+        $rollbackWindow = trim((string) ($options['rollback_window'] ?? ''));
+        $postActivationSmokeAcknowledged = ($options['post_activation_smoke_acknowledged'] ?? false) === true;
+        $strict = ($options['strict'] ?? false) === true;
+
+        $this->ensureDirectory($artifactDir);
+
+        $contract = $this->readJson($contractPath, 'Production manual gate contract');
+        $contractErrors = $this->contractErrors($contract);
+        $approvalPacket = $this->approvalPacket(
+            $releaseId,
+            $confirmReleaseId,
+            $candidateManifestSha256,
+            $runtimeRegistrySha256,
+            $rollbackWindow,
+            $postActivationSmokeAcknowledged,
+        );
+        $rollbackWindowPlan = $this->rollbackWindowPlan($releaseId, $rollbackWindow, $artifactDir);
+        $postActivationSmokePlan = $this->postActivationSmokePlan($releaseId, $artifactDir);
+
+        $errors = array_values(array_unique(array_merge(
+            $contractErrors,
+            $strict ? (array) ($approvalPacket['errors'] ?? []) : [],
+        )));
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'production_manual_gate_runbook',
+            'run_id' => $runId,
+            'contract' => [
+                'relative_path' => $this->relativePath($contractPath),
+                'sha256' => hash_file('sha256', $contractPath) ?: '',
+                'valid' => $contractErrors === [],
+                'errors' => $contractErrors,
+            ],
+            'manual_approval_packet' => $approvalPacket,
+            'rollback_window' => $rollbackWindowPlan,
+            'post_activation_smoke_plan' => $postActivationSmokePlan,
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'production_manual_gate_report.json' => $this->writeJson($artifactDir.'/production_manual_gate_report.json', $report),
+            'manual_approval_packet.json' => $this->writeJson($artifactDir.'/manual_approval_packet.json', $approvalPacket),
+            'post_activation_smoke_plan.json' => $this->writeJson($artifactDir.'/post_activation_smoke_plan.json', $postActivationSmokePlan),
+            'rollback_window.md' => $this->writeText($artifactDir.'/rollback_window.md', $this->rollbackWindowMarkdown($rollbackWindowPlan)),
+        ];
+
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'summary' => [
+                'manual_approval_packet_valid' => (bool) ($approvalPacket['valid'] ?? false),
+                'release_id' => $releaseId === '' ? self::EXPECTED_RELEASE_ID : $releaseId,
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
+                'post_activation_smoke_plan_ready' => true,
+                'rollback_window_recorded' => $rollbackWindow !== '',
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function approvalPacket(
+        string $releaseId,
+        string $confirmReleaseId,
+        string $candidateManifestSha256,
+        string $runtimeRegistrySha256,
+        string $rollbackWindow,
+        bool $postActivationSmokeAcknowledged,
+    ): array {
+        $errors = [];
+        if ($releaseId !== self::EXPECTED_RELEASE_ID) {
+            $errors[] = 'release_id_mismatch';
+        }
+        if ($confirmReleaseId !== $releaseId || $confirmReleaseId !== self::EXPECTED_RELEASE_ID) {
+            $errors[] = 'confirm_release_id_mismatch';
+        }
+        if ($candidateManifestSha256 !== self::EXPECTED_CANDIDATE_MANIFEST_SHA256) {
+            $errors[] = 'candidate_manifest_sha256_mismatch';
+        }
+        if ($runtimeRegistrySha256 !== self::EXPECTED_RUNTIME_REGISTRY_SHA256) {
+            $errors[] = 'runtime_registry_sha256_mismatch';
+        }
+        if ($rollbackWindow === '') {
+            $errors[] = 'rollback_window_missing';
+        }
+        if (! $postActivationSmokeAcknowledged) {
+            $errors[] = 'post_activation_smoke_acknowledgement_missing';
+        }
+
+        return [
+            'valid' => $errors === [],
+            'release_id' => $releaseId,
+            'confirm_release_id' => $confirmReleaseId,
+            'expected_release_id' => self::EXPECTED_RELEASE_ID,
+            'candidate_manifest_sha256' => $candidateManifestSha256,
+            'expected_candidate_manifest_sha256' => self::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => $runtimeRegistrySha256,
+            'expected_runtime_registry_sha256' => self::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => $rollbackWindow,
+            'post_activation_smoke_acknowledged' => $postActivationSmokeAcknowledged,
+            'production_execution_allowed_for_agent' => false,
+            'manual_human_approval_required' => true,
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function rollbackWindowPlan(string $releaseId, string $rollbackWindow, string $artifactDir): array
+    {
+        return [
+            'release_id' => $releaseId === '' ? self::EXPECTED_RELEASE_ID : $releaseId,
+            'rollback_window' => $rollbackWindow === '' ? '<required-window>' : $rollbackWindow,
+            'rollback_command_template' => 'php artisan enneagram:rollback-inactive-candidate-release --release-id=<exact-release-id> --confirm-release-id=<same-exact-release-id> --output-dir=<output-dir> --json',
+            'output_dir' => $this->redactPath($artifactDir.'/rollback'),
+            'agent_execution_allowed' => false,
+            'production_rollback_allowed_for_agent' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function postActivationSmokePlan(string $releaseId, string $artifactDir): array
+    {
+        return [
+            'release_id' => $releaseId === '' ? self::EXPECTED_RELEASE_ID : $releaseId,
+            'required_smoke_steps' => [
+                'verify_active_release_id_matches_exact_manual_approval',
+                'run_api_result_page_smoke',
+                'run_web_rendered_result_page_smoke',
+                'verify_rollback_target_snapshot_exists',
+            ],
+            'artifact_dir' => $this->redactPath($artifactDir.'/post_activation_smoke'),
+            'agent_execution_allowed_after_human_activation' => true,
+            'agent_production_activation_allowed' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $rollbackWindowPlan
+     */
+    private function rollbackWindowMarkdown(array $rollbackWindowPlan): string
+    {
+        return implode(PHP_EOL, [
+            '# Enneagram Production Rollback Window',
+            '',
+            '- release_id: '.(string) ($rollbackWindowPlan['release_id'] ?? ''),
+            '- rollback_window: '.(string) ($rollbackWindowPlan['rollback_window'] ?? ''),
+            '- agent_execution_allowed: false',
+            '- production_rollback_allowed_for_agent: false',
+            '',
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function contractErrors(array $contract): array
+    {
+        $errors = [];
+        if (($contract['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($contract['manual_approval_required'] ?? null) !== true) {
+            $errors[] = 'manual_approval_required_must_be_true';
+        }
+        if (($contract['production_use_allowed_for_agent'] ?? null) !== false) {
+            $errors[] = 'production_use_allowed_for_agent_must_be_false';
+        }
+        if (($contract['expected_release_id'] ?? null) !== self::EXPECTED_RELEASE_ID) {
+            $errors[] = 'expected_release_id_mismatch';
+        }
+        if (($contract['expected_candidate_manifest_sha256'] ?? null) !== self::EXPECTED_CANDIDATE_MANIFEST_SHA256) {
+            $errors[] = 'expected_candidate_manifest_sha256_mismatch';
+        }
+        if (($contract['expected_runtime_registry_sha256'] ?? null) !== self::EXPECTED_RUNTIME_REGISTRY_SHA256) {
+            $errors[] = 'expected_runtime_registry_sha256_mismatch';
+        }
+        foreach ($this->negativeGuarantees() as $key => $expected) {
+            if (data_get($contract, 'negative_guarantees.'.$key) !== $expected) {
+                $errors[] = 'negative_guarantee_mismatch:'.$key;
+            }
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'agent_production_activation_allowed' => false,
+            'agent_production_rollback_allowed' => false,
+            'bulk_content_generation_happened' => false,
+            'production_import_happened' => false,
+            'production_activation_happened' => false,
+            'production_rollback_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $label): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException($label.' is not valid JSON: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    private function contractPath(string $path): string
+    {
+        return $path !== '' ? $path : base_path(self::DEFAULT_CONTRACT_RELATIVE_PATH);
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = $root !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'production-manual-gate';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function writeText(string $path, string $payload): array
+    {
+        file_put_contents($path, $payload);
+
+        return [
+            'relative_path' => $this->relativePath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function relativePath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $this->redactPath($path);
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/content_assets/enneagram/result_page/production_manual_gate/README.md
+++ b/backend/content_assets/enneagram/result_page/production_manual_gate/README.md
@@ -1,0 +1,9 @@
+# Enneagram Production Manual Gate Runbook
+
+This directory defines the manual production approval packet for Enneagram result page activation.
+
+The agent may prepare the packet, rollback window, and post-activation smoke plan. A human operator must approve and execute production activation separately.
+
+The required approval fields are exact release id, candidate manifest SHA256, runtime registry SHA256, rollback window, and post-activation smoke plan acknowledgement.
+
+This scaffold does not execute activation, rollback, runtime switching, production writes, bulk content generation, or frontend changes.

--- a/backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "fap.enneagram.result_page.production_manual_gate.v0.1",
+  "runtime_use": "not_runtime_until_human_approval",
+  "production_use_allowed_for_agent": false,
+  "manual_approval_required": true,
+  "expected_release_id": "enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4",
+  "expected_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+  "expected_runtime_registry_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+  "required_human_approval_fields": [
+    "release_id",
+    "confirm_release_id",
+    "candidate_manifest_sha256",
+    "runtime_registry_sha256",
+    "rollback_window",
+    "post_activation_smoke_acknowledged"
+  ],
+  "activation_command_template": "php artisan enneagram:activate-inactive-candidate-release --release-id=<exact-release-id> --confirm-release-id=<same-exact-release-id> --candidate-manifest-sha256=<exact-candidate-sha256> --runtime-registry-sha256=<exact-runtime-sha256> --output-dir=<output-dir> --json",
+  "rollback_command_template": "php artisan enneagram:rollback-inactive-candidate-release --release-id=<exact-release-id> --confirm-release-id=<same-exact-release-id> --output-dir=<output-dir> --json",
+  "negative_guarantees": {
+    "agent_production_activation_allowed": false,
+    "agent_production_rollback_allowed": false,
+    "bulk_content_generation_happened": false,
+    "production_import_happened": false,
+    "production_activation_happened": false,
+    "production_rollback_happened": false,
+    "runtime_switch_happened": false,
+    "production_write_happened": false,
+    "frontend_change_happened": false
+  }
+}

--- a/backend/tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageProductionManualGateRunbook;
+use Tests\TestCase;
+
+final class EnneagramResultPageProductionManualGateCommandTest extends TestCase
+{
+    public function test_production_manual_gate_command_succeeds_with_exact_manual_approval_packet(): void
+    {
+        $this->artisan('enneagram:result-page-production-manual-gate', [
+            'action' => 'audit',
+            '--run-id' => 'command-manual-pass',
+            '--artifact-dir' => sys_get_temp_dir().'/enneagram-production-manual-gate-command',
+            '--release-id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            '--confirm-release-id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            '--candidate-manifest-sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            '--runtime-registry-sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            '--rollback-window' => '2026-06-22T01:00:00Z/2026-06-22T02:00:00Z',
+            '--post-activation-smoke-acknowledged' => true,
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(0);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2969,6 +2969,29 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_result_page_production_manual_gate_runbook(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php',
+            'backend/content_assets/enneagram/result_page/production_manual_gate/README.md',
+            'backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\EnneagramResultPageProductionManualGateCommand;',
+            '+        EnneagramResultPageProductionManualGateCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_agent_runner_harness(): void
     {
         $changed = [
@@ -4901,6 +4924,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramResultPageProductionManualGateRunbookFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageAgentRunnerHarnessFile($file)) {
                 continue;
             }
@@ -5014,6 +5041,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageReportSidecarIssueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramResultPageProductionManualGateRunbookOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramInactiveCandidateActivationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
@@ -6962,6 +6990,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isEnneagramResultPageProductionManualGateRunbookFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php',
+            'backend/content_assets/enneagram/result_page/production_manual_gate/README.md',
+            'backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json',
+        ], true);
+    }
+
     private function isEnneagramResultPageAgentRunnerHarnessFile(string $file): bool
     {
         return $file === 'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentBatchRunner.php';
@@ -8182,6 +8220,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageReportSidecarIssueCommand;',
             '        EnneagramResultPageReportSidecarIssueCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramResultPageProductionManualGateRunbookOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\EnneagramResultPageProductionManualGateCommand;',
+            '        EnneagramResultPageProductionManualGateCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageProductionManualGateRunbook;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class EnneagramResultPageProductionManualGateRunbookTest extends TestCase
+{
+    public function test_manual_gate_packet_passes_only_with_exact_release_and_hashes(): void
+    {
+        $artifactRoot = storage_path('framework/testing/production_manual_gate_artifacts/pass');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageProductionManualGateRunbook::class)->run([
+            'run_id' => 'manual-pass',
+            'artifact_dir' => $artifactRoot,
+            'release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'confirm_release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'candidate_manifest_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => '2026-06-22T01:00:00Z/2026-06-22T02:00:00Z',
+            'post_activation_smoke_acknowledged' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.manual_approval_packet_valid', false));
+        $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+        $this->assertTrue((bool) data_get($summary, 'summary.production_manual_gate_required', false));
+        $this->assertFileExists($artifactRoot.'/manual-pass/manual_approval_packet.json');
+
+        $packet = $this->readJson($artifactRoot.'/manual-pass/manual_approval_packet.json');
+        $this->assertFalse((bool) data_get($packet, 'production_execution_allowed_for_agent', true));
+        $this->assertTrue((bool) data_get($packet, 'manual_human_approval_required', false));
+    }
+
+    public function test_manual_gate_fails_closed_on_release_mismatch(): void
+    {
+        $artifactRoot = storage_path('framework/testing/production_manual_gate_artifacts/release_mismatch');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageProductionManualGateRunbook::class)->run([
+            'run_id' => 'manual-fail',
+            'artifact_dir' => $artifactRoot,
+            'release_id' => 'wrong-release',
+            'confirm_release_id' => 'wrong-release',
+            'candidate_manifest_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => '2026-06-22T01:00:00Z/2026-06-22T02:00:00Z',
+            'post_activation_smoke_acknowledged' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('release_id_mismatch', $summary['errors'] ?? []);
+        $this->assertContains('confirm_release_id_mismatch', $summary['errors'] ?? []);
+    }
+
+    public function test_manual_gate_fails_closed_without_smoke_acknowledgement(): void
+    {
+        $artifactRoot = storage_path('framework/testing/production_manual_gate_artifacts/no_smoke_ack');
+        File::deleteDirectory($artifactRoot);
+
+        $summary = app(EnneagramResultPageProductionManualGateRunbook::class)->run([
+            'run_id' => 'manual-no-smoke',
+            'artifact_dir' => $artifactRoot,
+            'release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'confirm_release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'candidate_manifest_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => '2026-06-22T01:00:00Z/2026-06-22T02:00:00Z',
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertContains('post_activation_smoke_acknowledgement_missing', $summary['errors'] ?? []);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added an Enneagram production manual approval gate/runbook contract.
- Added `enneagram:result-page-production-manual-gate audit` to prepare exact-release approval packets, rollback window records, and post-activation smoke plans.
- Enforced exact release id, candidate manifest hash, runtime registry hash, rollback window, and post-activation smoke acknowledgement in strict mode.
- Added unit/command coverage and a narrow BigFive runtime freeze allowlist for this Enneagram-only runbook scaffold.

## Why
This fixes the final production boundary for the Enneagram result page operations agent: the agent can prepare evidence and approval packets, but production rollout remains a human-approved gate.

## Validation
- `php -l backend/app/Console/Kernel.php && php -l backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php && php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php && php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php && php -l backend/tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php && php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_freeze_classifier_ignores_enneagram_result_page_production_manual_gate_runbook|runtime_paths_have_no_uncommitted_diff" --no-ansi`
- `php artisan list --no-ansi | rg "enneagram:result-page-(production-manual-gate|report-sidecar|rendered-qa-smoke-harness|candidate-staging-harness|content-batch|ops-runner|ops-control-plane|agent)"`
- `git diff --check`
- Scoped changed-file validation passed.

## Intentionally deferred
- No production activation.
- No production rollback.
- No production import.
- No runtime switch.
- No production writes.
- No bulk content generation.
- No frontend changes.
