### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-01: docs(riasec): record import gate dry-run no-go

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run/v0_1/riasec_result_page_v2_production_import_gate_dry_run_no_go_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run/v0_1/riasec_result_page_v2_production_import_gate_dry_run_no_go_v0_1.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_import_gate_dry_run.v0.1",
+  "task_id": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-01",
+  "created_date": "2026-06-22",
+  "record_type": "production_import_gate_dry_run",
+  "decision": "NO-GO",
+  "dry_run_status": "blocked_external_no_go",
+  "external_blocker": {
+    "blocker_id": "production_approved_snapshot_missing_due_to_missing_human_approval",
+    "introduced_by_current_pr": false,
+    "source_task_id": "RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01",
+    "source_artifact": "backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json",
+    "train_should_continue": true
+  },
+  "approved_snapshot_lookup": {
+    "directory": "backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1",
+    "approved_snapshot_found": false,
+    "approved_snapshot_id": null,
+    "approved_snapshot_sha256": null
+  },
+  "dry_run_check_matrix": {
+    "manifest": "NO-GO_no_authorized_production_import_manifest",
+    "sha256": "NO-GO_no_approved_snapshot_hash",
+    "release_snapshot": "NO-GO_no_production_approved_snapshot",
+    "approval_evidence": "NO-GO_missing_human_approval",
+    "rendered_qa_evidence": "REVIEW_INPUT_ONLY",
+    "all_surface_pass_evidence": "REVIEW_INPUT_ONLY",
+    "staging_only_rejection": "PASS_FAIL_CLOSED",
+    "safety": "PASS_NO_MUTATION"
+  },
+  "future_go_requirements": [
+    "production_approved_snapshot_artifact_present",
+    "complete_human_production_import_approval_evidence_present",
+    "approved_snapshot_sha256_verified",
+    "staging_only_artifacts_rejected",
+    "rollback_kill_switch_acknowledged",
+    "import_approval_does_not_claim_rollout_approval"
+  ],
+  "negative_guarantees": {
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "approved_snapshot_generated": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "codex_approved_production_activation": false
+  },
+  "go_no_go": {
+    "import_gate_dry_run_can_pass_now": false,
+    "production_import_allowed_now": false,
+    "cms_production_write_allowed_now": false,
+    "runtime_production_enablement_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "continue_train_with_external_no_go_sidecar": true
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-import-gate-dry-run-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-import-gate-dry-run-2026-06-22.md
@@ -1,0 +1,94 @@
+# RIASEC Result Page V2 Production Import Gate Dry-Run
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-01`
+
+Scope: docs/artifact-only production import gate dry-run report. This report does not write CMS data, import production content, change runtime code, mutate environment variables, open production gates, or enable production rollout.
+
+## Verdict
+
+Production import gate dry-run result: `NO-GO`.
+
+Reason: no production-approved snapshot artifact exists. The previous approved snapshot artifact PR produced an external `NO-GO` sidecar because complete human approval evidence was missing. Per the train protocol, this dry-run records the blocker and continues without CMS writes or runtime changes.
+
+## Inputs Reviewed
+
+| Input | Path / reference | Result |
+| --- | --- | --- |
+| Approved snapshot operating model | `backend/content_assets/riasec/result_page_v2/governance/production_approved_snapshot_operating_model/v0_1/riasec_result_page_v2_production_approved_snapshot_operating_model_v0_1.json` | Requires complete human approval and a new approved snapshot artifact. |
+| Approved snapshot artifact decision | `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json` | Confirms no approved snapshot was generated. |
+| Production import gate preflight | `backend/content_assets/riasec/result_page_v2/qa/production_import_gate_preflight/v0_1/riasec_result_page_v2_production_import_gate_preflight_v0_1.json` | Import remains `NO-GO`. |
+| Production import gate policy | `backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json` | Fail-closed and rejects staging-only artifacts. |
+
+## Approved Snapshot Lookup
+
+Expected directory:
+
+`backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/`
+
+Lookup result: no production-approved snapshot artifact was found.
+
+This is expected because `RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01` correctly emitted a `NO-GO` sidecar instead of generating a snapshot without human approval.
+
+## Dry-Run Check Matrix
+
+| Gate check | Dry-run input | Result |
+| --- | --- | --- |
+| `manifest` | No authorized production import manifest exists. | `NO-GO` |
+| `sha256` | Source RC hash is known, but no approved snapshot hash exists. | `NO-GO` |
+| `release_snapshot` | No production-approved snapshot artifact exists. | `NO-GO` |
+| `approval_evidence` | Current approval is missing human approval. | `NO-GO` |
+| `rendered_qa_evidence` | PR `#2285` evidence exists, but only as review input. | `REVIEW_INPUT_ONLY` |
+| `all_surface_pass_evidence` | PR `#2285` evidence exists, but only as review input. | `REVIEW_INPUT_ONLY` |
+| `staging_only_rejection` | Staging-only assets remain rejected. | `PASS_FAIL_CLOSED` |
+| `safety` | No private payload export, CMS write, or runtime change occurred in this dry-run. | `PASS_NO_MUTATION` |
+
+## External Blocker
+
+The blocker is not introduced by this PR:
+
+- blocker id: `production_approved_snapshot_missing_due_to_missing_human_approval`
+- source: `RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-ARTIFACT-01`
+- current behavior: continue train with `NO-GO` sidecar
+- production import allowed: `false`
+- CMS write allowed: `false`
+- runtime enablement allowed: `false`
+- production rollout allowed: `false`
+
+## Required Future Condition
+
+A future dry-run can pass only after a separate approved snapshot artifact PR produces:
+
+1. a new production-approved snapshot under `backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/`;
+2. a complete human production import approval evidence artifact under `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/`;
+3. a matching snapshot SHA256;
+4. explicit staging-only rejection;
+5. explicit rollback and kill-switch acknowledgement;
+6. import approval that does not claim rollout approval.
+
+## Explicit Non-Actions
+
+This dry-run did not:
+
+- write CMS data;
+- run a production import command;
+- create a production-approved snapshot;
+- modify the RC snapshot;
+- enable runtime;
+- mutate environment variables;
+- open production import gate;
+- open production rollout;
+- mark staging-only assets as production-ready;
+- approve production activation.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Import gate dry-run can pass now | `NO` |
+| Production import allowed now | `NO` |
+| CMS write/import allowed now | `NO` |
+| Runtime production enablement allowed now | `NO` |
+| Production rollout allowed now | `NO` |
+| Continue train with external NO-GO sidecar | `YES` |


### PR DESCRIPTION
## What changed
- Added production import gate dry-run report.
- Added JSON dry-run sidecar recording external `NO-GO` because no production-approved snapshot exists.

## Why
- PR #2293 did not generate an approved snapshot because complete human approval evidence is missing.
- The train should continue with a documented external blocker and no CMS/runtime mutation.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run/v0_1/riasec_result_page_v2_production_import_gate_dry_run_no_go_v0_1.json`
- `git diff --check main...HEAD`
- Scope validation: only the import gate dry-run doc and QA artifact changed.

## Result
- Import gate dry-run can pass now: NO.
- Production import: NO-GO.
- CMS write/import: NO-GO.
- Runtime production enablement: NO-GO.
- Production rollout: NO-GO.
- Continue train with external NO-GO sidecar: YES.

## Intentionally deferred
- No production import.
- No CMS write/import.
- No runtime/env changes.
- No production rollout.
- No staging-only asset promotion.

## Repository rule impact
Docs/artifact-only dry-run record. No runtime, API, CMS, media, sitemap, llms, or publishing workflow behavior changed.
