### PR TITLE
RIASEC-RESULT-V2-MANUAL-PRODUCTION-GATE-READINESS-AUDIT-01: docs(riasec): audit manual production gate readiness

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/riasec_result_page_v2_manual_production_gate_readiness_audit_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/riasec_result_page_v2_manual_production_gate_readiness_audit_v0_1.json
@@ -1,0 +1,157 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.manual_production_gate_readiness_audit.v0.1",
+  "task_id": "RIASEC-RESULT-V2-MANUAL-PRODUCTION-GATE-READINESS-AUDIT-01",
+  "created_date": "2026-06-22",
+  "audit_type": "read_only_manual_gate_readiness",
+  "inputs": {
+    "release_snapshot": "backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json",
+    "production_import_gate_policy": "backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json",
+    "production_rollout_gate_policy": "backend/content_assets/riasec/result_page_v2/governance/production_rollout_gate_v0_1/riasec_result_page_v2_production_rollout_gate_policy_v0_1.json",
+    "release_approval_evidence": "backend/content_assets/riasec/result_page_v2/governance/release_approval_v0_1/riasec_result_page_v2_release_approval_evidence_v0_1.json",
+    "production_rollout_gate_validation": "backend/content_assets/riasec/result_page_v2/qa/production_rollout_gate/v0_1/riasec_result_page_v2_production_rollout_gate_validation_v0_1.json",
+    "post_deploy_staging_pilot_evidence": "backend/content_assets/riasec/result_page_v2/qa/post_deploy_staging_pilot_evidence/v0_1/riasec_result_page_v2_post_deploy_staging_pilot_evidence_v0_1.json",
+    "runtime_config_defaults": "backend/config/riasec_result_page_v2.php"
+  },
+  "release_snapshot_audit": {
+    "snapshot_id": "riasec_result_page_v2_rc_0_1",
+    "immutable": true,
+    "release_candidate": false,
+    "production_use_allowed": false,
+    "ready_for_production": false,
+    "production_rollout_enabled": false,
+    "cms_write_performed": false,
+    "approval_evidence_status": "pending",
+    "result": "NO_GO_FOR_PRODUCTION_IMPORT"
+  },
+  "production_import_gate_audit": {
+    "fail_closed": true,
+    "reject_staging_only_artifacts": true,
+    "production_use_allowed": false,
+    "ready_for_production": false,
+    "production_import_enabled": false,
+    "production_rollout_enabled": false,
+    "human_production_approval_required": true,
+    "result": "PASS_FAIL_CLOSED_POLICY_NO_GO_FOR_IMPORT"
+  },
+  "production_rollout_gate_audit": {
+    "automatic_rollout_allowed": false,
+    "manual_approval_required": true,
+    "production_use_allowed": false,
+    "ready_for_production": false,
+    "production_rollout_enabled": false,
+    "blocked_modes": [
+      "automatic_production_rollout",
+      "unscoped_global_rollout",
+      "cms_production_write",
+      "frontend_fallback_enablement"
+    ],
+    "required_before_rollout": [
+      "production_import_gate_passed",
+      "explicit_human_production_rollout_approval",
+      "approved_release_snapshot_id",
+      "tenant_scope",
+      "form_scope",
+      "locale_scope",
+      "percentage_max",
+      "rollback_kill_switch",
+      "post_deploy_smoke_procedure"
+    ],
+    "result": "PASS_MANUAL_ONLY_POLICY_NO_GO_FOR_ROLLOUT"
+  },
+  "release_approval_audit": {
+    "approval_status": "not_approved",
+    "production_import_approved": false,
+    "production_rollout_enabled": false,
+    "approver": null,
+    "approved_at": null,
+    "approval_evidence_status": "pending_human_approval",
+    "result": "MISSING_HUMAN_APPROVAL"
+  },
+  "post_deploy_smoke_audit": {
+    "policy_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+    "configured_production_procedure_id_observed_in_evidence": "",
+    "result": "MISSING_CONFIGURED_POST_DEPLOY_SMOKE_PROCEDURE_ID"
+  },
+  "rollback_kill_switch_audit": {
+    "kill_switch_config": "riasec_result_page_v2.production_emergency_disabled",
+    "release_disable_supported": true,
+    "emergency_disable_supported": true,
+    "rollback_strategy": "do_not_import_until_approved",
+    "result": "DOCUMENTED_BUT_NOT_ACTIVATED"
+  },
+  "pilot_allowlist_audit": {
+    "pilot_runtime_enabled": false,
+    "pilot_production_allowlist_enabled": false,
+    "production_runtime_enabled": false,
+    "production_rollout_enabled": false,
+    "production_rollout_configured": false,
+    "production_import_gate_passed": false,
+    "production_rollout_mode": "disabled",
+    "result": "PASS_NO_PRODUCTION_PILOT_ENABLEMENT"
+  },
+  "public_payload_safety_audit": {
+    "staging_agent_audit_leak_hits": 0,
+    "staging_import_dry_run_leak_hits": 0,
+    "private_payload_exported": false,
+    "cms_write_performed": false,
+    "runtime_change_performed": false,
+    "surface_coverage": [
+      "result_page",
+      "pdf",
+      "share",
+      "history",
+      "compare",
+      "locked",
+      "free",
+      "low_quality",
+      "fallback"
+    ],
+    "result": "SUFFICIENT_FOR_HUMAN_REVIEW_INPUT_NOT_PRODUCTION_APPROVAL"
+  },
+  "post_deploy_staging_pilot_evidence_audit": {
+    "source_pr": 2285,
+    "accepted_as_manual_gate_input": true,
+    "accepted_as_production_approval": false,
+    "automatic_production_rollout": "NO_GO",
+    "manual_production_gate_required": true
+  },
+  "blockers": {
+    "production_import": [
+      "release_candidate_false",
+      "production_use_allowed_false",
+      "ready_for_production_false",
+      "approval_status_not_approved",
+      "production_import_gate_current_state_no_go",
+      "staging_only_artifacts_rejected"
+    ],
+    "production_rollout": [
+      "production_import_gate_not_passed",
+      "human_rollout_approval_missing",
+      "approved_release_snapshot_id_missing",
+      "production_rollout_disabled",
+      "production_rollout_not_configured",
+      "production_rollout_mode_disabled",
+      "configured_post_deploy_smoke_procedure_id_missing",
+      "scoped_rollout_evidence_missing"
+    ]
+  },
+  "go_no_go": {
+    "production_import_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "automatic_production_rollout_allowed": false,
+    "cms_production_write_allowed": false,
+    "runtime_production_flag_mutation_allowed": false,
+    "manual_gate_preparation_allowed": true
+  },
+  "negative_guarantees": {
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "staging_only_assets_marked_production_ready": false,
+    "frontend_fallback_added": false,
+    "private_payload_exported": false
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-manual-production-gate-readiness-audit-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-manual-production-gate-readiness-audit-2026-06-22.md
@@ -1,0 +1,259 @@
+# RIASEC Result Page V2 Manual Production Gate Readiness Audit
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-MANUAL-PRODUCTION-GATE-READINESS-AUDIT-01`
+
+Scope: docs/artifact-only readiness audit for the manual production gate. This audit is read-only. It does not modify runtime code, environment variables, CMS data, production imports, production rollout gates, release approval state, or frontend fallback behavior. It does not mark staging-only assets as production-ready.
+
+## Verdict
+
+| Gate | Verdict | Reason |
+| --- | --- | --- |
+| Production import | `NO-GO` | Current release snapshot is not a production release candidate, production use is not allowed, and human approval evidence is pending. |
+| Production rollout | `NO-GO` | Rollout policy is manual-only, production rollout config remains disabled, production import gate is not passed, and runtime production flags are not enabled. |
+| Human review preparation | `GO_FOR_HUMAN_REVIEW_PREP` | Post-deploy staging/pilot evidence from PR `#2285` is available as an input, but it is not production approval. |
+
+## Evidence Inputs
+
+| Evidence | Path | Audit result |
+| --- | --- | --- |
+| Release snapshot | `backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json` | Present, immutable, not production-approved. |
+| Production import gate policy | `backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json` | Present, fail-closed. |
+| Production rollout gate policy | `backend/content_assets/riasec/result_page_v2/governance/production_rollout_gate_v0_1/riasec_result_page_v2_production_rollout_gate_policy_v0_1.json` | Present, manual-only. |
+| Release approval evidence | `backend/content_assets/riasec/result_page_v2/governance/release_approval_v0_1/riasec_result_page_v2_release_approval_evidence_v0_1.json` | Present, not approved. |
+| Production rollout gate QA | `backend/content_assets/riasec/result_page_v2/qa/production_rollout_gate/v0_1/riasec_result_page_v2_production_rollout_gate_validation_v0_1.json` | Present, automatic rollout blocked. |
+| Post-deploy staging/pilot evidence | `backend/content_assets/riasec/result_page_v2/qa/post_deploy_staging_pilot_evidence/v0_1/riasec_result_page_v2_post_deploy_staging_pilot_evidence_v0_1.json` | Present, valid as staging/pilot review input only. |
+| Runtime config defaults | `backend/config/riasec_result_page_v2.php` | Production runtime and rollout default to disabled. |
+
+## Release Snapshot
+
+The current snapshot is `riasec_result_page_v2_rc_0_1`.
+
+Observed fields:
+
+- `immutable=true`
+- `release_candidate=false`
+- `production_use_allowed=false`
+- `ready_for_production=false`
+- `production_rollout_enabled=false`
+- `cms_write_performed=false`
+- approval evidence reference status: `pending`
+- rollback strategy: `do_not_import_until_approved`
+- emergency disable support: `true`
+
+Audit result: `NO-GO_FOR_PRODUCTION_IMPORT`.
+
+Reason: the snapshot is intentionally an immutable candidate record, not a production-approved release candidate.
+
+## Production Import Gate
+
+Observed import gate policy:
+
+- `fail_closed=true`
+- `production_use_allowed=false`
+- `ready_for_production=false`
+- `production_rollout_enabled=false`
+- `cms_write_performed=false`
+- rejects staging-only artifacts
+- requires manifest, SHA256, release snapshot, rendered QA evidence, all-surface pass evidence, and approval evidence
+- rejects missing approval evidence, staging-only manifests, snapshot mismatch, CMS writes, and production rollout enablement
+
+Production status in policy:
+
+- `current_state=NO-GO`
+- `production_import_enabled=false`
+- `production_rollout_enabled=false`
+- `human_production_approval_required=true`
+
+Audit result: `PASS_FAIL_CLOSED_POLICY`, `NO-GO_FOR_IMPORT`.
+
+## Production Rollout Gate
+
+Observed rollout gate policy:
+
+- `automatic_rollout_allowed=false`
+- `manual_approval_required=true`
+- `production_use_allowed=false`
+- `ready_for_production=false`
+- `production_rollout_enabled=false`
+- `cms_write_performed=false`
+- allowed modes are constrained to `disabled`, `allowlist_only`, `percentage`, and `allowlist_or_percentage`
+- blocked modes include automatic production rollout, unscoped global rollout, CMS production write, and frontend fallback enablement
+
+Required before rollout:
+
+- production import gate passed
+- explicit human production rollout approval
+- approved release snapshot id
+- tenant scope
+- form scope
+- locale scope
+- percentage max
+- rollback kill switch
+- post-deploy smoke procedure
+
+Audit result: `PASS_MANUAL_ONLY_POLICY`, `NO-GO_FOR_ROLLOUT`.
+
+## Release Approval Evidence
+
+Observed release approval evidence:
+
+- `approval_status=not_approved`
+- `production_import_approved=false`
+- `production_rollout_enabled=false`
+- `production_use_allowed=false`
+- `ready_for_production=false`
+- `approver=null`
+- `approved_at=null`
+- `approval_evidence_status=pending_human_approval`
+
+Required before approval:
+
+- rendered preview QA pass
+- all-surface pilot QA pass
+- release snapshot hash verified
+- staging-only artifacts rejected
+- production rollout gate manual approval
+
+Audit result: `MISSING_HUMAN_APPROVAL`.
+
+## Post-Deploy Smoke Procedure
+
+The rollout gate policy defines expected post-deploy smoke procedure id:
+
+- `riasec_result_page_v2_post_deploy_smoke_v0_1`
+
+However, the deployed production gate evidence captured in PR `#2285` reported:
+
+- `production_post_deploy_smoke_procedure_id=""`
+
+Audit result: `MISSING_CONFIGURED_POST_DEPLOY_SMOKE_PROCEDURE_ID`.
+
+This is not a runtime defect because production rollout remains disabled. It is a precondition gap for any future manual rollout.
+
+## Rollback, Kill Switch, And Emergency Disable
+
+Observed policy and config support:
+
+- Rollout policy documents kill switch config: `riasec_result_page_v2.production_emergency_disabled`
+- Release snapshot rollback strategy: `do_not_import_until_approved`
+- Release disable supported: `true`
+- Emergency disable supported: `true`
+- Production config includes `production_emergency_disabled`, disabled release snapshot ids, rollout percentage, max percentage, scoped allowlists, tenant requirement, and post-deploy smoke controls.
+
+Audit result: `DOCUMENTED_BUT_NOT_ACTIVATED`.
+
+The controls are documented and fail-closed by default, but no production rollout should proceed until an operator prepares the exact approved snapshot id, rollout scope, smoke procedure id, rollback instruction, and kill-switch verification evidence.
+
+## Pilot Allowlist
+
+PR `#2285` evidence captured production gate state:
+
+- `pilot_runtime_enabled=false`
+- `pilot_production_allowlist_enabled=false`
+- `production_runtime_enabled=false`
+- `production_rollout_enabled=false`
+- `production_rollout_configured=false`
+- `production_import_gate_passed=false`
+- `production_rollout_mode=disabled`
+
+Audit result: `PASS_NO_PRODUCTION_PILOT_ENABLEMENT`.
+
+Pilot/staging evidence exists, but it has not opened production.
+
+## Public Payload Leak And Redaction Evidence
+
+PR `#2285` staging/pilot evidence reported:
+
+- staging agent audit leak hits: `0`
+- staging import dry-run leak hits: `0`
+- selector-ready package count: `2`
+- selector-ready asset count: `6`
+- `cms_write_performed=false`
+- `runtime_change_performed=false`
+- `private_payload_exported=false`
+
+All-surface coverage:
+
+| Surface | QA decision | Redaction state |
+| --- | --- | --- |
+| `result_page` | `pass_staging_only` | `full_only` |
+| `pdf` | `pass_deferred_to_render_preview` | `no_pdf_payload_export` |
+| `share` | `pass_deferred_to_render_preview` | `no_share_block_leak` |
+| `history` | `pass_deferred_to_render_preview` | `no_raw_history_vector` |
+| `compare` | `pass_deferred_to_render_preview` | `no_raw_compare_vector` |
+| `locked` | `pass_fail_closed` | `locked_payload_allowed_false` |
+| `free` | `pass_fail_closed` | `free_payload_allowed_false` |
+| `low_quality` | `pass_staging_guarded` | `no_raw_quality_flags_export` |
+| `fallback` | `pass_fail_closed` | `frontend_fallback_forbidden` |
+
+Audit result: `SUFFICIENT_FOR_HUMAN_REVIEW_INPUT`, not production approval.
+
+Reason: evidence supports manual review preparation, but policy still requires production approval evidence and a production-approved release snapshot before import or rollout.
+
+## PR #2285 Evidence As Input
+
+PR `#2285` can be used as a manual gate input because it preserved:
+
+- deployed SHA: `ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9`
+- PR `#2276` merge commit: `fb6e64468bc33063b229ca8ff5ced8076ddae088`
+- production runtime/import/rollout disabled state
+- public API RIASEC 60/140 smoke
+- staging agent audit summary
+- staging import dry-run summary
+- ops staging runner summary
+- fap-api focused test result: `26 passed`
+- fap-web rendered preview contract result: `14 passed`
+
+Audit result: `ACCEPT_AS_REVIEW_INPUT_ONLY`.
+
+The package explicitly says automatic production rollout is `NO-GO` and manual production gate is required.
+
+## Current Blockers To Production Import
+
+1. Release snapshot `riasec_result_page_v2_rc_0_1` has `release_candidate=false`.
+2. Release snapshot has `production_use_allowed=false`.
+3. Release snapshot has `ready_for_production=false`.
+4. Release approval evidence has `approval_status=not_approved`.
+5. Production import gate policy current state is `NO-GO`.
+6. Staging-only assets are rejected by policy and must not be reclassified in this audit.
+
+## Current Blockers To Production Rollout
+
+1. Production import gate is not passed.
+2. Explicit human production rollout approval is missing.
+3. Approved release snapshot id is missing from production config evidence.
+4. Production rollout remains disabled.
+5. Production rollout is not configured.
+6. Production rollout mode is `disabled`.
+7. Post-deploy smoke procedure id is missing in production config evidence.
+8. Scoped rollout evidence for tenant/form/locale/percentage is not present.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Allow production import now | `NO` |
+| Allow production rollout now | `NO` |
+| Allow automatic production rollout | `NO` |
+| Allow CMS production write | `NO` |
+| Allow runtime production flag mutation | `NO` |
+| Allow manual gate preparation | `YES` |
+
+Next safe task: prepare a manual production gate checklist or remediation PR that fills missing approval/smoke/scope evidence without changing runtime or opening production.
+
+## Negative Guarantees
+
+This audit did not perform or authorize:
+
+- runtime code changes;
+- environment variable changes;
+- CMS writes;
+- production import;
+- production rollout;
+- production gate enablement;
+- production-ready asset marking;
+- frontend fallback content;
+- public payload expansion;
+- private score, raw score, vector, percentile, selector trace, source, QA, editor metadata, attempt id, user id, or private URL exposure.


### PR DESCRIPTION
## What changed
- Added a read-only RIASEC Result Page V2 manual production gate readiness audit.
- Added a redacted JSON audit summary under the result_page_v2 QA evidence lane.

## Why
- Confirm whether the current release snapshot, import gate, rollout gate, approval evidence, smoke procedure, rollback/kill-switch, pilot allowlist, and public-payload safety evidence are sufficient for production import or rollout.
- Preserve a clear Go / No-Go decision before any manual production gate preparation.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/riasec_result_page_v2_manual_production_gate_readiness_audit_v0_1.json`
- `git diff --check main...HEAD`
- Scope validation: only `backend/docs/riasec/riasec-result-page-v2-manual-production-gate-readiness-audit-2026-06-22.md` and `backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/*` changed.

## Result
- Production import: NO-GO.
- Production rollout: NO-GO.
- Manual gate preparation: allowed as a follow-up, without changing runtime or opening production.

## Intentionally deferred
- No runtime changes.
- No environment changes.
- No CMS writes or imports.
- No production import gate opening.
- No production rollout.
- No staging-only asset reclassification as production-ready.

## Repository rule impact
- Docs/artifact-only audit package. No content ownership, public API, runtime, CMS, media, sitemap, llms, or publishing workflow behavior changed.