### PR TITLE
B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot

### DIFF
--- a/backend/docs/big5/result-asset-agent-live-dry-run-pilot.md
+++ b/backend/docs/big5/result-asset-agent-live-dry-run-pilot.md
@@ -1,0 +1,64 @@
+# Big Five V2 Live Dry-Run PR Mutation Pilot
+
+Status: `B5-RESULT-LIVE-DRY-RUN-PILOT-01`
+
+This evidence note records a no-production-impact live GitHub mutation pilot for the Big Five Result Page V2 asset agent execution runner. The pilot validated branch creation, commit, push, and PR creation only. It did not merge the created PR.
+
+## Scope
+
+- Source action: `generate-candidates`
+- Planning action: `plan-pr`
+- Execution action: `execute-github-mutation`
+- Live flags used: `--mutation-mode=live --allow-github-mutation`
+- GitHub repository: `fermatmind/fap-api`
+- Created pilot branch: `codex/big5-v2-live-dry-run-artifact`
+- Created pilot PR: `https://github.com/fermatmind/fap-api/pull/2266`
+- Pilot PR state at evidence capture: `OPEN`
+
+## Pilot PR Files
+
+The live-created pilot PR is artifact-only and limited to:
+
+- `backend/content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-source/candidate_generation_summary.json`
+- `backend/content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-source/content_asset_candidates.jsonl`
+- `backend/content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-source/selector_asset_candidates.jsonl`
+
+The pilot PR intentionally remains unmerged for the later live merge-cleanup pilot.
+
+## Execution Summary
+
+The successful live execution produced:
+
+- `preflight_valid=true`
+- `blocker_count=0`
+- `step_count=8`
+- `live_execution_performed=true`
+- `git_branch_created=true`
+- `git_commit_created=true`
+- `github_pr_created=true`
+- `github_merge_performed=false`
+- `auto_merge_performed=false`
+- `remote_branch_deleted=false`
+- `local_main_synced=false`
+
+The generated candidate summary stayed non-runtime:
+
+- `ready_for_pilot=false`
+- `ready_for_runtime=false`
+- `ready_for_production=false`
+- `production_use_allowed=false`
+- `validation_error_count=0`
+- `leak_hit_count=0`
+
+## Operator Notes
+
+An initial attempt using `backend/artifacts/big5_result_page_v2_agent/**` failed closed because `backend/artifacts` is ignored by git and the execution runner does not force-add ignored paths. The successful pilot used `backend/content_assets/big5/result_page_v2/agent_runs/**`, which is a non-runtime artifact/evidence lane and can be staged by the runner without weakening git add policy.
+
+A temporary clean clone was used for the live pilot because the active worktree is a Git worktree whose `.git` path is a file. The runner's current preflight accepts a normal `.git` directory. No production data, CMS content, DB state, runtime flags, import gates, release snapshots, rollout gates, or frontend files were touched.
+
+## Deferred
+
+- The pilot PR was not merged.
+- GitHub check polling remains deferred to `B5-RESULT-AUTO-CHECK-POLLER-01`.
+- Mechanical fixes remain deferred to `B5-RESULT-MECHANICAL-FIX-APPLY-01`.
+- Live merge cleanup remains deferred to `B5-RESULT-AUTO-MERGE-LIVE-PILOT-01`.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57270,8 +57270,8 @@
     ],
     "checks": {},
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "7a4d75d8ef66deaf9f8d8fd0121f57d6989ba1f6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2267",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57790,6 +57790,11 @@
         "at": "2026-06-22T02:15:00Z",
         "status": "local_validated",
         "note": "Live dry-run pilot created artifact-only PR #2266 via execute-github-mutation live mode. The pilot PR is open and unmerged for the later merge cleanup pilot."
+      },
+      {
+        "at": "2026-06-22T02:20:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2267 after live dry-run evidence and scope validation passed; waiting for required GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57747,7 +57747,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-live-dry-run-pilot",
     "base": "main",
-    "status": "local_validated",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot",
     "depends_on": [
@@ -57777,6 +57777,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "PR2 changed files are limited to backend/docs/big5/result-asset-agent-live-dry-run-pilot.md and docs/codex/pr-train-state.json. No fap-web copy, production import gate, release snapshot, rollout gate, runtime flag, CMS write, or DB write changed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2267 required GitHub checks completed successfully on head 345b8ba7b234dfc40a28eef2bdff17798bdaf334; mergeStateStatus CLEAN; PR title/body and changed-file scope were re-reviewed."
       }
     },
     "failure_reason": null,
@@ -57795,6 +57799,11 @@
         "at": "2026-06-22T02:20:00Z",
         "status": "pr_open",
         "note": "Opened PR #2267 after live dry-run evidence and scope validation passed; waiting for required GitHub checks."
