### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01: docs(riasec): record approved snapshot no-go decision

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_approved_snapshot_artifact_no_go.v0.1",
+  "task_id": "RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01",
+  "created_date": "2026-06-22",
+  "record_type": "production_approved_snapshot_artifact_decision",
+  "decision": "NO-GO",
+  "approved_snapshot_generated": false,
+  "human_authorization_status": "missing_complete_human_approval_block",
+  "source_snapshot": {
+    "snapshot_id": "riasec_result_page_v2_rc_0_1",
+    "snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+    "source_snapshot_modified": false,
+    "release_candidate": false,
+    "production_use_allowed": false,
+    "ready_for_production": false,
+    "production_rollout_enabled": false
+  },
+  "reviewed_approval_record": {
+    "path": "backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/riasec_result_page_v2_manual_production_gate_approval_evidence_v0_1.json",
+    "approval_type": "production_import",
+    "decision": "NO-GO",
+    "status": "missing_human_approval",
+    "approved_by": null,
+    "approved_at": null,
+    "approval_channel": null,
+    "approval_evidence_url_or_ref": null,
+    "private_payload_leak_ack": false,
+    "staging_only_rejection_ack": false,
+    "production_import_allowed": false
+  },
+  "no_go_conditions_triggered": [
+    "approved_by_missing_or_agent_authored",
+    "approved_at_missing_partial_or_placeholder",
+    "approval_channel_missing",
+    "approval_evidence_ref_missing",
+    "scope_missing_or_placeholder",
+    "private_payload_leak_ack_not_true",
+    "staging_only_rejection_ack_not_true"
+  ],
+  "downstream_sidecar": {
+    "import_gate_dry_run_should_continue": true,
+    "external_blocker": "production_approved_snapshot_missing_due_to_missing_human_approval",
+    "production_import_allowed": false,
+    "cms_write_allowed": false,
+    "runtime_enablement_allowed": false,
+    "production_rollout_allowed": false
+  },
+  "required_future_human_authorization_fields": [
+    "approval_type",
+    "decision",
+    "approved_by",
+    "approver_role",
+    "approved_at",
+    "approval_channel",
+    "approval_evidence_url_or_ref",
+    "deployed_backend_sha",
+    "source_release_snapshot_id",
+    "source_release_snapshot_sha256",
+    "approved_release_snapshot_id",
+    "scope.tenant_ids",
+    "scope.form_codes",
+    "scope.locales",
+    "scope.allowlist",
+    "scope.percentage",
+    "scope.max_percentage",
+    "rollback_kill_switch_confirmed",
+    "kill_switch_ref",
+    "post_deploy_smoke_procedure_id",
+    "private_payload_leak_ack",
+    "staging_only_rejection_ack"
+  ],
+  "negative_guarantees": {
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "approved_snapshot_generated": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "codex_approved_production_activation": false
+  },
+  "go_no_go": {
+    "production_approved_snapshot_generated_now": false,
+    "current_approval_template_is_human_approval": false,
+    "production_import_allowed_now": false,
+    "cms_production_write_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "continue_train_with_external_no_go_sidecar": true
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-approved-snapshot-artifact-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-approved-snapshot-artifact-2026-06-22.md
@@ -1,0 +1,132 @@
+# RIASEC Result Page V2 Production-Approved Snapshot Artifact Decision
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01`
+
+Scope: docs/artifact-only decision record for production-approved snapshot artifact generation. This PR does not import CMS data, write production content, change runtime code, mutate environment variables, open production gates, or enable production rollout.
+
+## Verdict
+
+Production-approved snapshot artifact generated: `NO`.
+
+Reason: a complete, human-authored, placeholder-free production import approval block is not present. Per the operating model from `RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-OPERATING-MODEL-01`, the correct behavior is to emit a `NO-GO` sidecar/report and continue the train without creating an approved snapshot.
+
+## Inputs Reviewed
+
+| Input | Path / reference | Result |
+| --- | --- | --- |
+| Operating model | `backend/content_assets/riasec/result_page_v2/governance/production_approved_snapshot_operating_model/v0_1/riasec_result_page_v2_production_approved_snapshot_operating_model_v0_1.json` | Requires complete human approval before approved snapshot generation. |
+| Approval evidence template | `backend/content_assets/riasec/result_page_v2/qa/manual_production_gate_approval_evidence/v0_1/riasec_result_page_v2_manual_production_gate_approval_evidence_v0_1.json` | Current production import approval is `NO-GO`. |
+| Source RC snapshot | `backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json` | Still not production-approved. |
+| Production import preflight | `backend/content_assets/riasec/result_page_v2/qa/production_import_gate_preflight/v0_1/riasec_result_page_v2_production_import_gate_preflight_v0_1.json` | Import remains `NO-GO`. |
+
+## Source Snapshot Under Review
+
+| Field | Value |
+| --- | --- |
+| Source snapshot id | `riasec_result_page_v2_rc_0_1` |
+| Source snapshot SHA256 | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` |
+| Deployed backend SHA | `ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9` |
+| `release_candidate` | `false` |
+| `production_use_allowed` | `false` |
+| `ready_for_production` | `false` |
+| `production_rollout_enabled` | `false` |
+
+The original RC snapshot was not modified.
+
+## Missing Human Authorization
+
+The current approval record has:
+
+- `decision=NO-GO`
+- `status=missing_human_approval`
+- `approved_by=null`
+- `approved_at=null`
+- `approval_channel=null`
+- `approval_evidence_url_or_ref=null`
+- `private_payload_leak_ack=false`
+- `staging_only_rejection_ack=false`
+- `production_import_allowed=false`
+
+These facts fail the operating model. Codex must not convert them into approval.
+
+## NO-GO Conditions Triggered
+
+The following operating-model NO-GO conditions are active:
+
+1. `approved_by_missing_or_agent_authored`
+2. `approved_at_missing_partial_or_placeholder`
+3. `approval_channel_missing`
+4. `approval_evidence_ref_missing`
+5. `scope_missing_or_placeholder`
+6. `private_payload_leak_ack_not_true`
+7. `staging_only_rejection_ack_not_true`
+8. `codex_filled_human_identity_timestamp_scope_or_channel` would be triggered if Codex tried to fill the missing values.
+
+## Artifact Outcome
+
+| Artifact type | Outcome |
+| --- | --- |
+| `production_approved_snapshot` | Not generated. |
+| `production_import_human_approval` | Not generated as `GO`. |
+| `NO-GO` sidecar/report | Generated. |
+
+The downstream import gate dry-run must treat this as an external `NO-GO` blocker and continue without CMS writes, production import, runtime enablement, or rollout.
+
+## Required Future Human Approval Block
+
+A future approved snapshot PR may generate the production-approved snapshot only after a human operator provides a complete block with all fields below:
+
+```yaml
+approval_type: production_import
+decision: GO
+approved_by: "<human operator id/name>"
+approver_role: "<authorized approval role>"
+approved_at: "<complete ISO-8601 timestamp>"
+approval_channel: "<durable source>"
+approval_evidence_url_or_ref: "<durable approval evidence>"
+deployed_backend_sha: "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9"
+source_release_snapshot_id: "riasec_result_page_v2_rc_0_1"
+source_release_snapshot_sha256: "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853"
+approved_release_snapshot_id: "<new production-approved snapshot id>"
+scope:
+  tenant_ids: []
+  form_codes: ["riasec_60", "riasec_140"]
+  locales: ["zh-CN"]
+  allowlist: []
+  percentage: 0
+  max_percentage: 0
+rollback_kill_switch_confirmed: true
+kill_switch_ref: "riasec_result_page_v2.production_emergency_disabled"
+post_deploy_smoke_procedure_id: "riasec_result_page_v2_post_deploy_smoke_v0_1"
+private_payload_leak_ack: true
+staging_only_rejection_ack: true
+```
+
+Any placeholder in a real approval block keeps the result at `NO-GO`.
+
+## Explicit Non-Actions
+
+This PR did not:
+
+- create a production-approved snapshot;
+- modify `riasec_result_page_v2_rc_0_1`;
+- import CMS data;
+- write production content;
+- open production import gate;
+- enable production runtime;
+- enable production rollout;
+- mark staging-only assets as production-ready;
+- approve production activation.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Generate production-approved snapshot now | `NO` |
+| Treat current approval template as human approval | `NO` |
+| Allow production import now | `NO` |
+| Allow CMS production write now | `NO` |
+| Allow production rollout now | `NO` |
+| Continue train with external NO-GO sidecar | `YES` |


### PR DESCRIPTION
## What changed
- Added a production-approved snapshot artifact decision report.
- Added a `NO-GO` production approval evidence sidecar because no complete human approval block exists.

## Why
- The operating model requires complete human-authored approval before generating a production-approved snapshot.
- Current approval evidence is still `NO-GO` / `missing_human_approval`, so no approved snapshot was generated.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json`
- `git diff --check main...HEAD`
- Scope validation: only the production-approved snapshot artifact doc and governance sidecar changed.
- Confirmed no `backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/*` artifact was generated.

## Result
- Production-approved snapshot generated: NO.
- Production import: NO-GO.
- CMS write/import: NO-GO.
- Production rollout: NO-GO.
- Continue train with external NO-GO sidecar: YES.

## Intentionally deferred
- No approved snapshot artifact generated.
- No production import.
- No CMS write/import.
- No runtime/env changes.
- No production rollout.
- No staging-only asset promotion.

## Repository rule impact
Docs/artifact-only decision record. No runtime, API, CMS, media, sitemap, llms, or publishing workflow behavior changed.
