### PR TITLE
B5-RESULT-RUNNER-SOP-RUNBOOK-01: Document Big Five V2 agent execution runner SOP

### DIFF
--- a/backend/docs/big5/result-asset-agent-execution-runner-sop.md
+++ b/backend/docs/big5/result-asset-agent-execution-runner-sop.md
@@ -1,0 +1,212 @@
+# Big Five Result Page V2 Agent Execution Runner SOP
+
+Status: `B5-RESULT-RUNNER-SOP-RUNBOOK-01`
+
+This SOP defines the backend-only execution sequence for the Big Five Result Page V2 content asset agent after the GitHub mutation runner was introduced. It does not authorize frontend copy, final `big5_result_page_v2` payload generation, CMS writes, database writes, runtime flag changes, release snapshots, production import gates, rollout gates, or production content changes.
+
+## Authority
+
+The backend remains the content asset authority. Frontend consumers may render backend-provided payloads and fixtures, but they must not create or patch Big Five result page copy.
+
+`big5_report_engine_v2` remains a legacy fallback compatibility fact. It is not the primary content asset path.
+
+Nightly and weekly scheduled jobs do not run live GitHub mutation:
+
+```bash
+php artisan big5:result-page-v2-agent audit --strict --json --no-ansi
+php artisan big5:result-page-v2-agent weekly-ops --json --no-ansi
+```
+
+The only allowed live GitHub mutation path is the explicit execution runner:
+
+```bash
+php artisan big5:result-page-v2-agent execute-github-mutation \
+  --mutation-mode=live \
+  --allow-github-mutation \
+  --json --no-ansi
+```
+
+## Canonical Sequence
+
+Run each step from the repository root unless the command starts with `cd backend`.
+
+1. Audit current assets:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent audit \
+  --run-id=<audit-run> \
+  --strict \
+  --json --no-ansi
+```
+
+2. Generate candidate drafts:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates \
+  --run-id=<candidate-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --json --no-ansi
+```
+
+3. Stage reviewed candidates only after a human review manifest exists:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent stage-candidates \
+  --run-id=<stage-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --candidate-dir=artifacts/big5_result_page_v2_agent/<operator-run>/<candidate-run> \
+  --staging-output-dir=content_assets/big5/result_page_v2/staging_candidate_imports/<stage-run> \
+  --allow-staging-write \
+  --json --no-ansi
+```
+
+4. Plan an artifact PR:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr \
+  --run-id=<plan-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --source-run-dir=artifacts/big5_result_page_v2_agent/<operator-run>/<source-run> \
+  --pr-id=<train-or-artifact-pr-id> \
+  --branch=codex/<safe-task-branch> \
+  --title="<PR title>" \
+  --json --no-ansi
+```
+
+5. Execute the PR plan in simulate mode first:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation \
+  --run-id=<execute-simulate-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --execution-plan-json=artifacts/big5_result_page_v2_agent/<operator-run>/<plan-run>/auto_pr_orchestration_plan.json \
+  --repo-root=<repo-root> \
+  --github-repo=fermatmind/fap-api \
+  --mutation-mode=simulate \
+  --json --no-ansi
+```
+
+6. Execute the PR plan live only when scope validation is green and the operator explicitly intends to create a branch, commit, push, and PR:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation \
+  --run-id=<execute-live-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --execution-plan-json=artifacts/big5_result_page_v2_agent/<operator-run>/<plan-run>/auto_pr_orchestration_plan.json \
+  --repo-root=<repo-root> \
+  --github-repo=fermatmind/fap-api \
+  --mutation-mode=live \
+  --allow-github-mutation \
+  --json --no-ansi
+```
+
+7. Inspect checks from an exported PR state or status rollup artifact:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci \
+  --run-id=<ci-inspection-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --checks-json=<status-check-rollup-json> \
+  --json --no-ansi
+```
+
+8. Plan merge cleanup after GitHub required checks are green:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-merge-cleanup \
+  --run-id=<merge-plan-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --pr-state-json=<green-pr-state-json> \
+  --json --no-ansi
+```
+
+9. Execute merge cleanup in simulate mode first:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation \
+  --run-id=<merge-simulate-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --execution-plan-json=artifacts/big5_result_page_v2_agent/<operator-run>/<merge-plan-run>/auto_merge_cleanup_plan.json \
+  --repo-root=<repo-root> \
+  --github-repo=fermatmind/fap-api \
+  --mutation-mode=simulate \
+  --json --no-ansi
+```
+
+10. Execute merge cleanup live only when the merge plan says `gate.can_merge=true`, required checks are green, scope validation is green, and the PR is artifact-only or otherwise explicitly safe:
+
+```bash
+cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation \
+  --run-id=<merge-live-run> \
+  --artifact-dir=artifacts/big5_result_page_v2_agent/<operator-run> \
+  --execution-plan-json=artifacts/big5_result_page_v2_agent/<operator-run>/<merge-plan-run>/auto_merge_cleanup_plan.json \
+  --repo-root=<repo-root> \
+  --github-repo=fermatmind/fap-api \
+  --mutation-mode=live \
+  --allow-github-mutation \
+  --json --no-ansi
+```
+
+## Redaction
+
+Artifacts and PR bodies must not include private URLs, real attempt identifiers, PDF files, raw report bodies, raw scores, domain or facet vectors, shareable percentiles, internal metadata, credentials, local absolute paths, or raw GitHub tokens.
+
+When evidence needs a path, use placeholders such as `<repo-root>`, `<backend>`, `<artifact-run>`, and `<pr-number>`.
+
+## Artifact Retention
+
+Operator runs may keep redacted JSON and Markdown evidence under `backend/artifacts/big5_result_page_v2_agent/<run-id>/` or a reviewed `backend/content_assets/big5/result_page_v2/agent_runs/<run-id>/` package.
+
+Do not commit temporary smoke artifacts unless the active PR explicitly allows artifact evidence. Always remove `testing-*` runs before commit unless the PR scope says they are intentional evidence.
+
+## Sidecar Issues
+
+If a blocker is not introduced by the current PR, GitHub required checks are green, and scope validation is green, record a sidecar issue or follow-up note and continue the train.
+
+Sidecar records must include:
+
+- observed blocker;
+- why it is outside the current PR scope;
+- evidence artifact or check name;
+- owner or next PR lane;
+- whether the current PR was allowed to continue.
+
+## Failure Attribution
+
+Classify failures before fixing:
+
+- `current_pr_scope`: introduced by files changed in the current PR; inspect and fix before continuing.
+- `external_blocker`: unrelated system, dependency, or existing failure; record sidecar if required checks and scope validation are green.
+- `operator_input_missing`: missing review manifest, PR state export, check rollup, or live authorization; stop until provided.
+- `policy_block`: production gate, runtime flag, frontend copy, CMS write, DB write, or unsafe payload request; stop and do not work around it.
+
+## Stop Conditions
+
+Stop immediately when:
+
+- worktree dirt overlaps the current PR scope;
+- a dependency PR is not merged into `main`;
+- local validation fails;
+- changed files exceed the declared allowed paths;
+- required GitHub checks fail;
+- merge state is not clean;
+- a live command would touch production/import/rollout/runtime gates;
+- a live command would run without `--mutation-mode=live --allow-github-mutation`;
+- a report contains private URL, attempt id, raw payload, raw scores, shareable percentiles, internal metadata, or credentials.
+
+## Post-Merge Cleanup
+
+After each merged PR:
+
+```bash
+git fetch origin --prune
+git merge-base --is-ancestor <merge-commit> origin/main
+git switch main
+git pull --ff-only origin main
+test "$(git rev-parse main)" = "$(git rev-parse origin/main)"
+git status --porcelain=v1
+git branch -d <task-branch>
+git ls-remote --heads origin <task-branch>
+```
+
+Delete the remote branch only when it is the merged PR head branch and cleanup is allowed. Finish on clean synced `main` before starting the next PR.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57673,5 +57673,167 @@
         "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
+  },
+  "B5-RESULT-RUNNER-SOP-RUNBOOK-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-runner-sop-runbook",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
+    "title": "B5-RESULT-RUNNER-SOP-RUNBOOK-01: Document Big Five V2 agent execution runner SOP",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided an explicit /goal execution request and authorized adding/updating manifest and state entries for the Big Five V2 execution-runner PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "No train dependency for PR1; local main is synced with origin/main before branch creation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Docs-only runbook PR validation passed; JSON and YAML metadata parse successfully."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to backend/docs/big5/result-asset-agent-execution-runner-sop.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No runtime, scheduler, production gate, CMS, DB, or fap-web files changed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T09:00:00Z",
+        "status": "in_progress",
+        "note": "Started PR1 from latest origin/main. Scope is docs-only runbook/SOP plus authorized train manifest and state initialization."
+      },
+      {
+        "at": "2026-06-22T09:05:00Z",
+        "status": "local_validated",
+        "note": "Local validation and scope validation passed for runner SOP/runbook and authorized train metadata initialization."
+      }
+    ]
+  },
+  "B5-RESULT-LIVE-DRY-RUN-PILOT-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-live-dry-run-pilot",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
+    "title": "B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot",
+    "depends_on": [
+      "B5-RESULT-RUNNER-SOP-RUNBOOK-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized this PR train item in the /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for B5-RESULT-RUNNER-SOP-RUNBOOK-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": []
+  },
+  "B5-RESULT-AUTO-CHECK-POLLER-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-auto-check-poller",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
+    "title": "B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts",
+    "depends_on": [
+      "B5-RESULT-LIVE-DRY-RUN-PILOT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized this PR train item in the /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for B5-RESULT-LIVE-DRY-RUN-PILOT-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": []
+  },
+  "B5-RESULT-MECHANICAL-FIX-APPLY-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-mechanical-fix-apply",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
+    "title": "B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes",
+    "depends_on": [
+      "B5-RESULT-AUTO-CHECK-POLLER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized this PR train item in the /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for B5-RESULT-AUTO-CHECK-POLLER-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": []
+  },
+  "B5-RESULT-AUTO-MERGE-LIVE-PILOT-01": {
+    "repo": "fap-api",
+    "branch": "codex/big5-v2-auto-merge-live-pilot",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
+    "title": "B5-RESULT-AUTO-MERGE-LIVE-PILOT-01: Record Big Five V2 live merge cleanup pilot",
+    "depends_on": [
+      "B5-RESULT-MECHANICAL-FIX-APPLY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized this PR train item in the /goal execution request."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for B5-RESULT-MECHANICAL-FIX-APPLY-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": []
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57212,8 +57212,8 @@
     ],
     "checks": {},
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "b28ebdf17b37745d6a5dffc46c7ee01c0820b0d6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2264",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57721,6 +57721,11 @@
         "at": "2026-06-22T09:05:00Z",
         "status": "local_validated",
         "note": "Local validation and scope validation passed for runner SOP/runbook and authorized train metadata initialization."
+      },
+      {
+        "at": "2026-06-22T09:10:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2264 after local validation and scope validation passed; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57678,7 +57678,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-runner-sop-runbook",
     "base": "main",
-    "status": "in_progress",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-RUNNER-SOP-RUNBOOK-01: Document Big Five V2 agent execution runner SOP",
     "depends_on": [],
@@ -57703,6 +57703,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to backend/docs/big5/result-asset-agent-execution-runner-sop.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No runtime, scheduler, production gate, CMS, DB, or fap-web files changed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2264 required GitHub checks completed successfully on head 2226112bfef22b3bbc0ae74da99230bd8762cff4; mergeStateStatus CLEAN; PR title/body and changed-file scope were re-reviewed."
       }
     },
     "failure_reason": null,
@@ -57726,6 +57730,11 @@
         "at": "2026-06-22T09:10:00Z",
         "status": "pr_open",
         "note": "Opened PR #2264 after local validation and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T09:25:00Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26607,3 +26607,192 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: B5-RESULT-RUNNER-SOP-RUNBOOK-01
+    repo: fap-api
+    branch: codex/big5-v2-runner-sop-runbook
+    title: "B5-RESULT-RUNNER-SOP-RUNBOOK-01: Document Big Five V2 agent execution runner SOP"
+    train_scope: big5_result_page_v2_asset_agent_execution_runner
+    status: user_authorized
+    scope:
+      - Add backend runbook/SOP for the real execution sequence audit -> generate-candidates -> stage-candidates -> plan-pr -> execute-github-mutation -> inspect-ci -> plan-merge-cleanup -> execute-github-mutation.
+      - Include exact command templates for simulate and live modes.
+      - Document redaction, artifact retention, sidecar issue rules, failure attribution, and stop/continue rules.
+      - Make clear that nightly/weekly scheduled jobs do not run live GitHub mutation.
+    allowed_paths:
+      - backend/docs/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify backend runtime code.
+      - Modify scheduler.
+      - Open live GitHub mutation from this PR.
+    validation:
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: B5-RESULT-LIVE-DRY-RUN-PILOT-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-RUNNER-SOP-RUNBOOK-01
+    branch: codex/big5-v2-live-dry-run-pilot
+    title: "B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot"
+    train_scope: big5_result_page_v2_asset_agent_execution_runner
+    status: user_authorized
+    scope:
+      - Use a no-production-impact artifact-only pilot run to validate live GitHub mutation path.
+      - The live runner may create branch, commit, push, and create a pilot artifact PR.
+      - Do not merge the pilot artifact PR in this PR.
+      - Record redacted evidence including created branch, PR URL, command summary, preflight, scope validation, and negative guarantees.
+    allowed_paths:
+      - backend/docs/**
+      - backend/artifacts/big5_result_page_v2_agent/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify agent runtime code unless required to fix a bug introduced by this PR.
+      - Modify content_assets runtime packages.
+      - Merge the live-created pilot artifact PR.
+      - Touch production/import/rollout gates.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=live-dry-run-source --artifact-dir=artifacts/big5_result_page_v2_agent/testing-live-dry-run --json --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=live-dry-run-plan --artifact-dir=artifacts/big5_result_page_v2_agent/testing-live-dry-run --source-run-dir=artifacts/big5_result_page_v2_agent/testing-live-dry-run/live-dry-run-source --pr-id=B5-RESULT-LIVE-DRY-RUN-ARTIFACT-01 --branch=codex/big5-v2-live-dry-run-artifact --json --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation --run-id=live-dry-run-execution --artifact-dir=artifacts/big5_result_page_v2_agent/testing-live-dry-run --execution-plan-json=artifacts/big5_result_page_v2_agent/testing-live-dry-run/live-dry-run-plan/auto_pr_orchestration_plan.json --repo-root=<repo-root> --github-repo=fermatmind/fap-api --mutation-mode=live --allow-github-mutation --json --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: B5-RESULT-AUTO-CHECK-POLLER-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-LIVE-DRY-RUN-PILOT-01
+    branch: codex/big5-v2-auto-check-poller
+    title: "B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts"
+    train_scope: big5_result_page_v2_asset_agent_execution_runner
+    status: user_authorized
+    scope:
+      - Add a controlled poll-github-checks action.
+      - Output redacted statusCheckRollup artifact, pending/failed/success counts, required-check summary, mergeStateStatus, and sidecar blocker classification.
+      - Do not mutate source, branches, PRs, or checks.
+      - Do not auto-fix in this PR.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - backend/tests/Feature/Console/BigFiveResultPageV2AgentAutomationTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Apply mechanical fixes.
+      - Merge PRs.
+      - Delete branches.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent poll-github-checks --run-id=check-poller --artifact-dir=artifacts/big5_result_page_v2_agent/testing-check-poller --pr-state-json=<fixture-json> --json --no-ansi
+      - rm -rf backend/artifacts/big5_result_page_v2_agent/testing-check-poller
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: B5-RESULT-MECHANICAL-FIX-APPLY-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-AUTO-CHECK-POLLER-01
+    branch: codex/big5-v2-mechanical-fix-apply
+    title: "B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes"
+    train_scope: big5_result_page_v2_asset_agent_execution_runner
+    status: user_authorized
+    scope:
+      - Extend inspect-ci / mechanical fix flow to allow only bounded mechanical fixes for schema, checksum, format, and scope manifest/artifact list.
+      - Add explicit allow flag and fail closed by default.
+      - Record repair_log entries for each applied fix.
+      - Reject security, supply-chain, test logic, content semantics, runtime, production, and frontend-copy fixes.
+    allowed_paths:
+      - backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+      - backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Auto-edit user-visible Big Five copy.
+      - Auto-edit production gates.
+      - Auto-edit tests to make failures pass.
+      - Auto-fix security/supply-chain/test failures.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=mechanical-fix --artifact-dir=artifacts/big5_result_page_v2_agent/testing-mechanical-fix --checks-json=<fixture-json> --apply-mechanical-fixes --json --no-ansi
+      - rm -rf backend/artifacts/big5_result_page_v2_agent/testing-mechanical-fix
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: B5-RESULT-AUTO-MERGE-LIVE-PILOT-01
+    repo: fap-api
+    depends_on:
+      - B5-RESULT-MECHANICAL-FIX-APPLY-01
+    branch: codex/big5-v2-auto-merge-live-pilot
+    title: "B5-RESULT-AUTO-MERGE-LIVE-PILOT-01: Record Big Five V2 live merge cleanup pilot"
+    train_scope: big5_result_page_v2_asset_agent_execution_runner
+    status: user_authorized
+    scope:
+      - Use a low-risk PR created by the live dry-run/pilot flow or another explicitly safe artifact-only PR.
+      - Validate plan-merge-cleanup + execute-github-mutation live path including squash merge, branch cleanup, main sync, and post-merge revalidation.
+      - Record redacted evidence and negative guarantees.
+      - Keep this PR as evidence/runbook hardening, not production rollout.
+    allowed_paths:
+      - backend/docs/**
+      - backend/artifacts/big5_result_page_v2_agent/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Merge any PR that touches runtime/production/import/rollout gates.
+      - Merge any PR with failed required checks.
+      - Merge if scope validation is not green.
+    validation:
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-merge-cleanup --run-id=merge-pilot-plan --artifact-dir=artifacts/big5_result_page_v2_agent/testing-merge-pilot --pr-state-json=<green-safe-pr-state-json> --json --no-ansi
+      - cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation --run-id=merge-pilot-execution --artifact-dir=artifacts/big5_result_page_v2_agent/testing-merge-pilot --execution-plan-json=artifacts/big5_result_page_v2_agent/testing-merge-pilot/merge-pilot-plan/auto_merge_cleanup_plan.json --repo-root=<repo-root> --github-repo=fermatmind/fap-api --mutation-mode=live --allow-github-mutation --json --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi
+      - git diff --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added the Big Five V2 agent execution runner SOP under backend docs.
- Registered the five authorized execution-runner PR train items in `docs/codex/pr-train.yaml`.
- Initialized state ledger entries for the train, with PR1 in progress and later PRs pending dependencies.

## Why
- Operators and Codex need one audited command sequence for `audit -> generate-candidates -> stage-candidates -> plan-pr -> execute-github-mutation -> inspect-ci -> plan-merge-cleanup -> execute-github-mutation`.
- The SOP makes live GitHub mutation explicit and keeps nightly/weekly scheduled jobs from being treated as live mutation runners.

## Validation
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No backend runtime code changed.
- No scheduler changed.
- No live GitHub mutation executed in this PR.
- No fap-web copy, final Big Five payload, production import gate, release snapshot, rollout gate, runtime flag, CMS write, or DB write changed.
