### PR TITLE
RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar

### DIFF
--- a/backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php
+++ b/backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php
@@ -131,6 +131,9 @@ final class RiasecResultPageOpsAgentRunOrchestrator
             'mode' => $mode,
             'scope_id' => $scopeId,
             'strict' => $strict,
+            'scope_validation' => $scopeReport,
+            'failure_classification' => $failureReport,
+            'sidecar_issue_payload' => $sidecarPayload,
             'summary' => [
                 'permission_model_valid' => $permissionErrors === [],
                 'scope_valid' => (bool) $scopeReport['valid'],
@@ -241,6 +244,129 @@ final class RiasecResultPageOpsAgentRunOrchestrator
                 'production_manual_gate_required' => true,
                 'cms_write_performed' => false,
                 'runtime_change_performed' => false,
+            ],
+            'artifacts' => $artifacts,
+            'errors' => array_values(array_unique($errors)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     permission_model_path?:string,
+     *     mode?:string,
+     *     scope_id?:string,
+     *     pr_title?:string,
+     *     base_branch?:string,
+     *     changed_files?:list<string>,
+     *     strict?:bool,
+     *     simulate_external_blocker?:bool,
+     *     simulate_current_scope_failure?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function report(array $options = []): array
+    {
+        $options['mode'] = $options['mode'] ?? 'auto-to-report';
+        $plan = $this->plan($options);
+        $runId = (string) ($plan['run_id'] ?? $this->runId('', 'auto-to-report', 'ops-agent-reporting-sidecar', 'main', 'RIASEC reporting sidecar'));
+        $scopeId = (string) ($plan['scope_id'] ?? $this->sanitizeSlug((string) ($options['scope_id'] ?? 'ops-agent-reporting-sidecar')));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $this->ensureDirectory($artifactDir);
+
+        $scopeValid = (bool) data_get($plan, 'scope_validation.valid', false);
+        $permissionModelValid = (bool) data_get($plan, 'summary.permission_model_valid', false);
+        $failureReport = (array) ($plan['failure_classification'] ?? []);
+        $externalBlockersRecorded = (bool) ($failureReport['external_blockers_recorded_as_sidecar'] ?? false);
+        $currentScopeBlocked = in_array('current_pr_scope_failure', (array) ($failureReport['blocking_errors'] ?? []), true);
+        $trainCanContinue = $scopeValid && $permissionModelValid && ! $currentScopeBlocked;
+        $goNoGo = $trainCanContinue ? 'GO_FOR_TRAIN_CONTINUATION' : 'NO_GO_CURRENT_PR_BLOCKED';
+
+        $goNoGoReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ops_reporting_go_no_go',
+            'run_id' => $runId,
+            'scope_id' => $scopeId,
+            'go_no_go' => $goNoGo,
+            'train_can_continue' => $trainCanContinue,
+            'external_blockers_do_not_stop_train' => $externalBlockersRecorded && $trainCanContinue,
+            'current_pr_scope_failure_stops_train' => $currentScopeBlocked,
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'production_rollout_performed' => false,
+            'production_manual_gate_required' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $failureAttributionReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ops_reporting_failure_attribution',
+            'run_id' => $runId,
+            'scope_id' => $scopeId,
+            'scope_valid' => $scopeValid,
+            'permission_model_valid' => $permissionModelValid,
+            'events' => (array) ($failureReport['events'] ?? []),
+            'blocking_errors' => (array) ($failureReport['blocking_errors'] ?? []),
+            'external_blockers_recorded_as_sidecar' => $externalBlockersRecorded,
+            'current_pr_introduced_blocker' => $currentScopeBlocked || ! $scopeValid,
+            'train_can_continue' => $trainCanContinue,
+        ];
+        $nextStepReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'ops_reporting_next_step',
+            'run_id' => $runId,
+            'scope_id' => $scopeId,
+            'recommended_next_action' => $trainCanContinue ? 'continue_next_pr_after_merge_cleanup' : 'stop_and_fix_current_pr_scope',
+            'sidecar_issue_required' => $externalBlockersRecorded,
+            'production_rollout_next_action' => 'manual_approval_gate_only',
+            'allowed_automation_modes' => self::ALLOWED_MODES,
+            'disallowed_actions' => [
+                'cms_production_write',
+                'production_rollout',
+                'runtime_wrapper_enablement',
+                'frontend_fallback',
+            ],
+        ];
+        $sidecarPayload = (array) ($plan['sidecar_issue_payload'] ?? $this->sidecarIssuePayload($runId, $scopeId, $failureReport));
+
+        $artifacts = [
+            'ops_agent_pr_train_orchestrator_plan.json' => (array) data_get($plan, 'artifacts.ops_agent_pr_train_orchestrator_plan.json', []),
+            'go_no_go_report.json' => $this->writeJson($artifactDir.'/go_no_go_report.json', $goNoGoReport),
+            'sidecar_issue_payload.json' => $this->writeJson($artifactDir.'/sidecar_issue_payload.json', $sidecarPayload),
+            'failure_attribution_report.json' => $this->writeJson($artifactDir.'/failure_attribution_report.json', $failureAttributionReport),
+            'next_step_report.json' => $this->writeJson($artifactDir.'/next_step_report.json', $nextStepReport),
+        ];
+
+        $errors = (array) ($plan['errors'] ?? []);
+        if (! $trainCanContinue && $errors === []) {
+            $errors[] = 'reporting_go_no_go_blocked';
+        }
+        if ($externalBlockersRecorded && $scopeValid && $permissionModelValid && ! $currentScopeBlocked) {
+            $errors = array_values(array_diff($errors, ['external_blocker_recorded']));
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $trainCanContinue,
+            'status' => $trainCanContinue ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $this->redactPath($artifactDir),
+            'mode' => 'auto-to-report',
+            'scope_id' => $scopeId,
+            'summary' => [
+                'go_no_go' => $goNoGo,
+                'train_can_continue' => $trainCanContinue,
+                'sidecar_issue_payload_created' => true,
+                'failure_attribution_report_created' => true,
+                'next_step_report_created' => true,
+                'external_blockers_recorded_as_sidecar' => $externalBlockersRecorded,
+                'production_execution_allowed_for_agent' => false,
+                'production_manual_gate_required' => true,
             ],
             'artifacts' => $artifacts,
             'errors' => array_values(array_unique($errors)),

--- a/backend/tests/Unit/Services/Riasec/Ops/RiasecOpsAgentRunOrchestratorTest.php
+++ b/backend/tests/Unit/Services/Riasec/Ops/RiasecOpsAgentRunOrchestratorTest.php
@@ -152,6 +152,75 @@ final class RiasecOpsAgentRunOrchestratorTest extends TestCase
         }
     }
 
