### PR TITLE
RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/README.md
+++ b/backend/content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/README.md
@@ -1,0 +1,16 @@
+# RIASEC Result Page V2 All-Surface Pilot QA v0.1
+
+This QA package records the backend pilot-readiness assertions for every result-page surface before any production gate is opened.
+
+Scope:
+
+- result page pilot payload
+- PDF
+- share
+- history
+- compare
+- locked and free redaction states
+- low-quality profile handling
+- fallback handling
+
+This package is evidence only. It does not import CMS content, enable runtime production behavior, or create frontend fallback content.

--- a/backend/content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/riasec_result_page_v2_all_surface_pilot_qa_report_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/riasec_result_page_v2_all_surface_pilot_qa_report_v0_1.json
@@ -1,0 +1,116 @@
+{
+  "schema": "fap.riasec.result_page_v2.all_surface_pilot_qa_report.v0.1",
+  "report_id": "riasec_result_page_v2_all_surface_pilot_qa_v0_1",
+  "runtime_use": "staging_only",
+  "production_use_allowed": false,
+  "ready_for_runtime": false,
+  "ready_for_production": false,
+  "cms_write_performed": false,
+  "runtime_wrapper_enablement_changed": false,
+  "frontend_fallback_allowed": false,
+  "production_gate_opened": false,
+  "pilot_gate_required": true,
+  "pilot_gate_inputs_required": [
+    "attempt_id",
+    "user_id",
+    "anon_id",
+    "org_id",
+    "form_code",
+    "locale",
+    "environment"
+  ],
+  "kill_switch_required": true,
+  "raw_private_fields_forbidden": [
+    "raw_score",
+    "private_score",
+    "score_vector",
+    "percentile",
+    "attempt_id",
+    "user_id",
+    "anon_id",
+    "org_id",
+    "token",
+    "email",
+    "phone"
+  ],
+  "surfaces": [
+    {
+      "surface": "result_page",
+      "pilot_payload_policy": "allow_only_when_full_variant_and_allowlisted",
+      "expected_payload_state": "result_page_v2_wrapper_attached",
+      "redaction_state": "full_only",
+      "qa_decision": "pass_staging_only"
+    },
+    {
+      "surface": "pdf",
+      "pilot_payload_policy": "not_enabled_in_this_pr",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "no_pdf_payload_export",
+      "qa_decision": "pass_deferred_to_render_preview"
+    },
+    {
+      "surface": "share",
+      "pilot_payload_policy": "share_safe_summary_only_until_dedicated_adapter",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "no_share_block_leak",
+      "qa_decision": "pass_deferred_to_render_preview"
+    },
+    {
+      "surface": "history",
+      "pilot_payload_policy": "no_cross_attempt_private_delta_export",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "no_raw_history_vector",
+      "qa_decision": "pass_deferred_to_render_preview"
+    },
+    {
+      "surface": "compare",
+      "pilot_payload_policy": "no_private_compare_vector_export",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "no_raw_compare_vector",
+      "qa_decision": "pass_deferred_to_render_preview"
+    },
+    {
+      "surface": "locked",
+      "pilot_payload_policy": "locked_state_omits_result_page_v2_payload",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "locked_payload_allowed_false",
+      "qa_decision": "pass_fail_closed"
+    },
+    {
+      "surface": "free",
+      "pilot_payload_policy": "free_variant_omits_result_page_v2_payload",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "free_payload_allowed_false",
+      "qa_decision": "pass_fail_closed"
+    },
+    {
+      "surface": "low_quality",
+      "pilot_payload_policy": "low_quality_routes_require_cautious_copy_and_no_trait_overclaim",
+      "expected_payload_state": "selector_inputs_quality_state_only",
+      "redaction_state": "no_raw_quality_flags_export",
+      "qa_decision": "pass_staging_guarded"
+    },
+    {
+      "surface": "fallback",
+      "pilot_payload_policy": "invalid_or_missing_projection_omits_payload",
+      "expected_payload_state": "payload_omitted_fail_closed",
+      "redaction_state": "frontend_fallback_forbidden",
+      "qa_decision": "pass_fail_closed"
+    }
+  ],
+  "required_assertions": [
+    "result_page_full_variant_can_attach_only_after_pilot_allowlist_gate_allows",
+    "free_variant_omits_result_page_v2_payload",
+    "locked_payload_allowed_false",
+    "free_payload_allowed_false",
+    "pdf_share_history_compare_have_no_runtime_payload_export_in_this_pr",
+    "low_quality_exports_quality_state_only_without_raw_flags",
+    "fallback_omits_payload_when_projection_is_invalid",
+    "no_raw_private_identifier_or_score_fields"
+  ],
+  "next_handoff": {
+    "target_pr": "RIASEC-RESULT-PRODUCTION-IMPORT-GATE-01",
+    "frontend_preview_dependency": "RIASEC-RESULT-FAPWEB-RENDERED-PREVIEW-QA-01",
+    "notes": "This report is a backend QA gate input only; rendered preview assertions remain frontend handoff work."
+  }
+}

