### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01: docs(riasec): record production import execution no-go

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_no_go_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_no_go_v0_1.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_import_execution.v0.1",
+  "task_id": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01",
+  "created_date": "2026-06-22",
+  "record_type": "production_import_execution_gate",
+  "decision": "NO-GO",
+  "execution_status": "not_executed",
+  "second_execution_authorization_present": false,
+  "inputs_reviewed": {
+    "production_import_gate_dry_run": "backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run/v0_1/riasec_result_page_v2_production_import_gate_dry_run_no_go_v0_1.json",
+    "approved_snapshot_sidecar": "backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json",
+    "production_import_gate_policy": "backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json"
+  },
+  "preconditions": {
+    "production_approved_snapshot_exists": false,
+    "import_gate_dry_run_passed": false,
+    "complete_human_import_approval_exists": false,
+    "explicit_second_execution_authorization_exists": false,
+    "cms_import_command_target_authorized": false,
+    "public_payload_leak_scan_passed_for_approved_snapshot": false,
+    "rollout_separation_preserved": true
+  },
+  "non_execution_record": {
+    "production_import_command_run": false,
+    "cms_write_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_opened": false
+  },
+  "required_future_execution_conditions": [
+    "production_approved_snapshot_exists",
+    "production_import_human_approval_evidence_complete_and_go",
+    "import_gate_dry_run_passes_for_exact_snapshot",
+    "explicit_second_authorization_for_production_import_execution_present",
+    "import_command_target_dry_run_and_rollback_named",
+    "public_payload_leak_scan_passes",
+    "production_rollout_remains_disabled_and_separately_gated"
+  ],
+  "negative_guarantees": {
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "approved_snapshot_generated": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "codex_approved_production_activation": false
+  },
+  "go_no_go": {
+    "execute_production_import_now": false,
+    "cms_production_write_allowed_now": false,
+    "runtime_production_enablement_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "import_approval_counts_as_rollout_approval": false,
+    "continue_train_to_rollout_approval_packet": true
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-import-execution-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-import-execution-2026-06-22.md
@@ -1,0 +1,84 @@
+# RIASEC Result Page V2 Production Import Execution Gate
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01`
+
+Scope: docs/artifact-only production import execution readiness record. This PR does not execute production import, write CMS data, change runtime code, mutate environment variables, open production gates, or enable production rollout.
+
+## Verdict
+
+Production import execution result: `NO-GO`.
+
+Reason: no explicit second authorization for real production import was provided. The import gate dry-run is also `NO-GO` because no production-approved snapshot exists.
+
+## Inputs Reviewed
+
+| Input | Path / reference | Result |
+| --- | --- | --- |
+| Production import gate dry-run | `backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run/v0_1/riasec_result_page_v2_production_import_gate_dry_run_no_go_v0_1.json` | Dry-run is `NO-GO`. |
+| Approved snapshot sidecar | `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_approved_snapshot_artifact_no_go_v0_1.json` | No approved snapshot was generated. |
+| Production import gate policy | `backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json` | Current state is `NO-GO`. |
+
+## Execution Preconditions
+
+| Precondition | Current status | Result |
+| --- | --- | --- |
+| Complete production-approved snapshot | Missing. | `NO-GO` |
+| Import gate dry-run pass | Dry-run result is `NO-GO`. | `NO-GO` |
+| Complete human import approval | Missing. | `NO-GO` |
+| Explicit second execution authorization | Missing in this task. | `NO-GO` |
+| CMS import command target | Not authorized. | `NO-GO` |
+| Public payload leak scan for approved snapshot | Not applicable without approved snapshot. | `NO-GO` |
+| Rollout separation | Import must not imply rollout. | `PASS_FAIL_CLOSED` |
+
+## Non-Execution Record
+
+No production import command was run.
+
+No production CMS write was performed.
+
+No runtime flag or environment variable was changed.
+
+No rollout was opened.
+
+This is the intended fail-closed behavior because import execution requires both a passing dry-run and a separate explicit execution authorization.
+
+## Required Future Execution Authorization
+
+A future production import execution task may proceed only if all conditions are met:
+
+1. production-approved snapshot exists;
+2. production import human approval evidence is complete and `GO`;
+3. import gate dry-run passes for the exact approved snapshot;
+4. user provides explicit second authorization for production import execution in the same task;
+5. import command, target, dry-run result, and rollback path are named;
+6. public payload leak scan passes;
+7. production rollout remains disabled and separately gated.
+
+## Explicit Non-Actions
+
+This PR did not:
+
+- execute production import;
+- write CMS data;
+- run an import command;
+- generate a production-approved snapshot;
+- modify the RC snapshot;
+- enable runtime;
+- mutate environment variables;
+- open production import gate;
+- open production rollout;
+- mark staging-only assets as production-ready;
+- approve production activation.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Execute production import now | `NO` |
+| CMS production write/import allowed now | `NO` |
+| Runtime production enablement allowed now | `NO` |
+| Production rollout allowed now | `NO` |
+| Treat import approval as rollout approval | `NO` |
+| Continue train to rollout approval packet | `YES` |


### PR DESCRIPTION
## What changed
- Added production import execution gate report.
- Added JSON execution readiness artifact recording `NO-GO` because no second execution authorization exists and the dry-run is still blocked.

## Why
- Real production import requires a passing import gate dry-run plus explicit second authorization in the same task.
- Neither condition is satisfied, so the correct behavior is fail-closed documentation only.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_no_go_v0_1.json`
- `git diff --check origin/main...HEAD`
- Scope validation: only the production import execution doc and QA artifact changed.

## Result
- Production import executed: NO.
- CMS write/import: NO-GO.
- Runtime production enablement: NO-GO.
- Production rollout: NO-GO.
- Continue train to rollout approval packet: YES.

## Intentionally deferred
- No production import command.
- No CMS write/import.
- No runtime/env changes.
- No production rollout.
- No staging-only asset promotion.

## Repository rule impact
Docs/artifact-only execution gate record. No runtime, API, CMS, media, sitemap, llms, or publishing workflow behavior changed.