+      },
+      {
+        "at": "2026-06-22T02:35:00Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47753,7 +47753,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-api-smoke-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "test(benefit): add DailyGiving public API smoke gate",
     "depends_on": [
@@ -57241,11 +57241,11 @@
     ],
     "checks": {},
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "commit_sha": "91ad717799e6813eebfdf730ed99431b6d9dd958",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2264",
+    "merged_at": "2026-06-22T02:11:20Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57735,6 +57735,11 @@
         "at": "2026-06-22T09:25:00Z",
         "status": "ready_to_merge",
         "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
+      },
+      {
+        "at": "2026-06-22T02:14:00Z",
+        "status": "merged",
+        "note": "PR #2264 merged with merge commit 91ad717799e6813eebfdf730ed99431b6d9dd958; origin/main contains the merge commit, local main was fast-forwarded, task branch was deleted locally/remotely, and post-merge JSON/YAML/diff validation passed."
       }
     ]
   },
@@ -57742,7 +57747,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-live-dry-run-pilot",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_validated",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot",
     "depends_on": [
@@ -57754,8 +57759,24 @@
         "evidence": "User authorized this PR train item in the /goal execution request."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for B5-RESULT-RUNNER-SOP-RUNBOOK-01 to merge into main."
+        "status": "pass",
+        "evidence": "B5-RESULT-RUNNER-SOP-RUNBOOK-01 is merged and origin/main contains merge commit 91ad717799e6813eebfdf730ed99431b6d9dd958."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=live-dry-run-source --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --json --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=live-dry-run-plan --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --source-run-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-source --pr-id=B5-RESULT-LIVE-DRY-RUN-ARTIFACT-01 --branch=codex/big5-v2-live-dry-run-artifact --json --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation --run-id=live-dry-run-execution --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --execution-plan-json=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-plan/auto_pr_orchestration_plan.json --repo-root=<clean-clone-root> --github-repo=fermatmind/fap-api --mutation-mode=live --allow-github-mutation --json --no-ansi",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Live execution succeeded in a temporary clean clone with preflight_valid=true, blocker_count=0, step_count=8, live_execution_performed=true, git_branch_created=true, git_commit_created=true, github_pr_created=true. Created pilot PR #2266 and left it open/unmerged."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "PR2 changed files are limited to backend/docs/big5/result-asset-agent-live-dry-run-pilot.md and docs/codex/pr-train-state.json. No fap-web copy, production import gate, release snapshot, rollout gate, runtime flag, CMS write, or DB write changed."
       }
     },
     "failure_reason": null,
@@ -57764,7 +57785,13 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "transitions": []
+    "transitions": [
+      {
+        "at": "2026-06-22T02:15:00Z",
+        "status": "local_validated",
+        "note": "Live dry-run pilot created artifact-only PR #2266 via execute-github-mutation live mode. The pilot PR is open and unmerged for the later merge cleanup pilot."
+      }
+    ]
   },
   "B5-RESULT-AUTO-CHECK-POLLER-01": {
     "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Added redacted evidence for a live GitHub mutation dry-run pilot.
- Reconciled PR1 as merged in the PR train state ledger.
- Recorded pilot PR #2266 as created by `execute-github-mutation` live mode and intentionally left open/unmerged.

## Why
- Validates the real GitHub mutation path added by #2260 without touching production/runtime gates or merging the created artifact PR.
- Documents the operational adjustment that `backend/artifacts/**` is gitignored, so the live pilot used the non-runtime `content_assets/.../agent_runs/**` evidence lane.

## Validation
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent generate-candidates --run-id=live-dry-run-source --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --json --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent plan-pr --run-id=live-dry-run-plan --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --source-run-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-source --pr-id=B5-RESULT-LIVE-DRY-RUN-ARTIFACT-01 --branch=codex/big5-v2-live-dry-run-artifact --json --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent execute-github-mutation --run-id=live-dry-run-execution --artifact-dir=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run --execution-plan-json=content_assets/big5/result_page_v2/agent_runs/testing-live-dry-run/live-dry-run-plan/auto_pr_orchestration_plan.json --repo-root=<clean-clone-root> --github-repo=fermatmind/fap-api --mutation-mode=live --allow-github-mutation --json --no-ansi`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- Pilot PR #2266 is not merged in this PR.
- No fap-web copy added.
- No final Big Five result page payload generated.
- No production import, release snapshot, rollout gate, runtime flag, CMS write, or DB write changed.
- GitHub check polling is deferred to `B5-RESULT-AUTO-CHECK-POLLER-01`.