+    public function test_reporting_sidecar_allows_external_blocker_when_current_pr_scope_is_clean(): void
+    {
+        $root = $this->tempDir('riasec-ops-runner-report');
+
+        try {
+            $summary = app(RiasecResultPageOpsAgentRunOrchestrator::class)->report([
+                'run_id' => 'report-run',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-report',
+                'scope_id' => 'ops-agent-reporting-sidecar',
+                'changed_files' => [
+                    'backend/app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php',
+                ],
+                'simulate_external_blocker' => true,
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertSame('GO_FOR_TRAIN_CONTINUATION', data_get($summary, 'summary.go_no_go'));
+            $this->assertTrue((bool) data_get($summary, 'summary.external_blockers_recorded_as_sidecar', false));
+            $this->assertFalse((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true));
+
+            $goNoGo = $this->readJson($root.'/report-run/go_no_go_report.json');
+            $this->assertTrue((bool) ($goNoGo['train_can_continue'] ?? false));
+            $this->assertTrue((bool) ($goNoGo['external_blockers_do_not_stop_train'] ?? false));
+            $this->assertFalse((bool) ($goNoGo['production_use_allowed'] ?? true));
+
+            $failureAttribution = $this->readJson($root.'/report-run/failure_attribution_report.json');
+            $this->assertTrue((bool) ($failureAttribution['external_blockers_recorded_as_sidecar'] ?? false));
+            $this->assertFalse((bool) ($failureAttribution['current_pr_introduced_blocker'] ?? true));
+
+            $nextStep = $this->readJson($root.'/report-run/next_step_report.json');
+            $this->assertSame('continue_next_pr_after_merge_cleanup', $nextStep['recommended_next_action'] ?? null);
+            $this->assertSame('manual_approval_gate_only', $nextStep['production_rollout_next_action'] ?? null);
+            $this->assertFileExists($root.'/report-run/sidecar_issue_payload.json');
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_reporting_sidecar_blocks_current_pr_scope_failure(): void
+    {
+        $root = $this->tempDir('riasec-ops-runner-report-block');
+
+        try {
+            $summary = app(RiasecResultPageOpsAgentRunOrchestrator::class)->report([
+                'run_id' => 'report-block',
+                'artifact_dir' => $root,
+                'mode' => 'auto-to-report',
+                'scope_id' => 'ops-agent-reporting-sidecar',
+                'simulate_current_scope_failure' => true,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertSame('NO_GO_CURRENT_PR_BLOCKED', data_get($summary, 'summary.go_no_go'));
+            $this->assertContains('current_pr_scope_failure', $summary['errors'] ?? []);
+
+            $goNoGo = $this->readJson($root.'/report-block/go_no_go_report.json');
+            $this->assertFalse((bool) ($goNoGo['train_can_continue'] ?? true));
+            $this->assertTrue((bool) ($goNoGo['current_pr_scope_failure_stops_train'] ?? false));
+
+            $nextStep = $this->readJson($root.'/report-block/next_step_report.json');
+            $this->assertSame('stop_and_fix_current_pr_scope', $nextStep['recommended_next_action'] ?? null);
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
     private function tempDir(string $prefix): string
     {
         $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44311,7 +44311,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-postcheck-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): archive Help CMS draft postcheck",
     "depends_on": [
@@ -56986,14 +56986,17 @@
       "scope_validation": "passed",
       "pr_created": "passed",
       "github_required_checks": "passed",
-      "pre_merge_scope_recheck": "passed"
+      "pre_merge_scope_recheck": "passed",
+      "github_merge_confirmed": "passed",
+      "origin_main_contains_merge_commit": "passed",
+      "post_merge_cleanup": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "07a361200f3021088cac9333ef1a6c10287e67f8",
+    "commit_sha": "73080ce0a6a89bda7779a07355b1ec8ebaf71741",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2255",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T00:46:44Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57027,6 +57030,12 @@
         "from": "pull_request_open",
         "to": "ready_to_merge",
         "notes": "GitHub required checks passed after rebasing onto origin/main; pre-merge scope recheck stayed within PR4 allowed files."
+      },
+      {
+        "at": "2026-06-22T08:51:19+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "PR #2255 merged at 2026-06-22T00:46:44Z; origin/main contains merge commit 73080ce0a6a89bda7779a07355b1ec8ebaf71741; local and remote task branches cleaned."
       }
     ]
   },
@@ -57034,15 +57043,19 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-reporting-sidecar-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar",
     "depends_on": [
       "RIASEC-OPS-AGENT-STAGING-RUNNER-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr4_merged": "passed",
+      "php_lint_orchestrator": "passed",
+      "php_artisan_test_filter_RiasecOpsAgent": "passed"
+    },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "ff39897ea46ba4f680ad2b0fb75350578b9ab9f2",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57056,6 +57069,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T08:51:19+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "PR4 dependency verified merged and cleaned; RiasecOpsAgent tests passed for reporting sidecar service support."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57043,7 +57043,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-reporting-sidecar-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar",
     "depends_on": [
@@ -57052,11 +57052,14 @@
     "checks": {
       "dependency_pr4_merged": "passed",
       "php_lint_orchestrator": "passed",
-      "php_artisan_test_filter_RiasecOpsAgent": "passed"
+      "php_artisan_test_filter_RiasecOpsAgent": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
     "commit_sha": "9655f76a11c657707398098007a45695bc9749f2",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2259",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57075,6 +57078,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed",
         "notes": "PR4 dependency verified merged and cleaned; RiasecOpsAgent tests passed for reporting sidecar service support."
+      },
+      {
+        "at": "2026-06-22T08:54:18+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2259 after local checks and path scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57043,7 +57043,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-reporting-sidecar-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar",
     "depends_on": [
@@ -57055,7 +57055,9 @@
       "php_artisan_test_filter_RiasecOpsAgent": "passed",
       "git_diff_check": "passed",
       "scope_validation": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_recheck": "passed"
     },
     "failure_reason": null,
     "commit_sha": "9655f76a11c657707398098007a45695bc9749f2",
@@ -57084,6 +57086,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2259 after local checks and path scope validation passed."
+      },
+      {
+        "at": "2026-06-22T08:59:23+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks passed and pre-merge scope recheck stayed within PR5 allowed files."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57055,7 +57055,7 @@
       "php_artisan_test_filter_RiasecOpsAgent": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "ff39897ea46ba4f680ad2b0fb75350578b9ab9f2",
+    "commit_sha": "9655f76a11c657707398098007a45695bc9749f2",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,


### PR DESCRIPTION
## What changed
- Added RIASEC ops agent `report()` support for go/no-go, sidecar issue payload, failure attribution, and next-step reports.
- Added focused RiasecOpsAgent tests for external blockers that can continue as sidecars and current-PR scope blockers that must stop.
- Reconciled PR4 merge/cleanup state and recorded PR5 local validation state.

## Why
- This PR completes the reporting sidecar layer for auto-to-report behavior without changing runtime, CMS, or production rollout behavior.
- External blockers outside the current PR can be recorded as sidecar issues only when current scope and required gates are clean.

## Validation commands
- `cd backend && php -l app/Services/Riasec/Ops/RiasecResultPageOpsAgentRunOrchestrator.php`
- `cd backend && php artisan test --filter=RiasecOpsAgent --no-ansi`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- PR5 allowed-path scope validation passed locally.

## Intentionally deferred
- No Artisan command action is added in this PR because the PR5 manifest scope does not allow console command changes.
- No runtime wrapper enablement.
- No CMS import or write.
- No production gate opening or automated production rollout.
