### PR TITLE
SEO-AGENT-GSC-COHORT-HANDOFF-01: add GSC cohort artifact adapter

### DIFF
--- a/backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php
@@ -1,0 +1,679 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Services\SeoAgent\OpportunityAggregator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class SeoAgentGscCohortHandoffCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-gsc-cohort-handoff.v1';
+
+    private const CLASSIFIED_SCHEMA_VERSION = 'fermatmind-gsc-seo-agent-cohort.v1';
+
+    private const PROPOSALS_SCHEMA_VERSION = 'fermatmind-seo-agent-gsc-draft-proposals.v1';
+
+    private const SOURCE_FAMILY = 'gsc_cohort_artifact';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:gsc-cohort-handoff
+        {--classified= : Path to a fermatmind-gsc-seo-agent-cohort.v1 JSON artifact}
+        {--proposals= : Path to a fermatmind-seo-agent-gsc-draft-proposals.v1 JSON artifact}
+        {--limit=10 : Candidate limit, bounded 1..100}
+        {--artifact-dir= : Directory for sanitized JSON artifacts}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Convert exported GSC cohort artifacts into standard SEO Agent review and CMS draft dry-run artifacts without writes.';
+
+    public function handle(): int
+    {
+        $classified = $this->readArtifact((string) $this->option('classified'), self::CLASSIFIED_SCHEMA_VERSION, 'classified');
+        if (($classified['ok'] ?? false) !== true) {
+            return $this->finish($this->failureSummary((string) ($classified['issue'] ?? 'classified_unreadable')));
+        }
+
+        $proposals = $this->readArtifact((string) $this->option('proposals'), self::PROPOSALS_SCHEMA_VERSION, 'proposals');
+        if (($proposals['ok'] ?? false) !== true) {
+            return $this->finish($this->failureSummary((string) ($proposals['issue'] ?? 'proposals_unreadable')));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $limit = $this->limit();
+        $timestamp = Carbon::now('UTC')->format('Ymd\THis\Z');
+        $prepared = $this->prepareCandidates((array) data_get($proposals, 'payload.proposals', []), $limit);
+        $sourceArtifact = $this->sourceArtifact(
+            (array) $classified['payload'],
+            (array) $proposals['payload'],
+            (array) $classified['ref'],
+            (array) $proposals['ref'],
+            $prepared,
+            $limit
+        );
+        $sourceRef = $this->writeArtifact($artifactDir, 'seo-agent-gsc-cohort-source-'.$timestamp.'.json', $sourceArtifact);
+
+        $aggregate = (new OpportunityAggregator)->aggregate([$sourceArtifact], $limit);
+        $aggregate['input_artifacts'] = [$sourceRef];
+        $aggregateRef = $this->writeArtifact($artifactDir, 'seo-agent-gsc-cohort-aggregate-'.$timestamp.'.json', $aggregate);
+
+        $handoff = $this->codexReviewHandoff($sourceRef, $aggregateRef, $aggregate);
+        $handoffRef = $this->writeArtifact($artifactDir, 'seo-agent-gsc-cohort-codex-handoff-'.$timestamp.'.json', $handoff);
+
+        $verdictRef = $this->runCodexReview($handoffRef, $artifactDir);
+        if ($verdictRef === null) {
+            return $this->finish($this->failureSummary('codex_review_runner_failed', [
+                'source_artifact' => $sourceRef,
+                'aggregate_artifact' => $aggregateRef,
+                'handoff_artifact' => $handoffRef,
+            ]));
+        }
+
+        $draftRef = $this->runDraftPackageDryRun($verdictRef, $artifactDir);
+        if ($draftRef === null) {
+            return $this->finish($this->failureSummary('cms_draft_package_dry_run_failed', [
+                'source_artifact' => $sourceRef,
+                'aggregate_artifact' => $aggregateRef,
+                'handoff_artifact' => $handoffRef,
+                'verdict_artifact' => $verdictRef,
+            ]));
+        }
+
+        $evidence = $this->runEvidence($prepared, $sourceRef, $aggregateRef, $handoffRef, $verdictRef, $draftRef);
+        $evidenceRef = $this->writeArtifact($artifactDir, 'seo-agent-gsc-cohort-handoff-evidence-'.$timestamp.'.json', $evidence);
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'candidate_count' => count((array) ($prepared['candidates'] ?? [])),
+            'deferred_non_draft_count' => count((array) ($prepared['deferred_non_draft_groups'] ?? [])),
+            'unresolved_article_count' => count((array) ($prepared['unresolved_article_targets'] ?? [])),
+            'draft_brief_count' => (int) data_get($draftRef, 'sanitized_summary.draft_brief_count', 0),
+            'artifact' => $evidenceRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 10;
+        }
+
+        return max(1, min((int) $raw, 100));
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return array{ok:bool, issue?:string, payload?:array<string,mixed>, ref?:array<string,mixed>}
+     */
+    private function readArtifact(string $path, string $schemaVersion, string $label): array
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return ['ok' => false, 'issue' => $label.'_path_missing'];
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+        if (! is_file($path) || ! is_readable($path)) {
+            return ['ok' => false, 'issue' => $label.'_unreadable'];
+        }
+
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return ['ok' => false, 'issue' => 'forbidden_input_field_present'];
+        }
+
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            return ['ok' => false, 'issue' => $label.'_json_invalid'];
+        }
+
+        if (($payload['schema_version'] ?? null) !== $schemaVersion) {
+            return ['ok' => false, 'issue' => $label.'_schema_invalid'];
+        }
+
+        return [
+            'ok' => true,
+            'payload' => $payload,
+            'ref' => [
+                'path_hash' => hash('sha256', $path),
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'schema_version' => $schemaVersion,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     * @return array{candidates:list<array<string,mixed>>, deferred_non_draft_groups:list<array<string,mixed>>, unresolved_article_targets:list<array<string,mixed>>}
+     */
+    private function prepareCandidates(array $proposals, int $limit): array
+    {
+        $candidates = [];
+        $deferred = [];
+        $unresolved = [];
+
+        foreach ($proposals as $proposal) {
+            if (! is_array($proposal)) {
+                continue;
+            }
+
+            if (($proposal['proposal_type'] ?? null) !== 'article_title_meta_faq_internal_link_draft') {
+                $deferred[] = $this->deferredProposal($proposal, 'non_article_or_non_draft_proposal');
+
+                continue;
+            }
+
+            $safePath = $this->safePath((string) ($proposal['target_url'] ?? ''));
+            $articleTarget = $safePath === null ? null : $this->articleTarget($safePath);
+            if ($articleTarget === null) {
+                $unresolved[] = [
+                    'safe_path_hash' => $safePath === null ? '' : hash('sha256', $safePath),
+                    'reason' => $safePath === null ? 'target_path_invalid' : 'article_target_missing',
+                ];
+
+                continue;
+            }
+
+            $candidates[] = $this->candidate($proposal, $safePath, $articleTarget);
+            if (count($candidates) >= $limit) {
+                break;
+            }
+        }
+
+        return [
+            'candidates' => $candidates,
+            'deferred_non_draft_groups' => $deferred,
+            'unresolved_article_targets' => $unresolved,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array{id:int, locale:string}  $articleTarget
+     * @return array<string, mixed>
+     */
+    private function candidate(array $proposal, string $safePath, array $articleTarget): array
+    {
+        $runtime = (array) ($proposal['runtime_seo_check'] ?? []);
+        $evidence = (array) ($proposal['evidence_7d_or_28d'] ?? []);
+        $impressions = (int) ($evidence['impressions'] ?? 0);
+        $clicks = (int) ($evidence['clicks'] ?? 0);
+        $ctrPpm = $this->ctrPpm($evidence['ctr'] ?? null, $clicks, $impressions);
+        $positionMilli = $this->positionMilli($evidence['position'] ?? null);
+        $gapTypes = $this->gapTypes($runtime, $ctrPpm);
+        $sourceId = hash('sha256', implode('|', [
+            self::SOURCE_FAMILY,
+            $safePath,
+            (string) $articleTarget['id'],
+            implode(',', $gapTypes),
+            (string) $impressions,
+            (string) $positionMilli,
+        ]));
+
+        return [
+            'source_family' => self::SOURCE_FAMILY,
+            'source_id' => $sourceId,
+            'subject_type' => 'article',
+            'subject_ref' => 'article:'.$articleTarget['id'].':'.$articleTarget['locale'],
+            'safe_path' => $safePath,
+            'locale' => $articleTarget['locale'],
+            'severity' => $impressions >= 500 && $ctrPpm <= 5000 ? 'p1' : 'p2',
+            'gap_types' => $gapTypes,
+            'evidence_refs' => $this->evidenceRefs($runtime, $ctrPpm),
+            'metrics' => [
+                'clicks' => $clicks,
+                'impressions' => $impressions,
+                'ctr_ppm' => $ctrPpm,
+                'average_position_milli' => $positionMilli,
+                'title_length' => (int) ($runtime['title_length'] ?? 0),
+                'meta_description_length' => (int) ($runtime['meta_description_length'] ?? 0),
+                'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
+                'internal_link_count' => (int) data_get($runtime, 'internal_link_summary.total_internal_links', 0),
+            ],
+            'safe_path_hash' => hash('sha256', $safePath),
+            'recommended_next_step' => 'codex_review_then_cms_draft_package_dry_run',
+            'allowed_action' => 'cms_draft_package_dry_run',
+            'blocked_actions' => [
+                'database_write',
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $runtime
+     * @return list<string>
+     */
+    private function gapTypes(array $runtime, int $ctrPpm): array
+    {
+        $gapTypes = [
+            'gsc_low_ctr_title_opportunity',
+            'missing_visible_faq',
+        ];
+
+        if ((int) ($runtime['meta_description_length'] ?? 0) < 80 || $ctrPpm <= 10000) {
+            $gapTypes[] = 'gsc_low_ctr_description_opportunity';
+        }
+
+        if ((int) ($runtime['jsonld_total'] ?? 0) === 0) {
+            $gapTypes[] = 'missing_structured_data';
+        }
+
+        return array_values(array_unique($gapTypes));
+    }
+
+    /**
+     * @param  array<string, mixed>  $runtime
+     * @return list<array<string, string>>
+     */
+    private function evidenceRefs(array $runtime, int $ctrPpm): array
+    {
+        $refs = [
+            [
+                'code' => 'gsc_cohort_article_proposal',
+                'field_status' => 'artifact_only_candidate',
+            ],
+            [
+                'code' => 'gsc_low_ctr_rank_8_20',
+                'field_status' => $ctrPpm <= 10000 ? 'eligible_low_ctr' : 'review_required',
+            ],
+        ];
+
+        if ((int) ($runtime['meta_description_length'] ?? 0) < 80) {
+            $refs[] = [
+                'code' => 'gsc_low_ctr_description_opportunity',
+                'field_status' => 'short_meta_description',
+            ];
+        }
+
+        if ((int) ($runtime['jsonld_total'] ?? 0) === 0) {
+            $refs[] = [
+                'code' => 'missing_structured_data',
+                'field_status' => 'jsonld_total_zero',
+            ];
+        }
+
+        return $refs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function deferredProposal(array $proposal, string $reason): array
+    {
+        $safePath = $this->safePath((string) ($proposal['target_url'] ?? ''));
+
+        return [
+            'group' => (string) ($proposal['group'] ?? 'unknown'),
+            'proposal_type' => (string) ($proposal['proposal_type'] ?? 'unknown'),
+            'safe_path_hash' => $safePath === null ? '' : hash('sha256', $safePath),
+            'reason' => $reason,
+        ];
+    }
+
+    /**
+     * @return array{id:int, locale:string}|null
+     */
+    private function articleTarget(string $safePath): ?array
+    {
+        if (preg_match('~^/(en|zh)/articles/([^/?#]+)$~', $safePath, $matches) !== 1) {
+            return null;
+        }
+
+        $localeCandidates = $matches[1] === 'zh' ? ['zh-CN', 'zh'] : ['en'];
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->where('slug', $matches[2])
+            ->whereIn('locale', $localeCandidates)
+            ->orderByRaw('case when locale = ? then 0 else 1 end', [$localeCandidates[0]])
+            ->first(['id', 'locale']);
+
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+        ];
+    }
+
+    private function safePath(string $url): ?string
+    {
+        if (trim($url) === '') {
+            return null;
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        if (! is_string($path) || $path === '') {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function ctrPpm(mixed $ctr, int $clicks, int $impressions): int
+    {
+        if (is_string($ctr) && preg_match('/^([0-9]+(?:\.[0-9]+)?)%$/', trim($ctr), $matches) === 1) {
+            return (int) round(((float) $matches[1] / 100) * 1_000_000);
+        }
+
+        return $impressions > 0 ? (int) floor(($clicks / $impressions) * 1_000_000) : 0;
+    }
+
+    private function positionMilli(mixed $position): ?int
+    {
+        if (! is_numeric($position)) {
+            return null;
+        }
+
+        return (int) round(((float) $position) * 1000);
+    }
+
+    /**
+     * @param  array<string, mixed>  $classified
+     * @param  array<string, mixed>  $proposals
+     * @param  array<string, mixed>  $classifiedRef
+     * @param  array<string, mixed>  $proposalsRef
+     * @param  array<string, mixed>  $prepared
+     * @return array<string, mixed>
+     */
+    private function sourceArtifact(
+        array $classified,
+        array $proposals,
+        array $classifiedRef,
+        array $proposalsRef,
+        array $prepared,
+        int $limit
+    ): array {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-GSC-COHORT-HANDOFF-01',
+            'run_mode' => 'readonly_gsc_cohort_artifact_to_draft_dry_run',
+            'source_family' => self::SOURCE_FAMILY,
+            'input_artifacts' => [
+                'classified' => $classifiedRef,
+                'proposals' => $proposalsRef,
+            ],
+            'input_summary' => [
+                'classified_row_counts' => (array) ($classified['row_counts'] ?? []),
+                'proposal_count' => (int) ($proposals['proposal_count'] ?? count((array) ($proposals['proposals'] ?? []))),
+            ],
+            'candidate_contract' => [
+                'draft_eligible_proposal_type' => 'article_title_meta_faq_internal_link_draft',
+                'allowed_subject_types' => ['article'],
+                'source_family' => self::SOURCE_FAMILY,
+                'safe_path_only' => true,
+                'target_url_output_allowed' => false,
+            ],
+            'candidate_count' => count((array) ($prepared['candidates'] ?? [])),
+            'limit' => $limit,
+            'candidates' => (array) ($prepared['candidates'] ?? []),
+            'deferred_non_draft_groups' => (array) ($prepared['deferred_non_draft_groups'] ?? []),
+            'unresolved_article_targets' => (array) ($prepared['unresolved_article_targets'] ?? []),
+            'forbidden_output_fields_absent' => true,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $sourceRef
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $aggregate
+     * @return array<string, mixed>
+     */
+    private function codexReviewHandoff(array $sourceRef, array $aggregateRef, array $aggregate): array
+    {
+        return [
+            'schema_version' => 'seo-agent-codex-review-handoff.v1',
+            'task' => 'SEO-AGENT-GSC-COHORT-HANDOFF-01',
+            'reviewer' => 'codex',
+            'role' => 'review_only',
+            'execution_permission' => false,
+            'input_candidates' => $aggregateRef,
+            'input_artifacts' => [$sourceRef],
+            'candidate_count' => (int) ($aggregate['candidate_count'] ?? 0),
+            'review_output_contract' => [
+                'worth_optimizing' => 'boolean',
+                'recommended_action' => 'cms_draft_package_dry_run|defer',
+                'risk_flags' => 'list<string>',
+                'needs_human_approval' => 'boolean',
+            ],
+            'candidate_preview' => array_slice((array) ($aggregate['candidates'] ?? []), 0, 100),
+            'forbidden_actions' => [
+                'database_write',
+                'cms_write',
+                'cms_publish',
+                'search_channel_enqueue',
+                'search_channel_submit',
+                'indexing_request',
+                'scheduler_activation',
+                'queue_worker_activation',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $handoffRef
+     * @return array<string, mixed>|null
+     */
+    private function runCodexReview(array $handoffRef, string $artifactDir): ?array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('seo-agent:codex-review-runner', [
+            '--handoff' => (string) ($handoffRef['path'] ?? ''),
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ], $output);
+        $summary = json_decode(trim($output->fetch()), true);
+
+        return $exit === self::SUCCESS && is_array($summary) && is_array($summary['artifact'] ?? null)
+            ? $summary['artifact']
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $verdictRef
+     * @return array<string, mixed>|null
+     */
+    private function runDraftPackageDryRun(array $verdictRef, string $artifactDir): ?array
+    {
+        $output = new BufferedOutput;
+        $exit = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => (string) ($verdictRef['path'] ?? ''),
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ], $output);
+        $summary = json_decode(trim($output->fetch()), true);
+
+        return $exit === self::SUCCESS && is_array($summary) && is_array($summary['artifact'] ?? null)
+            ? $summary['artifact']
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $prepared
+     * @param  array<string, mixed>  $sourceRef
+     * @param  array<string, mixed>  $aggregateRef
+     * @param  array<string, mixed>  $handoffRef
+     * @param  array<string, mixed>  $verdictRef
+     * @param  array<string, mixed>  $draftRef
+     * @return array<string, mixed>
+     */
+    private function runEvidence(
+        array $prepared,
+        array $sourceRef,
+        array $aggregateRef,
+        array $handoffRef,
+        array $verdictRef,
+        array $draftRef
+    ): array {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'SEO-AGENT-GSC-COHORT-HANDOFF-01',
+            'status' => 'success',
+            'candidate_count' => count((array) ($prepared['candidates'] ?? [])),
+            'deferred_non_draft_groups' => (array) ($prepared['deferred_non_draft_groups'] ?? []),
+            'unresolved_article_targets' => (array) ($prepared['unresolved_article_targets'] ?? []),
+            'artifacts' => [
+                'gsc_cohort_source' => $sourceRef,
+                'opportunity_aggregate' => $aggregateRef,
+                'codex_review_handoff' => $handoffRef,
+                'codex_review_verdict' => $verdictRef,
+                'cms_draft_package_dry_run' => $draftRef,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? 'unknown'),
+            'sanitized_summary' => [
+                'candidate_count' => (int) ($payload['candidate_count'] ?? 0),
+                'draft_brief_count' => (int) ($payload['draft_brief_count'] ?? 0),
+                'forbidden_output_fields_absent' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'google_search_console_api_call' => false,
+            'google_indexing_api_call' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -191,6 +191,7 @@ use App\Console\Commands\SeoAgentCmsPublishAutoCanaryCommand;
 use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
+use App\Console\Commands\SeoAgentGscCohortHandoffCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentGscPostPublishFeedbackCommand;
 use App\Console\Commands\SeoAgentL5aContentPagePublishCanaryCommand;
@@ -419,6 +420,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsPublishCanaryCommand::class,
         SeoAgentL5aContentPagePublishCanaryCommand::class,
         SeoAgentL5aIndexnowSubmitCanaryCommand::class,
+        SeoAgentGscCohortHandoffCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentGscPostPublishFeedbackCommand::class,
         SeoAgentPostPublishIndexnowAutoCommand::class,

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-06-22T15:48:08+08:00",
+  "updated_at": "2026-06-22T15:57:46+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,9 +9,9 @@
     "SEO-AGENT-GSC-COHORT-HANDOFF-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "ci_fix_local_checks_passed",
       "branch": "codex/seo-agent-gsc-cohort-handoff-01",
-      "commit_sha": "880117681",
+      "commit_sha": "b7e1944da9678e9f31d981c109407150716761d3",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2284",
       "checks": {
         "local": [
@@ -48,11 +48,26 @@
           {
             "command": "git diff --check && git diff --cached --check",
             "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|gsc_cohort_handoff' --no-ansi",
+            "status": "passed",
+            "details": "2 tests and 44 assertions passed after adding the scoped SEO-agent GSC cohort handoff freeze-classifier allowlist."
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/SeoAgentGscCohortHandoffCommand.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "verify-bigfive",
+            "status": "failed_diagnosed_local_fix_pushed_pending_rerun",
+            "details": "Initial PR #2284 push and pull_request verify-bigfive runs failed because BigFiveResultPageV2CoreBodyPreviewTest flagged backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php and backend/app/Console/Kernel.php as runtime-impacting. Added a scoped classifier allowlist test and helper for the SEO-agent GSC cohort handoff command; local focused BigFive filter now passes."
+          }
+        ]
       },
-      "failure_reason": "",
+      "failure_reason": "Initial GitHub verify-bigfive failed because the BigFive runtime freeze classifier did not yet recognize the new SEO-agent GSC cohort handoff command and Kernel registration as non-BigFive runtime changes. Scoped classifier fix committed and local verification passed; GitHub rerun pending.",
       "resume_policy": "manual_only",
       "merged_at": "",
       "remote_branch_deleted": false,
@@ -72,6 +87,11 @@
           "at": "2026-06-22T15:48:08+08:00",
           "status": "pr_open",
           "summary": "Opened PR #2284 for SEO-AGENT-GSC-COHORT-HANDOFF-01 after scoped local checks passed."
+        },
+        {
+          "at": "2026-06-22T15:57:46+08:00",
+          "status": "ci_fix_local_checks_passed",
+          "summary": "Diagnosed initial GitHub verify-bigfive failure as a scoped BigFive runtime freeze classifier allowlist miss for SeoAgentGscCohortHandoffCommand plus Kernel registration. Added the focused classifier regression test/helper and reran the failing BigFive filter, PR-A feature tests, delegated runner/draft package tests, Pint, command discovery, JSON validation, and diff checks locally."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,7 +1,7 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-06-22T15:46:14+08:00",
+  "updated_at": "2026-06-22T15:48:08+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
@@ -9,10 +9,10 @@
     "SEO-AGENT-GSC-COHORT-HANDOFF-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "branch": "codex/seo-agent-gsc-cohort-handoff-01",
       "commit_sha": "880117681",
-      "pr_url": "",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2284",
       "checks": {
         "local": [
           {
@@ -67,6 +67,11 @@
           "at": "2026-06-22T15:46:14+08:00",
           "status": "local_checks_passed",
           "summary": "Added readonly GSC cohort artifact adapter, generated contract, command registration, and focused tests. Command discovery, focused PHPUnit, runner/draft-package regressions, Pint, JSON/YAML validation, and diff checks passed."
+        },
+        {
+          "at": "2026-06-22T15:48:08+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #2284 for SEO-AGENT-GSC-COHORT-HANDOFF-01 after scoped local checks passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "local_checks_passed",
       "branch": "codex/seo-agent-gsc-cohort-handoff-01",
-      "commit_sha": "",
+      "commit_sha": "880117681",
       "pr_url": "",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,75 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-06-11T20:24:49+08:00",
+  "updated_at": "2026-06-22T15:46:14+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "SEO-AGENT-GSC-COHORT-HANDOFF-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/seo-agent-gsc-cohort-handoff-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "checks": {
+        "local": [
+          {
+            "command": "php artisan list | rg seo-agent:gsc-cohort-handoff",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php",
+            "status": "passed",
+            "details": "4 tests and 102 assertions passed."
+          },
+          {
+            "command": "vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php",
+            "status": "passed",
+            "details": "6 tests and 106 assertions passed."
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/SeoAgentGscCohortHandoffCommand.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-22T15:42:32+08:00",
+          "status": "in_progress",
+          "summary": "Initialized SEO-AGENT-GSC-COHORT-HANDOFF-01 for a backend-only readonly GSC cohort artifact adapter that produces standard SEO Agent review and CMS draft dry-run artifacts without DB, CMS, publish, search, indexing, scheduler, worker, production, or fap-web mutation."
+        },
+        {
+          "at": "2026-06-22T15:46:14+08:00",
+          "status": "local_checks_passed",
+          "summary": "Added readonly GSC cohort artifact adapter, generated contract, command registration, and focused tests. Command discovery, focused PHPUnit, runner/draft-package regressions, Pint, JSON/YAML validation, and diff checks passed."
+        }
+      ]
+    },
     "PERSONALITY-EN-CONTENT-00": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -3810,3 +3810,39 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: SEO-AGENT-GSC-COHORT-HANDOFF-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/seo-agent-gsc-cohort-handoff-01
+    base: main
+    depends_on: []
+    mode: execute
+    title: "SEO-AGENT-GSC-COHORT-HANDOFF-01: add GSC cohort artifact adapter"
+    scope: >
+      Backend-only readonly GSC cohort artifact adapter. Add an Artisan
+      command that consumes exported GSC cohort/proposal JSON artifacts and
+      converts article draft proposals into standard SEO Agent source,
+      aggregate, Codex review handoff, verdict, and CMS draft-package dry-run
+      artifacts. Do not write DB rows, write CMS drafts, publish content,
+      enqueue or submit search/indexing, call live GSC APIs, enable scheduler,
+      start workers, mutate production, or change fap-web.
+    checks:
+      - "php artisan list | rg seo-agent:gsc-cohort-handoff"
+      - "vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php"
+      - "vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php"
+      - "vendor/bin/pint --test app/Console/Commands/SeoAgentGscCohortHandoffCommand.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php"
+      - "python3 -m json.tool docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json >/dev/null"
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json
@@ -1,0 +1,66 @@
+{
+  "version": "seo-agent-gsc-cohort-handoff.v1",
+  "task": "SEO-AGENT-GSC-COHORT-HANDOFF-01",
+  "repo": "fap-api",
+  "type": "readonly_gsc_cohort_artifact_to_cms_draft_dryrun_contract",
+  "command": "php artisan seo-agent:gsc-cohort-handoff",
+  "inputs": [
+    "fermatmind-gsc-seo-agent-cohort.v1",
+    "fermatmind-seo-agent-gsc-draft-proposals.v1"
+  ],
+  "outputs": [
+    "seo-agent-gsc-cohort-handoff.v1",
+    "seo-agent-opportunity-aggregate.v1",
+    "seo-agent-codex-review-handoff.v1",
+    "seo-agent-codex-review-verdict.v1",
+    "seo-agent-cms-draft-package-dry-run.v1"
+  ],
+  "candidate_contract": {
+    "source_family": "gsc_cohort_artifact",
+    "draft_eligible_proposal_type": "article_title_meta_faq_internal_link_draft",
+    "allowed_subject_types": ["article"],
+    "subject_ref": "article:<id>:<locale>",
+    "target_path_contract": "/<locale>/articles/<slug>",
+    "safe_path_only": true,
+    "deferred_groups": [
+      "mbti_personality_variant",
+      "career_job_longtail"
+    ],
+    "target_gap_types": [
+      "gsc_low_ctr_title_opportunity",
+      "gsc_low_ctr_description_opportunity",
+      "missing_structured_data",
+      "missing_visible_faq"
+    ]
+  },
+  "forbidden_input_or_output_fields": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "google_search_console_api_call": false,
+    "google_indexing_api_call": false,
+    "external_model_api_call": false
+  },
+  "next_step": "A separate controlled CMS draft writer may consume the dry-run package after policy approval; this command never writes or publishes CMS content."
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentGscCohortHandoffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function command_converts_gsc_cohort_article_proposals_into_standard_draft_dry_run_artifacts(): void
+    {
+        $articleOne = $this->createArticle('what-is-riasec-holland-code-career-interest-test', 'en');
+        $articleTwo = $this->createArticle('mbti-vs-holland-career-choice', 'zh-CN');
+        $artifactDir = $this->artifactDir();
+        $classifiedPath = $this->writeClassifiedArtifact();
+        $proposalsPath = $this->writeProposalsArtifact([
+            $this->articleProposal('/en/articles/what-is-riasec-holland-code-career-interest-test', 977, 4, '0.4%', 16.9, 67, 125, 2),
+            $this->articleProposal('/zh/articles/mbti-vs-holland-career-choice', 257, 0, '0%', 8.9, 37, 47, 0),
+            $this->personalityProposal('/zh/personality/istj-a'),
+            $this->careerProposal('/en/career/jobs/shipping-receiving-and-inventory-clerks'),
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:gsc-cohort-handoff', [
+            '--classified' => $classifiedPath,
+            '--proposals' => $proposalsPath,
+            '--artifact-dir' => $artifactDir,
+            '--limit' => 10,
+            '--json' => true,
+        ]);
+
+        $countsAfter = $this->rowCounts();
+        $evidence = $this->readJson($this->latestArtifact($artifactDir, 'seo-agent-gsc-cohort-handoff-evidence-*.json'));
+        $source = $this->readJson(data_get($evidence, 'artifacts.gsc_cohort_source.path'));
+        $aggregate = $this->readJson(data_get($evidence, 'artifacts.opportunity_aggregate.path'));
+        $handoff = $this->readJson(data_get($evidence, 'artifacts.codex_review_handoff.path'));
+        $verdict = $this->readJson(data_get($evidence, 'artifacts.codex_review_verdict.path'));
+        $draftPackage = $this->readJson(data_get($evidence, 'artifacts.cms_draft_package_dry_run.path'));
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame($countsBefore, $countsAfter);
+        $this->assertSame('success', $evidence['status'] ?? null);
+        $this->assertSame(2, $evidence['candidate_count'] ?? null);
+        $this->assertCount(2, $evidence['deferred_non_draft_groups'] ?? []);
+        $this->assertSame([], $evidence['unresolved_article_targets'] ?? null);
+
+        $this->assertSame('seo-agent-gsc-cohort-handoff.v1', $source['schema_version'] ?? null);
+        $this->assertSame('gsc_cohort_artifact', data_get($source, 'candidates.0.source_family'));
+        $this->assertSame('article:'.$articleOne->id.':en', data_get($source, 'candidates.0.subject_ref'));
+        $this->assertSame('article:'.$articleTwo->id.':zh-CN', data_get($source, 'candidates.1.subject_ref'));
+        $this->assertSame('/en/articles/what-is-riasec-holland-code-career-interest-test', data_get($source, 'candidates.0.safe_path'));
+        $this->assertSame('/zh/articles/mbti-vs-holland-career-choice', data_get($source, 'candidates.1.safe_path'));
+        $this->assertSame(2, $source['candidate_count'] ?? null);
+        $this->assertCount(2, $source['deferred_non_draft_groups'] ?? []);
+        $this->assertSame('mbti_personality_variant', data_get($source, 'deferred_non_draft_groups.0.group'));
+        $this->assertSame('career_job_longtail', data_get($source, 'deferred_non_draft_groups.1.group'));
+
+        $this->assertSame('seo-agent-opportunity-aggregate.v1', $aggregate['schema_version'] ?? null);
+        $this->assertSame(2, $aggregate['candidate_count'] ?? null);
+        $this->assertSame('seo-agent-codex-review-handoff.v1', $handoff['schema_version'] ?? null);
+        $this->assertFalse((bool) ($handoff['execution_permission'] ?? true));
+        $this->assertSame('seo-agent-codex-review-verdict.v1', $verdict['schema_version'] ?? null);
+        $this->assertSame('cms_draft_package_dry_run', data_get($verdict, 'candidate_verdicts.0.recommended_action'));
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $draftPackage['schema_version'] ?? null);
+        $this->assertSame(2, $draftPackage['draft_brief_count'] ?? null);
+        $this->assertSame('article', data_get($draftPackage, 'draft_briefs.0.target_model'));
+        $this->assertContains('seo_title', data_get($draftPackage, 'draft_briefs.0.target_fields'));
+        $this->assertContains('seo_description', data_get($draftPackage, 'draft_briefs.1.target_fields'));
+        $this->assertContains('faq_items', data_get($draftPackage, 'draft_briefs.1.target_fields'));
+        $this->assertContains('manual_review_required', data_get($draftPackage, 'draft_briefs.1.target_fields'));
+
+        $encoded = json_encode([$evidence, $source, $aggregate, $handoff, $verdict, $draftPackage], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenOutputStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'queue_worker_started',
+            'google_search_console_api_call',
+            'google_indexing_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($evidence, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function command_defers_missing_article_targets_without_failing_the_run(): void
+    {
+        $artifactDir = $this->artifactDir();
+        $classifiedPath = $this->writeClassifiedArtifact();
+        $proposalsPath = $this->writeProposalsArtifact([
+            $this->articleProposal('/en/articles/missing-gsc-cohort-article', 180, 0, '0%', 12.0, 44, 55, 0),
+            $this->personalityProposal('/zh/personality/istj-a'),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:gsc-cohort-handoff', [
+            '--classified' => $classifiedPath,
+            '--proposals' => $proposalsPath,
+            '--artifact-dir' => $artifactDir,
+            '--limit' => 10,
+            '--json' => true,
+        ]);
+
+        $evidence = $this->readJson($this->latestArtifact($artifactDir, 'seo-agent-gsc-cohort-handoff-evidence-*.json'));
+        $source = $this->readJson(data_get($evidence, 'artifacts.gsc_cohort_source.path'));
+        $draftPackage = $this->readJson(data_get($evidence, 'artifacts.cms_draft_package_dry_run.path'));
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $evidence['status'] ?? null);
+        $this->assertSame(0, $evidence['candidate_count'] ?? null);
+        $this->assertCount(1, $evidence['unresolved_article_targets'] ?? []);
+        $this->assertSame('article_target_missing', data_get($source, 'unresolved_article_targets.0.reason'));
+        $this->assertSame(0, $draftPackage['draft_brief_count'] ?? null);
+    }
+
+    #[Test]
+    public function command_fails_closed_for_invalid_schema_and_forbidden_input_fields(): void
+    {
+        $classifiedPath = $this->writeJson(['schema_version' => 'wrong.v1']);
+        $proposalsPath = $this->writeProposalsArtifact([]);
+
+        $exitCode = Artisan::call('seo-agent:gsc-cohort-handoff', [
+            '--classified' => $classifiedPath,
+            '--proposals' => $proposalsPath,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('classified_schema_invalid', $summary['issues'] ?? []);
+
+        $classifiedPath = $this->writeClassifiedArtifact();
+        $forbiddenPath = $this->writeJson([
+            'schema_version' => 'fermatmind-seo-agent-gsc-draft-proposals.v1',
+            'proposal_count' => 1,
+            'proposals' => [
+                [
+                    'proposal_type' => 'article_title_meta_faq_internal_link_draft',
+                    'raw_query' => 'forbidden',
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:gsc-cohort-handoff', [
+            '--classified' => $classifiedPath,
+            '--proposals' => $forbiddenPath,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_gsc_cohort_handoff_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json'));
+
+        $this->assertSame('seo-agent-gsc-cohort-handoff.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:gsc-cohort-handoff', $contract['command'] ?? null);
+        $this->assertSame('gsc_cohort_artifact', data_get($contract, 'candidate_contract.source_family'));
+        $this->assertSame(['article'], data_get($contract, 'candidate_contract.allowed_subject_types'));
+        $this->assertTrue((bool) data_get($contract, 'candidate_contract.safe_path_only'));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.google_search_console_api_call', true));
+    }
+
+    private function createArticle(string $slug, string $locale): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => Str::headline($slug),
+            'excerpt' => 'Published article used for GSC cohort handoff routing.',
+            'content_md' => 'Sentinel markdown body is not read or emitted by this command.',
+            'content_html' => '<p>Sentinel HTML body is not read or emitted by this command.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function writeProposalsArtifact(array $proposals): string
+    {
+        return $this->writeJson([
+            'schema_version' => 'fermatmind-seo-agent-gsc-draft-proposals.v1',
+            'captured_at' => '2026-06-22T07:04:53.055Z',
+            'mode' => 'artifact_only',
+            'proposal_count' => count($proposals),
+            'proposals' => $proposals,
+            'boundaries' => [
+                'cms_write' => false,
+                'cms_publish' => false,
+                'search_submission' => false,
+                'indexing_request' => false,
+            ],
+        ]);
+    }
+
+    private function writeClassifiedArtifact(): string
+    {
+        return $this->writeJson([
+            'schema_version' => 'fermatmind-gsc-seo-agent-cohort.v1',
+            'captured_at' => '2026-06-22T07:04:53.055Z',
+            'row_counts' => [
+                'pages_7d' => 451,
+                'queries_7d' => 301,
+                'pages_28d' => 628,
+                'queries_28d' => 451,
+            ],
+            'groups' => [
+                'riasec_bigfive_enneagram_articles' => [],
+                'mbti_personality_variant' => [],
+                'career_job_longtail' => [],
+            ],
+            'boundaries' => [
+                'cms_write' => false,
+                'cms_publish' => false,
+                'search_submission' => false,
+                'indexing_request' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articleProposal(
+        string $safePath,
+        int $impressions,
+        int $clicks,
+        string $ctr,
+        float $position,
+        int $titleLength,
+        int $metaLength,
+        int $jsonldTotal
+    ): array {
+        return [
+            'target_url' => 'https://fermatmind.com'.$safePath,
+            'group' => 'riasec_bigfive_enneagram_articles',
+            'proposal_type' => 'article_title_meta_faq_internal_link_draft',
+            'evidence_7d_or_28d' => [
+                'clicks' => $clicks,
+                'ctr' => $ctr,
+                'impressions' => $impressions,
+                'key' => 'https://fermatmind.com'.$safePath,
+                'position' => $position,
+            ],
+            'draft_angle' => basename($safePath),
+            'runtime_seo_check' => [
+                'http_status' => 200,
+                'title_length' => $titleLength,
+                'meta_description_length' => $metaLength,
+                'jsonld_total' => $jsonldTotal,
+                'internal_link_summary' => [
+                    'total_internal_links' => 36,
+                ],
+                'checks' => [
+                    'html_200' => true,
+                    'canonical_present' => true,
+                    'title_present' => true,
+                    'meta_description_present' => true,
+                    'robots_not_noindex' => true,
+                    'has_internal_links' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function personalityProposal(string $safePath): array
+    {
+        return [
+            'target_url' => 'https://fermatmind.com'.$safePath,
+            'group' => 'mbti_personality_variant',
+            'proposal_type' => 'public_projection_tdk_schema_internal_link_check',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function careerProposal(string $safePath): array
+    {
+        return [
+            'target_url' => 'https://fermatmind.com'.$safePath,
+            'group' => 'career_job_longtail',
+            'proposal_type' => 'indexability_query_mapping_only',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(array $payload): string
+    {
+        $path = storage_path('framework/testing/seo-agent-gsc-cohort-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-gsc-cohort-handoff-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    private function latestArtifact(string $dir, string $pattern): ?string
+    {
+        $paths = File::glob(rtrim($dir, '/').'/'.$pattern) ?: [];
+        rsort($paths);
+
+        return $paths[0] ?? null;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return array_filter([
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_revisions' => Schema::hasTable('article_revisions') ? DB::table('article_revisions')->count() : null,
+            'article_translation_revisions' => Schema::hasTable('article_translation_revisions') ? DB::table('article_translation_revisions')->count() : null,
+        ], static fn ($value): bool => is_int($value));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenOutputStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'https://fermatmind.com',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(?string $path): array
+    {
+        $this->assertIsString($path);
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1405,6 +1405,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_cohort_handoff_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentGscCohortHandoffCommand;',
+            '+        SeoAgentGscCohortHandoffCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_auto_approval_policy_file(): void
     {
         $changed = [
@@ -4370,6 +4384,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentGscCohortHandoffFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentAutoApprovalPolicyFile($file)) {
                 continue;
             }
@@ -5059,6 +5077,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPriorityQueueSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentGscCohortHandoffOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2AssetAgentAuditOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2InactiveCandidateScaffoldOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFiveV2AssetAgentHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5875,6 +5894,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscOpportunityAutoDraftCommand.php',
             'backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentGscCohortHandoffFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php',
         ], true);
     }
 
@@ -8061,6 +8087,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentGscOpportunityAutoDraftCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentGscCohortHandoffOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentGscCohortHandoffCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added readonly `seo-agent:gsc-cohort-handoff` to convert exported GSC cohort/proposal artifacts into standard SEO Agent source, aggregate, Codex review handoff, verdict, and CMS draft-package dry-run artifacts.
- Registered the command in the console kernel and documented the generated contract.
- Added focused feature coverage for success, deferred non-draft groups, missing article targets, invalid schema, forbidden input fields, and boundary guarantees.
- Added PR train manifest/state entry for `SEO-AGENT-GSC-COHORT-HANDOFF-01`.

## Why
This lets Codex/SEO Agent rehearse against manually exported Chrome/GSC cohort data without requiring a DB read-model import and without crossing CMS, publish, or search-submission boundaries.

## Validation
- `php artisan list | rg seo-agent:gsc-cohort-handoff`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php`
- `vendor/bin/pint --test app/Console/Commands/SeoAgentGscCohortHandoffCommand.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`\n- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`\n- `git diff --check && git diff --cached --check`\n\n## Intentionally deferred\n- No DB writes or `seo_gsc_daily` import.\n- No CMS draft writes, publishing, or content mutation.\n- No Search Channel enqueue/submit, IndexNow, Google Indexing, sitemap submission, scheduler activation, queue worker start, production mutation, or fap-web change.\n- MBTI/personality and career/job cohort proposals are recorded as deferred groups only; article proposals are the only draft-eligible candidates.\n\n## Repository rule impact\nBackend/CMS authority is preserved. This PR adds a readonly adapter and artifact handoff only; it does not introduce frontend editorial fallback, publishable content authority, or search submission behavior.