### PR TITLE
MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -28,6 +28,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--qa= : Path to the MBTI64 agent expansion QA JSON artifact}
         {--dry-run : Validate and plan without database writes}
         {--write : Create CMS projection draft revision rows}
+        {--visible-query-backed-3 : Dry-run only; restrict planning to the approved 3 query-backed visible MBTI64 URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--draft-only : Required for --write; confirms revision draft only}
@@ -70,6 +71,10 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
         if (! $write && ! $dryRun) {
             throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write && (bool) $this->option('visible-query-backed-3')) {
+            throw new RuntimeException('--visible-query-backed-3 is dry-run only and cannot be combined with --write.');
         }
 
         if ($write) {
@@ -144,6 +149,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         return [
             'dry_run' => (bool) $this->option('dry-run'),
             'write' => (bool) $this->option('write'),
+            'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
             'draft_only' => (bool) $this->option('draft-only'),
             'no_publish' => (bool) $this->option('no-publish'),
             'no_index' => (bool) $this->option('no-index'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -18,6 +18,12 @@ final class Mbti64CmsProjectionDraftWriter
 
     private const QA_ARTIFACT = 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01';
 
+    private const VISIBLE_QUERY_BACKED_3_URLS = [
+        'https://fermatmind.com/en/personality/enfj-a',
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfp-a',
+    ];
+
     private const FORBIDDEN_ROUTE_PATTERNS = [
         '#/results?(?:/|$)#i',
         '#/orders?(?:/|$)#i',
@@ -69,9 +75,10 @@ final class Mbti64CmsProjectionDraftWriter
         $errors = $this->validatePackageAndQa($package, $qa);
         $warnings = array_values(array_filter((array) ($qa['warnings'] ?? []), static fn (mixed $warning): bool => is_string($warning)));
         $qaResultsByUrl = $this->qaResultsByUrl($qa);
+        $recommendations = $this->recommendationsForOptions($package, $options, $write, $errors);
 
         $preparedRows = [];
-        foreach ($this->recommendations($package) as $position => $recommendation) {
+        foreach ($recommendations as $position => $recommendation) {
             $identity = $this->identityForRecommendation($recommendation);
             if ($identity === null) {
                 $errors[] = [
@@ -136,7 +143,7 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         if ($errors !== []) {
-            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $options), [
                 'ok' => false,
                 'status' => 'fail',
                 'row_count' => count($preparedRows),
@@ -180,7 +187,7 @@ final class Mbti64CmsProjectionDraftWriter
             unset($preparedRow);
         }
 
-        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $options), [
             'ok' => true,
             'status' => 'pass',
             'row_count' => count($preparedRows),
@@ -270,6 +277,48 @@ final class Mbti64CmsProjectionDraftWriter
             is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
             static fn (mixed $item): bool => is_array($item)
         ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $options
+     * @param  list<array<string,string>>  $errors
+     * @return list<array<string,mixed>>
+     */
+    private function recommendationsForOptions(array $package, array $options, bool $write, array &$errors): array
+    {
+        $recommendations = $this->recommendations($package);
+        if (! (bool) ($options['visible_query_backed_3'] ?? false)) {
+            return $recommendations;
+        }
+
+        if ($write) {
+            $errors[] = [
+                'field' => 'options.visible_query_backed_3',
+                'code' => 'visible_query_backed_subset_write_not_allowed',
+                'message' => 'Visible query-backed 3-page subset is dry-run only.',
+            ];
+        }
+
+        $allowed = array_fill_keys(self::VISIBLE_QUERY_BACKED_3_URLS, true);
+        $subset = array_values(array_filter(
+            $recommendations,
+            static fn (array $item): bool => isset($allowed[(string) ($item['target_url'] ?? '')])
+        ));
+        $subsetUrls = array_map(static fn (array $item): string => (string) ($item['target_url'] ?? ''), $subset);
+        sort($subsetUrls);
+        $expectedUrls = self::VISIBLE_QUERY_BACKED_3_URLS;
+        sort($expectedUrls);
+
+        if ($subsetUrls !== $expectedUrls) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'visible_query_backed_subset_required_urls_missing',
+                'message' => 'The visible query-backed subset must resolve exactly the 3 approved URLs.',
+            ];
+        }
+
+        return $subset;
     }
 
     /**
@@ -504,7 +553,7 @@ final class Mbti64CmsProjectionDraftWriter
      * @param  array<string,mixed>  $qa
      * @return array<string,mixed>
      */
-    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write, array $options): array
     {
         return [
             'artifact' => 'MBTI64-CMS-PROJECTION-DRAFT-88-01',
@@ -523,6 +572,23 @@ final class Mbti64CmsProjectionDraftWriter
             'sitemap_llms_release_attempted' => false,
             'search_release_attempted' => false,
             'writes_committed' => false,
+            'subset' => $this->subsetSummary($options),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function subsetSummary(array $options): array
+    {
+        $enabled = (bool) ($options['visible_query_backed_3'] ?? false);
+
+        return [
+            'mode' => $enabled ? 'visible_query_backed_3' : 'full_88',
+            'enabled' => $enabled,
+            'dry_run_only' => $enabled,
+            'allowed_urls' => $enabled ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
         ];
     }
 

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -32,6 +32,12 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         '/zh/personality/intj-t',
     ];
 
+    private const VISIBLE_QUERY_BACKED_3_URLS = [
+        'https://fermatmind.com/en/personality/enfj-a',
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfp-a',
+    ];
+
     public function test_dry_run_plans_eighty_eight_projection_drafts_without_writes(): void
     {
         $this->seedAllTargets();
@@ -54,6 +60,100 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(58, $payload['variant_row_count']);
         $this->assertSame(30, $payload['comparison_row_count']);
         $this->assertSame(88, $payload['would_create_revision_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_visible_query_backed_three_dry_run_plans_only_approved_urls_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['would_create_revision_count']);
+        $this->assertSame('visible_query_backed_3', $payload['subset']['mode']);
+        $this->assertTrue($payload['subset']['enabled']);
+        $this->assertTrue($payload['subset']['dry_run_only']);
+
+        $plannedUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($plannedUrls);
+        $expectedUrls = self::VISIBLE_QUERY_BACKED_3_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $plannedUrls);
+        $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_visible_query_backed_three_is_dry_run_only_and_rejects_write_mode(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--visible-query-backed-3'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('dry-run only', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_visible_query_backed_three_fails_closed_when_allowlisted_url_is_missing(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        foreach ($package['recommendations'] as &$recommendation) {
+            if (($recommendation['target_url'] ?? null) === 'https://fermatmind.com/en/personality/enfj-a') {
+                $recommendation['target_url'] = 'https://fermatmind.com/en/personality/entj-a';
+                break;
+            }
+        }
+        unset($recommendation);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('visible_query_backed_subset_required_urls_missing', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
         $this->assertSame(0, PersonalityProfileRevision::query()->count());
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
@@ -601,5 +701,17 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertIsArray($payload);
 
         return $payload;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function sortedStrings(array $values): array
+    {
+        $values = array_values(array_map(static fn (string $value): string => $value, $values));
+        sort($values);
+
+        return $values;
     }
 }


### PR DESCRIPTION
## What changed
- Added a dry-run-only `--visible-query-backed-3` option to `personality:mbti64-cms-projection-draft`.
- The option keeps the existing 88-page package and QA validation, then restricts planning to exactly these approved query-backed URLs:
  - `https://fermatmind.com/en/personality/enfj-a`
  - `https://fermatmind.com/zh/personality/intp-a`
  - `https://fermatmind.com/zh/personality/esfp-a`
- Added focused tests proving the 3-page subset plans 3 rows / 0 writes, rejects write mode, and fails closed when an allowlisted URL is missing.

## Why
This lets production run a controlled visible-3 dry-run without opening arbitrary URL subset support or changing the existing 88-page write gate.

## Validation
- `php -l backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php`
- `php -l backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php`
- `php -l backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only projection draft command, writer, and focused command test changed.

## Intentionally deferred
- No production dry-run executed in this PR.
- No CMS write, live promotion, publish, index/search, sitemap, llms, frontend, URL Truth, queue, approve, or submit changes.
- Next task: `MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-DRY-RUN-01` after deploy readiness and explicit read-only production verification authorization.
