### PR TITLE
B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts

### DIFF
--- a/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
+++ b/backend/app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php
@@ -11,7 +11,7 @@ use Throwable;
 final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
 {
     protected $signature = 'big5:result-page-v2-agent
-        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup, execute-github-mutation, weekly-ops}
+        {action=audit : Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, poll-github-checks, plan-merge-cleanup, execute-github-mutation, weekly-ops}
         {--run-id= : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/big5_result_page_v2_agent}
         {--content-asset-root= : Optional content asset root for tests}
@@ -24,6 +24,7 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
         {--title= : Planned PR title for plan-pr}
         {--checks-json= : Exported GitHub statusCheckRollup JSON for inspect-ci}
         {--pr-state-json= : Exported GitHub PR state JSON for plan-merge-cleanup}
+        {--pr-number= : GitHub PR number for poll-github-checks live read}
         {--execution-plan-json= : Auto PR or merge cleanup plan JSON for execute-github-mutation}
         {--repo-root= : Git repository root for execute-github-mutation}
         {--github-repo= : GitHub repository slug, for example fermatmind/fap-api}
@@ -75,6 +76,13 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
                     'checks_json' => trim((string) $this->option('checks-json')),
                     'apply_mechanical_fixes' => (bool) $this->option('apply-mechanical-fixes'),
                 ]),
