### PR TITLE
RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run

### DIFF
--- a/backend/app/Console/Commands/RiasecResultPageAssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/RiasecResultPageAssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class RiasecResultPageAssetAgentAuditCommand extends Command
 {
     protected $signature = 'riasec:result-page-v2-agent
-        {action=audit : Supported action: audit}
+        {action=audit : Supported action: audit, staging-import-dry-run}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/riasec_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -25,19 +25,22 @@ final class RiasecResultPageAssetAgentAuditCommand extends Command
     {
         try {
             $action = (string) $this->argument('action');
-            if ($action !== 'audit') {
-                $this->error('Unsupported action. Supported action: audit');
+            if (! in_array($action, ['audit', 'staging-import-dry-run'], true)) {
+                $this->error('Unsupported action. Supported actions: audit, staging-import-dry-run');
 
                 return self::FAILURE;
             }
 
-            $summary = $agent->audit([
+            $options = [
                 'run_id' => trim((string) $this->option('run-id')),
                 'artifact_dir' => trim((string) $this->option('artifact-dir')),
                 'content_asset_root' => trim((string) $this->option('content-asset-root')),
                 'source_ledger_dir' => trim((string) $this->option('source-ledger-dir')),
                 'strict' => (bool) $this->option('strict'),
-            ]);
+            ];
+            $summary = $action === 'staging-import-dry-run'
+                ? $agent->stagingImportDryRun($options)
+                : $agent->audit($options);
 
             if ((bool) $this->option('json')) {
                 $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));

--- a/backend/app/Services/Riasec/AssetAgent/RiasecResultPageAssetAgent.php
+++ b/backend/app/Services/Riasec/AssetAgent/RiasecResultPageAssetAgent.php
@@ -16,7 +16,9 @@ final class RiasecResultPageAssetAgent
 
     public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/riasec_result_page_v2_agent';
 
-    private const CONTENT_ASSET_RELATIVE_PATH = 'content_assets/riasec';
+    private const CONTENT_ASSET_RELATIVE_PATH = 'content_assets/riasec/result_page_v2';
+
+    private const SELECTOR_READY_RELATIVE_PATH = 'content_assets/riasec/result_page_v2/selector_ready_assets';
 
     private const SOURCE_LEDGER_RELATIVE_PATH = 'content_assets/riasec/result_page_v2/source_ledger';
 
@@ -164,6 +166,107 @@ final class RiasecResultPageAssetAgent
     }
 
     /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
+     *   content_asset_root?:string,
+     *   strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function stagingImportDryRun(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? 'riasec-result-page-staging-import-dry-run'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $selectorReadyRoot = $this->optionalPath(
+            (string) ($options['content_asset_root'] ?? ''),
+            base_path(self::SELECTOR_READY_RELATIVE_PATH)
+        );
+        $strict = ($options['strict'] ?? false) === true;
+
+        $checksumInventory = $this->selectorReadyChecksumInventory($selectorReadyRoot);
+        $publicLeakScan = $this->selectorReadyPublicLeakScan($selectorReadyRoot);
+        $failClosedReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_fail_closed_policy',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'frontend_fallback_allowed' => false,
+            'private_payload_exported' => false,
+            'import_allowed' => false,
+            'runtime_selector_wiring_allowed' => false,
+            'production_rollout_allowed' => false,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $errors = [];
+        if (! (bool) ($checksumInventory['valid'] ?? false)) {
+            $errors[] = 'selector_ready_inventory_invalid';
+        }
+        if (((int) data_get($publicLeakScan, 'leak_scan.hit_count', 0)) > 0) {
+            $errors[] = 'forbidden_public_payload_leaks';
+        }
+
+        $dryRunReport = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_dry_run',
+            'run_id' => $runId,
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'frontend_fallback_allowed' => false,
+            'private_payload_exported' => false,
+            'selector_ready_root' => $this->redactPath($selectorReadyRoot),
+            'selector_ready_package_count' => (int) ($checksumInventory['package_count'] ?? 0),
+            'selector_ready_asset_count' => (int) ($checksumInventory['asset_count'] ?? 0),
+            'checksum_inventory_valid' => (bool) ($checksumInventory['valid'] ?? false),
+            'public_leak_scan_status' => (string) data_get($publicLeakScan, 'leak_scan.status', 'blocked'),
+            'fail_closed_policy_present' => true,
+            'error_count' => count(array_unique($errors)),
+            'errors' => array_values(array_unique($errors)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+
+        $this->ensureDirectory($artifactDir);
+        $artifacts = [
+            'staging_import_dry_run_report.json' => $this->writeJson($artifactDir.'/staging_import_dry_run_report.json', $dryRunReport),
+            'checksum_inventory.json' => $this->writeJson($artifactDir.'/checksum_inventory.json', $checksumInventory),
+            'public_leak_scan_report.json' => $this->writeJson($artifactDir.'/public_leak_scan_report.json', $publicLeakScan),
+            'fail_closed_report.json' => $this->writeJson($artifactDir.'/fail_closed_report.json', $failClosedReport),
+            'go_no_go.md' => $this->writeText($artifactDir.'/go_no_go.md', $this->buildStagingImportGoNoGo($dryRunReport)),
+        ];
+        $ok = $errors === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => ! $strict || $ok,
+            'status' => ($strict && ! $ok) ? 'blocked' : 'success',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'strict' => $strict,
+            'summary' => [
+                'selector_ready_package_count' => (int) ($checksumInventory['package_count'] ?? 0),
+                'selector_ready_asset_count' => (int) ($checksumInventory['asset_count'] ?? 0),
+                'checksum_inventory_valid' => (bool) ($checksumInventory['valid'] ?? false),
+                'leak_hit_count' => (int) data_get($publicLeakScan, 'leak_scan.hit_count', 0),
+                'cms_write_performed' => false,
+                'runtime_change_performed' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'errors' => array_values(array_unique($errors)),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function buildInventory(string $contentAssetRoot, string $sourceLedgerDir): array
@@ -243,9 +346,10 @@ final class RiasecResultPageAssetAgent
                 continue;
             }
 
-            foreach ((array) $decoded as $rowIndex => $payload) {
+            $payloads = array_is_list($decoded) ? $decoded : [$decoded];
+            foreach ($payloads as $rowIndex => $payload) {
                 if (is_array($payload)) {
-                    $hits = array_merge($hits, $this->scanPayload($payload, $relativePath, (string) $rowIndex));
+                    $hits = array_merge($hits, $this->scanPublicPayloads($payload, $relativePath, (string) $rowIndex));
                 }
             }
         }
@@ -480,6 +584,182 @@ final class RiasecResultPageAssetAgent
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    private function selectorReadyChecksumInventory(string $selectorReadyRoot): array
+    {
+        $packages = [];
+        $assetCount = 0;
+        $errors = [];
+
+        foreach ($this->selectorReadyPackageDirs($selectorReadyRoot) as $packageDir) {
+            $assetsPath = $packageDir.'/assets.jsonl';
+            $manifestPath = $packageDir.'/manifest.json';
+            $package = [
+                'package_id' => basename($packageDir),
+                'assets_path' => $this->repoRelativePath($assetsPath),
+                'manifest_path' => is_file($manifestPath) ? $this->repoRelativePath($manifestPath) : null,
+                'assets_sha256' => is_file($assetsPath) ? hash_file('sha256', $assetsPath) : null,
+                'assets_line_count' => 0,
+                'manifest_valid' => is_file($manifestPath),
+                'assets_valid' => is_file($assetsPath),
+            ];
+
+            if (! is_file($assetsPath)) {
+                $errors[] = basename($packageDir).': missing_assets_jsonl';
+            } else {
+                $fileErrors = $this->structuredFileErrors($assetsPath);
+                if ($fileErrors !== []) {
+                    $errors[] = basename($packageDir).': '.implode(',', $fileErrors);
+                    $package['assets_valid'] = false;
+                }
+                $lineCount = count($this->readJsonLines($assetsPath));
+                $package['assets_line_count'] = $lineCount;
+                $assetCount += $lineCount;
+            }
+
+            if (is_file($manifestPath)) {
+                $manifest = $this->readJson($manifestPath);
+                foreach ($this->requiredFalseFlags() as $flag) {
+                    if (($manifest[$flag] ?? null) !== false) {
+                        $errors[] = basename($packageDir).': invalid_'.$flag;
+                    }
+                }
+                if (($manifest['runtime_use'] ?? null) !== 'staging_only') {
+                    $errors[] = basename($packageDir).': invalid_runtime_use';
+                }
+            } else {
+                $errors[] = basename($packageDir).': missing_manifest_json';
+            }
+
+            $packages[] = $package;
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_checksum_inventory',
+            'runtime_use' => 'staging_only',
+            'selector_ready_root' => $this->redactPath($selectorReadyRoot),
+            'package_count' => count($packages),
+            'asset_count' => $assetCount,
+            'packages' => $packages,
+            'valid' => is_dir($selectorReadyRoot) && $packages !== [] && $errors === [],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function selectorReadyPublicLeakScan(string $selectorReadyRoot): array
+    {
+        $hits = [];
+        foreach ($this->selectorReadyPackageDirs($selectorReadyRoot) as $packageDir) {
+            $assetsPath = $packageDir.'/assets.jsonl';
+            if (! is_file($assetsPath)) {
+                continue;
+            }
+            foreach ($this->readJsonLines($assetsPath) as $rowIndex => $payload) {
+                $hits = array_merge(
+                    $hits,
+                    $this->scanPublicPayloads($payload, $this->repoRelativePath($assetsPath), (string) $rowIndex)
+                );
+            }
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'staging_import_public_leak_scan',
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'forbidden_public_fields' => self::FORBIDDEN_PUBLIC_FIELDS,
+            'forbidden_public_terms' => self::FORBIDDEN_PUBLIC_TERMS,
+            'leak_scan' => [
+                'status' => $hits === [] ? 'pass' : 'blocked',
+                'hit_count' => count($hits),
+                'hits' => array_slice($hits, 0, 100),
+                'truncated' => count($hits) > 100,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function scanPublicPayloads(array $payload, string $sourceFile, string $pathPrefix): array
+    {
+        $hits = [];
+        if (isset($payload['public_payload']) && is_array($payload['public_payload'])) {
+            $hits = array_merge($hits, $this->scanPayload($payload['public_payload'], $sourceFile, $pathPrefix.'.public_payload'));
+        }
+
+        foreach ($payload as $key => $value) {
+            if (is_array($value) && $key !== 'public_payload') {
+                $hits = array_merge($hits, $this->scanPublicPayloads($value, $sourceFile, $pathPrefix.'.'.(string) $key));
+            }
+        }
+
+        return $hits;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectorReadyPackageDirs(string $selectorReadyRoot): array
+    {
+        if (! is_dir($selectorReadyRoot)) {
+            return [];
+        }
+
+        $dirs = [];
+        foreach (scandir($selectorReadyRoot) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $selectorReadyRoot.'/'.$entry;
+            if (is_dir($path)) {
+                $dirs[] = $path;
+            }
+        }
+        sort($dirs);
+
+        return $dirs;
+    }
+
+    private function buildStagingImportGoNoGo(array $dryRunReport): string
+    {
+        return implode("\n", [
+            '# RIASEC Result Page Staging Import Dry Run',
+            '',
+            'runtime_use: staging_only',
+            'production_use_allowed: false',
+            'ready_for_runtime: false',
+            'ready_for_production: false',
+            'cms_write_performed: false',
+            'runtime_change_performed: false',
+            'frontend_fallback_allowed: false',
+            'private_payload_exported: false',
+            '',
+            '## Summary',
+            '',
+            '- selector_ready_package_count: '.(string) ($dryRunReport['selector_ready_package_count'] ?? 0),
+            '- selector_ready_asset_count: '.(string) ($dryRunReport['selector_ready_asset_count'] ?? 0),
+            '- checksum_inventory_valid: '.($this->boolText((bool) ($dryRunReport['checksum_inventory_valid'] ?? false))),
+            '- public_leak_scan_status: '.(string) ($dryRunReport['public_leak_scan_status'] ?? 'blocked'),
+            '- error_count: '.(string) ($dryRunReport['error_count'] ?? 0),
+            '',
+            '## Decision',
+            '',
+            'GO for staging-only dry-run evidence when error_count is 0. NO-GO for CMS import, runtime wrapper enablement, pilot access, or production rollout.',
+            '',
+        ]);
+    }
+
+    /**
      * @return list<SplFileInfo>
      */
     private function assetFiles(string $root): array
@@ -555,6 +835,25 @@ final class RiasecResultPageAssetAgent
             return null;
         }
 
+        $rows = [];
+        foreach (file($path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            if (trim((string) $line) === '') {
+                continue;
+            }
+            $decoded = json_decode((string) $line, true, 512, JSON_THROW_ON_ERROR);
+            if (is_array($decoded)) {
+                $rows[] = $decoded;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function readJsonLines(string $path): array
+    {
         $rows = [];
         foreach (file($path, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
             if (trim((string) $line) === '') {

--- a/backend/tests/Unit/Services/Riasec/RiasecResultPageAssetAgentTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecResultPageAssetAgentTest.php
@@ -130,6 +130,103 @@ final class RiasecResultPageAssetAgentTest extends TestCase
         }
     }
 
+    public function test_staging_import_dry_run_writes_inventory_leak_scan_and_fail_closed_reports(): void
+    {
+        $artifactRoot = $this->tempDir('riasec-result-staging-import-dry-run');
+
+        try {
+            $summary = app(RiasecResultPageAssetAgent::class)->stagingImportDryRun([
+                'run_id' => 'unit-staging-import',
+                'artifact_dir' => $artifactRoot,
+                'strict' => true,
+            ]);
+
+            $this->assertTrue((bool) ($summary['ok'] ?? false));
+            $this->assertSame('success', $summary['status'] ?? null);
+            $this->assertGreaterThanOrEqual(2, (int) data_get($summary, 'summary.selector_ready_package_count', 0));
+            $this->assertGreaterThanOrEqual(6, (int) data_get($summary, 'summary.selector_ready_asset_count', 0));
+            $this->assertSame(0, (int) data_get($summary, 'summary.leak_hit_count', -1));
+            $this->assertFalse((bool) data_get($summary, 'summary.cms_write_performed', true));
+            $this->assertFalse((bool) data_get($summary, 'summary.runtime_change_performed', true));
+
+            $runDir = $artifactRoot.'/unit-staging-import';
+            foreach ([
+                'staging_import_dry_run_report.json',
+                'checksum_inventory.json',
+                'public_leak_scan_report.json',
+                'fail_closed_report.json',
+                'go_no_go.md',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $dryRun = $this->readJson($runDir.'/staging_import_dry_run_report.json');
+            $this->assertSame('staging_only', $dryRun['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($dryRun['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($dryRun['ready_for_runtime'] ?? true));
+            $this->assertFalse((bool) ($dryRun['ready_for_production'] ?? true));
+            $this->assertFalse((bool) ($dryRun['cms_write_performed'] ?? true));
+            $this->assertFalse((bool) ($dryRun['runtime_change_performed'] ?? true));
+            $this->assertSame('pass', $dryRun['public_leak_scan_status'] ?? null);
+
+            $failClosed = $this->readJson($runDir.'/fail_closed_report.json');
+            $this->assertFalse((bool) ($failClosed['import_allowed'] ?? true));
+            $this->assertFalse((bool) ($failClosed['runtime_selector_wiring_allowed'] ?? true));
+            $this->assertFalse((bool) ($failClosed['production_rollout_allowed'] ?? true));
+
+            $goNoGo = (string) file_get_contents($runDir.'/go_no_go.md');
+            $this->assertStringContainsString('NO-GO for CMS import', $goNoGo);
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
+    public function test_staging_import_dry_run_fails_closed_for_public_payload_leaks(): void
+    {
+        $artifactRoot = $this->tempDir('riasec-result-staging-import-leak-artifacts');
+        $selectorReadyRoot = $this->tempDir('riasec-result-staging-import-leak-assets');
+        $packageRoot = $selectorReadyRoot.'/leaky_package';
+        mkdir($packageRoot, 0777, true);
+        file_put_contents($packageRoot.'/assets.jsonl', json_encode([
+            'version' => 'fap.riasec.result_page_v2.selector_asset.v0.1',
+            'asset_key' => 'leaky.asset',
+            'public_payload' => [
+                'title' => 'Leak fixture',
+                'attempt_id' => 'private-attempt-id',
+            ],
+        ], JSON_UNESCAPED_SLASHES)."\n");
+        file_put_contents($packageRoot.'/manifest.json', json_encode([
+            'runtime_use' => 'staging_only',
+            'production_use_allowed' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'cms_write_performed' => false,
+            'runtime_change_performed' => false,
+            'frontend_fallback_allowed' => false,
+            'private_payload_exported' => false,
+        ], JSON_PRETTY_PRINT));
+
+        try {
+            $summary = app(RiasecResultPageAssetAgent::class)->stagingImportDryRun([
+                'run_id' => 'leaky-staging-import',
+                'artifact_dir' => $artifactRoot,
+                'content_asset_root' => $selectorReadyRoot,
+                'strict' => true,
+            ]);
+
+            $this->assertFalse((bool) ($summary['ok'] ?? true));
+            $this->assertSame('blocked', $summary['status'] ?? null);
+            $this->assertContains('forbidden_public_payload_leaks', (array) ($summary['errors'] ?? []));
+
+            $leakScan = $this->readJson($artifactRoot.'/leaky-staging-import/public_leak_scan_report.json');
+            $this->assertSame('blocked', data_get($leakScan, 'leak_scan.status'));
+            $this->assertSame('attempt_id', data_get($leakScan, 'leak_scan.hits.0.value'));
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+            $this->deleteDirectory($selectorReadyRoot);
+        }
+    }
+
     private function tempDir(string $prefix): string
     {
         $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57289,7 +57289,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-staging-import-dry-run-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run",
     "depends_on": [
@@ -57303,10 +57303,12 @@
       "git_diff_check": "passed",
       "scope_validation": "passed",
       "branch_pushed": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_recheck": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "d276f239983ff47a82e2120c69aac7e0e44d102e",
+    "commit_sha": "871a768ee148b836c6e2e550dabb5c4a24260f7d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2268",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57332,6 +57334,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2268 after local validation and scope validation passed. No CMS write, runtime wrapper, frontend fallback, pilot gate, or production rollout."
+      },
+      {
+        "at": "2026-06-22T11:06:00+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed for PR #2268 and pre-merge scope recheck stayed within PR9 allowed files."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57213,7 +57213,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-selector-coverage-batch-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01: content(riasec): fill selector coverage gaps",
     "depends_on": [
@@ -57231,14 +57231,18 @@
       "branch_pushed": "passed",
       "pr_created": "passed",
       "github_required_checks": "passed",
-      "pre_merge_scope_recheck": "passed"
+      "pre_merge_scope_recheck": "passed",
+      "github_merge_confirmed": "passed",
+      "origin_main_contains_merge_commit": "passed",
+      "post_merge_cleanup": "passed",
+      "post_merge_revalidate": "passed"
     },
-    "failure_reason": "Strict audit command returns exit code 1 only for pre-existing RIASEC leak-scan hits outside selector_coverage_batch_20260622T0948Z; current PR new hit count is 0. Registered sidecar issue at backend/content_assets/riasec/result_page_v2/qa/sidecar_issues/strict_audit_preexisting_leak_scan_20260622.json per user continuation protocol.",
-    "commit_sha": "2737fb131d9316eed77590d80314b5ef26e07b1d",
+    "failure_reason": null,
+    "commit_sha": "124d1754e9248f102b82c5f65149f1206fe6bb57",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2265",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T02:23:36Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57272,6 +57276,12 @@
         "from": "pull_request_open",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed for PR #2265 and pre-merge scope recheck stayed within PR8 allowed files. Strict audit external sidecar remains documented."
+      },
+      {
+        "at": "2026-06-22T10:47:00+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled before PR9: GitHub PR #2265 merged as 124d1754e9248f102b82c5f65149f1206fe6bb57; origin/main contains the merge commit; local/remote branch cleanup and RiasecResultPage post-merge revalidation passed."
       }
     ]
   },
@@ -57279,13 +57289,20 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-staging-import-dry-run-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run",
     "depends_on": [
       "RIASEC-RESULT-SELECTOR-COVERAGE-BATCH-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr8_merged": "passed",
+      "php_artisan_test_filter_RiasecResultPage": "passed",
+      "php_artisan_riasec_result_page_v2_agent_audit_strict": "passed",
+      "php_artisan_riasec_result_page_v2_agent_staging_import_dry_run_strict": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": "91ad717799e6813eebfdf730ed99431b6d9dd958",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2264",
@@ -57301,6 +57318,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T10:53:00+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "PR8 dependency reconciled merged. Added staging-import-dry-run action/report support, result_page_v2 scoped public payload leak scan, checksum inventory, fail-closed report, and RiasecResultPage tests. No CMS write or runtime change."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57289,7 +57289,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-staging-import-dry-run-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-STAGING-IMPORT-DRY-RUN-01: feat(riasec): add staging import dry-run",
     "depends_on": [
@@ -57301,14 +57301,16 @@
       "php_artisan_riasec_result_page_v2_agent_audit_strict": "passed",
       "php_artisan_riasec_result_page_v2_agent_staging_import_dry_run_strict": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "branch_pushed": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "91ad717799e6813eebfdf730ed99431b6d9dd958",
-    "pr_url": "https://github.com/fermatmind/fap-api/pull/2264",
-    "merged_at": "2026-06-22T02:11:20Z",
-    "remote_branch_deleted": true,
-    "local_cleanup_executed": true,
+    "commit_sha": "d276f239983ff47a82e2120c69aac7e0e44d102e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2268",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57324,6 +57326,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed",
         "notes": "PR8 dependency reconciled merged. Added staging-import-dry-run action/report support, result_page_v2 scoped public payload leak scan, checksum inventory, fail-closed report, and RiasecResultPage tests. No CMS write or runtime change."
+      },
+      {
+        "at": "2026-06-22T11:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2268 after local validation and scope validation passed. No CMS write, runtime wrapper, frontend fallback, pilot gate, or production rollout."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added `staging-import-dry-run` support to `riasec:result-page-v2-agent`.
- Added staging dry-run artifacts for checksum inventory, public payload leak scan, fail-closed policy, dry-run summary, and go/no-go output.
- Scoped the result-page-v2 asset audit to explicit public payload nodes so policy/ledger metadata is not treated as public copy, while public payload leaks still fail closed.
- Added tests covering successful staging dry-run reporting and strict failure on leaked public payload fields.
- Reconciled PR8 as merged in the train state before starting PR9.

## Why
This creates the backend-only staging import dry-run harness required before any runtime wrapper, pilot allowlist, CMS import, or production gate work.

## Validation commands
- `cd backend && php artisan test --filter=RiasecResultPage --no-ansi`
- `cd backend && php artisan riasec:result-page-v2-agent audit --strict --json`
- `cd backend && php artisan riasec:result-page-v2-agent staging-import-dry-run --strict --json`
- `git diff --check`
- scope validation against PR9 allowed paths

## Intentionally deferred
- No CMS import or CMS write.
- No runtime wrapper enablement.
- No frontend fallback.
- No pilot allowlist or production gate changes.
- No production rollout automation.
