### PR TITLE
SEO-AGENT-GSC-ARTICLE41-DRAFT-READBACK-QA-01 add CMS draft readback QA

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php
@@ -1,0 +1,627 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentCmsDraftReadbackQaCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-cms-draft-readback-qa.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const WRITER_TASK = 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:cms-draft-readback-qa
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--target= : Exact target subject ref, e.g. article:41:en}
+        {--package-sha256= : Optional expected package sha256}
+        {--artifact-dir= : Directory for sanitized readback QA evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only SEO Agent CMS draft readback QA; verifies draft revision payload against a dry-run package and write evidence.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        $writeEvidencePath = $this->readablePath((string) $this->option('write-evidence'));
+        $target = trim((string) $this->option('target'));
+
+        if ($packagePath === null) {
+            return $this->finish($this->failureSummary('package_unreadable'));
+        }
+        if ($writeEvidencePath === null) {
+            return $this->finish($this->failureSummary('write_evidence_unreadable'));
+        }
+        if ($target === '' || str_contains($target, "\0")) {
+            return $this->finish($this->failureSummary('target_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $packageRaw = (string) file_get_contents($packagePath);
+        $writeRaw = (string) file_get_contents($writeEvidencePath);
+        $forbidden = array_values(array_unique(array_merge(
+            $this->forbiddenStringsPresent($packageRaw),
+            $this->forbiddenStringsPresent($writeRaw),
+        )));
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($packageRaw, true);
+        $writeEvidence = json_decode($writeRaw, true);
+        if (! is_array($package)) {
+            return $this->finish($this->failureSummary('package_json_invalid'));
+        }
+        if (! is_array($writeEvidence)) {
+            return $this->finish($this->failureSummary('write_evidence_json_invalid'));
+        }
+
+        $packageIssue = $this->validatePackage($package);
+        if ($packageIssue !== null) {
+            return $this->finish($this->failureSummary($packageIssue));
+        }
+        $writeIssue = $this->validateWriteEvidence($writeEvidence);
+        if ($writeIssue !== null) {
+            return $this->finish($this->failureSummary($writeIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $expectedSha = trim((string) $this->option('package-sha256'));
+        if ($expectedSha !== '' && $expectedSha !== $packageSha) {
+            return $this->finish($this->failureSummary('package_sha256_mismatch', [
+                'package_sha256' => $packageSha,
+                'expected_package_sha256' => $expectedSha,
+            ]));
+        }
+        if ((string) ($writeEvidence['package_sha256'] ?? '') !== $packageSha) {
+            return $this->finish($this->failureSummary('write_evidence_package_sha256_mismatch', [
+                'package_sha256' => $packageSha,
+                'write_evidence_package_sha256' => (string) ($writeEvidence['package_sha256'] ?? ''),
+            ]));
+        }
+
+        $proposal = $this->proposalForTarget($package, $target);
+        if ($proposal === null) {
+            return $this->finish($this->failureSummary('target_not_found_in_package', [
+                'target' => $target,
+            ]));
+        }
+
+        if ((string) ($proposal['target_model'] ?? $proposal['subject_type'] ?? '') !== 'article') {
+            return $this->finish($this->failureSummary('target_model_not_supported_for_readback_qa', [
+                'target' => $target,
+            ]));
+        }
+
+        $writeRef = $this->writeRefForTarget($writeEvidence, $target);
+        if ($writeRef === null) {
+            return $this->finish($this->failureSummary('target_not_found_in_write_evidence', [
+                'target' => $target,
+            ]));
+        }
+
+        $articleId = $this->idFromSubjectRef($target, 'article');
+        $article = Article::query()->withoutGlobalScopes()->find($articleId);
+        if (! $article instanceof Article) {
+            return $this->finish($this->failureSummary('article_not_found', [
+                'target' => $target,
+            ]));
+        }
+
+        $revision = $this->matchingArticleRevision($articleId, $packageSha, $target, $proposal, $writeRef);
+        if (! $revision instanceof ArticleRevision) {
+            return $this->finish($this->failureSummary('draft_revision_not_found', [
+                'target' => $target,
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $evidence = $this->evidence($packagePath, $writeEvidencePath, $packageSha, $package, $writeEvidence, $proposal, $writeRef, $article, $revision, $target);
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-cms-draft-readback-qa-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) ($evidence['ok'] ?? false),
+            'status' => (string) ($evidence['status'] ?? 'unknown'),
+            'target' => $target,
+            'artifact' => $artifactRef,
+            'matched_field_count' => count((array) ($evidence['matched_fields'] ?? [])),
+            'mismatch_count' => count((array) ($evidence['mismatches'] ?? [])),
+            'qa_finding_count' => count((array) ($evidence['qa_findings'] ?? [])),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/cms-draft-readback-qa');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true) {
+            return 'package_not_dry_run';
+        }
+        if ((bool) ($package['cms_write_allowed'] ?? true) !== false) {
+            return 'package_cms_write_boundary_invalid';
+        }
+        if ((bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     */
+    private function validateWriteEvidence(array $writeEvidence): ?string
+    {
+        if (($writeEvidence['schema_version'] ?? null) !== self::WRITE_SCHEMA_VERSION) {
+            return 'write_evidence_schema_invalid';
+        }
+        if (($writeEvidence['status'] ?? null) !== 'success') {
+            return 'write_evidence_not_success';
+        }
+        if ((bool) ($writeEvidence['execute'] ?? false) !== true) {
+            return 'write_evidence_not_execute';
+        }
+        if ((bool) ($writeEvidence['writes_attempted'] ?? false) !== true) {
+            return 'write_evidence_writes_not_attempted';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array<string, mixed>|null
+     */
+    private function proposalForTarget(array $package, string $target): ?array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return null;
+        }
+
+        foreach ($items as $item) {
+            if (is_array($item) && (string) ($item['subject_ref'] ?? '') === $target) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     * @return array<string, mixed>|null
+     */
+    private function writeRefForTarget(array $writeEvidence, string $target): ?array
+    {
+        foreach ((array) ($writeEvidence['affected_refs'] ?? []) as $ref) {
+            if (is_array($ref) && (string) ($ref['subject_ref'] ?? '') === $target) {
+                return $ref;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $writeRef
+     */
+    private function matchingArticleRevision(int $articleId, string $packageSha, string $target, array $proposal, array $writeRef): ?ArticleRevision
+    {
+        $revisionId = $writeRef['revision_id'] ?? null;
+        if (is_int($revisionId) || (is_string($revisionId) && ctype_digit($revisionId))) {
+            $revision = ArticleRevision::query()->withoutGlobalScopes()
+                ->where('article_id', $articleId)
+                ->whereKey((int) $revisionId)
+                ->first();
+            if ($revision instanceof ArticleRevision && $this->revisionMatches($revision, $packageSha, $target, $proposal)) {
+                return $revision;
+            }
+        }
+
+        return ArticleRevision::query()->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->orderByDesc('revision_no')
+            ->get()
+            ->first(fn (ArticleRevision $revision): bool => $this->revisionMatches($revision, $packageSha, $target, $proposal));
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function revisionMatches(ArticleRevision $revision, string $packageSha, string $target, array $proposal): bool
+    {
+        $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+
+        return data_get($payload, 'seo_agent.task') === self::WRITER_TASK
+            && data_get($payload, 'seo_agent.package_sha256') === $packageSha
+            && data_get($payload, 'seo_agent.subject_ref') === $target
+            && $this->sortedStrings((array) data_get($payload, 'seo_agent.target_fields', [])) === $this->sortedStrings((array) ($proposal['target_fields'] ?? []));
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<string, mixed>  $writeEvidence
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $writeRef
+     * @return array<string, mixed>
+     */
+    private function evidence(
+        string $packagePath,
+        string $writeEvidencePath,
+        string $packageSha,
+        array $package,
+        array $writeEvidence,
+        array $proposal,
+        array $writeRef,
+        Article $article,
+        ArticleRevision $revision,
+        string $target
+    ): array {
+        $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+        $comparisons = $this->comparisons($proposal, $payload);
+        $mismatches = array_values(array_filter($comparisons, static fn (array $row): bool => ($row['matched'] ?? false) !== true));
+        $matched = array_values(array_map(
+            static fn (array $row): string => (string) ($row['field'] ?? ''),
+            array_filter($comparisons, static fn (array $row): bool => ($row['matched'] ?? false) === true)
+        ));
+
+        $isPublishedRevision = (int) ($article->published_revision_id ?? 0) === (int) $revision->id;
+        $liveMutationIssues = [];
+        if ($isPublishedRevision) {
+            $liveMutationIssues[] = 'draft_revision_is_published_revision';
+        }
+        if (data_get($payload, 'seo_agent.publish_allowed') !== false) {
+            $liveMutationIssues[] = 'publish_allowed_not_false';
+        }
+        if (data_get($payload, 'seo_agent.search_submit_allowed') !== false) {
+            $liveMutationIssues[] = 'search_submit_allowed_not_false';
+        }
+        if (data_get($payload, 'seo_agent.indexing_request_allowed') !== false) {
+            $liveMutationIssues[] = 'indexing_request_allowed_not_false';
+        }
+
+        $qaFindings = array_values(array_merge(
+            array_map(static fn (array $row): string => 'field_mismatch:'.(string) ($row['field'] ?? 'unknown'), $mismatches),
+            $liveMutationIssues
+        ));
+        $ok = $qaFindings === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $ok ? 'success' : 'qa_failed',
+            'target' => $target,
+            'package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'write_evidence' => $this->artifactRef($writeEvidencePath, self::WRITE_SCHEMA_VERSION),
+            'package_sha256' => $packageSha,
+            'package_summary' => [
+                'draft_brief_count' => (int) ($package['draft_brief_count'] ?? $package['proposal_count'] ?? 0),
+                'claim_gate_required' => (bool) ($package['claim_gate_required'] ?? false),
+                'human_approval_required' => (bool) ($package['human_approval_required'] ?? false),
+            ],
+            'write_summary' => [
+                'status' => (string) ($writeEvidence['status'] ?? ''),
+                'rows_created' => (int) ($writeEvidence['rows_created'] ?? 0),
+                'rows_skipped_existing' => (int) ($writeEvidence['rows_skipped_existing'] ?? 0),
+                'target_write_ref' => [
+                    'status' => (string) ($writeRef['status'] ?? ''),
+                    'target_model' => (string) ($writeRef['target_model'] ?? ''),
+                    'subject_ref' => (string) ($writeRef['subject_ref'] ?? ''),
+                    'revision_id' => isset($writeRef['revision_id']) ? (int) $writeRef['revision_id'] : null,
+                ],
+            ],
+            'draft_revision' => [
+                'exists' => true,
+                'model' => 'article_revision',
+                'revision_id' => (int) $revision->id,
+                'revision_no' => (int) $revision->revision_no,
+                'article_id' => (int) $revision->article_id,
+                'change_note' => (string) $revision->change_note,
+                'created_at' => optional($revision->created_at)->toIso8601String(),
+                'is_published_revision' => $isPublishedRevision,
+                'task' => (string) data_get($payload, 'seo_agent.task', ''),
+                'claim_gate_required' => (bool) data_get($payload, 'seo_agent.claim_gate_required', false),
+                'human_approval_required' => (bool) data_get($payload, 'seo_agent.human_approval_required', false),
+                'publish_allowed' => (bool) data_get($payload, 'seo_agent.publish_allowed', true),
+                'search_submit_allowed' => (bool) data_get($payload, 'seo_agent.search_submit_allowed', true),
+                'indexing_request_allowed' => (bool) data_get($payload, 'seo_agent.indexing_request_allowed', true),
+            ],
+            'live_article_state' => [
+                'article_id' => (int) $article->id,
+                'locale' => (string) $article->locale,
+                'slug' => (string) $article->slug,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+                'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+                'published_at' => optional($article->published_at)->toIso8601String(),
+                'published_revision_unchanged_by_this_read' => true,
+            ],
+            'matched_fields' => $matched,
+            'mismatches' => $mismatches,
+            'qa_findings' => $qaFindings,
+            'read_only_counts' => [
+                'article_revisions_for_article' => ArticleRevision::query()->withoutGlobalScopes()
+                    ->where('article_id', (int) $article->id)
+                    ->count(),
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function comparisons(array $proposal, array $payload): array
+    {
+        $rows = [
+            $this->comparison('seo_agent.task', self::WRITER_TASK, data_get($payload, 'seo_agent.task')),
+            $this->comparison('seo_agent.subject_ref', (string) ($proposal['subject_ref'] ?? ''), data_get($payload, 'seo_agent.subject_ref')),
+            $this->comparison('seo_agent.target_fields', $this->sortedStrings((array) ($proposal['target_fields'] ?? [])), $this->sortedStrings((array) data_get($payload, 'seo_agent.target_fields', []))),
+            $this->comparison('proposal.safe_path', (string) ($proposal['safe_path'] ?? ''), data_get($payload, 'proposal.safe_path')),
+            $this->comparison('proposal.proposed_seo_title', $proposal['proposed_seo_title'] ?? null, data_get($payload, 'proposal.proposed_seo_title')),
+            $this->comparison('proposal.proposed_seo_description', $proposal['proposed_seo_description'] ?? null, data_get($payload, 'proposal.proposed_seo_description')),
+            $this->comparison('proposal.proposed_faq_items', $proposal['proposed_faq_items'] ?? [], data_get($payload, 'proposal.proposed_faq_items', [])),
+        ];
+
+        if (array_key_exists('proposed_internal_link_actions', $proposal)) {
+            $rows[] = $this->comparison(
+                'proposal.proposed_internal_link_actions',
+                $proposal['proposed_internal_link_actions'] ?? [],
+                data_get($payload, 'proposal.proposed_internal_link_actions', [])
+            );
+        }
+
+        if (array_key_exists('proposal_quality', $proposal)) {
+            $rows[] = $this->comparison(
+                'proposal.proposal_quality',
+                $proposal['proposal_quality'] ?? [],
+                data_get($payload, 'proposal.proposal_quality', [])
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  mixed  $expected
+     * @param  mixed  $actual
+     * @return array<string, mixed>
+     */
+    private function comparison(string $field, $expected, $actual): array
+    {
+        return [
+            'field' => $field,
+            'matched' => $expected === $actual,
+            'expected_hash' => hash('sha256', json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            'actual_hash' => hash('sha256', json_encode($actual, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            'expected_summary' => $this->summaryValue($expected),
+            'actual_summary' => $this->summaryValue($actual),
+        ];
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return mixed
+     */
+    private function summaryValue($value)
+    {
+        if (is_string($value)) {
+            return mb_substr($value, 0, 160);
+        }
+        if (is_array($value)) {
+            return [
+                'type' => 'array',
+                'count' => count($value),
+            ];
+        }
+
+        return $value;
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[0] ?? '') !== $expectedType || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            throw new RuntimeException('subject_ref_invalid');
+        }
+
+        return (int) $parts[1];
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return list<string>
+     */
+    private function sortedStrings(array $values): array
+    {
+        $strings = array_values(array_unique(array_map('strval', $values)));
+        sort($strings);
+
+        return $strings;
+    }
+
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $artifactDir, string $filename, array $payload): array
+    {
+        $path = rtrim($artifactDir, '/').'/'.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded) || file_put_contents($path, $encoded."\n") === false) {
+            throw new RuntimeException('artifact_write_failed');
+        }
+
+        return [
+            'path' => $path,
+            'size' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'schema_version' => (string) ($payload['schema_version'] ?? ''),
+            'sanitized_summary' => [
+                'target' => (string) ($payload['target'] ?? ''),
+                'status' => (string) ($payload['status'] ?? ''),
+                'mismatch_count' => count((array) ($payload['mismatches'] ?? [])),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+            if (is_array($summary['artifact'] ?? null)) {
+                $this->line('artifact_path='.(string) ($summary['artifact']['path'] ?? ''));
+                $this->line('artifact_size='.(string) ($summary['artifact']['size'] ?? 0));
+                $this->line('artifact_sha256='.(string) ($summary['artifact']['sha256'] ?? ''));
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -119,8 +119,8 @@ use App\Console\Commands\EnneagramResultPageContentBatchCommand;
 use App\Console\Commands\EnneagramResultPageOpsControlPlaneCommand;
 use App\Console\Commands\EnneagramResultPageOpsRunnerCommand;
 use App\Console\Commands\EnneagramResultPageProductionManualGateCommand;
-use App\Console\Commands\EnneagramResultPageReportSidecarIssueCommand;
 use App\Console\Commands\EnneagramResultPageRenderedQaSmokeHarnessCommand;
+use App\Console\Commands\EnneagramResultPageReportSidecarIssueCommand;
 use App\Console\Commands\EnneagramRollbackInactiveCandidateRelease;
 use App\Console\Commands\EnneagramRollbackRegistryRelease;
 use App\Console\Commands\Eq60PsychometricsReport;
@@ -185,6 +185,7 @@ use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
+use App\Console\Commands\SeoAgentCmsDraftReadbackQaCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
 use App\Console\Commands\SeoAgentCmsPublishAutoCanaryCommand;
@@ -415,6 +416,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
+        SeoAgentCmsDraftReadbackQaCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
         SeoAgentCmsPublishAutoCanaryCommand::class,
         SeoAgentCmsPublishCanaryCommand::class,

--- a/backend/docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json
@@ -1,0 +1,62 @@
+{
+  "version": "seo-agent-cms-draft-readback-qa.v1",
+  "task": "SEO-AGENT-GSC-ARTICLE41-DRAFT-READBACK-QA-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-draft-readback-qa",
+  "input_schemas": [
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-controlled-cms-draft-write.v1"
+  ],
+  "output_schema": "seo-agent-cms-draft-readback-qa.v1",
+  "default_mode": "read_only_qa_artifact",
+  "required_options": [
+    "--package=<seo-agent-cms-draft-package-dry-run.v1 path>",
+    "--write-evidence=<seo-agent-controlled-cms-draft-write.v1 path>",
+    "--target=<subject_ref>"
+  ],
+  "optional_options": [
+    "--package-sha256=<expected package sha256>",
+    "--artifact-dir=<directory>",
+    "--json"
+  ],
+  "supported_targets": [
+    "article"
+  ],
+  "checks": [
+    "target exists in dry-run package",
+    "target exists in write evidence",
+    "matching article_revision exists for subject_ref + package_sha256 + target_fields",
+    "draft revision is not the live published revision",
+    "draft revision payload preserves title/meta/FAQ/internal-link/proposal-quality fields when present in the package",
+    "live article state remains published separately from the draft revision"
+  ],
+  "forbidden_output": [
+    "raw_url",
+    "raw_query",
+    "credentials",
+    "cookies",
+    "tokens",
+    "content_html",
+    "content_md",
+    "cms_draft_body"
+  ],
+  "publishes_content": false,
+  "mutates_cms": false,
+  "mutates_published_revision": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "published_revision_mutation": false,
+    "live_published_content_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "external_model_api_call": false
+  },
+  "next_step": "Continue to additional CMS draft write canary only when readback evidence has ok=true and status=success."
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsDraftReadbackQaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_verifies_article_draft_payload_against_package_and_write_evidence_without_mutating_live_article(): void
+    {
+        $article = $this->article();
+        $proposal = $this->proposal((int) $article->id);
+        $packagePath = $this->writePackage([$proposal]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $revision = $this->articleRevision($article, $proposal, $sha, includeOptionalProposalFields: true);
+        $writeEvidencePath = $this->writeEvidence($sha, $proposal['subject_ref'], (int) $revision->id);
+        $artifactDir = $this->artifactDir();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $sha,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame($proposal['subject_ref'], $summary['target'] ?? null);
+        $this->assertSame(0, $summary['mismatch_count'] ?? null);
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_write', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertTrue((bool) ($artifact['ok'] ?? false));
+        $this->assertSame('success', $artifact['status'] ?? null);
+        $this->assertFalse((bool) data_get($artifact, 'draft_revision.is_published_revision', true));
+        $this->assertFalse((bool) data_get($artifact, 'draft_revision.publish_allowed', true));
+        $this->assertSame((int) $article->published_revision_id, data_get($artifact, 'live_article_state.published_revision_id'));
+        $this->assertContains('proposal.proposed_internal_link_actions', $artifact['matched_fields'] ?? []);
+        $this->assertContains('proposal.proposal_quality', $artifact['matched_fields'] ?? []);
+
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function it_records_qa_findings_when_writer_payload_did_not_preserve_optional_proposal_quality_fields(): void
+    {
+        $article = $this->article();
+        $proposal = $this->proposal((int) $article->id);
+        $packagePath = $this->writePackage([$proposal]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $revision = $this->articleRevision($article, $proposal, $sha, includeOptionalProposalFields: false);
+        $writeEvidencePath = $this->writeEvidence($sha, $proposal['subject_ref'], (int) $revision->id);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $sha,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('qa_failed', $summary['status'] ?? null);
+        $this->assertSame(2, $summary['mismatch_count'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertContains('field_mismatch:proposal.proposed_internal_link_actions', $artifact['qa_findings'] ?? []);
+        $this->assertContains('field_mismatch:proposal.proposal_quality', $artifact['qa_findings'] ?? []);
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_publish', true));
+    }
+
+    #[Test]
+    public function it_fails_closed_for_wrong_schema_missing_target_and_forbidden_input(): void
+    {
+        $article = $this->article();
+        $proposal = $this->proposal((int) $article->id);
+        $packagePath = $this->writePackage([$proposal]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $revision = $this->articleRevision($article, $proposal, $sha, includeOptionalProposalFields: true);
+        $writeEvidencePath = $this->writeEvidence($sha, $proposal['subject_ref'], (int) $revision->id);
+
+        $badSchema = $this->writeJson('bad-package-', [
+            'schema_version' => 'wrong',
+        ]);
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $badSchema,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_schema_invalid', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:999:en',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('target_not_found_in_package', $summary['issues'] ?? []);
+
+        $forbiddenPackage = $this->writeJson('forbidden-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_items' => [
+                ['subject_ref' => $proposal['subject_ref'], 'raw_query' => 'blocked'],
+            ],
+        ]);
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $forbiddenPackage,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_readback_qa_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json'));
+
+        $this->assertSame('seo-agent-cms-draft-readback-qa.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-draft-readback-qa', $contract['command'] ?? null);
+        $this->assertContains('article', $contract['supported_targets'] ?? []);
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+        $this->assertFalse((bool) ($contract['mutates_cms'] ?? true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+    }
+
+    private function article(): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'big-five-career-fit',
+            'locale' => 'en',
+            'title' => 'Big Five Career Fit',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'working_revision_id' => 101,
+            'published_revision_id' => 100,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function proposal(int $articleId): array
+    {
+        return [
+            'source_id' => hash('sha256', 'article'.$articleId),
+            'source_family' => 'gsc_cohort_artifact',
+            'target_model' => 'article',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:'.$articleId.':en',
+            'safe_path' => '/en/articles/big-five-career-fit',
+            'severity' => 'p1',
+            'target_fields' => ['seo_title', 'seo_description', 'faq_items'],
+            'proposed_seo_title' => 'Big Five Career Fit | FermatMind',
+            'proposed_seo_description' => 'Review Big Five career fit patterns with careful, non-diagnostic guidance.',
+            'proposed_faq_items' => [
+                [
+                    'question' => 'Can Big Five scores predict career success?',
+                    'answer' => 'No. They can support reflection, but they do not guarantee outcomes.',
+                ],
+            ],
+            'proposed_internal_link_actions' => [
+                'Add internal link to /en/tests/big-five-personality-test',
+            ],
+            'proposal_quality' => [
+                'source' => 'gsc_cohort_artifact',
+                'locale_preserved' => true,
+                'slug_generated_copy' => false,
+                'needs_human_approval' => true,
+            ],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function writePackage(array $proposals): string
+    {
+        return $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'run_mode' => 'cms_draft_package_dry_run',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'draft_brief_count' => count($proposals),
+            'draft_briefs' => $proposals,
+            'proposal_count' => count($proposals),
+            'proposal_items' => $proposals,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ]);
+    }
+
+    private function writeEvidence(string $packageSha, string $subjectRef, int $revisionId): string
+    {
+        return $this->writeJson('seo-agent-controlled-cms-draft-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'planned_count' => 1,
+            'rows_created' => 1,
+            'rows_skipped_existing' => 0,
+            'rows_failed' => [],
+            'affected_refs' => [
+                [
+                    'status' => 'created',
+                    'target_model' => 'article',
+                    'subject_ref' => $subjectRef,
+                    'revision_id' => $revisionId,
+                ],
+            ],
+            'negative_guarantees' => [
+                'cms_publish' => false,
+                'search_channel_submit' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function articleRevision(Article $article, array $proposal, string $packageSha, bool $includeOptionalProposalFields): ArticleRevision
+    {
+        $proposalPayload = [
+            'safe_path' => $proposal['safe_path'],
+            'proposed_seo_title' => $proposal['proposed_seo_title'],
+            'proposed_seo_description' => $proposal['proposed_seo_description'],
+            'proposed_faq_items' => $proposal['proposed_faq_items'],
+            'proposed_canonical_path' => null,
+            'proposed_indexability' => null,
+        ];
+        if ($includeOptionalProposalFields) {
+            $proposalPayload['proposed_internal_link_actions'] = $proposal['proposed_internal_link_actions'];
+            $proposalPayload['proposal_quality'] = $proposal['proposal_quality'];
+        }
+
+        return ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => 2,
+            'editor_admin_user_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'change_note' => 'SEO Agent controlled draft proposal',
+            'payload_json' => [
+                'seo_agent' => [
+                    'task' => 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01',
+                    'package_sha256' => $packageSha,
+                    'subject_ref' => $proposal['subject_ref'],
+                    'target_fields' => $proposal['target_fields'],
+                    'claim_gate_required' => true,
+                    'human_approval_required' => true,
+                    'publish_allowed' => false,
+                    'search_submit_allowed' => false,
+                    'indexing_request_allowed' => false,
+                ],
+                'proposal' => $proposalPayload,
+            ],
+            'created_at' => now(),
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-cms-draft-readback-qa-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->count(),
+            'article_revisions' => ArticleRevision::query()->count(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1157,6 +1157,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_draft_readback_qa_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '-use App\\Console\\Commands\\EnneagramResultPageReportSidecarIssueCommand;',
+            '+use App\\Console\\Commands\\EnneagramResultPageReportSidecarIssueCommand;',
+            '+use App\\Console\\Commands\\SeoAgentCmsDraftReadbackQaCommand;',
+            '+        SeoAgentCmsDraftReadbackQaCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4312,6 +4328,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsDraftReadbackQaFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentRuntimeSeoQaReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5061,6 +5081,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentControlledCmsDraftWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsDraftReadbackQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5764,6 +5785,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsDraftReadbackQaFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php',
         ], true);
     }
 
@@ -7735,6 +7763,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentCmsDraftWriteCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsDraftReadbackQaOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\b(SeoAgentCmsDraftReadbackQaCommand|EnneagramResultPageReportSidecarIssueCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:cms-draft-readback-qa`, a read-only QA command for comparing a CMS draft revision payload against the source dry-run package and controlled write evidence.
- Added a generated contract doc for the readback QA artifact.
- Added focused feature coverage for success, mismatch findings, fail-closed inputs, and contract boundaries.

## Why
This is the first step after the `article:41:en` GSC cohort CMS draft write canary. It gives Codex a repeatable readback QA artifact before any further draft write batch is considered.

## Validation
- `php artisan list | rg seo-agent:cms-draft-readback-qa`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php`
- `vendor/bin/pint --test app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php app/Console/Kernel.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No production readback execution until deployed.
- No CMS draft writes.
- No CMS publish.
- No search channel enqueue/submit, IndexNow, Google Indexing, sitemap, llms, scheduler, or queue worker action.

## Repository rule impact
Backend-only SEO agent operational QA command. It does not change content ownership, publishing authority, public rendering, or search submission policy.