### PR TITLE
RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/README.md
@@ -1,0 +1,9 @@
+# RIASEC Result Page V2 Staging Import Handoff v0.1
+
+This package is a governance handoff for staging import preparation only.
+
+It does not write CMS data, enable a runtime wrapper, open a production gate, or
+authorize production rollout. The package exists so a later staging dry-run PR
+can consume a stable input list, checksum inventory, acceptance matrix, and
+no-touch policy before any import runner is allowed to execute.
+

--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/acceptance_matrix.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/acceptance_matrix.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.staging_import_acceptance_matrix.v0.1",
+  "task_id": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "acceptance_gates": [
+    {
+      "id": "checksum_inventory_complete",
+      "required": true,
+      "status": "pass",
+      "evidence": "Six handoff input files have sha256 entries."
+    },
+    {
+      "id": "fap_web_rendered_preview_handoff_complete",
+      "required": true,
+      "status": "pass",
+      "evidence": "Rendered preview handoff report covers result_page, pdf, share, history, compare, locked_free_redaction, low_quality, and fallback."
+    },
+    {
+      "id": "selector_candidate_import_blocked",
+      "required": true,
+      "status": "pass",
+      "evidence": "Share safety selector pilot manifest remains selector_ready_candidate=false and import_allowed=false."
+    },
+    {
+      "id": "route_matrix_not_runtime_input",
+      "required": true,
+      "status": "pass",
+      "evidence": "Route matrix QA remains partial_go_share_safety_only for staging and no_go for runtime."
+    },
+    {
+      "id": "cms_write_not_authorized",
+      "required": true,
+      "status": "pass",
+      "evidence": "This PR defines governance only; no CMS import command or write path is executed."
+    },
+    {
+      "id": "production_gate_closed",
+      "required": true,
+      "status": "pass",
+      "evidence": "production_use_allowed=false and ready_for_production=false across handoff files."
+    }
+  ],
+  "go_no_go": "GO_FOR_STAGING_IMPORT_DRY_RUN_PR_ONLY",
+  "production_go_no_go": "NO_GO"
+}

--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/checksum_inventory.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/checksum_inventory.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.staging_import_checksum_inventory.v0.1",
+  "task_id": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "checksum_algorithm": "sha256",
+  "files": [
+    {
+      "id": "render_preview_fixture_manifest",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/render_preview_fixture_manifest.json",
+      "sha256": "8f7403067336aea64d7e10b444f6c20efebb73227e16b5ebc7622c447cc6c4ec"
+    },
+    {
+      "id": "render_preview_expected_assertions",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/expected_assertions.json",
+      "sha256": "b2231fc109e45bd72d714d7c43b93fed6abd134071ab584f8422cf169d7466b2"
+    },
+    {
+      "id": "render_preview_handoff_report",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/handoff_report.json",
+      "sha256": "0e45e7a1e6522592ad389abcfc7cae19d26ef69513ce22ee02fd9218436acd2b"
+    },
+    {
+      "id": "share_safety_selector_candidate_manifest",
+      "path": "backend/content_assets/riasec/result_page_v2/selector_ready_assets/share_safety_pilot_20260621T1555Z/manifest.json",
+      "sha256": "19e809feb5b580c1699c48a08b73289b297a20d90be65e2a7679a7ee94e4d7a5"
+    },
+    {
+      "id": "route_matrix_report",
+      "path": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json",
+      "sha256": "4e7a4e9f480669413470ca57957b1811277ecdadc440000440a19730ad1c85d5"
+    },
+    {
+      "id": "golden_case_report",
+      "path": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/golden_case_report.json",
+      "sha256": "9bcd1e5e3e38c4e737bf8b4daa0fd5ad9ba6e4161b60a88e03374b5149f1a7a9"
+    }
+  ],
+  "file_count": 6
+}

