### PR TITLE
Fix AI impact boundary projection wording

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -198,18 +198,20 @@ final class CareerAiImpactAssetPreviewService
 
     private function sanitizeReaderText(string $text): string
     {
-        return str_replace([
+        $sanitized = str_replace([
             'career disappearance',
             'job-loss risk',
             'job loss risk',
             'wage-loss risk',
             'wage loss risk',
             '岗位会消失',
+            '职业会消失',
             '职业消失',
             '失业风险',
             '降薪风险',
+            '降薪',
         ], [
-            'individual career outcome',
+            'individual career outcome forecast',
             'individual career outcome forecast',
             'individual career outcome forecast',
             'individual wage outcome forecast',
@@ -217,8 +219,18 @@ final class CareerAiImpactAssetPreviewService
             '个人职业结果预测',
             '个人职业结果预测',
             '个人职业结果预测',
-            '个人收入结果预测',
+            '个人职业结果预测',
+            '个人职业结果预测',
+            '个人职业结果预测',
         ], $text);
+
+        $sanitized = str_replace('预测预测', '预测', $sanitized);
+
+        return preg_replace(
+            '/个人(?:职业|收入)结果预测(?:[、，,或和及以及\s]+个人(?:职业|收入)结果预测)+/u',
+            '个人职业结果预测',
+            $sanitized
+        ) ?? $sanitized;
     }
 
     public function normalizeSlug(string $slug): string

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -728,6 +728,43 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertStringContainsString('individual career outcome', $asset['items']['reader_boundary']['body']);
     }
 
+    public function test_preview_api_normalizes_zh_boundary_outcome_wording(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['accountants-and-auditors']);
+        $occupation = $this->seedOccupation('accountants-and-auditors');
+        $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $row['summary'] = '该分数不是岗位会消失或降薪预测。';
+        $row['items']['reader_boundary']['body'] = '该分数不是岗位会消失、降薪或个人职业结果预测预测。';
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'accountants-and-auditors',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $asset = $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('ai_impact_asset_v1.locale', 'zh-CN')
+            ->json('ai_impact_asset_v1');
+
+        $encodedAsset = json_encode($asset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('岗位会消失', $encodedAsset);
+        $this->assertStringNotContainsString('职业会消失', $encodedAsset);
+        $this->assertStringNotContainsString('降薪', $encodedAsset);
+        $this->assertStringNotContainsString('预测预测', $encodedAsset);
+        $this->assertStringContainsString('不是个人职业结果预测', $asset['items']['reader_boundary']['body']);
+    }
+
     public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
     {
         Config::set('career_ai_impact_assets.staging_preview_enabled', false);


### PR DESCRIPTION
## What changed
- Normalized AI Impact reader-safe projection wording for zh-CN outcome boundaries.
- Collapsed duplicate boundary wording such as `预测预测`.
- Added feature coverage for zh-CN projection sanitization.

## Why
50-slug staging page/editorial QA found awkward zh-CN boundary copy such as repeated `预测预测` and `降薪` framing. This keeps the fix in the API reader-safe projection layer without changing the underlying AI Impact assets.

## Validation
- `composer install --no-interaction --prefer-dist`
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `./vendor/bin/pint --test app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`

## Deferred
- No asset JSONL edits.
- No evidence/source/score/seed identity changes.
- No staging write or production import.
- No frontend/runtime/SEO changes.