### PR TITLE
RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate

### DIFF
--- a/backend/app/Services/Report/RiasecReportComposer.php
+++ b/backend/app/Services/Report/RiasecReportComposer.php
@@ -7,6 +7,7 @@ namespace App\Services\Report;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Riasec\RiasecPublicProjectionService;
+use Illuminate\Support\Facades\Log;
 
 final class RiasecReportComposer
 {
@@ -81,7 +82,12 @@ final class RiasecReportComposer
      */
     private function buildResultPageV2RuntimeWrapper(Attempt $attempt, Result $result, string $variant, array $projectionV2, array $ctx): ?array
     {
-        if (! $this->resultPageV2GateAllowsRuntime($ctx)) {
+        $gateDecision = $this->resultPageV2GateDecision($attempt, $projectionV2, $ctx);
+        if ((bool) ($ctx['riasec_result_page_v2_pilot'] ?? false)) {
+            $this->recordResultPageV2PilotGateDecision($gateDecision);
+        }
+
+        if (! (bool) $gateDecision['allowed']) {
             return null;
         }
         if ($variant !== ReportAccess::VARIANT_FULL) {
@@ -110,6 +116,12 @@ final class RiasecReportComposer
                 'pilot_runtime_enabled' => (bool) config('riasec_result_page_v2.pilot_runtime_enabled', false),
                 'production_runtime_enabled' => false,
                 'environment' => app()->environment(),
+                'mode' => $gateDecision['mode'],
+                'pilot_gate_decision' => $gateDecision['allowed'] ? 'allow' : 'deny',
+                'pilot_gate_reason' => $gateDecision['reason'],
+                'pilot_gate_matched_rule' => $gateDecision['matched_rule'],
+                'pilot_kill_switch_enabled' => (bool) config('riasec_result_page_v2.pilot_kill_switch_enabled', false),
+                'raw_identifier_exported' => false,
             ],
             'identity' => [
                 'scale_code' => 'RIASEC',
@@ -141,20 +153,24 @@ final class RiasecReportComposer
 
     /**
      * @param  array<string,mixed>  $ctx
+     * @param  array<string,mixed>  $projectionV2
+     * @return array{allowed: bool, mode: string, reason: string, matched_rule: string|null, context: array<string,string>}
      */
-    private function resultPageV2GateAllowsRuntime(array $ctx): bool
+    private function resultPageV2GateDecision(Attempt $attempt, array $projectionV2, array $ctx): array
     {
+        $context = $this->resultPageV2PilotContext($attempt, $projectionV2);
+
         if ((bool) config('riasec_result_page_v2.production_runtime_enabled', false)) {
-            return false;
+            return $this->resultPageV2GateDenied('none', 'production_runtime_flag_denied', $context);
         }
         if ((bool) config('riasec_result_page_v2.production_rollout_enabled', false)) {
-            return false;
+            return $this->resultPageV2GateDenied('none', 'production_rollout_flag_denied', $context);
         }
         if ((bool) config('riasec_result_page_v2.production_rollout_manual_approval_granted', false)) {
-            return false;
+            return $this->resultPageV2GateDenied('none', 'production_manual_approval_flag_denied', $context);
         }
         if (! (bool) config('riasec_result_page_v2.enabled', false)) {
-            return false;
+            return $this->resultPageV2GateDenied('none', 'runtime_gate_disabled', $context);
         }
 
         $allowedEnvironments = array_map(
@@ -162,15 +178,184 @@ final class RiasecReportComposer
             (array) config('riasec_result_page_v2.allowed_environments', [])
         );
         if (! in_array(app()->environment(), $allowedEnvironments, true)) {
-            return false;
+            return $this->resultPageV2GateDenied('none', 'runtime_environment_denied', $context);
         }
 
         if ((bool) ($ctx['riasec_result_page_v2_staging'] ?? false) && (bool) config('riasec_result_page_v2.staging_runtime_enabled', false)) {
-            return true;
+            return $this->resultPageV2GateAllowed('staging', 'staging_runtime_allowed', null, $context);
         }
 
-        return (bool) ($ctx['riasec_result_page_v2_pilot'] ?? false)
-            && (bool) config('riasec_result_page_v2.pilot_runtime_enabled', false);
+        if (! (bool) ($ctx['riasec_result_page_v2_pilot'] ?? false) || ! (bool) config('riasec_result_page_v2.pilot_runtime_enabled', false)) {
+            return $this->resultPageV2GateDenied('none', 'runtime_context_denied', $context);
+        }
+
+        return $this->resultPageV2PilotAllowlistDecision($context);
+    }
+
+    /**
+     * @param  array<string,string>  $context
+     * @return array{allowed: bool, mode: string, reason: string, matched_rule: string|null, context: array<string,string>}
+     */
+    private function resultPageV2PilotAllowlistDecision(array $context): array
+    {
+        if ((bool) config('riasec_result_page_v2.pilot_kill_switch_enabled', false)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_kill_switch_enabled', $context);
+        }
+
+        if (! in_array($context['environment'], $this->resultPageV2ConfiguredList('pilot_allowed_environments'), true)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_environment_denied', $context);
+        }
+
+        if ($context['environment'] === 'production' && ! (bool) config('riasec_result_page_v2.pilot_production_allowlist_enabled', false)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_production_denied', $context);
+        }
+
+        $allowedFormCodes = $this->resultPageV2ConfiguredList('pilot_allowed_form_codes');
+        if ($allowedFormCodes !== [] && ! in_array($context['form_code'], $allowedFormCodes, true)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_form_denied', $context);
+        }
+
+        $allowedLocales = $this->resultPageV2ConfiguredList('pilot_allowed_locales');
+        if ($allowedLocales !== [] && ! in_array($context['locale'], $allowedLocales, true)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_locale_denied', $context);
+        }
+
+        $allowlists = [
+            'attempt_id' => $this->resultPageV2ConfiguredList('pilot_access_allowed_attempt_ids'),
+            'user_id' => $this->resultPageV2ConfiguredList('pilot_access_allowed_user_ids'),
+            'anon_id' => $this->resultPageV2ConfiguredList('pilot_access_allowed_anon_ids'),
+            'org_id' => $this->resultPageV2ConfiguredList('pilot_access_allowed_org_ids'),
+        ];
+
+        if (! $this->resultPageV2HasConfiguredAllowlist($allowlists)) {
+            return $this->resultPageV2GateDenied('pilot', 'pilot_allowlist_empty', $context);
+        }
+
+        foreach ($allowlists as $field => $allowedValues) {
+            $candidate = $context[$field] ?? '';
+            if ($candidate !== '' && in_array($candidate, $allowedValues, true)) {
+                return $this->resultPageV2GateAllowed('pilot', 'pilot_allowlist_allowed', $field, $context);
+            }
+        }
+
+        return $this->resultPageV2GateDenied('pilot', 'pilot_allowlist_denied', $context);
+    }
+
+    /**
+     * @param  array<string,mixed>  $projectionV2
+     * @return array<string,string>
+     */
+    private function resultPageV2PilotContext(Attempt $attempt, array $projectionV2): array
+    {
+        return [
+            'attempt_id' => trim((string) ($attempt->attempt_id ?? $attempt->id ?? '')),
+            'user_id' => trim((string) ($attempt->user_id ?? '')),
+            'anon_id' => trim((string) ($attempt->anon_id ?? '')),
+            'org_id' => trim((string) ($attempt->org_id ?? '')),
+            'scale_code' => strtoupper(trim((string) ($attempt->scale_code ?? ''))),
+            'environment' => (string) app()->environment(),
+            'form_code' => trim((string) (data_get($projectionV2, 'form.form_code') ?? data_get($attempt->answers_summary_json, 'meta.form_code', ''))),
+            'locale' => trim((string) ($attempt->locale ?? data_get($projectionV2, 'locale', ''))),
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $context
+     * @return array{allowed: bool, mode: string, reason: string, matched_rule: string|null, context: array<string,string>}
+     */
+    private function resultPageV2GateAllowed(string $mode, string $reason, ?string $matchedRule, array $context): array
+    {
+        return [
+            'allowed' => true,
+            'mode' => $mode,
+            'reason' => $reason,
+            'matched_rule' => $matchedRule,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $context
+     * @return array{allowed: bool, mode: string, reason: string, matched_rule: string|null, context: array<string,string>}
+     */
+    private function resultPageV2GateDenied(string $mode, string $reason, array $context): array
+    {
+        return [
+            'allowed' => false,
+            'mode' => $mode,
+            'reason' => $reason,
+            'matched_rule' => null,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resultPageV2ConfiguredList(string $key): array
+    {
+        $configured = config('riasec_result_page_v2.'.$key, []);
+        if (is_string($configured)) {
+            $configured = explode(',', $configured);
+        }
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            $configured,
+        )));
+    }
+
+    /**
+     * @param  array<string,list<string>>  $allowlists
+     */
+    private function resultPageV2HasConfiguredAllowlist(array $allowlists): bool
+    {
+        foreach ($allowlists as $allowedValues) {
+            if ($allowedValues !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array{allowed: bool, mode: string, reason: string, matched_rule: string|null, context: array<string,string>}  $decision
+     */
+    private function recordResultPageV2PilotGateDecision(array $decision): void
+    {
+        $context = $decision['context'];
+
+        Log::info('RIASEC_RESULT_PAGE_V2_PILOT_GATE', [
+            'decision' => $decision['allowed'] ? 'allow' : 'deny',
+            'mode' => $decision['mode'],
+            'reason' => $decision['reason'],
+            'matched_rule' => $decision['matched_rule'],
+            'environment' => $context['environment'] ?? '',
+            'scale_code' => $context['scale_code'] ?? '',
+            'form_code' => $context['form_code'] ?? '',
+            'locale' => $context['locale'] ?? '',
+            'attempt_hash' => $this->resultPageV2HashIdentifier($context['attempt_id'] ?? ''),
+            'user_hash' => $this->resultPageV2HashIdentifier($context['user_id'] ?? ''),
+            'anon_hash' => $this->resultPageV2HashIdentifier($context['anon_id'] ?? ''),
+            'org_hash' => $this->resultPageV2HashIdentifier($context['org_id'] ?? ''),
+            'raw_identifier_exported' => false,
+            'production_rollout_enabled' => false,
+        ]);
+    }
+
+    private function resultPageV2HashIdentifier(string $identifier): string
+    {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            return '';
+        }
+
+        return hash('sha256', $identifier);
     }
 
     /**

--- a/backend/config/riasec_result_page_v2.php
+++ b/backend/config/riasec_result_page_v2.php
@@ -4,9 +4,39 @@ return [
     'enabled' => env('RIASEC_RESULT_PAGE_V2_ENABLED', false),
     'staging_runtime_enabled' => env('RIASEC_RESULT_PAGE_V2_STAGING_RUNTIME_ENABLED', false),
     'pilot_runtime_enabled' => env('RIASEC_RESULT_PAGE_V2_PILOT_RUNTIME_ENABLED', false),
+    'pilot_kill_switch_enabled' => env('RIASEC_RESULT_PAGE_V2_PILOT_KILL_SWITCH_ENABLED', false),
     'allowed_environments' => array_values(array_filter(array_map(
         static fn (string $environment): string => trim($environment),
         explode(',', (string) env('RIASEC_RESULT_PAGE_V2_ALLOWED_ENVIRONMENTS', 'local,testing,staging')),
+    ))),
+    'pilot_allowed_environments' => array_values(array_filter(array_map(
+        static fn (string $environment): string => trim($environment),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_ENVIRONMENTS', 'local,testing,staging')),
+    ))),
+    'pilot_production_allowlist_enabled' => env('RIASEC_RESULT_PAGE_V2_PILOT_PRODUCTION_ALLOWLIST_ENABLED', false),
+    'pilot_allowed_form_codes' => array_values(array_filter(array_map(
+        static fn (string $formCode): string => trim($formCode),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_FORM_CODES', 'riasec_60,riasec_140')),
+    ))),
+    'pilot_allowed_locales' => array_values(array_filter(array_map(
+        static fn (string $locale): string => trim($locale),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_LOCALES', 'zh-CN')),
+    ))),
+    'pilot_access_allowed_attempt_ids' => array_values(array_filter(array_map(
+        static fn (string $attemptId): string => trim($attemptId),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_ATTEMPT_IDS', '')),
+    ))),
+    'pilot_access_allowed_user_ids' => array_values(array_filter(array_map(
+        static fn (string $userId): string => trim($userId),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_USER_IDS', '')),
+    ))),
+    'pilot_access_allowed_anon_ids' => array_values(array_filter(array_map(
+        static fn (string $anonId): string => trim($anonId),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_ANON_IDS', '')),
+    ))),
+    'pilot_access_allowed_org_ids' => array_values(array_filter(array_map(
+        static fn (string $orgId): string => trim($orgId),
+        explode(',', (string) env('RIASEC_RESULT_PAGE_V2_PILOT_ALLOWED_ORG_IDS', '')),
     ))),
     'production_runtime_enabled' => env('RIASEC_RESULT_PAGE_V2_PRODUCTION_RUNTIME_ENABLED', false),
     'production_rollout_enabled' => env('RIASEC_RESULT_PAGE_V2_PRODUCTION_ROLLOUT_ENABLED', false),

--- a/backend/tests/Unit/Services/Riasec/RiasecPilotAllowlistGateTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecPilotAllowlistGateTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\ReportAccess;
+use App\Services\Report\RiasecReportComposer;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+final class RiasecPilotAllowlistGateTest extends TestCase
+{
+    public function test_pilot_gate_defaults_closed_without_allowlist(): void
+    {
+        Log::spy();
+        $this->enablePilotGate();
+
+        $payload = $this->compose($this->attempt());
+
+        $this->assertNull($payload);
+        Log::shouldHaveReceived('info')->once()->with('RIASEC_RESULT_PAGE_V2_PILOT_GATE', \Mockery::on(
+            static fn (array $context): bool => ($context['decision'] ?? null) === 'deny'
+                && ($context['reason'] ?? null) === 'pilot_allowlist_empty'
+                && ($context['raw_identifier_exported'] ?? true) === false
+        ));
+    }
+
+    public function test_pilot_gate_allows_attempt_user_anon_and_org_allowlist_matches(): void
+    {
+        foreach ([
+            'attempt_id' => 'pilot_attempt_1',
+            'user_id' => 'pilot_user_1',
+            'anon_id' => 'pilot_anon_1',
+            'org_id' => '314159',
+        ] as $field => $allowedValue) {
+            $this->enablePilotGate();
+            config()->set('riasec_result_page_v2.pilot_access_allowed_'.$field.'s', [$allowedValue]);
+
+            $attempt = $this->attempt([$field => $allowedValue]);
+            $payload = $this->compose($attempt);
+
+            $this->assertIsArray($payload, $field);
+            $this->assertSame('allow', data_get($payload, 'gate.pilot_gate_decision'));
+            $this->assertSame('pilot_allowlist_allowed', data_get($payload, 'gate.pilot_gate_reason'));
+            $this->assertSame($field, data_get($payload, 'gate.pilot_gate_matched_rule'));
+            $this->assertFalse((bool) data_get($payload, 'gate.raw_identifier_exported', true));
+            $this->assertStringNotContainsString($allowedValue, json_encode($payload, JSON_THROW_ON_ERROR));
+        }
+    }
+
+    public function test_pilot_gate_denies_wrong_form_locale_environment_and_kill_switch(): void
+    {
+        $this->enablePilotGate([
+            'pilot_access_allowed_anon_ids' => ['pilot_anon_1'],
+            'pilot_allowed_form_codes' => ['riasec_140'],
+        ]);
+        $this->assertNull($this->compose($this->attempt(['anon_id' => 'pilot_anon_1'])));
+
+        $this->enablePilotGate([
+            'pilot_access_allowed_anon_ids' => ['pilot_anon_1'],
+            'pilot_allowed_locales' => ['en-US'],
+        ]);
+        $this->assertNull($this->compose($this->attempt(['anon_id' => 'pilot_anon_1'])));
+
+        $this->enablePilotGate([
+            'pilot_access_allowed_anon_ids' => ['pilot_anon_1'],
+            'pilot_allowed_environments' => ['staging'],
+        ]);
+        $this->assertNull($this->compose($this->attempt(['anon_id' => 'pilot_anon_1'])));
+
+        $this->enablePilotGate([
+            'pilot_access_allowed_anon_ids' => ['pilot_anon_1'],
+            'pilot_kill_switch_enabled' => true,
+        ]);
+        $this->assertNull($this->compose($this->attempt(['anon_id' => 'pilot_anon_1'])));
+    }
+
+    public function test_pilot_gate_denies_production_by_default(): void
+    {
+        $this->app->detectEnvironment(static fn (): string => 'production');
+        $this->app['env'] = 'production';
+        $this->enablePilotGate([
+            'allowed_environments' => ['production', 'testing'],
+            'pilot_allowed_environments' => ['production', 'testing'],
+            'pilot_access_allowed_anon_ids' => ['pilot_anon_1'],
+            'pilot_production_allowlist_enabled' => false,
+        ]);
+
+        $payload = $this->compose($this->attempt(['anon_id' => 'pilot_anon_1']));
+
+        $this->assertNull($payload);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function enablePilotGate(array $overrides = []): void
+    {
+        config()->set('riasec_result_page_v2.enabled', true);
+        config()->set('riasec_result_page_v2.staging_runtime_enabled', false);
+        config()->set('riasec_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('riasec_result_page_v2.pilot_kill_switch_enabled', false);
+        config()->set('riasec_result_page_v2.allowed_environments', ['testing']);
+        config()->set('riasec_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('riasec_result_page_v2.pilot_production_allowlist_enabled', false);
+        config()->set('riasec_result_page_v2.pilot_allowed_form_codes', ['riasec_60', 'riasec_140']);
+        config()->set('riasec_result_page_v2.pilot_allowed_locales', ['zh-CN']);
+        config()->set('riasec_result_page_v2.pilot_access_allowed_attempt_ids', []);
+        config()->set('riasec_result_page_v2.pilot_access_allowed_user_ids', []);
+        config()->set('riasec_result_page_v2.pilot_access_allowed_anon_ids', []);
+        config()->set('riasec_result_page_v2.pilot_access_allowed_org_ids', []);
+        config()->set('riasec_result_page_v2.production_runtime_enabled', false);
+        config()->set('riasec_result_page_v2.production_rollout_enabled', false);
+        config()->set('riasec_result_page_v2.production_rollout_manual_approval_granted', false);
+
+        foreach ($overrides as $key => $value) {
+            config()->set('riasec_result_page_v2.'.$key, $value);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function attempt(array $overrides = []): Attempt
+    {
+        $attempt = new Attempt;
+        $attempt->attempt_id = 'pilot_attempt_default';
+        $attempt->user_id = 'pilot_user_default';
+        $attempt->anon_id = 'pilot_anon_default';
+        $attempt->org_id = '271828';
+        $attempt->scale_code = 'RIASEC';
+        $attempt->locale = 'zh-CN';
+
+        foreach ($overrides as $key => $value) {
+            $attempt->{$key} = $value;
+        }
+
+        return $attempt;
+    }
+
+    private function riasecResult(): Result
+    {
+        $result = new Result;
+        $result->scale_code = 'RIASEC';
+        $result->type_code = 'RIA';
+        $result->result_json = [
+            'top_code' => 'RIA',
+            'primary_type' => 'R',
+            'secondary_type' => 'I',
+            'tertiary_type' => 'A',
+            'form_code' => 'riasec_60',
+            'answer_count' => 60,
+            'scores_0_100' => [
+                'R' => 100,
+                'I' => 80,
+                'A' => 60,
+                'S' => 40,
+                'E' => 20,
+                'C' => 10,
+            ],
+        ];
+
+        return $result;
+    }
+
+    private function compose(Attempt $attempt): ?array
+    {
+        $result = app(RiasecReportComposer::class)->composeVariant(
+            $attempt,
+            $this->riasecResult(),
+            ReportAccess::VARIANT_FULL,
+            [
+                'snapshot_bound' => true,
+                'riasec_result_page_v2_pilot' => true,
+            ]
+        );
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        return data_get($result, 'report._meta.result_page_v2');
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:03:44+08:00",
+  "updated_at": "2026-06-22T11:17:33+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57357,7 +57357,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-runtime-wrapper-staging-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01: feat(riasec): add staging runtime wrapper gate",
     "depends_on": [
@@ -57380,14 +57380,18 @@
       "git_diff_check_after_ci_fix": "passed",
       "github_required_checks_after_ci_fix": "passed",
       "pre_merge_scope_validation": "passed",
-      "pre_merge_git_diff_check": "passed"
+      "pre_merge_git_diff_check": "passed",
+      "post_merge_php_artisan_test_filter_RiasecResultPage": "passed",
+      "post_merge_php_artisan_test_filter_RiasecAssessmentFlowTest": "passed",
+      "post_merge_php_artisan_test_filter_BigFive_runtime_paths": "passed",
+      "main_equals_origin_main": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "471292a70218ca0389990c06ccd149c8622b360d",
+    "commit_sha": "f786c03aaaa6ecd41050f943bdd3e1a6e38dc53e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2270",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T03:10:17Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57427,6 +57431,12 @@
         "from": "pull_request_open_fix_pushed_pending_checks",
         "to": "ready_to_merge",
         "notes": "GitHub required checks are green on PR #2270. Pre-merge scope validation and git diff --check passed; production rollout remains disabled."
+      },
+      {
+        "at": "2026-06-22T11:17:08+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled PR #2270 after squash merge. Merge commit f786c03aaaa6ecd41050f943bdd3e1a6e38dc53e is on origin/main; remote/local task branch cleanup and post-merge revalidation passed."
       }
     ]
   },
@@ -57434,13 +57444,21 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-pilot-allowlist-gate-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate",
     "depends_on": [
       "RIASEC-RESULT-RUNTIME-WRAPPER-STAGING-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr10_merged": "passed",
+      "manifest_scope_correction": "added_backend_app_Services_Report_for_runtime_wrapper_connection",
+      "php_artisan_test_filter_RiasecPilot": "passed",
+      "php_artisan_test_filter_RiasecResultPage": "passed",
+      "php_artisan_test_filter_BigFive_runtime_paths": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -57456,6 +57474,18 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T11:17:08+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "Implemented pilot allowlist gate with attempt/user/anon/org/form/locale/environment checks, kill switch, and pilot gate observability. Corrected manifest allowed_paths to include the existing RiasecReportComposer runtime wrapper connection point."
+      },
+      {
+        "at": "2026-06-22T11:17:33+08:00",
+        "from": "local_checks_passed",
+        "to": "local_checks_passed",
+        "notes": "Scope validation passed after manifest allowed_paths correction; changed files are limited to config, Report composer wrapper gate, RiasecPilot test, and pr-train metadata."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:17:33+08:00",
+  "updated_at": "2026-06-22T11:17:42+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57460,7 +57460,7 @@
       "scope_validation": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "f3aea0cb18df06c039b6fc18435e75a304bddf4f",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57486,6 +57486,12 @@
         "from": "local_checks_passed",
         "to": "local_checks_passed",
         "notes": "Scope validation passed after manifest allowed_paths correction; changed files are limited to config, Report composer wrapper gate, RiasecPilot test, and pr-train metadata."
+      },
+      {
+        "at": "2026-06-22T11:17:42+08:00",
+        "from": "local_checks_passed",
+        "to": "local_checks_passed",
+        "notes": "Recorded local implementation commit f3aea0cb18df06c039b6fc18435e75a304bddf4f before push."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:18:19+08:00",
+  "updated_at": "2026-06-22T11:24:44+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57444,7 +57444,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-pilot-allowlist-gate-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate",
     "depends_on": [
@@ -57459,10 +57459,13 @@
       "git_diff_check": "passed",
       "scope_validation": "passed",
       "branch_pushed": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_validation": "passed",
+      "pre_merge_git_diff_check": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "e3401d23b3163ebf8340fd97f5bbe100370d3f0e",
+    "commit_sha": "48cd4b20708d7b4d22564ac072eedd77061a4daf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2273",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57500,6 +57503,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2273 after local validation and scope validation passed. Pilot gate remains default-off and production denied by default."
+      },
+      {
+        "at": "2026-06-22T11:24:44+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks are green on PR #2273. Pre-merge scope validation and git diff --check passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:17:42+08:00",
+  "updated_at": "2026-06-22T11:18:19+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57444,7 +57444,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-pilot-allowlist-gate-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate",
     "depends_on": [
@@ -57457,11 +57457,13 @@
       "php_artisan_test_filter_RiasecResultPage": "passed",
       "php_artisan_test_filter_BigFive_runtime_paths": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "branch_pushed": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "f3aea0cb18df06c039b6fc18435e75a304bddf4f",
-    "pr_url": null,
+    "commit_sha": "e3401d23b3163ebf8340fd97f5bbe100370d3f0e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2273",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57492,6 +57494,12 @@
         "from": "local_checks_passed",
         "to": "local_checks_passed",
         "notes": "Recorded local implementation commit f3aea0cb18df06c039b6fc18435e75a304bddf4f before push."
+      },
+      {
+        "at": "2026-06-22T11:18:19+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2273 after local validation and scope validation passed. Pilot gate remains default-off and production denied by default."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26493,6 +26493,7 @@ prs:
       - Keep production default denied.
     allowed_paths:
       - backend/config/**
+      - backend/app/Services/Report/**
       - backend/app/Services/Riasec/**
       - backend/tests/**/RiasecPilot*
       - backend/tests/**/RiasecResultPage*


### PR DESCRIPTION
## What changed
- Adds RIASEC result_page_v2 pilot gating for attempt, user, anon, org, form, locale, and environment allowlists.
- Adds a default-off pilot kill switch and pilot gate observability logs without exporting raw identifiers.
- Keeps production rollout, CMS writes, and frontend fallback disabled; production pilot access remains denied by default.
- Corrects the PR11 manifest allowed_paths to include the existing RiasecReportComposer runtime wrapper connection point.
- Reconciles PR10 post-merge state after PR #2270 merged and cleanup/revalidation passed.

## Why
- The runtime wrapper staging gate existed, but pilot mode needed a fail-closed allowlist before any pilot exposure could be used safely.

## Validation
- cd backend && php artisan test --filter=RiasecPilot --no-ansi
- cd backend && php artisan test --filter=RiasecResultPage --no-ansi
- cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
- git diff --check
- scope validation against PR11 manifest allowed paths

## Intentionally deferred
- No CMS import or write.
- No production gate enablement or rollout automation.
- No fap-web fallback or public production rollout behavior.
- All-surface pilot QA remains in the next PR.