--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/import_package_list.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/import_package_list.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.staging_import_package_list.v0.1",
+  "task_id": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "import_execution_allowed_in_this_pr": false,
+  "candidate_inputs": [
+    {
+      "id": "render_preview_fixture_manifest",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/render_preview_fixture_manifest.json",
+      "role": "fap_web_rendered_preview_fixture_manifest",
+      "import_action": "read_only_reference",
+      "required_for_staging_dry_run": true
+    },
+    {
+      "id": "render_preview_expected_assertions",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/expected_assertions.json",
+      "role": "fap_web_expected_assertions",
+      "import_action": "read_only_reference",
+      "required_for_staging_dry_run": true
+    },
+    {
+      "id": "render_preview_handoff_report",
+      "path": "backend/content_assets/riasec/result_page_v2/rendered_preview/handoff_v0_1/handoff_report.json",
+      "role": "handoff_readiness_report",
+      "import_action": "read_only_reference",
+      "required_for_staging_dry_run": true
+    },
+    {
+      "id": "share_safety_selector_candidate_manifest",
+      "path": "backend/content_assets/riasec/result_page_v2/selector_ready_assets/share_safety_pilot_20260621T1555Z/manifest.json",
+      "role": "staging_selector_candidate_manifest",
+      "import_action": "dry_run_candidate_only",
+      "required_for_staging_dry_run": true
+    },
+    {
+      "id": "route_matrix_report",
+      "path": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/route_matrix_report.json",
+      "role": "route_matrix_staging_readiness_gate",
+      "import_action": "read_only_gate",
+      "required_for_staging_dry_run": true
+    },
+    {
+      "id": "golden_case_report",
+      "path": "backend/content_assets/riasec/result_page_v2/qa/route_matrix_golden_case_qa/v0_1/golden_case_report.json",
+      "role": "golden_case_staging_readiness_gate",
+      "import_action": "read_only_gate",
+      "required_for_staging_dry_run": true
+    }
+  ],
+  "candidate_input_count": 6
+}

--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/runtime_no_touch_policy.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/runtime_no_touch_policy.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.runtime_no_touch_policy.v0.1",
+  "task_id": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_change_performed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "no_touch_runtime_paths": [
+    "backend/app/Http/**",
+    "backend/app/Services/**/Runtime/**",
+    "backend/routes/**",
+    "backend/database/**"
+  ],
+  "forbidden_in_this_pr": [
+    "CMS writes",
+    "staging import execution",
+    "production import",
+    "runtime wrapper enablement",
+    "production rollout",
+    "frontend fallback"
+  ],
+  "allowed_in_this_pr": [
+    "governance handoff package",
+    "checksum inventory",
+    "acceptance matrix",
+    "no-touch policy",
+    "tests validating staging-only governance"
+  ],
+  "next_stage_requires": [
+    "explicit staging dry-run PR",
+    "checksum revalidation",
+    "leak scan",
+    "fail-closed import harness",
+    "staging-only artifact output"
+  ]
+}

--- a/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/staging_import_handoff_manifest.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/staging_import_handoff_manifest.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.staging_import_handoff_manifest.v0.1",
+  "task_id": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01",
+  "created_at": "2026-06-22T09:30:00+08:00",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "content_authority": "backend",
+  "cms_write_performed": false,
+  "cms_write_allowed": false,
+  "runtime_change_performed": false,
+  "runtime_wrapper_enablement_allowed": false,
+  "frontend_fallback_allowed": false,
+  "private_payload_exported": false,
+  "production_import_gate_open": false,
+  "production_rollout_allowed": false,
+  "handoff_status": "ready_for_staging_import_dry_run_governance_only",
+  "import_execution_allowed_in_this_pr": false,
+  "package_files": [
+    "backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/import_package_list.json",
+    "backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/checksum_inventory.json",
+    "backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/acceptance_matrix.json",
+    "backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/runtime_no_touch_policy.json"
+  ],
+  "next_allowed_pr": "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01",
+  "blocked_actions": [
+    "cms_staging_write",
+    "cms_production_write",
+    "runtime_wrapper_enablement",
+    "frontend_fallback",
+    "production_import",
+    "production_rollout"
+  ]
+}

--- a/backend/docs/riasec/result-page-v2-staging-import-handoff.md
+++ b/backend/docs/riasec/result-page-v2-staging-import-handoff.md
@@ -1,0 +1,14 @@
+# RIASEC Result Page V2 Staging Import Handoff
+
+This document records the backend handoff boundary for the staging import lane.
+
+- The current PR is governance-only.
+- CMS writes are not authorized.
+- Runtime wrapper enablement is not authorized.
+- Production import and production rollout remain closed.
+- The next eligible step is a separate staging import dry-run PR that revalidates
+  checksums, inventory, leak scan, and fail-closed behavior.
+
+Authoritative package:
+`backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1/`.
+

