### PR TITLE
Improve GSC cohort draft proposal quality

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php
@@ -172,6 +172,7 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
         $subjectType = (string) ($candidate['subject_type'] ?? '');
         $targetModel = $subjectType === 'content_page' ? 'content_page' : 'article';
         $label = $this->labelFromSafePath($safePath);
+        $proposalPayload = $this->proposalPayload($candidate);
 
         return [
             'source_id' => (string) ($candidate['source_id'] ?? ''),
@@ -184,20 +185,22 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
             'target_model' => $targetModel,
             'target_fields' => $targetFields,
             'proposed_seo_title' => in_array('seo_title', $targetFields, true)
-                ? $this->proposedSeoTitle($label)
+                ? $this->proposedSeoTitle($label, $proposalPayload)
                 : null,
             'proposed_seo_description' => in_array('seo_description', $targetFields, true)
-                ? $this->proposedSeoDescription($label)
+                ? $this->proposedSeoDescription($label, $proposalPayload)
                 : null,
             'proposed_faq_items' => in_array('faq_items', $targetFields, true)
-                ? $this->proposedFaqItems($label)
+                ? $this->proposedFaqItems($label, $proposalPayload)
                 : [],
+            'proposed_internal_link_actions' => $this->proposedInternalLinkActions($proposalPayload),
             'proposed_canonical_path' => in_array('canonical_url_or_path', $targetFields, true)
                 ? $safePath
                 : null,
             'proposed_indexability' => in_array('is_indexable_or_robots', $targetFields, true)
                 ? 'indexable_after_manual_review'
                 : null,
+            'proposal_quality' => $this->proposalQuality($proposalPayload),
             'draft_instructions' => [
                 'prepare_field_level_proposal_only',
                 'do_not_generate_final_body_copy',
@@ -265,21 +268,51 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
         return $label !== '' ? ucwords($label) : 'FermatMind page';
     }
 
-    private function proposedSeoTitle(string $label): string
+    /**
+     * @param  array<string, mixed>  $proposalPayload
+     */
+    private function proposedSeoTitle(string $label, array $proposalPayload = []): string
     {
+        $runtimeTitle = trim((string) data_get($proposalPayload, 'runtime.title', ''));
+        if ($runtimeTitle !== '') {
+            return mb_substr($this->normalizeFermatMindTitle($runtimeTitle), 0, 70);
+        }
+
         return mb_substr($label.' | FermatMind', 0, 70);
     }
 
-    private function proposedSeoDescription(string $label): string
+    /**
+     * @param  array<string, mixed>  $proposalPayload
+     */
+    private function proposedSeoDescription(string $label, array $proposalPayload = []): string
     {
+        $runtimeDescription = trim((string) data_get($proposalPayload, 'runtime.meta_description', ''));
+        if ($runtimeDescription !== '') {
+            return mb_substr($runtimeDescription, 0, 155);
+        }
+
         return mb_substr('Review '.$label.' with FermatMind guidance, evidence, and next steps after claim-gate approval.', 0, 155);
     }
 
     /**
+     * @param  array<string, mixed>  $proposalPayload
      * @return list<array<string, string>>
      */
-    private function proposedFaqItems(string $label): array
+    private function proposedFaqItems(string $label, array $proposalPayload = []): array
     {
+        if ($this->isChineseLocale((string) ($proposalPayload['locale'] ?? ''))) {
+            return [
+                [
+                    'question' => '这篇文章需要补充哪些常见问题？',
+                    'answer' => '仅作为字段级草稿建议；答案需基于现有正文、claim gate 和人工审核后再写入。',
+                ],
+                [
+                    'question' => '读者下一步应该如何使用这篇文章？',
+                    'answer' => '仅作为字段级草稿建议；需人工确认内部链接和行动路径后再写入。',
+                ],
+            ];
+        }
+
         return [
             [
                 'question' => 'What should readers know about '.$label.'?',
@@ -290,6 +323,144 @@ final class SeoAgentCmsDraftPackageDryRunCommand extends Command
                 'answer' => 'Draft answer pending claim gate and human approval.',
             ],
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function proposalPayload(array $candidate): array
+    {
+        $payload = (array) ($candidate['proposal_payload'] ?? []);
+        if ($payload === [] || ($payload['source'] ?? '') !== 'gsc_cohort_artifact') {
+            return [];
+        }
+
+        $runtime = (array) ($payload['runtime'] ?? []);
+        $metrics = (array) ($payload['metrics'] ?? []);
+
+        return [
+            'source' => 'gsc_cohort_artifact',
+            'locale' => $this->cleanText((string) ($payload['locale'] ?? '')),
+            'safe_path' => (string) ($payload['safe_path'] ?? ''),
+            'draft_angle' => $this->cleanText((string) ($payload['draft_angle'] ?? '')),
+            'proposed_actions' => $this->cleanTextList((array) ($payload['proposed_actions'] ?? [])),
+            'runtime' => [
+                'title' => $this->cleanText((string) ($runtime['title'] ?? '')),
+                'meta_description' => $this->cleanText((string) ($runtime['meta_description'] ?? '')),
+                'title_length' => (int) ($runtime['title_length'] ?? 0),
+                'meta_description_length' => (int) ($runtime['meta_description_length'] ?? 0),
+                'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
+                'internal_link_count' => (int) ($runtime['internal_link_count'] ?? 0),
+                'sample_internal_paths' => array_values(array_filter(
+                    $this->strings((array) ($runtime['sample_internal_paths'] ?? [])),
+                    static fn (string $path): bool => str_starts_with($path, '/')
+                )),
+            ],
+            'metrics' => [
+                'clicks' => (int) ($metrics['clicks'] ?? 0),
+                'impressions' => (int) ($metrics['impressions'] ?? 0),
+                'ctr_ppm' => (int) ($metrics['ctr_ppm'] ?? 0),
+                'average_position_milli' => is_numeric($metrics['average_position_milli'] ?? null)
+                    ? (int) $metrics['average_position_milli']
+                    : null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposalPayload
+     * @return list<string>
+     */
+    private function proposedInternalLinkActions(array $proposalPayload): array
+    {
+        if ($proposalPayload === []) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            (array) ($proposalPayload['proposed_actions'] ?? []),
+            static fn (mixed $action): bool => is_string($action) && str_contains(strtolower($action), 'internal link')
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposalPayload
+     * @return array<string, mixed>
+     */
+    private function proposalQuality(array $proposalPayload): array
+    {
+        if ($proposalPayload === []) {
+            return [
+                'source' => 'fallback_slug_label',
+                'locale_preserved' => false,
+                'slug_generated_copy' => true,
+                'needs_human_approval' => true,
+            ];
+        }
+
+        return [
+            'source' => 'gsc_cohort_artifact',
+            'locale_preserved' => $this->isChineseLocale((string) ($proposalPayload['locale'] ?? ''))
+                ? $this->containsCjk((string) data_get($proposalPayload, 'runtime.title', '').' '.(string) data_get($proposalPayload, 'runtime.meta_description', ''))
+                : true,
+            'slug_generated_copy' => false,
+            'uses_runtime_title' => (string) data_get($proposalPayload, 'runtime.title', '') !== '',
+            'uses_runtime_meta_description' => (string) data_get($proposalPayload, 'runtime.meta_description', '') !== '',
+            'proposed_actions_preserved' => count((array) ($proposalPayload['proposed_actions'] ?? [])),
+            'sample_internal_path_count' => count((array) data_get($proposalPayload, 'runtime.sample_internal_paths', [])),
+            'needs_human_approval' => true,
+        ];
+    }
+
+    private function normalizeFermatMindTitle(string $title): string
+    {
+        $title = trim(preg_replace('/\s+/u', ' ', html_entity_decode($title, ENT_QUOTES | ENT_HTML5, 'UTF-8')) ?: '');
+        $title = preg_replace('/(?:\s*\|\s*FermatMind)+$/u', '', $title) ?: $title;
+
+        return trim($title).' | FermatMind';
+    }
+
+    private function isChineseLocale(string $locale): bool
+    {
+        return str_starts_with($locale, 'zh');
+    }
+
+    private function containsCjk(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
+    }
+
+    private function cleanText(string $value): string
+    {
+        $value = trim(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $value = preg_replace('~https?://[^\s<>"\']+~iu', '', $value) ?: '';
+
+        return preg_replace('/\s+/u', ' ', $value) ?: '';
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function cleanTextList(array $values): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map(fn (mixed $value): string => is_scalar($value) ? $this->cleanText((string) $value) : '', $values),
+            static fn (string $value): bool => $value !== ''
+        )));
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function strings(array $values): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', $values),
+            static fn (string $value): bool => $value !== ''
+        )));
     }
 
     /**

--- a/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php
@@ -216,7 +216,7 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
         $riskFlags = array_values(array_unique(array_merge($riskFlags, $sourceRiskFlags)));
         $worthOptimizing = in_array($recommendedAction, ['cms_draft_package_dry_run', 'technical_review_required'], true);
 
-        return [
+        $verdict = [
             'source_id' => $sourceId !== '' ? $sourceId : hash('sha256', $subjectRef.$safePath.json_encode($candidate)),
             'source_family' => $sourceFamily,
             'subject_type' => $subjectType,
@@ -232,6 +232,13 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             'needs_human_approval' => true,
             'execution_permission' => false,
         ];
+
+        $proposalPayload = $this->sanitizedProposalPayload((array) ($candidate['proposal_payload'] ?? []));
+        if ($proposalPayload !== []) {
+            $verdict['proposal_payload'] = $proposalPayload;
+        }
+
+        return $verdict;
     }
 
     /**
@@ -312,6 +319,80 @@ final class SeoAgentCodexReviewRunnerCommand extends Command
             $refs,
             static fn (array $ref): bool => $ref['code'] !== '' || $ref['field_status'] !== ''
         ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function sanitizedProposalPayload(array $payload): array
+    {
+        if ($payload === []) {
+            return [];
+        }
+
+        $runtime = (array) ($payload['runtime'] ?? []);
+        $metrics = (array) ($payload['metrics'] ?? []);
+
+        return [
+            'source' => $this->cleanText((string) ($payload['source'] ?? '')),
+            'locale' => $this->cleanText((string) ($payload['locale'] ?? '')),
+            'safe_path' => (string) ($payload['safe_path'] ?? ''),
+            'draft_angle' => $this->cleanText((string) ($payload['draft_angle'] ?? '')),
+            'proposed_actions' => $this->cleanTextList((array) ($payload['proposed_actions'] ?? [])),
+            'runtime' => [
+                'title' => $this->cleanText((string) ($runtime['title'] ?? '')),
+                'meta_description' => $this->cleanText((string) ($runtime['meta_description'] ?? '')),
+                'title_length' => (int) ($runtime['title_length'] ?? 0),
+                'meta_description_length' => (int) ($runtime['meta_description_length'] ?? 0),
+                'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
+                'internal_link_count' => (int) ($runtime['internal_link_count'] ?? 0),
+                'sample_internal_paths' => array_values(array_filter(
+                    $this->strings((array) ($runtime['sample_internal_paths'] ?? [])),
+                    static fn (string $path): bool => str_starts_with($path, '/')
+                )),
+            ],
+            'metrics' => [
+                'clicks' => (int) ($metrics['clicks'] ?? 0),
+                'impressions' => (int) ($metrics['impressions'] ?? 0),
+                'ctr_ppm' => (int) ($metrics['ctr_ppm'] ?? 0),
+                'average_position_milli' => is_numeric($metrics['average_position_milli'] ?? null)
+                    ? (int) $metrics['average_position_milli']
+                    : null,
+            ],
+        ];
+    }
+
+    private function cleanText(string $value): string
+    {
+        $value = trim(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $value = preg_replace('~https?://[^\s<>"\']+~iu', '', $value) ?: '';
+
+        return preg_replace('/\s+/u', ' ', $value) ?: '';
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function cleanTextList(array $values): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map(fn (mixed $value): string => is_scalar($value) ? $this->cleanText((string) $value) : '', $values),
+            static fn (string $value): bool => $value !== ''
+        )));
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function strings(array $values): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', $values),
+            static fn (string $value): bool => $value !== ''
+        )));
     }
 
     /**

--- a/backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscCohortHandoffCommand.php
@@ -274,6 +274,12 @@ final class SeoAgentGscCohortHandoffCommand extends Command
                 'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
                 'internal_link_count' => (int) data_get($runtime, 'internal_link_summary.total_internal_links', 0),
             ],
+            'proposal_payload' => $this->proposalPayload($proposal, $safePath, $articleTarget['locale'], [
+                'clicks' => $clicks,
+                'impressions' => $impressions,
+                'ctr_ppm' => $ctrPpm,
+                'average_position_milli' => $positionMilli,
+            ]),
             'safe_path_hash' => hash('sha256', $safePath),
             'recommended_next_step' => 'codex_review_then_cms_draft_package_dry_run',
             'allowed_action' => 'cms_draft_package_dry_run',
@@ -286,6 +292,102 @@ final class SeoAgentGscCohortHandoffCommand extends Command
                 'indexing_request',
             ],
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, int|null>  $metrics
+     * @return array<string, mixed>
+     */
+    private function proposalPayload(array $proposal, string $safePath, string $locale, array $metrics): array
+    {
+        $runtime = (array) ($proposal['runtime_seo_check'] ?? []);
+
+        return [
+            'source' => self::SOURCE_FAMILY,
+            'locale' => $locale,
+            'safe_path' => $safePath,
+            'draft_angle' => $this->safeText((string) ($proposal['draft_angle'] ?? ''), 160),
+            'proposed_actions' => $this->safeTextList((array) ($proposal['proposed_actions'] ?? []), 8, 240),
+            'runtime' => [
+                'title' => $this->safeText((string) ($runtime['title'] ?? ''), 180),
+                'meta_description' => $this->safeText((string) ($runtime['meta_description'] ?? ''), 260),
+                'title_length' => (int) ($runtime['title_length'] ?? 0),
+                'meta_description_length' => (int) ($runtime['meta_description_length'] ?? 0),
+                'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
+                'internal_link_count' => (int) data_get($runtime, 'internal_link_summary.total_internal_links', 0),
+                'sample_internal_paths' => $this->safeInternalPaths((array) data_get($runtime, 'internal_link_summary.sample_internal_paths', [])),
+            ],
+            'metrics' => [
+                'clicks' => (int) ($metrics['clicks'] ?? 0),
+                'impressions' => (int) ($metrics['impressions'] ?? 0),
+                'ctr_ppm' => (int) ($metrics['ctr_ppm'] ?? 0),
+                'average_position_milli' => is_int($metrics['average_position_milli'] ?? null)
+                    ? $metrics['average_position_milli']
+                    : null,
+            ],
+        ];
+    }
+
+    private function safeText(string $value, int $maxLength): string
+    {
+        $value = trim(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $value = preg_replace('~https?://[^\s<>"\']+~iu', '', $value) ?: '';
+        $value = preg_replace('/\s+/u', ' ', $value) ?: '';
+
+        return mb_substr($value, 0, $maxLength);
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function safeTextList(array $values, int $limit, int $maxLength): array
+    {
+        $items = [];
+        foreach ($values as $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $text = $this->safeText((string) $value, $maxLength);
+            if ($text === '') {
+                continue;
+            }
+
+            $items[] = $text;
+            if (count($items) >= $limit) {
+                break;
+            }
+        }
+
+        return array_values(array_unique($items));
+    }
+
+    /**
+     * @param  array<int, mixed>  $paths
+     * @return list<string>
+     */
+    private function safeInternalPaths(array $paths): array
+    {
+        $safe = [];
+        foreach ($paths as $path) {
+            if (! is_scalar($path)) {
+                continue;
+            }
+
+            $parsed = parse_url((string) $path, PHP_URL_PATH);
+            if (! is_string($parsed) || ! str_starts_with($parsed, '/')) {
+                continue;
+            }
+
+            $safe[] = $parsed;
+            if (count($safe) >= 10) {
+                break;
+            }
+        }
+
+        return array_values(array_unique($safe));
     }
 
     /**

--- a/backend/app/Services/SeoAgent/OpportunityAggregator.php
+++ b/backend/app/Services/SeoAgent/OpportunityAggregator.php
@@ -43,6 +43,7 @@ final class OpportunityAggregator
                 $dedupeKey = $this->dedupeKey($normalized);
                 if (! isset($merged[$dedupeKey])) {
                     $merged[$dedupeKey] = $normalized;
+
                     continue;
                 }
 
@@ -120,7 +121,7 @@ final class OpportunityAggregator
             $gapTypes = $this->gapTypesFromEvidence((array) ($candidate['evidence_refs'] ?? []));
         }
 
-        return [
+        $normalized = [
             'source_family' => $sourceFamily,
             'source_id' => (string) ($candidate['source_id'] ?? hash('sha256', json_encode($candidate) ?: 'candidate')),
             'subject_type' => $subjectType,
@@ -136,6 +137,13 @@ final class OpportunityAggregator
             'blocked_actions' => $this->strings((array) ($candidate['blocked_actions'] ?? [])),
             'source_ids' => [(string) ($candidate['source_id'] ?? '')],
         ];
+
+        $proposalPayload = $this->sanitizeProposalPayload((array) ($candidate['proposal_payload'] ?? []));
+        if ($proposalPayload !== []) {
+            $normalized['proposal_payload'] = $proposalPayload;
+        }
+
+        return $normalized;
     }
 
     /**
@@ -177,6 +185,10 @@ final class OpportunityAggregator
 
         if ($this->severityWeight((string) ($incoming['severity'] ?? 'p3')) > $this->severityWeight((string) ($existing['severity'] ?? 'p3'))) {
             $existing['severity'] = $incoming['severity'];
+        }
+
+        if (! isset($existing['proposal_payload']) && isset($incoming['proposal_payload'])) {
+            $existing['proposal_payload'] = $incoming['proposal_payload'];
         }
 
         return $existing;
@@ -259,6 +271,71 @@ final class OpportunityAggregator
         }
 
         return $refs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function sanitizeProposalPayload(array $payload): array
+    {
+        if ($payload === []) {
+            return [];
+        }
+
+        $runtime = (array) ($payload['runtime'] ?? []);
+        $metrics = (array) ($payload['metrics'] ?? []);
+
+        $safePath = (string) ($payload['safe_path'] ?? '');
+        if (! str_starts_with($safePath, '/')) {
+            $safePath = '';
+        }
+
+        return array_filter([
+            'source' => $this->cleanText((string) ($payload['source'] ?? '')),
+            'locale' => $this->cleanText((string) ($payload['locale'] ?? '')),
+            'safe_path' => $safePath,
+            'draft_angle' => $this->cleanText((string) ($payload['draft_angle'] ?? '')),
+            'proposed_actions' => $this->cleanTextList((array) ($payload['proposed_actions'] ?? [])),
+            'runtime' => array_filter([
+                'title' => $this->cleanText((string) ($runtime['title'] ?? '')),
+                'meta_description' => $this->cleanText((string) ($runtime['meta_description'] ?? '')),
+                'title_length' => (int) ($runtime['title_length'] ?? 0),
+                'meta_description_length' => (int) ($runtime['meta_description_length'] ?? 0),
+                'jsonld_total' => (int) ($runtime['jsonld_total'] ?? 0),
+                'internal_link_count' => (int) ($runtime['internal_link_count'] ?? 0),
+                'sample_internal_paths' => array_values(array_slice(array_filter(
+                    $this->cleanTextList((array) ($runtime['sample_internal_paths'] ?? [])),
+                    static fn (string $path): bool => str_starts_with($path, '/')
+                ), 0, 10)),
+            ], static fn (mixed $value): bool => $value !== '' && $value !== []),
+            'metrics' => array_filter([
+                'impressions' => (int) ($metrics['impressions'] ?? 0),
+                'clicks' => (int) ($metrics['clicks'] ?? 0),
+                'ctr_ppm' => (int) ($metrics['ctr_ppm'] ?? 0),
+                'average_position_milli' => (int) ($metrics['average_position_milli'] ?? 0),
+            ], static fn (mixed $value): bool => $value !== ''),
+        ], static fn (mixed $value): bool => $value !== '' && $value !== []);
+    }
+
+    private function cleanText(string $value): string
+    {
+        $value = preg_replace('#https?://\S+#i', '', $value) ?? '';
+        $value = preg_replace('/\s+/u', ' ', $value) ?? '';
+
+        return trim($value);
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function cleanTextList(array $values): array
+    {
+        return array_values(array_slice(array_filter(
+            array_map(fn (mixed $value): string => is_scalar($value) ? $this->cleanText((string) $value) : '', $values),
+            static fn (string $value): bool => $value !== ''
+        ), 0, 20));
     }
 
     /**

--- a/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json
@@ -21,8 +21,10 @@
     "proposed_seo_title",
     "proposed_seo_description",
     "proposed_faq_items",
+    "proposed_internal_link_actions",
     "proposed_canonical_path",
     "proposed_indexability",
+    "proposal_quality",
     "draft_instructions",
     "claim_gate_required",
     "human_approval_required"
@@ -31,8 +33,20 @@
     "proposed_seo_title",
     "proposed_seo_description",
     "proposed_faq_items",
+    "proposed_internal_link_actions",
     "proposed_canonical_path",
-    "proposed_indexability"
+    "proposed_indexability",
+    "proposal_quality"
+  ],
+  "optional_proposal_quality_fields": [
+    "source",
+    "locale_preserved",
+    "slug_generated_copy",
+    "uses_runtime_title",
+    "uses_runtime_meta_description",
+    "proposed_actions_preserved",
+    "sample_internal_path_count",
+    "needs_human_approval"
   ],
   "negative_guarantees": {
     "database_write": false,

--- a/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
+++ b/backend/docs/seo/generated/seo-agent-codex-review-runner.v1.json
@@ -32,6 +32,26 @@
     "content_html",
     "cms_draft_body"
   ],
+  "optional_passthrough_fields": {
+    "proposal_payload": [
+      "source",
+      "locale",
+      "safe_path",
+      "draft_angle",
+      "proposed_actions",
+      "runtime.title",
+      "runtime.meta_description",
+      "runtime.title_length",
+      "runtime.meta_description_length",
+      "runtime.jsonld_total",
+      "runtime.internal_link_count",
+      "runtime.sample_internal_paths",
+      "metrics.clicks",
+      "metrics.impressions",
+      "metrics.ctr_ppm",
+      "metrics.average_position_milli"
+    ]
+  },
   "negative_guarantees": {
     "database_write": false,
     "cms_write": false,

--- a/backend/docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json
@@ -31,6 +31,24 @@
       "gsc_low_ctr_description_opportunity",
       "missing_structured_data",
       "missing_visible_faq"
+    ],
+    "optional_proposal_payload": [
+      "source",
+      "locale",
+      "safe_path",
+      "draft_angle",
+      "proposed_actions",
+      "runtime.title",
+      "runtime.meta_description",
+      "runtime.title_length",
+      "runtime.meta_description_length",
+      "runtime.jsonld_total",
+      "runtime.internal_link_count",
+      "runtime.sample_internal_paths",
+      "metrics.clicks",
+      "metrics.impressions",
+      "metrics.ctr_ppm",
+      "metrics.average_position_milli"
     ]
   },
   "forbidden_input_or_output_fields": [

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php
@@ -105,6 +105,52 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
     }
 
     #[Test]
+    public function command_uses_gsc_cohort_payload_for_locale_aware_draft_proposals(): void
+    {
+        $this->createRows();
+        $artifactDir = $this->artifactDir();
+        $verdictPath = $this->writeVerdict([
+            $this->candidateVerdict('cms_draft_package_dry_run', true, [
+                'gsc_low_ctr_title_opportunity',
+                'gsc_low_ctr_description_opportunity',
+                'missing_visible_faq',
+            ], [
+                'source_family' => 'gsc_cohort_artifact',
+                'safe_path' => '/zh/articles/mbti-vs-holland-career-choice',
+                'proposal_payload' => $this->gscProposalPayload(),
+            ]),
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-package-dry-run', [
+            '--verdict' => $verdictPath,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $package = $this->readJson(data_get($summary, 'artifact.path'));
+        $brief = $package['draft_briefs'][0] ?? [];
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('用霍兰德职业兴趣代码理解 MBTI 职业选择 | FermatMind', $brief['proposed_seo_title'] ?? null);
+        $this->assertSame('这篇中文文章解释 MBTI 与霍兰德兴趣代码如何一起辅助职业选择。', $brief['proposed_seo_description'] ?? null);
+        $this->assertNotSame('Mbti Vs Holland Career Choice | FermatMind', $brief['proposed_seo_title'] ?? null);
+        $this->assertSame('这篇文章需要补充哪些常见问题？', data_get($brief, 'proposed_faq_items.0.question'));
+        $this->assertSame('Add internal link review targets from GSC cohort.', data_get($brief, 'proposed_internal_link_actions.0'));
+        $this->assertSame('gsc_cohort_artifact', data_get($brief, 'proposal_quality.source'));
+        $this->assertTrue((bool) data_get($brief, 'proposal_quality.locale_preserved'));
+        $this->assertFalse((bool) data_get($brief, 'proposal_quality.slug_generated_copy', true));
+        $this->assertTrue((bool) data_get($brief, 'proposal_quality.needs_human_approval'));
+
+        $encoded = json_encode([$summary, $package], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
     public function command_fails_closed_for_invalid_schema_and_forbidden_fields(): void
     {
         $invalidSchema = $this->writeJson(['schema_version' => 'wrong.v1']);
@@ -150,8 +196,10 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
             'proposed_seo_title',
             'proposed_seo_description',
             'proposed_faq_items',
+            'proposed_internal_link_actions',
             'proposed_canonical_path',
             'proposed_indexability',
+            'proposal_quality',
         ], $artifact['proposal_fields'] ?? null);
         $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
     }
@@ -263,6 +311,38 @@ final class SeoAgentCmsDraftPackageDryRunTest extends TestCase
             'forbidden_claims' => [],
             'status' => ContentPage::STATUS_PUBLISHED,
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function gscProposalPayload(): array
+    {
+        return [
+            'source' => 'gsc_cohort_artifact',
+            'locale' => 'zh-CN',
+            'safe_path' => '/zh/articles/mbti-vs-holland-career-choice',
+            'draft_angle' => 'mbti-vs-holland-career-choice',
+            'proposed_actions' => [
+                'Add internal link review targets from GSC cohort.',
+                'Review visible FAQ candidates after claim gate.',
+            ],
+            'runtime' => [
+                'title' => '用霍兰德职业兴趣代码理解 MBTI 职业选择 | FermatMind',
+                'meta_description' => '这篇中文文章解释 MBTI 与霍兰德兴趣代码如何一起辅助职业选择。',
+                'title_length' => 37,
+                'meta_description_length' => 47,
+                'jsonld_total' => 0,
+                'internal_link_count' => 36,
+                'sample_internal_paths' => ['/zh/articles/riasec-holland-code', '/zh/careers'],
+            ],
+            'metrics' => [
+                'clicks' => 0,
+                'impressions' => 257,
+                'ctr_ppm' => 0,
+                'average_position_milli' => 8900,
+            ],
+        ];
     }
 
     /**

--- a/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php
@@ -23,7 +23,10 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
         $this->createRows();
         $artifactDir = $this->artifactDir();
         $handoffPath = $this->writeHandoff([
-            $this->candidate('p1', 'title gap'),
+            $this->candidate('p1', 'title gap', [
+                'source_family' => 'gsc_cohort_artifact',
+                'proposal_payload' => $this->proposalPayload(),
+            ]),
             $this->candidate('p2', 'description gap'),
             $this->candidate('p1', 'canonical runtime', [
                 'source_family' => 'runtime_seo_qa',
@@ -96,6 +99,10 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
         $this->assertSame('runtime_seo_qa_requires_technical_review', data_get($verdict, 'candidate_verdicts.2.review_reason'));
         $this->assertSame('cms_faq_gap_ready_for_draft_dry_run', data_get($verdict, 'candidate_verdicts.3.review_reason'));
         $this->assertSame('gsc_candidate_without_cms_target', data_get($verdict, 'candidate_verdicts.4.review_reason'));
+        $this->assertSame('gsc_cohort_artifact', data_get($verdict, 'candidate_verdicts.0.proposal_payload.source'));
+        $this->assertSame('zh-CN', data_get($verdict, 'candidate_verdicts.0.proposal_payload.locale'));
+        $this->assertSame('中文 SEO 标题 | FermatMind', data_get($verdict, 'candidate_verdicts.0.proposal_payload.runtime.title'));
+        $this->assertSame('Review title/meta from sanitized GSC context.', data_get($verdict, 'candidate_verdicts.0.proposal_payload.proposed_actions.0'));
         $this->assertContains('technical_surface_requires_human_review', $verdict['risk_flags'] ?? []);
         $this->assertContains('cms_target_missing', $verdict['risk_flags'] ?? []);
         $this->assertContains('candidate_incomplete', $verdict['risk_flags'] ?? []);
@@ -262,6 +269,38 @@ final class SeoAgentCodexReviewRunnerTest extends TestCase
             'forbidden_claims' => [],
             'status' => ContentPage::STATUS_PUBLISHED,
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function proposalPayload(): array
+    {
+        return [
+            'source' => 'gsc_cohort_artifact',
+            'locale' => 'zh-CN',
+            'safe_path' => '/zh/articles/title-gap',
+            'draft_angle' => 'title-gap',
+            'proposed_actions' => [
+                'Review title/meta from sanitized GSC context.',
+                'Add internal link from /zh/careers.',
+            ],
+            'runtime' => [
+                'title' => '中文 SEO 标题 | FermatMind',
+                'meta_description' => '中文描述需要原样保留用于 dry-run proposal。',
+                'title_length' => 23,
+                'meta_description_length' => 29,
+                'jsonld_total' => 0,
+                'internal_link_count' => 12,
+                'sample_internal_paths' => ['/zh/careers'],
+            ],
+            'metrics' => [
+                'clicks' => 0,
+                'impressions' => 257,
+                'ctr_ppm' => 0,
+                'average_position_milli' => 8900,
+            ],
+        ];
     }
 
     /**

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php
@@ -62,6 +62,9 @@ final class SeoAgentGscCohortHandoffTest extends TestCase
         $this->assertSame('article:'.$articleTwo->id.':zh-CN', data_get($source, 'candidates.1.subject_ref'));
         $this->assertSame('/en/articles/what-is-riasec-holland-code-career-interest-test', data_get($source, 'candidates.0.safe_path'));
         $this->assertSame('/zh/articles/mbti-vs-holland-career-choice', data_get($source, 'candidates.1.safe_path'));
+        $this->assertSame('gsc_cohort_artifact', data_get($source, 'candidates.0.proposal_payload.source'));
+        $this->assertSame('What Is the RIASEC Holland Code Career Interest Test? | FermatMind', data_get($source, 'candidates.0.proposal_payload.runtime.title'));
+        $this->assertSame('/en/articles/career-interest-test', data_get($source, 'candidates.0.proposal_payload.runtime.sample_internal_paths.0'));
         $this->assertSame(2, $source['candidate_count'] ?? null);
         $this->assertCount(2, $source['deferred_non_draft_groups'] ?? []);
         $this->assertSame('mbti_personality_variant', data_get($source, 'deferred_non_draft_groups.0.group'));
@@ -69,10 +72,12 @@ final class SeoAgentGscCohortHandoffTest extends TestCase
 
         $this->assertSame('seo-agent-opportunity-aggregate.v1', $aggregate['schema_version'] ?? null);
         $this->assertSame(2, $aggregate['candidate_count'] ?? null);
+        $this->assertSame('zh-CN', data_get($aggregate, 'candidates.1.proposal_payload.locale'));
         $this->assertSame('seo-agent-codex-review-handoff.v1', $handoff['schema_version'] ?? null);
         $this->assertFalse((bool) ($handoff['execution_permission'] ?? true));
         $this->assertSame('seo-agent-codex-review-verdict.v1', $verdict['schema_version'] ?? null);
         $this->assertSame('cms_draft_package_dry_run', data_get($verdict, 'candidate_verdicts.0.recommended_action'));
+        $this->assertSame('Add internal link review targets from GSC cohort.', data_get($verdict, 'candidate_verdicts.0.proposal_payload.proposed_actions.0'));
         $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $draftPackage['schema_version'] ?? null);
         $this->assertSame(2, $draftPackage['draft_brief_count'] ?? null);
         $this->assertSame('article', data_get($draftPackage, 'draft_briefs.0.target_model'));
@@ -80,6 +85,13 @@ final class SeoAgentGscCohortHandoffTest extends TestCase
         $this->assertContains('seo_description', data_get($draftPackage, 'draft_briefs.1.target_fields'));
         $this->assertContains('faq_items', data_get($draftPackage, 'draft_briefs.1.target_fields'));
         $this->assertContains('manual_review_required', data_get($draftPackage, 'draft_briefs.1.target_fields'));
+        $this->assertSame('What Is the RIASEC Holland Code Career Interest Test? | FermatMind', data_get($draftPackage, 'draft_briefs.0.proposed_seo_title'));
+        $this->assertSame('用霍兰德职业兴趣代码理解 MBTI 职业选择 | FermatMind', data_get($draftPackage, 'draft_briefs.1.proposed_seo_title'));
+        $this->assertSame('这篇中文文章解释 MBTI 与霍兰德兴趣代码如何一起辅助职业选择。', data_get($draftPackage, 'draft_briefs.1.proposed_seo_description'));
+        $this->assertSame('gsc_cohort_artifact', data_get($draftPackage, 'draft_briefs.1.proposal_quality.source'));
+        $this->assertTrue((bool) data_get($draftPackage, 'draft_briefs.1.proposal_quality.locale_preserved'));
+        $this->assertFalse((bool) data_get($draftPackage, 'draft_briefs.1.proposal_quality.slug_generated_copy', true));
+        $this->assertSame('Add internal link review targets from GSC cohort.', data_get($draftPackage, 'draft_briefs.0.proposed_internal_link_actions.0'));
 
         $encoded = json_encode([$evidence, $source, $aggregate, $handoff, $verdict, $draftPackage], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         $this->assertIsString($encoded);
@@ -282,13 +294,20 @@ final class SeoAgentGscCohortHandoffTest extends TestCase
                 'position' => $position,
             ],
             'draft_angle' => basename($safePath),
+            'proposed_actions' => [
+                'Add internal link review targets from GSC cohort.',
+                'Review visible FAQ candidates after claim gate.',
+            ],
             'runtime_seo_check' => [
                 'http_status' => 200,
+                'title' => $this->runtimeTitle($safePath),
+                'meta_description' => $this->runtimeMetaDescription($safePath),
                 'title_length' => $titleLength,
                 'meta_description_length' => $metaLength,
                 'jsonld_total' => $jsonldTotal,
                 'internal_link_summary' => [
                     'total_internal_links' => 36,
+                    'sample_internal_paths' => $this->sampleInternalPaths($safePath),
                 ],
                 'checks' => [
                     'html_200' => true,
@@ -300,6 +319,30 @@ final class SeoAgentGscCohortHandoffTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    private function runtimeTitle(string $safePath): string
+    {
+        return str_starts_with($safePath, '/zh/')
+            ? '用霍兰德职业兴趣代码理解 MBTI 职业选择 | FermatMind'
+            : 'What Is the RIASEC Holland Code Career Interest Test? | FermatMind';
+    }
+
+    private function runtimeMetaDescription(string $safePath): string
+    {
+        return str_starts_with($safePath, '/zh/')
+            ? '这篇中文文章解释 MBTI 与霍兰德兴趣代码如何一起辅助职业选择。'
+            : 'Learn how RIASEC Holland Codes connect interests, work environments, and career exploration with FermatMind.';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sampleInternalPaths(string $safePath): array
+    {
+        return str_starts_with($safePath, '/zh/')
+            ? ['/zh/articles/riasec-holland-code', 'https://fermatmind.com/zh/careers']
+            : ['/en/articles/career-interest-test', 'https://fermatmind.com/en/careers'];
     }
 
     /**


### PR DESCRIPTION
## What changed
- Carry sanitized GSC cohort `proposal_payload` from handoff candidates through opportunity aggregation and Codex review verdicts.
- Teach CMS draft package dry-run to prefer sanitized runtime/proposal context for GSC cohort article briefs, including locale-aware title/meta, review-only FAQ prompts, internal-link proposal actions, and `proposal_quality` metadata.
- Update generated SEO contract docs and focused feature tests for English/Chinese TDK preservation, proposed action passthrough, forbidden field blocking, and fallback behavior.

## Why
PR-A made the GSC cohort artifact reproducible, but the downstream dry-run package still fell back to slug-derived placeholder copy. This PR keeps the read-only chain intact while making the dry-run artifact useful enough for reviewing first CMS draft write canary candidates, especially Chinese article TDK.

## Validation
- `php -l app/Console/Commands/SeoAgentGscCohortHandoffCommand.php && php -l app/Services/SeoAgent/OpportunityAggregator.php && php -l app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php && php -l app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php`
- `vendor/bin/pint --test app/Console/Commands/SeoAgentGscCohortHandoffCommand.php app/Console/Commands/SeoAgentCodexReviewRunnerCommand.php app/Console/Commands/SeoAgentCmsDraftPackageDryRunCommand.php app/Services/SeoAgent/OpportunityAggregator.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php tests/Feature/SeoIntel/SeoAgentCodexReviewRunnerTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php`
- `php artisan list | rg seo-agent:gsc-cohort-handoff`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-package-dryrun.v1.json >/dev/null && python3 -m json.tool docs/seo/generated/seo-agent-codex-review-runner.v1.json >/dev/null && python3 -m json.tool docs/seo/generated/seo-agent-gsc-cohort-handoff.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No DB write.
- No CMS write.
- No CMS publish.
- No search enqueue or submit.
- No IndexNow, Google Indexing API, sitemap/llms update, scheduler, queue worker, live GSC/API call, or external model call.
- No production dry-run in this PR; rerun production GSC cohort dry-run only after merge and separately approved deploy.
