### PR TITLE
fix(seo-intel): allow root content page URL Truth handoff

### DIFF
--- a/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php
@@ -89,10 +89,17 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
             ));
         }
 
-        usort($records, static fn (UrlTruthInventoryRecord $a, UrlTruthInventoryRecord $b): int => strcmp(
-            $a->canonicalUrlHash(),
-            $b->canonicalUrlHash(),
-        ));
+        usort($records, function (UrlTruthInventoryRecord $a, UrlTruthInventoryRecord $b) use ($canonicalPath): int {
+            if ($canonicalPath !== null) {
+                $exactCompare = ((int) $this->recordPathExactlyMatches($b, $canonicalPath))
+                    <=> ((int) $this->recordPathExactlyMatches($a, $canonicalPath));
+                if ($exactCompare !== 0) {
+                    return $exactCompare;
+                }
+            }
+
+            return strcmp($a->canonicalUrlHash(), $b->canonicalUrlHash());
+        });
 
         $payload = $artifact->fromRecords($records, $source->metadata(), $limit, $pageType);
         $validation = $artifact->validate($payload, $limit, $pageType);
@@ -346,6 +353,14 @@ final class SeoIntelUrlTruthHandoffCommand extends Command
 
         return $recordPath === $canonicalPath
             || $this->stripLocalePrefix($recordPath) === $canonicalPath;
+    }
+
+    private function recordPathExactlyMatches(UrlTruthInventoryRecord $record, string $canonicalPath): bool
+    {
+        $recordPath = (string) (parse_url($record->canonicalUrl, PHP_URL_PATH) ?: '');
+        $recordPath = $this->normalizedPathOption($recordPath) ?? '';
+
+        return $recordPath === $canonicalPath;
     }
 
     private function stripLocalePrefix(string $path): string

--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -688,7 +688,16 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             return $localeSegment === 'zh' ? '/' : '/en';
         }
 
+        if ($localeSegment === 'en' && $this->isRootLevelContentPagePath($path)) {
+            return $path;
+        }
+
         return '/'.$localeSegment.$path;
+    }
+
+    private function isRootLevelContentPagePath(string $path): bool
+    {
+        return preg_match('#^/[a-z0-9][a-z0-9_-]*$#', $path) === 1;
     }
 
     private function hasRequiredContentPageFields(ContentPage $page): bool

--- a/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
+++ b/backend/app/Services/SeoIntel/UrlTruthHandoffArtifact.php
@@ -81,7 +81,7 @@ final class UrlTruthHandoffArtifact
         ],
         self::CONTENT_PAGE_ENTITY_TYPE => [
             'mode' => 'two_stage_content_page_url_truth_handoff',
-            'route_regex' => '^/(en|zh)/(?!results(?:/|$)|orders(?:/|$)|share(?:/|$)|pay(?:/|$)|payment(?:/|$)|history(?:/|$)|private(?:/|$)|account(?:/|$)|admin(?:/|$)|ops(?:/|$))[a-z0-9][a-z0-9/_-]*$',
+            'route_regex' => '^(?:/(?:en|zh)/(?!results(?:/|$)|orders(?:/|$)|share(?:/|$)|pay(?:/|$)|payment(?:/|$)|history(?:/|$)|private(?:/|$)|account(?:/|$)|admin(?:/|$)|ops(?:/|$))[a-z0-9][a-z0-9/_-]*|/(?!en(?:/|$)|zh(?:/|$)|results(?:/|$)|orders(?:/|$)|share(?:/|$)|pay(?:/|$)|payment(?:/|$)|history(?:/|$)|private(?:/|$)|account(?:/|$)|admin(?:/|$)|ops(?:/|$))[a-z0-9][a-z0-9/_-]*)$',
             'entity_source' => 'content_pages',
             'route_fragment' => '/',
             'forbidden_route_fragments' => self::PRIVATE_ROUTE_FRAGMENTS,
@@ -384,7 +384,9 @@ final class UrlTruthHandoffArtifact
         $scheme = Str::lower((string) parse_url($url, PHP_URL_SCHEME));
         $host = Str::lower((string) parse_url($url, PHP_URL_HOST));
         $path = (string) (parse_url($url, PHP_URL_PATH) ?: '');
-        $pathLocale = Str::before(Str::after($path, '/'), '/');
+        $pathLocale = preg_match('#^/(en|zh)(?:/|$)#', $path, $localeMatches) === 1
+            ? (string) $localeMatches[1]
+            : null;
         $pathSlug = Str::after($path, $policy['route_fragment']);
         $locale = (string) ($candidate['locale'] ?? '');
 
@@ -441,7 +443,7 @@ final class UrlTruthHandoffArtifact
             }
         }
 