+                'poll-github-checks' => $agent->pollGithubChecks([
+                    'run_id' => trim((string) $this->option('run-id')),
+                    'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                    'pr_state_json' => trim((string) $this->option('pr-state-json')),
+                    'pr_number' => trim((string) $this->option('pr-number')),
+                    'github_repo' => trim((string) $this->option('github-repo')),
+                ]),
                 'plan-merge-cleanup' => $agent->planMergeCleanup([
                     'run_id' => trim((string) $this->option('run-id')),
                     'artifact_dir' => trim((string) $this->option('artifact-dir')),
@@ -98,7 +106,7 @@ final class BigFiveResultPageV2AssetAgentAuditCommand extends Command
             };
 
             if (! is_array($summary)) {
-                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, plan-merge-cleanup, execute-github-mutation, weekly-ops');
+                $this->error('Unsupported action. Supported actions: audit, generate-candidates, stage-candidates, plan-pr, inspect-ci, poll-github-checks, plan-merge-cleanup, execute-github-mutation, weekly-ops');
 
                 return self::FAILURE;
             }

--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -579,6 +579,120 @@ final class BigFiveResultPageV2AssetAgent
      * @param  array{
      *   run_id?:string,
      *   artifact_dir?:string,
+     *   pr_state_json?:string,
+     *   pr_number?:string,
+     *   github_repo?:string
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function pollGithubChecks(array $options = []): array
+    {
+        $runId = $this->sanitizeRunId((string) ($options['run_id'] ?? ''));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $prStateJson = trim((string) ($options['pr_state_json'] ?? '')) === ''
+            ? ''
+            : $this->absolutePath((string) ($options['pr_state_json'] ?? ''));
+        $prNumber = trim((string) ($options['pr_number'] ?? ''));
+        $githubRepo = trim((string) ($options['github_repo'] ?? ''));
+
+        $this->ensureDirectory($artifactDir);
+
+        $state = $this->pollGithubState($prStateJson, $prNumber, $githubRepo);
+        $checks = $this->readCheckRollupFromPayload($state);
+        $pending = array_values(array_filter($checks, static fn (array $check): bool => ($check['state'] ?? '') === 'pending'));
+        $failed = array_values(array_filter($checks, static fn (array $check): bool => ($check['state'] ?? '') === 'failed'));
+        $passed = array_values(array_filter($checks, static fn (array $check): bool => ($check['state'] ?? '') === 'passed'));
+        $blockingStatus = $state === []
+            ? 'missing_pr_state'
+            : ($failed !== [] ? 'failed_checks' : ($pending !== [] ? 'pending_checks' : 'green'));
+        $sidecarCandidates = $this->checkPollerSidecarCandidates($failed);
+
+        $rollup = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'github_check_poll_rollup',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'checks' => $checks,
+        ];
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'github_check_poller',
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'source' => $prStateJson !== '' ? 'exported_pr_state_json' : ($prNumber !== '' ? 'gh_pr_view' : 'missing'),
+            'pr_state_json' => $prStateJson === '' ? null : $this->redactPath($prStateJson),
+            'github_repo' => $this->redactGithubRepo($githubRepo),
+            'pr' => [
+                'number' => (string) ($state['number'] ?? $prNumber),
+                'state' => (string) ($state['state'] ?? ''),
+                'is_draft' => (bool) ($state['isDraft'] ?? false),
+                'merge_state_status' => (string) ($state['mergeStateStatus'] ?? ''),
+                'review_decision' => (string) ($state['reviewDecision'] ?? ''),
+                'head_ref_name' => (string) ($state['headRefName'] ?? ''),
+                'head_ref_oid' => (string) ($state['headRefOid'] ?? ''),
+                'url' => (string) ($state['url'] ?? ''),
+            ],
+            'required_check_summary' => [
+                'check_count' => count($checks),
+                'pending_check_count' => count($pending),
+                'failed_check_count' => count($failed),
+                'passed_check_count' => count($passed),
+                'blocking_status' => $blockingStatus,
+                'all_completed' => $checks !== [] && $pending === [],
+                'all_green' => $checks !== [] && $pending === [] && $failed === [],
+            ],
+            'sidecar_blocker_classification' => [
+                'sidecar_candidate_count' => count($sidecarCandidates),
+                'candidates' => $sidecarCandidates,
+            ],
+            'negative_guarantees' => $this->checkPollerNegativeGuarantees($prNumber !== '' && $prStateJson === ''),
+        ];
+
+        $artifacts = [
+            'github_check_poll_report.json' => $this->writeJson($artifactDir.'/github_check_poll_report.json', $report),
+            'status_check_rollup.redacted.json' => $this->writeJson($artifactDir.'/status_check_rollup.redacted.json', $rollup),
+            'repair_log.json' => $this->writeJson($artifactDir.'/repair_log.json', [
+                'schema_version' => self::SCHEMA_VERSION,
+                'task' => 'github_check_poller_repair_log',
+                'runtime_use' => 'not_runtime',
+                'production_use_allowed' => false,
+                'repair_required' => $blockingStatus !== 'green',
+                'entries' => array_values(array_map(
+                    static fn (array $check): string => (string) ($check['name'] ?? 'unknown').': '.(string) ($check['state'] ?? 'unknown'),
+                    array_merge($pending, $failed)
+                )),
+            ]),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $state !== [] && $checks !== [],
+            'status' => ($state !== [] && $checks !== []) ? 'success' : 'blocked',
+            'run_id' => $runId,
+            'artifact_dir' => $artifactDir,
+            'artifacts' => $artifacts,
+            'summary' => [
+                'check_count' => count($checks),
+                'pending_check_count' => count($pending),
+                'failed_check_count' => count($failed),
+                'passed_check_count' => count($passed),
+                'blocking_status' => $blockingStatus,
+                'all_green' => $checks !== [] && $pending === [] && $failed === [],
+                'ready_for_pilot' => false,
+                'ready_for_runtime' => false,
+                'ready_for_production' => false,
+            ],
+            'negative_guarantees' => $this->checkPollerNegativeGuarantees($prNumber !== '' && $prStateJson === ''),
+        ];
+    }
+
+    /**
+     * @param  array{
+     *   run_id?:string,
+     *   artifact_dir?:string,
      *   pr_state_json?:string
      * }  $options
      * @return array<string,mixed>
@@ -2216,6 +2330,64 @@ final class BigFiveResultPageV2AssetAgent
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    private function pollGithubState(string $prStateJson, string $prNumber, string $githubRepo): array
+    {
+        if ($prStateJson !== '') {
+            return $this->readOptionalJson($prStateJson) ?? [];
+        }
+
+        if ($prNumber === '' || $this->redactGithubRepo($githubRepo) === null) {
+            return [];
+        }
+
+        $process = new Process([
+            'gh',
+            'pr',
+            'view',
+            $prNumber,
+            '--repo',
+            $githubRepo,
+            '--json',
+            'number,title,state,isDraft,mergeStateStatus,reviewDecision,headRefName,headRefOid,url,statusCheckRollup',
+        ]);
+        $process->setTimeout(60);
+        $process->run();
+
+        if ($process->getExitCode() !== 0) {
+            return [];
+        }
+
+        $decoded = json_decode($process->getOutput(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $failed
+     * @return list<array<string,mixed>>
+     */
+    private function checkPollerSidecarCandidates(array $failed): array
+    {
+        return array_map(function (array $check): array {
+            $failureClass = (string) ($check['failure_class'] ?? 'unknown');
+            $mechanicalFixAllowed = (bool) ($check['mechanical_fix_allowed'] ?? false);
+
+            return [
+                'name' => (string) ($check['name'] ?? 'unknown'),
+                'state' => (string) ($check['state'] ?? 'failed'),
+                'failure_class' => $failureClass,
+                'mechanical_fix_allowed' => $mechanicalFixAllowed,
+                'sidecar_candidate' => ! $mechanicalFixAllowed,
+                'sidecar_policy' => $mechanicalFixAllowed
+                    ? 'repair_in_current_scope_if_manifest_allows'
+                    : 'record_as_sidecar_if_not_current_pr_scope',
+            ];
+        }, $failed);
+    }
+
+    /**
      * @return array{valid:bool,blockers:list<string>,allowed_plan_tasks:list<string>}
      */
     private function githubMutationPreflight(
@@ -2782,6 +2954,36 @@ final class BigFiveResultPageV2AssetAgent
             'github_pr_created' => false,
             'mechanical_fix_apply_requested' => $applyRequested,
             'mechanical_fix_apply_performed' => false,
+            'auto_merge_performed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function checkPollerNegativeGuarantees(bool $liveRead): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'content_assets_write' => false,
+            'frontend_copy_write' => false,
+            'final_result_payload_generation' => false,
+            'runtime_flag_change' => false,
+            'release_snapshot_change' => false,
+            'production_import_gate_change' => false,
+            'rollout_gate_change' => false,
+            'github_checks_read_live' => $liveRead,
+            'github_checks_mutation' => false,
+            'git_branch_created' => false,
+            'git_commit_created' => false,
+            'github_pr_created' => false,
+            'github_pr_mutation' => false,
+            'github_merge_performed' => false,
+            'remote_branch_deleted' => false,
+            'local_branch_deleted' => false,
+            'local_main_synced' => false,
+            'post_merge_revalidation_run' => false,
             'auto_merge_performed' => false,
         ];
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -568,6 +568,125 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_poll_github_checks_writes_redacted_rollup_without_mutation(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-check-poller');
+
+        $this->deleteDirectory($artifactRoot);
+        mkdir($artifactRoot, 0777, true);
+
+        try {
+            $statePath = $artifactRoot.'/pr-state.json';
+            file_put_contents($statePath, json_encode([
+                'number' => 2266,
+                'url' => 'https://github.com/fermatmind/fap-api/pull/2266',
+                'headRefName' => 'codex/big5-v2-live-dry-run-artifact',
+                'headRefOid' => 'abc123',
+                'state' => 'OPEN',
+                'isDraft' => false,
+                'mergeStateStatus' => 'UNSTABLE',
+                'reviewDecision' => '',
+                'statusCheckRollup' => [
+                    [
+                        'name' => 'hygiene',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'SUCCESS',
+                    ],
+                    [
+                        'name' => 'verify-bigfive',
+                        'status' => 'IN_PROGRESS',
+                        'conclusion' => '',
+                    ],
+                    [
+                        'name' => 'Semgrep blocking secrets',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'poll-github-checks',
+                '--run-id' => 'check-poller',
+                '--artifact-dir' => $artifactRoot,
+                '--pr-state-json' => $statePath,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/check-poller';
+            foreach ([
+                'github_check_poll_report.json',
+                'status_check_rollup.redacted.json',
+                'repair_log.json',
+            ] as $filename) {
+                $this->assertFileExists($runDir.'/'.$filename);
+            }
+
+            $report = $this->readJson($runDir.'/github_check_poll_report.json');
+            $rollup = $this->readJson($runDir.'/status_check_rollup.redacted.json');
+            $repairLog = $this->readJson($runDir.'/repair_log.json');
+
+            $this->assertSame('github_check_poller', $report['task'] ?? null);
+            $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertSame('exported_pr_state_json', $report['source'] ?? null);
+            $this->assertSame('2266', data_get($report, 'pr.number'));
+            $this->assertSame('UNSTABLE', data_get($report, 'pr.merge_state_status'));
+            $this->assertSame(3, (int) data_get($report, 'required_check_summary.check_count', 0));
+            $this->assertSame(1, (int) data_get($report, 'required_check_summary.pending_check_count', 0));
+            $this->assertSame(1, (int) data_get($report, 'required_check_summary.failed_check_count', 0));
+            $this->assertSame(1, (int) data_get($report, 'required_check_summary.passed_check_count', 0));
+            $this->assertSame('failed_checks', data_get($report, 'required_check_summary.blocking_status'));
+            $this->assertFalse((bool) data_get($report, 'required_check_summary.all_green', true));
+            $this->assertSame(1, (int) data_get($report, 'sidecar_blocker_classification.sidecar_candidate_count', 0));
+            $this->assertSame('security', data_get($report, 'sidecar_blocker_classification.candidates.0.failure_class'));
+            $this->assertTrue((bool) data_get($report, 'sidecar_blocker_classification.candidates.0.sidecar_candidate'));
+
+            $this->assertSame('github_check_poll_rollup', $rollup['task'] ?? null);
+            $this->assertCount(3, (array) ($rollup['checks'] ?? []));
+            $this->assertTrue((bool) ($repairLog['repair_required'] ?? false));
+
+            foreach ([
+                'github_checks_read_live',
+                'github_checks_mutation',
+                'git_branch_created',
+                'git_commit_created',
+                'github_pr_created',
+                'github_pr_mutation',
+                'github_merge_performed',
+                'remote_branch_deleted',
+                'local_branch_deleted',
+                'local_main_synced',
+                'post_merge_revalidation_run',
+                'auto_merge_performed',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+
+            $allArtifacts = implode("\n", [
+                (string) file_get_contents($runDir.'/github_check_poll_report.json'),
+                (string) file_get_contents($runDir.'/status_check_rollup.redacted.json'),
+                (string) file_get_contents($runDir.'/repair_log.json'),
+            ]);
+            foreach ([
+                'private_url',
+                'attempt_id',
+                'raw_score',
+                'percentile',
+                'fixed_type',
+                'user_confirmed_type',
+                'type_code',
+            ] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_plan_merge_cleanup_requires_clean_green_pr_and_does_not_execute_merge(): void
     {
         $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-merge-cleanup');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -39995,7 +39995,7 @@
     "repo": "fap-api",
     "branch": "codex/career-search-channel-readiness-gate-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
@@ -57892,6 +57892,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to the Big Five V2 asset agent command/service/test files and docs/codex PR-train state. git diff --check, JSON parse, and YAML parse passed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2269 required GitHub checks completed successfully on head d0053f7f8171724308e1bc535bbf58a711df5c8b; PR title/body and changed-file scope were re-reviewed."
       }
     },
     "failure_reason": null,
@@ -57910,6 +57914,11 @@
         "at": "2026-06-22T02:50:00Z",
         "status": "pr_open",
         "note": "Opened PR #2269 for the auto check poller after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T02:55:00Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed on head d0053f7f8171724308e1bc535bbf58a711df5c8b, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57793,7 +57793,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-live-dry-run-pilot",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-LIVE-DRY-RUN-PILOT-01: Record Big Five V2 live PR mutation pilot",
     "depends_on": [
@@ -57830,11 +57830,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "commit_sha": "aba183d5ccac3b75f6582b93024bc9c8b605ee7c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2267",
+    "merged_at": "2026-06-22T02:29:09Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T02:15:00Z",
@@ -57850,6 +57850,11 @@
         "at": "2026-06-22T02:35:00Z",
         "status": "ready_to_merge",
         "note": "GitHub checks passed, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
+      },
+      {
+        "at": "2026-06-22T02:40:00Z",
+        "status": "merged",
+        "note": "PR #2267 merged with merge commit aba183d5ccac3b75f6582b93024bc9c8b605ee7c; origin/main contains the merge commit, local main was fast-forwarded, task branch was deleted locally/remotely, and post-merge JSON/YAML/diff validation passed."
       }
     ]
   },
@@ -57857,7 +57862,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-check-poller",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_validated",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts",
     "depends_on": [
@@ -57869,8 +57874,24 @@
         "evidence": "User authorized this PR train item in the /goal execution request."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for B5-RESULT-LIVE-DRY-RUN-PILOT-01 to merge into main."
+        "status": "pass",
+        "evidence": "B5-RESULT-LIVE-DRY-RUN-PILOT-01 is merged and origin/main contains merge commit aba183d5ccac3b75f6582b93024bc9c8b605ee7c."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent poll-github-checks --run-id=check-poller --artifact-dir=artifacts/big5_result_page_v2_agent/testing-check-poller --pr-state-json=artifacts/big5_result_page_v2_agent/testing-check-poller/pr-state.json --json --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed with the new poll-github-checks fixture test; command smoke generated redacted github_check_poll_report.json, status_check_rollup.redacted.json, and repair_log.json from exported PR state without live mutation."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the Big Five V2 asset agent command/service/test files and docs/codex PR-train state. git diff --check, JSON parse, and YAML parse passed."
       }
     },
     "failure_reason": null,
@@ -57879,7 +57900,13 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "transitions": []
+    "transitions": [
+      {
+        "at": "2026-06-22T02:45:00Z",
+        "status": "local_validated",
+        "note": "Implemented poll-github-checks read-only artifact generation with exported PR state fixture coverage and command smoke. No GitHub mutation, runtime, production gate, release snapshot, CMS write, DB write, or fap-web copy changed."
+      }
+    ]
   },
   "B5-RESULT-MECHANICAL-FIX-APPLY-01": {
     "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57862,7 +57862,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-check-poller",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts",
     "depends_on": [
@@ -57895,8 +57895,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "8ae13aa5c4d390827853859b4f0d124bcd3288f5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2269",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57905,6 +57905,11 @@
         "at": "2026-06-22T02:45:00Z",
         "status": "local_validated",
         "note": "Implemented poll-github-checks read-only artifact generation with exported PR state fixture coverage and command smoke. No GitHub mutation, runtime, production gate, release snapshot, CMS write, DB write, or fap-web copy changed."
+      },
+      {
+        "at": "2026-06-22T02:50:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2269 for the auto check poller after local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Adds `poll-github-checks` to the Big Five V2 result-page asset agent.
- Writes redacted GitHub check artifacts: `github_check_poll_report.json`, `status_check_rollup.redacted.json`, and `repair_log.json`.
- Classifies pending/failed/passed checks and sidecar candidates without mutating GitHub state.
- Reconciles PR2 merge facts and records PR3 local validation in the train state ledger.

## Why
- Gives the execution runner a controlled read-only check poller before any mechanical fix or merge cleanup stage.
- Keeps backend artifact/reporting authority explicit while preserving not-runtime defaults.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent poll-github-checks --run-id=check-poller --artifact-dir=artifacts/big5_result_page_v2_agent/testing-check-poller --pr-state-json=artifacts/big5_result_page_v2_agent/testing-check-poller/pr-state.json --json --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/BigFiveResultPageV2AssetAgentAuditCommand.php app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy added.
- No final Big Five result page runtime payload generated.
- No production import, release snapshot, rollout gate, Ops gate, runtime flag, CMS write, or DB write changed.
- Legacy `big5_report_engine_v2` remains fallback only.
- Mechanical fix application and live merge cleanup remain later scoped PRs.