### PR TITLE
SEO-AGENT-GSC-DRAFT-PROPOSAL-PAYLOAD-PARITY-01 preserve draft proposal metadata

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php
@@ -464,14 +464,39 @@ final class SeoAgentCmsDraftReadbackQaCommand extends Command
      */
     private function comparison(string $field, $expected, $actual): array
     {
+        $normalizedExpected = $this->canonicalComparableValue($expected);
+        $normalizedActual = $this->canonicalComparableValue($actual);
+
         return [
             'field' => $field,
-            'matched' => $expected === $actual,
-            'expected_hash' => hash('sha256', json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
-            'actual_hash' => hash('sha256', json_encode($actual, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            'matched' => $normalizedExpected === $normalizedActual,
+            'expected_hash' => hash('sha256', json_encode($normalizedExpected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            'actual_hash' => hash('sha256', json_encode($normalizedActual, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
             'expected_summary' => $this->summaryValue($expected),
             'actual_summary' => $this->summaryValue($actual),
         ];
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return mixed
+     */
+    private function canonicalComparableValue($value)
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[$key] = $this->canonicalComparableValue($item);
+        }
+
+        if (! array_is_list($normalized)) {
+            ksort($normalized);
+        }
+
+        return $normalized;
     }
 
     /**

--- a/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftWriteCommand.php
@@ -411,6 +411,21 @@ final class SeoAgentCmsDraftWriteCommand extends Command
      */
     private function revisionPayload(array $proposal, string $packageSha, array $targetFields): array
     {
+        $proposalPayload = [
+            'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+            'proposed_seo_title' => $proposal['proposed_seo_title'] ?? null,
+            'proposed_seo_description' => $proposal['proposed_seo_description'] ?? null,
+            'proposed_faq_items' => $proposal['proposed_faq_items'] ?? [],
+            'proposed_canonical_path' => $proposal['proposed_canonical_path'] ?? null,
+            'proposed_indexability' => $proposal['proposed_indexability'] ?? null,
+        ];
+
+        foreach (['proposed_internal_link_actions', 'proposal_quality'] as $optionalField) {
+            if (array_key_exists($optionalField, $proposal)) {
+                $proposalPayload[$optionalField] = $proposal[$optionalField];
+            }
+        }
+
         return [
             'seo_agent' => [
                 'task' => self::TASK,
@@ -423,14 +438,7 @@ final class SeoAgentCmsDraftWriteCommand extends Command
                 'search_submit_allowed' => false,
                 'indexing_request_allowed' => false,
             ],
-            'proposal' => [
-                'safe_path' => (string) ($proposal['safe_path'] ?? ''),
-                'proposed_seo_title' => $proposal['proposed_seo_title'] ?? null,
-                'proposed_seo_description' => $proposal['proposed_seo_description'] ?? null,
-                'proposed_faq_items' => $proposal['proposed_faq_items'] ?? [],
-                'proposed_canonical_path' => $proposal['proposed_canonical_path'] ?? null,
-                'proposed_indexability' => $proposal['proposed_indexability'] ?? null,
-            ],
+            'proposal' => $proposalPayload,
         ];
     }
 

--- a/backend/docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json
@@ -28,6 +28,7 @@
     "matching article_revision exists for subject_ref + package_sha256 + target_fields",
     "draft revision is not the live published revision",
     "draft revision payload preserves title/meta/FAQ/internal-link/proposal-quality fields when present in the package",
+    "FAQ/object comparison canonicalizes associative key order before hashing",
     "live article state remains published separately from the draft revision"
   ],
   "forbidden_output": [

--- a/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
+++ b/backend/docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json
@@ -43,6 +43,16 @@
     "article": "article_revisions.payload_json isolated SEO Agent revision",
     "content_page": "cms_translation_revisions.payload_json draft revision"
   },
+  "preserved_proposal_fields": [
+    "safe_path",
+    "proposed_seo_title",
+    "proposed_seo_description",
+    "proposed_faq_items",
+    "proposed_canonical_path",
+    "proposed_indexability",
+    "proposed_internal_link_actions",
+    "proposal_quality"
+  ],
   "idempotency_policy": "subject_ref + package_sha256 + sorted target_fields",
   "max_rows_per_execution": 10,
   "publishes_content": false,

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
@@ -93,6 +93,35 @@ final class SeoAgentCmsDraftReadbackQaTest extends TestCase
     }
 
     #[Test]
+    public function it_normalizes_faq_object_key_order_before_comparing_readback_payload(): void
+    {
+        $article = $this->article();
+        $proposal = $this->proposal((int) $article->id);
+        $packagePath = $this->writePackage([$proposal]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $revision = $this->articleRevision($article, $proposal, $sha, includeOptionalProposalFields: true, reverseFaqKeyOrder: true);
+        $writeEvidencePath = $this->writeEvidence($sha, $proposal['subject_ref'], (int) $revision->id);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $sha,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(0, $summary['mismatch_count'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertContains('proposal.proposed_faq_items', $artifact['matched_fields'] ?? []);
+        $this->assertSame([], $artifact['qa_findings'] ?? []);
+    }
+
+    #[Test]
     public function it_fails_closed_for_wrong_schema_missing_target_and_forbidden_input(): void
     {
         $article = $this->article();
@@ -270,13 +299,29 @@ final class SeoAgentCmsDraftReadbackQaTest extends TestCase
     /**
      * @param  array<string, mixed>  $proposal
      */
-    private function articleRevision(Article $article, array $proposal, string $packageSha, bool $includeOptionalProposalFields): ArticleRevision
-    {
+    private function articleRevision(
+        Article $article,
+        array $proposal,
+        string $packageSha,
+        bool $includeOptionalProposalFields,
+        bool $reverseFaqKeyOrder = false
+    ): ArticleRevision {
+        $faqItems = $proposal['proposed_faq_items'];
+        if ($reverseFaqKeyOrder) {
+            $faqItems = array_map(
+                static fn (array $item): array => [
+                    'answer' => $item['answer'],
+                    'question' => $item['question'],
+                ],
+                $faqItems
+            );
+        }
+
         $proposalPayload = [
             'safe_path' => $proposal['safe_path'],
             'proposed_seo_title' => $proposal['proposed_seo_title'],
             'proposed_seo_description' => $proposal['proposed_seo_description'],
-            'proposed_faq_items' => $proposal['proposed_faq_items'],
+            'proposed_faq_items' => $faqItems,
             'proposed_canonical_path' => null,
             'proposed_indexability' => null,
         ];

--- a/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php
@@ -111,6 +111,9 @@ final class SeoAgentControlledCmsDraftWriterTest extends TestCase
         $this->assertSame('SEO Agent controlled draft proposal', $articleRevision->change_note);
         $this->assertSame($sha, data_get($articleRevision->payload_json, 'seo_agent.package_sha256'));
         $this->assertSame('Article Candidate | FermatMind', data_get($articleRevision->payload_json, 'proposal.proposed_seo_title'));
+        $this->assertSame(['Add internal link review target.'], data_get($articleRevision->payload_json, 'proposal.proposed_internal_link_actions'));
+        $this->assertSame('gsc_cohort_artifact', data_get($articleRevision->payload_json, 'proposal.proposal_quality.source'));
+        $this->assertFalse((bool) data_get($articleRevision->payload_json, 'proposal.proposal_quality.slug_generated_copy', true));
 
         $pageRevision = CmsTranslationRevision::query()->firstOrFail();
         $this->assertSame(CmsTranslationRevision::STATUS_DRAFT, $pageRevision->revision_status);
@@ -314,6 +317,15 @@ final class SeoAgentControlledCmsDraftWriterTest extends TestCase
             'target_fields' => ['seo_title', 'seo_description'],
             'proposed_seo_title' => ($targetModel === 'article' ? 'Article Candidate' : 'Content Page Candidate').' | FermatMind',
             'proposed_seo_description' => 'Review candidate with FermatMind guidance.',
+            'proposed_internal_link_actions' => [
+                'Add internal link review target.',
+            ],
+            'proposal_quality' => [
+                'source' => 'gsc_cohort_artifact',
+                'locale_preserved' => true,
+                'slug_generated_copy' => false,
+                'needs_human_approval' => true,
+            ],
             'claim_gate_required' => true,
             'human_approval_required' => true,
             'execution_permission' => false,


### PR DESCRIPTION
## What changed
- Preserve optional sanitized draft proposal metadata in controlled CMS draft writer payloads: proposed_internal_link_actions and proposal_quality.
- Canonicalize associative array key order in CMS draft readback QA comparisons before hashing/matching, so equivalent FAQ objects do not fail because of JSON key ordering.
- Update generated SEO command contracts and focused tests.

## Why
Production article:41:en readback QA proved title/meta matched, but the draft writer dropped optional proposal metadata and readback flagged FAQ object key ordering. This PR fixes that parity gap before any additional CMS draft write canary.

## Validation
- php artisan list | grep 'seo-agent:cms-draft-readback-qa'
- php artisan list | grep 'seo-agent:cms-draft-write'
- vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPackageDryRunTest.php tests/Feature/SeoIntel/SeoAgentGscCohortHandoffTest.php
- vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCmsPublishCanaryTest.php tests/Feature/SeoIntel/SeoAgentCmsPublishAutoCanaryTest.php tests/Feature/SeoIntel/SeoAgentL5aContentPagePublishCanaryTest.php
- vendor/bin/pint --test app/Console/Commands/SeoAgentCmsDraftWriteCommand.php app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
- python3 -m json.tool docs/seo/generated/seo-agent-controlled-cms-draft-write.v1.json >/dev/null
- python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-readback-qa.v1.json >/dev/null
- git diff --check

## Intentionally deferred
- No CMS write.
- No CMS publish.
- No search/indexing/sitemap submission.
- No production deploy or production readback rerun until exact SHA/release approval after merge.