-        if (! in_array($pathLocale, ['en', 'zh'], true)) {
+        if ($pathLocale === null && ! ($pageEntityType === self::CONTENT_PAGE_ENTITY_TYPE && $locale === 'en')) {
             $issues[] = 'candidate_locale_path_invalid:'.$index;
         }
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php
@@ -224,6 +224,76 @@ final class SeoIntelTwoStageUrlTruthHandoffTest extends TestCase
     }
 
     #[Test]
+    public function command_exports_root_level_english_content_page_handoff_artifact_without_locale_prefix(): void
+    {
+        config([
+            'app.frontend_url' => 'https://www.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
+
+        $about = $this->createPublishedContentPage([
+            'slug' => 'about',
+            'path' => '/about',
+            'canonical_path' => '/about',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company_static',
+            'locale' => 'en',
+            'title' => 'About FermatMind',
+        ]);
+        $this->createPublishedContentPage([
+            'slug' => 'about',
+            'path' => '/about',
+            'canonical_path' => '/about',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company_static',
+            'locale' => 'zh-CN',
+            'title' => '关于 FermatMind',
+        ]);
+
+        $path = sys_get_temp_dir().'/root-content-page-url-truth-handoff-'.bin2hex(random_bytes(4)).'.json';
+
+        $exportExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--export' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 1,
+            '--page-type' => 'content_page',
+            '--canonical-path' => '/about',
+        ]);
+        $exportOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exportExitCode, json_encode($exportOutput, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $this->assertSame('success', $exportOutput['status'] ?? null);
+        $this->assertSame('/about', $exportOutput['canonical_path_filter'] ?? null);
+        $this->assertSame(1, $exportOutput['planned_url_count'] ?? null);
+        $this->assertFalse((bool) ($exportOutput['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($exportOutput['search_url_submission'] ?? true));
+
+        $artifact = json_decode((string) file_get_contents($path), true);
+        $this->assertSame('content_page', data_get($artifact, 'constraints.allowed_page_entity_type'));
+        $this->assertSame('/about', parse_url((string) data_get($artifact, 'candidates.0.canonical_url'), PHP_URL_PATH));
+        $this->assertSame((string) $about->slug, data_get($artifact, 'candidates.0.entity_id_or_slug'));
+        $this->assertSame('content_pages', data_get($artifact, 'candidates.0.entity_source'));
+        $this->assertTrue((bool) data_get($artifact, 'candidates.0.attributes.claim_safe'));
+
+        $importExitCode = Artisan::call('seo-intel:url-truth-handoff', [
+            '--import' => $path,
+            '--dry-run' => true,
+            '--json' => true,
+            '--limit' => 1,
+            '--page-type' => 'content_page',
+        ]);
+        $importOutput = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $importExitCode, json_encode($importOutput, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $this->assertSame('success', $importOutput['status'] ?? null);
+        $this->assertSame('import_dry_run', $importOutput['mode'] ?? null);
+        $this->assertSame(1, $importOutput['planned_url_count'] ?? null);
+        $this->assertFalse((bool) ($importOutput['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($importOutput['search_url_submission'] ?? true));
+    }
+
+    #[Test]
     public function command_exports_and_validates_mbti64_variant_handoff_artifact_without_writes(): void
     {
         config([


### PR DESCRIPTION
## What changed
- Allows bounded URL Truth handoff artifacts for English root-level public ContentPage paths such as `/about`.
- Keeps localized ContentPage paths valid and preserves private-route blocking for `/results`, `/account`, `/orders`, `/admin`, etc.
- Makes `--canonical-path=/about --limit=1` prefer an exact `/about` candidate over locale-stripped matches like `/zh/about`.
- Adds focused coverage for exporting and import-dry-running a root-level English ContentPage handoff artifact.

## Why
PR4 production dry-run is currently blocked because PR3 published `content_page:21:en` with `safe_path=/about`, but the existing handoff source exported only localized ContentPage URL Truth candidates like `/zh/about`. PR4 requires exact URL Truth lookup for the PR3 `/about` canonical URL.

## Validation
- `cd backend && php artisan test --filter=SeoIntelTwoStageUrlTruthHandoffTest`
- `cd backend && php artisan test --filter=SeoAgentL5aIndexnowSubmitCanaryTest`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/SeoIntelUrlTruthHandoffCommand.php app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php app/Services/SeoIntel/UrlTruthHandoffArtifact.php tests/Feature/SeoIntel/SeoIntelTwoStageUrlTruthHandoffTest.php`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No URL Truth DB import write in this PR.
- No PR4 IndexNow live submit in this PR.
- After merge/deploy, rerun bounded URL Truth export/import dry-run for `/about`, then request separate URL Truth import approval before any DB write.