--- a/backend/tests/Unit/Services/Riasec/RiasecResultPageStagingImportHandoffTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecResultPageStagingImportHandoffTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use PHPUnit\Framework\TestCase;
+
+final class RiasecResultPageStagingImportHandoffTest extends TestCase
+{
+    public function test_staging_import_handoff_is_governance_only_and_no_touch(): void
+    {
+        $base = dirname(__DIR__, 4).'/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1';
+
+        $manifest = $this->readJson($base.'/staging_import_handoff_manifest.json');
+        $packageList = $this->readJson($base.'/import_package_list.json');
+        $checksumInventory = $this->readJson($base.'/checksum_inventory.json');
+        $acceptanceMatrix = $this->readJson($base.'/acceptance_matrix.json');
+        $noTouchPolicy = $this->readJson($base.'/runtime_no_touch_policy.json');
+
+        foreach ([$manifest, $packageList, $checksumInventory, $acceptanceMatrix, $noTouchPolicy] as $payload) {
+            self::assertSame('staging_only', $payload['runtime_use']);
+            self::assertFalse($payload['production_use_allowed']);
+            self::assertFalse($payload['ready_for_runtime']);
+            self::assertFalse($payload['ready_for_production']);
+            self::assertFalse($payload['cms_write_performed']);
+            self::assertFalse($payload['runtime_change_performed']);
+            self::assertFalse($payload['frontend_fallback_allowed']);
+            self::assertFalse($payload['private_payload_exported']);
+        }
+
+        self::assertFalse($manifest['import_execution_allowed_in_this_pr']);
+        self::assertFalse($manifest['cms_write_allowed']);
+        self::assertFalse($manifest['runtime_wrapper_enablement_allowed']);
+        self::assertFalse($manifest['production_import_gate_open']);
+        self::assertFalse($manifest['production_rollout_allowed']);
+        self::assertSame('RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01', $manifest['next_allowed_pr']);
+
+        self::assertSame(6, $packageList['candidate_input_count']);
+        foreach ($packageList['candidate_inputs'] as $candidate) {
+            self::assertContains($candidate['import_action'], ['read_only_reference', 'dry_run_candidate_only', 'read_only_gate']);
+        }
+
+        self::assertSame(6, $checksumInventory['file_count']);
+        foreach ($checksumInventory['files'] as $file) {
+            $path = dirname(__DIR__, 4).'/'.substr((string) $file['path'], strlen('backend/'));
+            self::assertFileExists($path);
+            self::assertSame($file['sha256'], hash_file('sha256', $path), (string) $file['id']);
+        }
+
+        $gateStatuses = array_column($acceptanceMatrix['acceptance_gates'], 'status', 'id');
+        self::assertSame('pass', $gateStatuses['cms_write_not_authorized'] ?? null);
+        self::assertSame('pass', $gateStatuses['production_gate_closed'] ?? null);
+        self::assertSame('GO_FOR_STAGING_IMPORT_DRY_RUN_PR_ONLY', $acceptanceMatrix['go_no_go']);
+        self::assertSame('NO_GO', $acceptanceMatrix['production_go_no_go']);
+
+        self::assertContains('backend/routes/**', $noTouchPolicy['no_touch_runtime_paths']);
+        self::assertContains('staging import execution', $noTouchPolicy['forbidden_in_this_pr']);
+        self::assertContains('fail-closed import harness', $noTouchPolicy['next_stage_requires']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        self::assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57162,7 +57162,7 @@
       "scope_validation": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "8af3ba6b521cd7bdd287612320a9d7df33974ba5",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57148,7 +57148,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-backend-staging-import-handoff-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff",
     "depends_on": [
@@ -57160,7 +57160,9 @@
       "php_artisan_test_filter_RiasecResultPage": "passed",
       "git_diff_check": "passed",
       "scope_validation": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_recheck": "passed"
     },
     "failure_reason": null,
     "commit_sha": "8af3ba6b521cd7bdd287612320a9d7df33974ba5",
@@ -57189,6 +57191,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2263 after local checks and path scope validation passed."
+      },
+      {
+        "at": "2026-06-22T09:44:00+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks passed and pre-merge scope recheck stayed within PR7 allowed files."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57148,7 +57148,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-backend-staging-import-handoff-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff",
     "depends_on": [
@@ -57159,11 +57159,12 @@
       "jq_empty_touched_json": "passed",
       "php_artisan_test_filter_RiasecResultPage": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
     "commit_sha": "8af3ba6b521cd7bdd287612320a9d7df33974ba5",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2263",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57182,6 +57183,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed",
         "notes": "PR6 dependency verified merged; staging import handoff governance package added with checksum inventory, acceptance matrix, no-touch policy, docs, and RiasecResultPage tests. No CMS write or runtime change."
+      },
+      {
+        "at": "2026-06-22T09:33:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2263 after local checks and path scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57043,7 +57043,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-ops-agent-reporting-sidecar-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01: feat(riasec): add ops reporting sidecar",
     "depends_on": [
@@ -57057,14 +57057,17 @@
       "scope_validation": "passed",
       "pr_created": "passed",
       "github_required_checks": "passed",
-      "pre_merge_scope_recheck": "passed"
+      "pre_merge_scope_recheck": "passed",
+      "github_merge_confirmed": "passed",
+      "origin_main_contains_merge_commit": "passed",
+      "post_merge_cleanup": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "9655f76a11c657707398098007a45695bc9749f2",
+    "commit_sha": "2a3b388274e5379c37c4ba98da9955f1c35621fa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2259",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T01:05:12Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57092,6 +57095,12 @@
         "from": "pull_request_open",
         "to": "ready_to_merge",
         "notes": "GitHub required checks passed and pre-merge scope recheck stayed within PR5 allowed files."
+      },
+      {
+        "at": "2026-06-22T09:29:21+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "PR #2259 merged at 2026-06-22T01:05:12Z; origin/main contains merge commit 2a3b388274e5379c37c4ba98da9955f1c35621fa; local and remote task branches cleaned."
       }
     ]
   },
@@ -57099,19 +57108,24 @@
     "repo": "fap-web",
     "branch": "codex/riasec-result-fapweb-rendered-preview-qa-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01: test(riasec): add rendered preview QA",
     "depends_on": [
       "RIASEC-OPS-AGENT-REPORTING-SIDECAR-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr5_merged": "passed",
+      "github_merge_confirmed": "passed",
+      "origin_main_contains_merge_commit": "passed",
+      "post_merge_cleanup": "passed"
+    },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "commit_sha": "be871196c982e15028dda51564c2c627b2abf71b",
+    "pr_url": "https://github.com/fermatmind/fap-web/pull/1301",
+    "merged_at": "2026-06-22T01:25:21Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57121,6 +57135,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T09:29:21+08:00",
+        "from": "pending_dependency",
+        "to": "merged",
+        "notes": "Cross-repo dependency verified: fap-web PR #1301 merged at 2026-06-22T01:25:21Z with merge commit be871196c982e15028dda51564c2c627b2abf71b; fap-web main was synced and task branch cleaned."
       }
     ]
   },
