### PR TITLE
B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes

### DIFF
--- a/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
+++ b/backend/app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php
@@ -506,10 +506,12 @@ final class BigFiveResultPageV2AssetAgent
         $failed = array_values(array_filter($classifications, static fn (array $check): bool => ($check['state'] ?? '') === 'failed'));
         $repairable = array_values(array_filter($failed, static fn (array $check): bool => ($check['mechanical_fix_allowed'] ?? false) === true));
         $blocked = array_values(array_filter($failed, static fn (array $check): bool => ($check['mechanical_fix_allowed'] ?? false) !== true));
+        $fixApplication = $this->applyMechanicalFixesForChecks($repairable, $applyMechanicalFixes);
         $repairLogEntries = array_map(
             static fn (array $check): string => (string) ($check['name'] ?? 'unknown').': '.(string) ($check['failure_class'] ?? 'unknown'),
             $failed
         );
+        $repairLogEntries = array_values(array_merge($repairLogEntries, (array) ($fixApplication['entries'] ?? [])));
 
         $report = [
             'schema_version' => self::SCHEMA_VERSION,
@@ -524,8 +526,12 @@ final class BigFiveResultPageV2AssetAgent
             'failed_check_count' => count($failed),
             'mechanical_fix_candidate_count' => count($repairable),
             'blocked_failure_count' => count($blocked),
+            'mechanical_fix_application' => $fixApplication,
             'checks' => $classifications,
-            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees(
+                $applyMechanicalFixes,
+                (bool) ($fixApplication['apply_performed'] ?? false)
+            ),
         ];
         $fixPlan = [
             'schema_version' => self::SCHEMA_VERSION,
@@ -533,11 +539,15 @@ final class BigFiveResultPageV2AssetAgent
             'runtime_use' => 'not_runtime',
             'production_use_allowed' => false,
             'apply_requested' => $applyMechanicalFixes,
-            'apply_performed' => false,
+            'apply_performed' => (bool) ($fixApplication['apply_performed'] ?? false),
             'allowed_failure_classes' => ['schema', 'checksum', 'format', 'scope'],
             'candidates' => $repairable,
             'blocked_failures' => $blocked,
-            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+            'application' => $fixApplication,
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees(
+                $applyMechanicalFixes,
+                (bool) ($fixApplication['apply_performed'] ?? false)
+            ),
         ];
         $repairLog = [
             'schema_version' => self::SCHEMA_VERSION,
@@ -566,12 +576,16 @@ final class BigFiveResultPageV2AssetAgent
                 'failed_check_count' => count($failed),
                 'mechanical_fix_candidate_count' => count($repairable),
                 'blocked_failure_count' => count($blocked),
-                'apply_performed' => false,
+                'apply_performed' => (bool) ($fixApplication['apply_performed'] ?? false),
+                'applied_fix_count' => (int) ($fixApplication['applied_fix_count'] ?? 0),
                 'ready_for_pilot' => false,
                 'ready_for_runtime' => false,
                 'ready_for_production' => false,
             ],
-            'negative_guarantees' => $this->ciInspectorNegativeGuarantees($applyMechanicalFixes),
+            'negative_guarantees' => $this->ciInspectorNegativeGuarantees(
+                $applyMechanicalFixes,
+                (bool) ($fixApplication['apply_performed'] ?? false)
+            ),
         ];
     }
 
@@ -2685,7 +2699,236 @@ final class BigFiveResultPageV2AssetAgent
             'failure_class' => $failureClass,
             'mechanical_fix_allowed' => in_array($failureClass, ['schema', 'checksum', 'format', 'scope'], true),
             'mechanical_fix_policy' => $this->mechanicalFixPolicy($failureClass),
