### PR TITLE
RIASEC-RESULT-V2-MANUAL-GATE-APPROVAL-EVIDENCE-01: docs(riasec): record manual gate approval evidence

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/riasec_result_page_v2_manual_production_gate_approval_evidence_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/riasec_result_page_v2_manual_production_gate_approval_evidence_v0_1.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.manual_production_gate_approval_evidence.v0.1",
+  "task_id": "RIASEC-RESULT-V2-MANUAL-GATE-APPROVAL-EVIDENCE-01",
+  "created_date": "2026-06-22",
+  "record_type": "manual_production_gate_approval_evidence",
+  "scope": "docs_artifact_only",
+  "codex_authority_boundary": {
+    "codex_approves_production_activation": false,
+    "human_approval_required": true,
+    "approval_evidence_provided_in_this_task": false,
+    "production_activation_authorized_by_this_record": false
+  },
+  "references": {
+    "staging_pilot_evidence_pr": 2285,
+    "manual_production_gate_readiness_audit_pr": 2286,
+    "manual_gate_prep_checklist_pr": 2288,
+    "staging_pilot_evidence_artifact": "backend/content_assets/riasec/result_page_v2/qa/post_deploy_staging_pilot_evidence/v0_1/riasec_result_page_v2_post_deploy_staging_pilot_evidence_v0_1.json",
+    "manual_production_gate_readiness_audit_artifact": "backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/riasec_result_page_v2_manual_production_gate_readiness_audit_v0_1.json",
+    "manual_gate_prep_artifact": "backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_prep/v0_1/riasec_result_page_v2_manual_production_gate_prep_v0_1.json",
+    "approval_evidence_doc": "backend/docs/riasec/riasec-result-page-v2-manual-production-gate-approval-evidence-2026-06-22.md"
+  },
+  "sha_under_review": {
+    "deployed_backend_sha": "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9",
+    "required_rollout_gate_merge_commit": "fb6e64468bc33063b229ca8ff5ced8076ddae088",
+    "release_snapshot_id": "riasec_result_page_v2_rc_0_1",
+    "release_snapshot_path": "backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json",
+    "release_snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+    "release_candidate": false,
+    "production_use_allowed": false,
+    "ready_for_production": false,
+    "production_rollout_enabled": false
+  },
+  "approval_authority_fields_required": [
+    "approval_record_id",
+    "approval_type",
+    "decision",
+    "approved_by",
+    "approver_role",
+    "approved_at",
+    "approval_channel",
+    "approval_evidence_url_or_ref",
+    "deployed_backend_sha",
+    "release_snapshot_id",
+    "release_snapshot_sha256",
+    "evidence_refs",
+    "scope",
+    "rollback_plan_ref",
+    "kill_switch_ref",
+    "post_deploy_smoke_procedure_id",
+    "private_payload_leak_ack",
+    "staging_only_rejection_ack"
+  ],
+  "approval_records": {
+    "production_import": {
+      "approval_type": "production_import",
+      "decision": "NO-GO",
+      "status": "missing_human_approval",
+      "approved_by": null,
+      "approver_role": null,
+      "approved_at": null,
+      "approval_channel": null,
+      "approval_evidence_url_or_ref": null,
+      "deployed_backend_sha": "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9",
+      "release_snapshot_id": "riasec_result_page_v2_rc_0_1",
+      "release_snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+      "post_deploy_smoke_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+      "private_payload_leak_ack": false,
+      "staging_only_rejection_ack": false,
+      "production_import_allowed": false
+    },
+    "production_rollout": {
+      "approval_type": "production_rollout",
+      "decision": "NO-GO",
+      "status": "missing_human_approval",
+      "approved_by": null,
+      "approver_role": null,
+      "approved_at": null,
+      "approval_channel": null,
+      "approval_evidence_url_or_ref": null,
+      "deployed_backend_sha": "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9",
+      "release_snapshot_id": "riasec_result_page_v2_rc_0_1",
+      "release_snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+      "post_deploy_smoke_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+      "private_payload_leak_ack": false,
+      "staging_only_rejection_ack": false,
+      "production_rollout_allowed": false
+    }
+  },
+  "rollback_kill_switch_confirmation_fields": {
+    "kill_switch_ref": "riasec_result_page_v2.production_emergency_disabled",
+    "kill_switch_reachable_by": null,
+    "kill_switch_verified_at": null,
+    "rollback_plan_ref": null,
+    "release_snapshot_disable_confirmed": false,
+    "rollout_percentage_reset_confirmed": false,
+    "rollout_mode_disable_confirmed": false,
+    "post_disable_smoke_owner": null
+  },
+  "post_deploy_smoke": {
+    "procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+    "production_status": "not_configured_for_production_rollout",
+    "required_surfaces": [
+      "result_page",
+      "pdf",
+      "share",
+      "history",
+      "compare",
+      "locked",
+      "free",
+      "low_quality",
+      "fallback"
+    ]
+  },
+  "scoped_rollout_template": {
+    "tenant_ids": [],
+    "form_codes": [
+      "riasec_60"
+    ],
+    "locales": [
+      "zh-CN"
+    ],
+    "allowed_attempt_ids": [],
+    "allowed_user_ids": [],
+    "allowed_anon_ids": [],
+    "allowed_org_ids": [],
+    "percentage": 0,
+    "max_percentage": 0,
+    "mode": "disabled"
+  },
+  "go_no_go": {
+    "record_usable_as_approval_template": true,
+    "record_is_human_approval": false,
+    "production_import_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "automatic_production_rollout_allowed": false,
+    "cms_production_write_allowed": false,
+    "runtime_production_flag_mutation_allowed": false
+  },
+  "negative_guarantees": {
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "staging_only_assets_marked_production_ready": false,
+    "frontend_fallback_added": false,
+    "private_payload_exported": false
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-manual-production-gate-approval-evidence-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-manual-production-gate-approval-evidence-2026-06-22.md
@@ -1,0 +1,203 @@
+# RIASEC Result Page V2 Manual Production Gate Approval Evidence
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-MANUAL-GATE-APPROVAL-EVIDENCE-01`
+
+Scope: docs/artifact-only approval evidence record. This record does not approve, import, publish, enable runtime, mutate environment variables, write CMS data, open production gates, or mark staging-only assets as production-ready.
+
+Codex does not approve production activation. A human operator must provide explicit production import approval and explicit production rollout approval before either gate can move from `NO-GO`.
+
+## Evidence Inputs
+
+| Input | Reference | Use in this record |
+| --- | --- | --- |
+| Staging/pilot evidence | PR `#2285` | Review input only; not production approval. |
+| Manual production gate readiness audit | PR `#2286` | Confirms production import and rollout remain `NO-GO`. |
+| Manual gate prep checklist | PR `#2288` | Defines approval fields, rollback checks, scoped rollout template, and smoke procedure proposal. |
+| Staging/pilot evidence artifact | `backend/content_assets/riasec/result_page_v2/qa/post_deploy_staging_pilot_evidence/v0_1/riasec_result_page_v2_post_deploy_staging_pilot_evidence_v0_1.json` | Source for deployed SHA, smoke summaries, and negative guarantees. |
+| Readiness audit artifact | `backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_readiness_audit/v0_1/riasec_result_page_v2_manual_production_gate_readiness_audit_v0_1.json` | Source for current blockers and gate verdict. |
+| Manual gate prep artifact | `backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_prep/v0_1/riasec_result_page_v2_manual_production_gate_prep_v0_1.json` | Source for required approval fields and rollout template. |
+
+## SHA Under Review
+
+| Field | Value | Status |
+| --- | --- | --- |
+| Deployed backend SHA | `ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9` | Under human review only. |
+| Required RIASEC rollout gate merge commit | `fb6e64468bc33063b229ca8ff5ced8076ddae088` | Present in deployed SHA evidence from PR `#2285`. |
+| Release snapshot id | `riasec_result_page_v2_rc_0_1` | Not production-approved. |
+| Release snapshot file SHA256 | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` | Hash of current review input file only. |
+| Release snapshot path | `backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json` | Immutable candidate record, not production release. |
+
+Observed release snapshot status remains:
+
+- `immutable=true`
+- `release_candidate=false`
+- `production_use_allowed=false`
+- `ready_for_production=false`
+- `production_rollout_enabled=false`
+
+Result: the release snapshot is eligible for manual review input only. It is not eligible for production import or rollout.
+
+## Approval Authority Fields
+
+All future human approval evidence must record these fields exactly. Missing or agent-only values keep both gates at `NO-GO`.
+
+| Field | Required value |
+| --- | --- |
+| `approval_record_id` | Stable approval record id. |
+| `approval_type` | `production_import` or `production_rollout`; separate approvals are required. |
+| `decision` | `GO` or `NO-GO`. |
+| `approved_by` | Human operator id/name. |
+| `approver_role` | Human role authorized for this gate. |
+| `approved_at` | ISO-8601 timestamp. |
+| `approval_channel` | Source of explicit approval, for example ticket, PR comment, release note, or signed checklist. |
+| `approval_evidence_url_or_ref` | Durable link or repository path to approval evidence. |
+| `deployed_backend_sha` | Exact deployed backend SHA under review. |
+| `release_snapshot_id` | Exact approved release snapshot id. |
+| `release_snapshot_sha256` | Exact approved release snapshot file hash. |
+| `evidence_refs` | PR `#2285`, PR `#2286`, PR `#2288`, and any superseding evidence. |
+| `scope` | Tenant, form, locale, allowlist, percentage, and max percentage. |
+| `rollback_plan_ref` | Exact rollback/disable procedure. |
+| `kill_switch_ref` | Exact kill switch control. |
+| `post_deploy_smoke_procedure_id` | `riasec_result_page_v2_post_deploy_smoke_v0_1`. |
+| `private_payload_leak_ack` | Human confirmation that no private payload leaks are accepted. |
+| `staging_only_rejection_ack` | Human confirmation that staging-only assets are not production imports. |
+
+## Current Decisions
+
+| Gate | Current decision | Reason |
+| --- | --- | --- |
+| Production import | `NO-GO` | No human production import approval evidence was provided in this task. |
+| Production rollout | `NO-GO` | No human production rollout approval evidence was provided in this task. |
+| Automatic production rollout | `BLOCKED` | Production rollout must remain manual-only. |
+| CMS production write/import | `BLOCKED` | No CMS write/import was requested or approved. |
+| Runtime production activation | `BLOCKED` | No runtime flag or environment change was requested or approved. |
+
+## Production Import Approval Evidence Record
+
+Current record status: `missing_human_approval`.
+
+| Required field | Current value |
+| --- | --- |
+| `approval_type` | `production_import` |
+| `decision` | `NO-GO` |
+| `approved_by` | `null` |
+| `approver_role` | `null` |
+| `approved_at` | `null` |
+| `approval_evidence_url_or_ref` | `null` |
+| `deployed_backend_sha` | `ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9` |
+| `release_snapshot_id` | `riasec_result_page_v2_rc_0_1` |
+| `release_snapshot_sha256` | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` |
+| `post_deploy_smoke_procedure_id` | `riasec_result_page_v2_post_deploy_smoke_v0_1` |
+| `private_payload_leak_ack` | `false` |
+| `staging_only_rejection_ack` | `false` |
+
+Import cannot proceed until a human operator records `decision=GO`, confirms the approved snapshot is production-ready, and supplies all required authority fields.
+
+## Production Rollout Approval Evidence Record
+
+Current record status: `missing_human_approval`.
+
+| Required field | Current value |
+| --- | --- |
+| `approval_type` | `production_rollout` |
+| `decision` | `NO-GO` |
+| `approved_by` | `null` |
+| `approver_role` | `null` |
+| `approved_at` | `null` |
+| `approval_evidence_url_or_ref` | `null` |
+| `deployed_backend_sha` | `ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9` |
+| `release_snapshot_id` | `riasec_result_page_v2_rc_0_1` |
+| `release_snapshot_sha256` | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` |
+| `post_deploy_smoke_procedure_id` | `riasec_result_page_v2_post_deploy_smoke_v0_1` |
+| `private_payload_leak_ack` | `false` |
+| `staging_only_rejection_ack` | `false` |
+
+Rollout cannot proceed until import is approved and passed, rollout scope is explicitly approved, rollback and kill-switch evidence is confirmed, and post-deploy smoke ownership is assigned.
+
+## Rollback And Kill-Switch Confirmation Fields
+
+These fields must be confirmed by a human operator before rollout can move to `GO`.
+
+| Field | Required value | Current value |
+| --- | --- | --- |
+| `kill_switch_ref` | `riasec_result_page_v2.production_emergency_disabled` | `riasec_result_page_v2.production_emergency_disabled` |
+| `kill_switch_reachable_by` | Human operator/team | `null` |
+| `kill_switch_verified_at` | ISO-8601 timestamp | `null` |
+| `rollback_plan_ref` | Exact rollback procedure path or ticket | `null` |
+| `release_snapshot_disable_confirmed` | `true` | `false` |
+| `rollout_percentage_reset_confirmed` | `true` | `false` |
+| `rollout_mode_disable_confirmed` | `true` | `false` |
+| `post_disable_smoke_owner` | Human operator/team | `null` |
+
+## Post-Deploy Smoke Procedure
+
+Proposed procedure id: `riasec_result_page_v2_post_deploy_smoke_v0_1`
+
+Required smoke surfaces:
+
+| Surface | Required assertion |
+| --- | --- |
+| `result_page` | Approved payload renders only for approved scope. |
+| `pdf` | PDF output omits or redacts private fields. |
+| `share` | Share payload uses public allowlist only. |
+| `history` | History output does not expose raw vectors or private deltas. |
+| `compare` | Compare output does not expose raw vectors, ranks, or percentiles. |
+| `locked` | Locked state omits Result Page V2 payload. |
+| `free` | Free state omits private measurements and share internals. |
+| `low_quality` | Cautious copy renders without overclaiming or raw quality flag leakage. |
+| `fallback` | Fail-closed behavior remains active and no frontend fallback copy appears. |
+
+Current smoke approval status: `not_configured_for_production_rollout`.
+
+## Scoped Rollout Evidence Template
+
+This is a record template only. It is not an executable rollout config.
+
+```json
+{
+  "tenant_ids": [],
+  "form_codes": ["riasec_60"],
+  "locales": ["zh-CN"],
+  "allowed_attempt_ids": [],
+  "allowed_user_ids": [],
+  "allowed_anon_ids": [],
+  "allowed_org_ids": [],
+  "percentage": 0,
+  "max_percentage": 0,
+  "mode": "disabled"
+}
+```
+
+Current scoped rollout status: `not_approved`.
+
+## Non-Goals
+
+This record does not:
+
+- approve production import;
+- approve production rollout;
+- write CMS data;
+- import assets into production;
+- enable runtime wrappers;
+- mutate environment variables;
+- open production gates;
+- mark staging-only assets as production-ready;
+- add frontend fallback content;
+- expose private payload fields;
+- replace human approval with Codex-generated evidence.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Use this record as approval evidence template | `YES` |
+| Treat this record as human approval | `NO` |
+| Allow production import now | `NO` |
+| Allow production rollout now | `NO` |
+| Allow automatic production rollout | `NO` |
+| Allow CMS production write | `NO` |
+| Allow runtime production flag mutation | `NO` |
+
+Next safe step: a human operator must either provide explicit approval evidence for a future approval PR or keep the gate at `NO-GO`. Codex cannot approve production activation.


### PR DESCRIPTION
## What changed
- Added a RIASEC Result Page V2 manual production gate approval evidence record.
- Added a redacted JSON approval evidence artifact under result_page_v2 QA evidence.

## Why
- Preserve a reviewable record after PR #2285 staging/pilot evidence, PR #2286 readiness audit, and PR #2288 manual gate prep checklist.
- Keep production import and production rollout at NO-GO until separate human approval evidence is provided.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/riasec_result_page_v2_manual_production_gate_approval_evidence_v0_1.json`
- `git diff --check main...HEAD`
- Scope validation: only `backend/docs/riasec/riasec-result-page-v2-manual-production-gate-approval-evidence-2026-06-22.md` and `backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/*` changed.

## Result
- Production import: NO-GO. No human import approval evidence was provided.
- Production rollout: NO-GO. No human rollout approval evidence was provided.
- Codex does not approve production activation.

## Intentionally deferred
- No runtime changes.
- No environment changes.
- No CMS writes or imports.
- No production import gate opening.
- No production rollout.
- No staging-only asset reclassification as production-ready.

## Repository rule impact
Docs/artifact-only approval evidence record. No content ownership, public API, runtime, CMS, media, sitemap, llms, or publishing workflow behavior changed.
