### PR TITLE
PR-TRAIN-STATE-SAFE-RECONCILE-01: reconcile safe merged PR train states

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -39995,7 +39995,7 @@
     "repo": "fap-api",
     "branch": "codex/career-search-channel-readiness-gate-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
@@ -43724,7 +43724,7 @@
     "repo": "fap-api",
     "branch": "codex/article-internal-link-plan-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article internal link plan",
     "depends_on": [
@@ -43760,7 +43760,7 @@
       "next_task": "ARTICLE-CTA-ROUTE-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "cd51c29ce0c8a4bc1760ffb75a1aac2eb7f95ec0",
+    "commit_sha": "6e0c78e7b2a2ff258597ebf9b079ab2bf14495fb",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1895",
     "merged_at": "2026-06-05T01:32:19Z",
     "remote_branch_deleted": true,
@@ -43802,7 +43802,7 @@
     "repo": "fap-api",
     "branch": "codex/article-cta-route-gate-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): gate article CTA routes",
     "depends_on": [
@@ -43839,7 +43839,7 @@
       "next_task": "ARTICLE-FAQ-SCHEMA-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": "d16e14083c6354736445212f984e651f5e0a58b6",
+    "commit_sha": "ff12145afc415d0d79370d5f3e5020962f2939b3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1897",
     "merged_at": "2026-06-05T01:41:29Z",
     "remote_branch_deleted": true,
@@ -43881,7 +43881,7 @@
     "repo": "fap-api",
     "branch": "codex/article-faq-schema-smoke-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article FAQ schema smoke",
     "depends_on": [
@@ -43917,7 +43917,7 @@
       "next_task": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "ac4ee0d138ea422f2b26ec34890b1ecc6c7bc875",
+    "commit_sha": "73d99a26b41714bd1569b378852f756622364cae",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1899",
     "merged_at": "2026-06-05T01:49:36Z",
     "remote_branch_deleted": true,
@@ -46388,7 +46388,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-content-request-card-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): add Foundation content request card",
     "depends_on": [
@@ -46521,7 +46521,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-cms-field-map-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): map Foundation CMS fields",
     "depends_on": [
@@ -46663,7 +46663,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-faq-schema-gate-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): gate Foundation FAQ schema",
     "depends_on": [
@@ -46803,7 +46803,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-proof-redaction-sop-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving proof redaction SOP",
     "depends_on": [
@@ -47855,7 +47855,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-first-record-review-template-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving first record review template",
     "depends_on": [
@@ -51717,7 +51717,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-daily-04",
     "base": "origin/main",
-    "status": "github_checks_passed_ready_to_merge",
+    "status": "merged",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "depends_on": [
@@ -51786,7 +51786,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "21b6fc6d2328d95cb09358aa0920e8708d23b1d4",
+    "commit_sha": "1cae5d854b22bccde0becf485d93f6cd19a98fc2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2011",
     "merged_at": "2026-06-09T04:18:01Z",
     "remote_branch_deleted": true,
@@ -54700,7 +54700,7 @@
     "id": "PERSONALITY-SEO-TITLE-METADATA-01",
     "branch": "codex/personality-seo-title-metadata-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "personality_seo",
     "title": "PERSONALITY-SEO-TITLE-METADATA-01: feat(personality): add search-intent metadata authority",
     "depends_on": [
@@ -55858,7 +55858,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-m8-production-ops",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent",
     "title": "B5-RESULT-M8-PRODUCTION-OPS-01: Add Big Five V2 production ops reporting",
     "depends_on": [
@@ -58181,7 +58181,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-auto-check-poller",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-AUTO-CHECK-POLLER-01: Add Big Five V2 GitHub check poller artifacts",
     "depends_on": [
@@ -58250,7 +58250,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-v2-mechanical-fix-apply",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "big5_result_page_v2_asset_agent_execution_runner",
     "title": "B5-RESULT-MECHANICAL-FIX-APPLY-01: Apply limited Big Five V2 mechanical fixes",
     "depends_on": [


### PR DESCRIPTION
## What changed

- Reconciled the 14 entries listed in `backend/docs/codex/pr-train-state-legacy-reconcile-audit-2026-06-22.md` section 4, `Suggested Next Safe Ledger-Only Reconcile Batch`.
- Updated only top-level `status`, `commit_sha`, and `merged_at` where needed in `docs/codex/pr-train-state.json`.
- Preserved existing cleanup facts; all 14 entries retain `remote_branch_deleted=true` and `local_cleanup_executed=true`.

## Why

- GitHub reports these PRs as `MERGED`, but the ledger still had stale operational statuses such as `pr_open`, `ready_to_merge`, or `github_checks_passed_ready_to_merge`.
- This keeps the PR train ledger aligned without changing semantic custom statuses or individually risky legacy entries.

## Validation

- `jq empty docs/codex/pr-train-state.json`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: changed and staged file list was exactly `docs/codex/pr-train-state.json`.
- Re-queried GitHub for the 14 PRs and confirmed each PR state is `MERGED` with merge commit and merged timestamp.

## Intentionally deferred

- No runtime changes.
- No content asset changes.
- No CMS import or write.
- No production gate or rollout changes.
- Did not process merged-like custom semantic statuses.
- Did not process the `Needs Individual Confirmation` list from the audit report.