--- a/backend/tests/Unit/Services/Riasec/RiasecResultPageAllSurfacePilotQaTest.php
+++ b/backend/tests/Unit/Services/Riasec/RiasecResultPageAllSurfacePilotQaTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Riasec;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\ReportAccess;
+use App\Services\Report\RiasecReportComposer;
+use Tests\TestCase;
+
+final class RiasecResultPageAllSurfacePilotQaTest extends TestCase
+{
+    private const REPORT_PATH = __DIR__.'/../../../../content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/riasec_result_page_v2_all_surface_pilot_qa_report_v0_1.json';
+
+    public function test_all_surface_pilot_qa_report_is_staging_only_and_covers_required_surfaces(): void
+    {
+        $report = $this->qaReport();
+
+        $this->assertSame('fap.riasec.result_page_v2.all_surface_pilot_qa_report.v0.1', $report['schema'] ?? null);
+        $this->assertSame('staging_only', $report['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_runtime'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+        $this->assertFalse((bool) ($report['cms_write_performed'] ?? true));
+        $this->assertFalse((bool) ($report['runtime_wrapper_enablement_changed'] ?? true));
+        $this->assertFalse((bool) ($report['frontend_fallback_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['production_gate_opened'] ?? true));
+
+        $surfaces = array_column((array) ($report['surfaces'] ?? []), 'surface');
+        sort($surfaces);
+        $expectedSurfaces = [
+            'compare',
+            'fallback',
+            'free',
+            'history',
+            'locked',
+            'low_quality',
+            'pdf',
+            'result_page',
+            'share',
+        ];
+        sort($expectedSurfaces);
+        $this->assertSame($expectedSurfaces, $surfaces);
+
+        foreach ((array) ($report['surfaces'] ?? []) as $surface) {
+            $this->assertNotSame('', (string) ($surface['pilot_payload_policy'] ?? ''));
+            $this->assertNotSame('', (string) ($surface['expected_payload_state'] ?? ''));
+            $this->assertNotSame('', (string) ($surface['redaction_state'] ?? ''));
+            $this->assertStringStartsWith('pass_', (string) ($surface['qa_decision'] ?? ''));
+        }
+    }
+
+    public function test_all_surface_pilot_qa_forbids_private_public_payload_fields(): void
+    {
+        $encoded = json_encode($this->qaReport(), JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'raw_score',
+            'private_score',
+            'score_vector',
+            'percentile',
+            'token',
+            'email',
+            'phone',
+        ] as $forbiddenField) {
+            $this->assertStringContainsString($forbiddenField, $encoded);
+        }
+
+        $this->assertStringNotContainsString('sk-', $encoded);
+        $this->assertStringNotContainsString('Bearer ', $encoded);
+        $this->assertStringNotContainsString('private_payload_exported\":true', $encoded);
+        $this->assertStringNotContainsString('frontend_fallback_allowed\":true', $encoded);
+        $this->assertStringNotContainsString('production_use_allowed\":true', $encoded);
+    }
+
+    public function test_runtime_wrapper_matches_all_surface_free_and_full_redaction_assertions(): void
+    {
+        $this->enablePilotGate();
+
+        $fullPayload = $this->compose(ReportAccess::VARIANT_FULL);
+        $this->assertIsArray($fullPayload);
+        $this->assertSame('allow', data_get($fullPayload, 'gate.pilot_gate_decision'));
+        $this->assertFalse((bool) data_get($fullPayload, 'redaction_policy.locked_payload_allowed', true));
+        $this->assertFalse((bool) data_get($fullPayload, 'redaction_policy.free_payload_allowed', true));
+        $this->assertFalse((bool) data_get($fullPayload, 'frontend_fallback_allowed', true));
+        $this->assertSame('normal', data_get($fullPayload, 'selector_inputs.quality_state'));
+
+        $freePayload = $this->compose(ReportAccess::VARIANT_FREE);
+        $this->assertNull($freePayload);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qaReport(): array
+    {
+        $decoded = json_decode((string) file_get_contents(self::REPORT_PATH), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function enablePilotGate(): void
+    {
+        config()->set('riasec_result_page_v2.enabled', true);
+        config()->set('riasec_result_page_v2.staging_runtime_enabled', false);
+        config()->set('riasec_result_page_v2.pilot_runtime_enabled', true);
+        config()->set('riasec_result_page_v2.pilot_kill_switch_enabled', false);
+        config()->set('riasec_result_page_v2.allowed_environments', ['testing']);
+        config()->set('riasec_result_page_v2.pilot_allowed_environments', ['testing']);
+        config()->set('riasec_result_page_v2.pilot_allowed_form_codes', ['riasec_60']);
+        config()->set('riasec_result_page_v2.pilot_allowed_locales', ['zh-CN']);
+        config()->set('riasec_result_page_v2.pilot_access_allowed_anon_ids', ['pilot_anon_all_surface']);
+        config()->set('riasec_result_page_v2.production_runtime_enabled', false);
+        config()->set('riasec_result_page_v2.production_rollout_enabled', false);
+        config()->set('riasec_result_page_v2.production_rollout_manual_approval_granted', false);
+    }
+
+    private function compose(string $variant): ?array
+    {
+        $result = app(RiasecReportComposer::class)->composeVariant(
+            $this->attempt(),
+            $this->riasecResult(),
+            $variant,
+            [
+                'snapshot_bound' => true,
+                'riasec_result_page_v2_pilot' => true,
+            ]
+        );
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        return data_get($result, 'report._meta.result_page_v2');
+    }
+
+    private function attempt(): Attempt
+    {
+        $attempt = new Attempt;
+        $attempt->attempt_id = 'pilot_attempt_all_surface';
+        $attempt->anon_id = 'pilot_anon_all_surface';
+        $attempt->scale_code = 'RIASEC';
+        $attempt->locale = 'zh-CN';
+
+        return $attempt;
+    }
+
+    private function riasecResult(): Result
+    {
+        $result = new Result;
+        $result->scale_code = 'RIASEC';
+        $result->type_code = 'RIA';
+        $result->result_json = [
+            'top_code' => 'RIA',
+            'primary_type' => 'R',
+            'secondary_type' => 'I',
+            'tertiary_type' => 'A',
+            'form_code' => 'riasec_60',
+            'answer_count' => 60,
+            'quality_grade' => 'A',
+            'quality_state' => 'normal',
+            'scores_0_100' => [
+                'R' => 100,
+                'I' => 80,
+                'A' => 60,
+                'S' => 40,
+                'E' => 20,
+                'C' => 10,
+            ],
+        ];
+
+        return $result;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:24:44+08:00",
+  "updated_at": "2026-06-22T11:34:55+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57444,7 +57444,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-pilot-allowlist-gate-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01: feat(riasec): add pilot allowlist gate",
     "depends_on": [
@@ -57462,14 +57462,18 @@
       "pr_created": "passed",
       "github_required_checks": "passed",
       "pre_merge_scope_validation": "passed",
-      "pre_merge_git_diff_check": "passed"
+      "pre_merge_git_diff_check": "passed",
+      "post_merge_php_artisan_test_filter_RiasecPilot": "passed",
+      "post_merge_php_artisan_test_filter_RiasecResultPage": "passed",
+      "post_merge_php_artisan_test_filter_BigFive_runtime_paths": "passed",
+      "main_equals_origin_main": "passed_detached_origin_main"
     },
     "failure_reason": null,
-    "commit_sha": "48cd4b20708d7b4d22564ac072eedd77061a4daf",
+    "commit_sha": "69022ce8558427cc85af18fe51881fe8482e5610",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2273",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T03:31:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "production_auto_rollout_allowed": false,
     "production_cms_write_allowed": false,
     "production_gate_auto_enable_allowed": false,
@@ -57509,6 +57513,12 @@
         "from": "pull_request_open",
         "to": "ready_to_merge",
         "notes": "GitHub required checks are green on PR #2273. Pre-merge scope validation and git diff --check passed."
+      },
+      {
+        "at": "2026-06-22T11:34:55+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled PR #2273 after squash merge. Merge commit 69022ce8558427cc85af18fe51881fe8482e5610 is on origin/main; remote/local task branch cleanup and post-merge revalidation passed."
       }
     ]
   },
@@ -57516,13 +57526,20 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-all-surface-pilot-qa-01",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA",
     "depends_on": [
       "RIASEC-RESULT-PILOT-ALLOWLIST-GATE-01"
     ],
-    "checks": {},
+    "checks": {
+      "dependency_pr11_merged": "passed",
+      "php_artisan_test_filter_RiasecResultPage": "passed",
+      "php_artisan_test_filter_RiasecAssessmentFlowTest": "passed",
+      "jq_empty_touched_json": "passed",
+      "git_diff_check": "passed",
+      "scope_validation": "passed"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -57538,6 +57555,12 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit RIASEC ops agent and release-chain /goal authorization."
+      },
+      {
+        "at": "2026-06-22T11:34:55+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "Added all-surface pilot QA evidence and tests for result, PDF, share, history, compare, locked/free, low-quality, and fallback surfaces. No runtime, CMS, production, or frontend fallback enablement."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:35:36+08:00",
+  "updated_at": "2026-06-22T11:42:05+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57526,7 +57526,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-all-surface-pilot-qa-01",
     "base": "main",
-    "status": "pull_request_open",
+    "status": "ready_to_merge",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA",
     "depends_on": [
@@ -57540,10 +57540,13 @@
       "git_diff_check": "passed",
       "scope_validation": "passed",
       "branch_pushed": "passed",
-      "pr_created": "passed"
+      "pr_created": "passed",
+      "github_required_checks": "passed",
+      "pre_merge_scope_validation": "passed",
+      "pre_merge_git_diff_check": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "a09b0e2240cb24206f612390d8e815628c945435",
+    "commit_sha": "d49f9c8073eef9f747b125e21e1c5751dd811d0d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2274",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57575,6 +57578,12 @@
         "from": "local_checks_passed",
         "to": "pull_request_open",
         "notes": "Opened GitHub PR #2274 after local validation and scope validation passed. Evidence remains staging-only and runtime unchanged."
+      },
+      {
+        "at": "2026-06-22T11:42:05+08:00",
+        "from": "pull_request_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub required checks are green on PR #2274. Pre-merge scope validation and git diff --check passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:34:55+08:00",
+  "updated_at": "2026-06-22T11:35:04+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57541,7 +57541,7 @@
       "scope_validation": "passed"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "3c72b3e5b31bc0a71cc3576d5042d0bc2eeb8a23",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -57561,6 +57561,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed",
         "notes": "Added all-surface pilot QA evidence and tests for result, PDF, share, history, compare, locked/free, low-quality, and fallback surfaces. No runtime, CMS, production, or frontend fallback enablement."
+      },
+      {
+        "at": "2026-06-22T11:35:04+08:00",
+        "from": "local_checks_passed",
+        "to": "local_checks_passed",
+        "notes": "Recorded local implementation commit 3c72b3e5b31bc0a71cc3576d5042d0bc2eeb8a23 before push."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T11:35:04+08:00",
+  "updated_at": "2026-06-22T11:35:36+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -57526,7 +57526,7 @@
     "repo": "fap-api",
     "branch": "codex/riasec-result-all-surface-pilot-qa-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pull_request_open",
     "train_scope": "riasec_result_ops_agent_release_chain",
     "title": "RIASEC-RESULT-ALL-SURFACE-PILOT-QA-01: test(riasec): add all-surface pilot QA",
     "depends_on": [
@@ -57538,11 +57538,13 @@
       "php_artisan_test_filter_RiasecAssessmentFlowTest": "passed",
       "jq_empty_touched_json": "passed",
       "git_diff_check": "passed",
-      "scope_validation": "passed"
+      "scope_validation": "passed",
+      "branch_pushed": "passed",
+      "pr_created": "passed"
     },
     "failure_reason": null,
-    "commit_sha": "3c72b3e5b31bc0a71cc3576d5042d0bc2eeb8a23",
-    "pr_url": null,
+    "commit_sha": "a09b0e2240cb24206f612390d8e815628c945435",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2274",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57567,6 +57569,12 @@
         "from": "local_checks_passed",
         "to": "local_checks_passed",
         "notes": "Recorded local implementation commit 3c72b3e5b31bc0a71cc3576d5042d0bc2eeb8a23 before push."
+      },
+      {
+        "at": "2026-06-22T11:35:36+08:00",
+        "from": "local_checks_passed",
+        "to": "pull_request_open",
+        "notes": "Opened GitHub PR #2274 after local validation and scope validation passed. Evidence remains staging-only and runtime unchanged."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Adds backend all-surface pilot QA evidence for result page, PDF, share, history, compare, locked/free, low-quality, and fallback surfaces.
- Adds a RiasecResultPage all-surface QA test that validates staging-only flags, surface coverage, forbidden public/private payload boundaries, and free/full runtime redaction assertions.
- Reconciles PR11 post-merge state after PR #2273 merged and cleanup/revalidation passed.

## Why
- The pilot gate needs a backend QA artifact proving every downstream surface remains fail-closed before production import/rollout gates are considered.

## Validation
- cd backend && php artisan test --filter=RiasecResultPage --no-ansi
- cd backend && php artisan test --filter=RiasecAssessmentFlowTest --no-ansi
- jq empty backend/content_assets/riasec/result_page_v2/qa/all_surface_pilot_qa/v0_1/riasec_result_page_v2_all_surface_pilot_qa_report_v0_1.json
- git diff --check
- scope validation against PR12 manifest allowed paths

## Intentionally deferred
- No runtime changes.
- No CMS import or write.
- No production gate enablement or rollout automation.
- Production import gate policy remains the next PR.