@@ -57128,13 +57148,19 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-backend-staging-import-handoff-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-BACKEND-STAGING-IMPORT-HANDOFF-01: docs(riasec): add staging import handoff",
     "depends_on": [
       "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr6_merged": "passed",
+      "jq_empty_touched_json": "passed",
+      "php_artisan_test_filter_RiasecResultPage": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -57150,6 +57176,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T09:29:21+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "PR6 dependency verified merged; staging import handoff governance package added with checksum inventory, acceptance matrix, no-touch policy, docs, and RiasecResultPage tests. No CMS write or runtime change."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added a RIASEC result_page_v2 staging import handoff governance package with import package list, checksum inventory, acceptance matrix, and runtime no-touch policy.
- Added backend docs for the staging import handoff boundary.
- Added a RiasecResultPage unit test validating staging-only flags, checksum integrity, no-touch runtime policy, and production NO-GO.
- Reconciled prior PR train dependencies in fap-api state for PR5 and the cross-repo fap-web PR6 dependency.

## Why
- This prepares the next staging import dry-run PR with stable governance inputs while keeping the current PR read-only/governance-only.

## Validation commands
- `find backend/content_assets/riasec/result_page_v2/governance/staging_import_handoff_v0_1 -name '*.json' -print0 | xargs -0 jq empty`
- `cd backend && php artisan test --filter=RiasecResultPage --no-ansi`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- PR7 allowed-path scope validation passed locally.

## Intentionally deferred
- No CMS staging import execution.
- No CMS production write.
- No runtime wrapper enablement.
- No frontend fallback content.
- No production import gate opening or automated production rollout.