+            'mechanical_fix_instruction' => $this->mechanicalFixInstruction($check),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $check
+     * @return array<string,string>|null
+     */
+    private function mechanicalFixInstruction(array $check): ?array
+    {
+        $instruction = $check['mechanical_fix'] ?? null;
+        if (! is_array($instruction)) {
+            return null;
+        }
+
+        $action = (string) ($instruction['action'] ?? '');
+        $targetPath = (string) ($instruction['target_path'] ?? '');
+        $sourcePath = (string) ($instruction['source_path'] ?? '');
+
+        return array_filter([
+            'action' => $action,
+            'target_path' => $targetPath,
+            'source_path' => $sourcePath,
+        ], static fn (string $value): bool => $value !== '');
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $repairable
+     * @return array<string,mixed>
+     */
+    private function applyMechanicalFixesForChecks(array $repairable, bool $applyRequested): array
+    {
+        $applied = [];
+        $rejected = [];
+        $skipped = [];
+        $entries = [];
+
+        foreach ($repairable as $check) {
+            $name = (string) ($check['name'] ?? 'unknown');
+            $instruction = is_array($check['mechanical_fix_instruction'] ?? null)
+                ? (array) $check['mechanical_fix_instruction']
+                : null;
+
+            if (! $applyRequested) {
+                $skipped[] = [
+                    'name' => $name,
+                    'reason' => 'apply_not_requested',
+                ];
+
+                continue;
+            }
+
+            if ($instruction === null) {
+                $skipped[] = [
+                    'name' => $name,
+                    'reason' => 'mechanical_fix_instruction_missing',
+                ];
+                $entries[] = $name.': skipped mechanical_fix_instruction_missing';
+
+                continue;
+            }
+
+            $result = $this->applyMechanicalFixInstruction($name, $instruction);
+            if (($result['applied'] ?? false) === true) {
+                $applied[] = $result;
+                $entries[] = $name.': applied '.(string) ($result['action'] ?? 'unknown');
+            } else {
+                $rejected[] = $result;
+                $entries[] = $name.': rejected '.(string) ($result['reason'] ?? 'unknown');
+            }
+        }
+
+        return [
+            'apply_requested' => $applyRequested,
+            'apply_performed' => $applied !== [],
+            'allowed_failure_classes' => ['schema', 'checksum', 'format', 'scope'],
+            'allowed_actions' => ['format_json', 'refresh_sha256', 'sort_json_list'],
+            'allowed_target_prefixes' => ['artifacts/big5_result_page_v2_agent/'],
+            'applied_fix_count' => count($applied),
+            'rejected_fix_count' => count($rejected),
+            'skipped_fix_count' => count($skipped),
+            'applied_fixes' => $applied,
+            'rejected_fixes' => $rejected,
+            'skipped_fixes' => $skipped,
+            'entries' => $entries,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $instruction
+     * @return array<string,mixed>
+     */
+    private function applyMechanicalFixInstruction(string $name, array $instruction): array
+    {
+        $action = (string) ($instruction['action'] ?? '');
+        $targetRelativePath = (string) ($instruction['target_path'] ?? '');
+        $targetPath = $this->mechanicalFixArtifactPath($targetRelativePath);
+
+        if (! in_array($action, ['format_json', 'refresh_sha256', 'sort_json_list'], true)) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'unsupported_mechanical_fix_action',
+            ];
+        }
+
+        if ($targetPath === null) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'target_path_outside_artifact_allowlist',
+                'target_path' => $targetRelativePath,
+            ];
+        }
+
+        if ($action === 'format_json') {
+            return $this->applyFormatJsonFix($name, $action, $targetPath, $targetRelativePath);
+        }
+
+        if ($action === 'sort_json_list') {
+            return $this->applySortJsonListFix($name, $action, $targetPath, $targetRelativePath);
+        }
+
+        return $this->applyRefreshSha256Fix($name, $action, $targetPath, $targetRelativePath, (string) ($instruction['source_path'] ?? ''));
+    }
+
+    private function applyFormatJsonFix(string $name, string $action, string $targetPath, string $targetRelativePath): array
+    {
+        $payload = $this->readOptionalJson($targetPath);
+        if ($payload === null) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'target_json_missing_or_invalid',
+                'target_path' => $targetRelativePath,
+            ];
+        }
+
+        $this->writeJson($targetPath, $payload);
+
+        return [
+            'name' => $name,
+            'action' => $action,
+            'applied' => true,
+            'target_path' => $targetRelativePath,
+        ];
+    }
+
+    private function applySortJsonListFix(string $name, string $action, string $targetPath, string $targetRelativePath): array
+    {
+        $payload = $this->readOptionalJson($targetPath);
+        if ($payload === null || array_is_list($payload) === false) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'target_json_list_missing_or_invalid',
+                'target_path' => $targetRelativePath,
+            ];
+        }
+
+        $values = array_values(array_map('strval', $payload));
+        sort($values, SORT_STRING);
+        $this->writeJson($targetPath, $values);
+
+        return [
+            'name' => $name,
+            'action' => $action,
+            'applied' => true,
+            'target_path' => $targetRelativePath,
+        ];
+    }
+
+    private function applyRefreshSha256Fix(
+        string $name,
+        string $action,
+        string $targetPath,
+        string $targetRelativePath,
+        string $sourceRelativePath,
+    ): array {
+        $sourcePath = $this->mechanicalFixArtifactPath($sourceRelativePath);
+        $payload = $this->readOptionalJson($targetPath);
+        if ($sourcePath === null || ! is_file($sourcePath)) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'source_path_outside_artifact_allowlist_or_missing',
+                'target_path' => $targetRelativePath,
+                'source_path' => $sourceRelativePath,
+            ];
+        }
+        if ($payload === null || array_is_list($payload)) {
+            return [
+                'name' => $name,
+                'action' => $action,
+                'applied' => false,
+                'reason' => 'target_json_object_missing_or_invalid',
+                'target_path' => $targetRelativePath,
+            ];
+        }
+
+        $payload['sha256'] = hash_file('sha256', $sourcePath) ?: '';
+        $this->writeJson($targetPath, $payload);
+
+        return [
+            'name' => $name,
+            'action' => $action,
+            'applied' => true,
+            'target_path' => $targetRelativePath,
+            'source_path' => $sourceRelativePath,
+        ];
+    }
+
+    private function mechanicalFixArtifactPath(string $relativePath): ?string
+    {
+        $relativePath = trim(str_replace('\\', '/', $relativePath));
+        if ($relativePath === ''
+            || str_starts_with($relativePath, '/')
+            || str_contains($relativePath, '../')
+            || $relativePath === '..'
+            || ! str_starts_with($relativePath, 'artifacts/big5_result_page_v2_agent/')
+        ) {
+            return null;
+        }
+
+        return base_path($relativePath);
     }
 
     private function failureClassForCheck(string $name): string
@@ -2936,7 +3179,7 @@ final class BigFiveResultPageV2AssetAgent
     /**
      * @return array<string,bool>
      */
-    private function ciInspectorNegativeGuarantees(bool $applyRequested): array
+    private function ciInspectorNegativeGuarantees(bool $applyRequested, bool $applyPerformed = false): array
     {
         return [
             'database_write' => false,
@@ -2953,7 +3196,7 @@ final class BigFiveResultPageV2AssetAgent
             'git_commit_created' => false,
             'github_pr_created' => false,
             'mechanical_fix_apply_requested' => $applyRequested,
-            'mechanical_fix_apply_performed' => false,
+            'mechanical_fix_apply_performed' => $applyPerformed,
             'auto_merge_performed' => false,
         ];
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php
@@ -568,6 +568,123 @@ final class BigFiveResultPageV2AssetAgentTest extends TestCase
         }
     }
 
+    public function test_inspect_ci_applies_only_explicit_artifact_mechanical_fixes(): void
+    {
+        $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-ci-mechanical-apply');
+
+        $this->deleteDirectory($artifactRoot);
+        mkdir($artifactRoot, 0777, true);
+
+        try {
+            $targetRelativePath = 'artifacts/big5_result_page_v2_agent/unit-ci-mechanical-apply/malformed.json';
+            $targetPath = base_path($targetRelativePath);
+            file_put_contents($targetPath, '{"z":2,"a":1}');
+
+            $checksPath = $artifactRoot.'/checks.json';
+            file_put_contents($checksPath, json_encode([
+                'statusCheckRollup' => [
+                    [
+                        'name' => 'hygiene format',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                        'mechanical_fix' => [
+                            'action' => 'format_json',
+                            'target_path' => $targetRelativePath,
+                        ],
+                    ],
+                    [
+                        'name' => 'Semgrep blocking secrets',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'FAILURE',
+                        'mechanical_fix' => [
+                            'action' => 'format_json',
+                            'target_path' => $targetRelativePath,
+                        ],
+                    ],
+                    [
+                        'name' => 'verify-bigfive',
+                        'status' => 'COMPLETED',
+                        'conclusion' => 'SUCCESS',
+                    ],
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+            $this->artisan('big5:result-page-v2-agent', [
+                'action' => 'inspect-ci',
+                '--run-id' => 'mechanical-fix',
+                '--artifact-dir' => $artifactRoot,
+                '--checks-json' => $checksPath,
+                '--apply-mechanical-fixes' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $runDir = $artifactRoot.'/mechanical-fix';
+            $this->assertFileExists($runDir.'/ci_inspection_report.json');
+            $this->assertFileExists($runDir.'/mechanical_fix_plan.json');
+            $this->assertFileExists($runDir.'/repair_log.json');
+
+            $formatted = (string) file_get_contents($targetPath);
+            $this->assertStringContainsString(PHP_EOL, $formatted);
+            $this->assertSame(['z' => 2, 'a' => 1], $this->readJson($targetPath));
+
+            $report = $this->readJson($runDir.'/ci_inspection_report.json');
+            $fixPlan = $this->readJson($runDir.'/mechanical_fix_plan.json');
+            $repairLog = $this->readJson($runDir.'/repair_log.json');
+
+            $this->assertSame(3, (int) ($report['check_count'] ?? 0));
+            $this->assertSame(2, (int) ($report['failed_check_count'] ?? 0));
+            $this->assertSame(1, (int) ($report['mechanical_fix_candidate_count'] ?? 0));
+            $this->assertSame(1, (int) ($report['blocked_failure_count'] ?? 0));
+            $this->assertTrue((bool) data_get($report, 'mechanical_fix_application.apply_requested'));
+            $this->assertTrue((bool) data_get($report, 'mechanical_fix_application.apply_performed'));
+            $this->assertSame(1, (int) data_get($report, 'mechanical_fix_application.applied_fix_count', 0));
+            $this->assertSame(0, (int) data_get($report, 'mechanical_fix_application.rejected_fix_count', -1));
+            $this->assertSame('format_json', data_get($report, 'mechanical_fix_application.applied_fixes.0.action'));
+            $this->assertSame([$targetRelativePath], [
+                data_get($report, 'mechanical_fix_application.applied_fixes.0.target_path'),
+            ]);
+
+            $this->assertTrue((bool) ($fixPlan['apply_requested'] ?? false));
+            $this->assertTrue((bool) ($fixPlan['apply_performed'] ?? false));
+            $this->assertSame('security', data_get($fixPlan, 'blocked_failures.0.failure_class'));
+            $this->assertStringContainsString(
+                'hygiene format: applied format_json',
+                implode("\n", (array) ($repairLog['entries'] ?? []))
+            );
+
+            foreach ([
+                'database_write',
+                'cms_write',
+                'content_assets_write',
+                'frontend_copy_write',
+                'final_result_payload_generation',
+                'runtime_flag_change',
+                'production_import_gate_change',
+                'rollout_gate_change',
+                'github_checks_read_live',
+                'git_branch_created',
+                'git_commit_created',
+                'github_pr_created',
+                'auto_merge_performed',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, "negative_guarantees.{$guarantee}", true), $guarantee);
+            }
+            $this->assertTrue((bool) data_get($report, 'negative_guarantees.mechanical_fix_apply_requested'));
+            $this->assertTrue((bool) data_get($report, 'negative_guarantees.mechanical_fix_apply_performed'));
+
+            $allArtifacts = implode("\n", [
+                (string) file_get_contents($runDir.'/ci_inspection_report.json'),
+                (string) file_get_contents($runDir.'/mechanical_fix_plan.json'),
+                (string) file_get_contents($runDir.'/repair_log.json'),
+            ]);
+            foreach (['private_url', 'attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $allArtifacts);
+            }
+        } finally {
+            $this->deleteDirectory($artifactRoot);
+        }
+    }
+
     public function test_poll_github_checks_writes_redacted_rollup_without_mutation(): void
     {
         $artifactRoot = base_path('artifacts/big5_result_page_v2_agent/unit-check-poller');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40107,7 +40107,7 @@
     "repo": "fap-api",
     "branch": "codex/career-10k-rollout-architecture-spec-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "title": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec",
     "depends_on": [
       "CAREER-SEARCH-CHANNEL-READINESS-GATE-01"
@@ -57938,11 +57938,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "8ae13aa5c4d390827853859b4f0d124bcd3288f5",
+    "commit_sha": "e531e55f6564b09d8577715d61b5cb5db4e721de",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2269",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T02:49:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T02:45:00Z",
@@ -57958,6 +57958,11 @@
         "at": "2026-06-22T02:55:00Z",
         "status": "ready_to_merge",
         "note": "GitHub checks passed on head d0053f7f8171724308e1bc535bbf58a711df5c8b, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
+      },
+      {
+        "at": "2026-06-22T02:59:00Z",
+        "status": "merged",
+        "note": "PR #2269 merged with merge commit e531e55f6564b09d8577715d61b5cb5db4e721de; origin/main contains the merge commit, local main was fast-forwarded, task branch was deleted locally/remotely, and post-merge JSON/YAML/diff plus AssetAgentTest validation passed."
       }
     ]
   },
@@ -57965,7 +57970,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-mechanical-fix-apply",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_validated",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes",
     "depends_on": [
@@ -57977,8 +57982,24 @@
         "evidence": "User authorized this PR train item in the /goal execution request."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for B5-RESULT-AUTO-CHECK-POLLER-01 to merge into main."
+        "status": "pass",
+        "evidence": "B5-RESULT-AUTO-CHECK-POLLER-01 is merged and origin/main contains merge commit e531e55f6564b09d8577715d61b5cb5db4e721de."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi",
+          "cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=mechanical-fix --artifact-dir=artifacts/big5_result_page_v2_agent/testing-mechanical-fix --checks-json=artifacts/big5_result_page_v2_agent/testing-mechanical-fix/checks.json --apply-mechanical-fixes --json --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "AssetAgentTest passed with explicit artifact-only mechanical fix coverage; inspect-ci --apply-mechanical-fixes smoke applied one format_json artifact fix, blocked one Semgrep security failure, and kept runtime/production/frontend negative guarantees false."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the Big Five V2 asset agent service/test files and docs/codex PR-train state. No fap-web copy, runtime flag, production gate, release snapshot, CMS write, or DB write changed."
       }
     },
     "failure_reason": null,
@@ -57987,7 +58008,13 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "transitions": []
+    "transitions": [
+      {
+        "at": "2026-06-22T03:05:00Z",
+        "status": "local_validated",
+        "note": "Implemented explicit artifact-only mechanical fix apply for format_json, refresh_sha256, and sort_json_list; security, supply-chain, test logic, content semantic, runtime, production, and frontend-copy fixes remain blocked."
+      }
+    ]
   },
   "B5-RESULT-AUTO-MERGE-LIVE-PILOT-01": {
     "repo": "fap-api",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -57970,7 +57970,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-mechanical-fix-apply",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes",
     "depends_on": [
@@ -58003,8 +58003,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "64421c3904bf13b927d1b998932e499418fd653a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2271",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -58013,6 +58013,11 @@
         "at": "2026-06-22T03:05:00Z",
         "status": "local_validated",
         "note": "Implemented explicit artifact-only mechanical fix apply for format_json, refresh_sha256, and sort_json_list; security, supply-chain, test logic, content semantic, runtime, production, and frontend-copy fixes remain blocked."
+      },
+      {
+        "at": "2026-06-22T03:10:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2271 after local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40213,7 +40213,7 @@
     "repo": "fap-api",
     "branch": "codex/analytics-funnel-ga4-baidu-mapping-scan-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01 freeze GA4 Baidu funnel mapping",
     "depends_on": [
       "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03"
@@ -58000,6 +58000,10 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to the Big Five V2 asset agent service/test files and docs/codex PR-train state. No fap-web copy, runtime flag, production gate, release snapshot, CMS write, or DB write changed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #2271 required GitHub checks completed successfully on head a144e3f6640fb4eb470383db0aa574437c0b4d8e; mergeStateStatus CLEAN; PR title/body and changed-file scope were re-reviewed."
       }
     },
     "failure_reason": null,
@@ -58018,6 +58022,11 @@
         "at": "2026-06-22T03:10:00Z",
         "status": "pr_open",
         "note": "Opened PR #2271 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T03:15:00Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed on head a144e3f6640fb4eb470383db0aa574437c0b4d8e, mergeStateStatus is CLEAN, and PR title/body/scope were re-reviewed. Ready to merge under squash policy after this state update is pushed and checks remain green."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Extends `inspect-ci --apply-mechanical-fixes` to perform explicit artifact-only mechanical fixes.
- Allows only `format_json`, `refresh_sha256`, and `sort_json_list` under `artifacts/big5_result_page_v2_agent/**`.
- Records applied/skipped/rejected entries in `mechanical_fix_plan.json`, `ci_inspection_report.json`, and `repair_log.json`.
- Blocks security, supply-chain, test logic, content semantic, runtime, production, and frontend-copy fixes.
- Reconciles PR3 merge facts and records PR4 local validation in the train state ledger.

## Why
- Gives the execution runner a fail-closed mechanical repair path before live merge automation.
- Keeps backend artifact/reporting authority explicit while preserving not-runtime defaults.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2AssetAgentTest --no-ansi`
- `cd backend && APP_ENV=testing php artisan big5:result-page-v2-agent inspect-ci --run-id=mechanical-fix --artifact-dir=artifacts/big5_result_page_v2_agent/testing-mechanical-fix --checks-json=artifacts/big5_result_page_v2_agent/testing-mechanical-fix/checks.json --apply-mechanical-fixes --json --no-ansi`
- `rm -rf backend/artifacts/big5_result_page_v2_agent/testing-mechanical-fix`
- `cd backend && vendor/bin/pint --test app/Services/BigFive/ResultPageV2/AssetAgent/BigFiveResultPageV2AssetAgent.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2AssetAgentTest.php`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`

## Intentionally deferred
- No frontend copy added.
- No final Big Five result page runtime payload generated.
- No production import, release snapshot, rollout gate, Ops gate, runtime flag, CMS write, or DB write changed.
- No auto-fix for security, supply-chain, test logic, or content semantics.
- Legacy `big5_report_engine_v2` remains fallback only.
- Live merge cleanup remains a later scoped PR.