### PR TITLE
MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -14,6 +14,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 {
     private const OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-88-01';
 
+    private const VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01';
+
     private const WRITE_SAFETY_FLAGS = [
         'draft-only',
         'no-publish',
@@ -28,7 +30,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--qa= : Path to the MBTI64 agent expansion QA JSON artifact}
         {--dry-run : Validate and plan without database writes}
         {--write : Create CMS projection draft revision rows}
-        {--visible-query-backed-3 : Dry-run only; restrict planning to the approved 3 query-backed visible MBTI64 URLs}
+        {--visible-query-backed-3 : Restrict planning/write to the approved 3 query-backed visible MBTI64 URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--draft-only : Required for --write; confirms revision draft only}
@@ -71,10 +73,6 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
         if (! $write && ! $dryRun) {
             throw new RuntimeException('Either --dry-run or --write is required.');
-        }
-
-        if ($write && (bool) $this->option('visible-query-backed-3')) {
-            throw new RuntimeException('--visible-query-backed-3 is dry-run only and cannot be combined with --write.');
         }
 
         if ($write) {
@@ -123,8 +121,12 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             }
         }
 
-        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
-            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        $expectedApproval = (bool) $this->option('visible-query-backed-3')
+            ? self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL
+            : self::OPERATOR_APPROVAL;
+
+        if ((string) $this->option('operator-approved') !== $expectedApproval) {
+            throw new RuntimeException('--operator-approved='.$expectedApproval.' is required with --write.');
         }
     }
 

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -292,14 +292,6 @@ final class Mbti64CmsProjectionDraftWriter
             return $recommendations;
         }
 
-        if ($write) {
-            $errors[] = [
-                'field' => 'options.visible_query_backed_3',
-                'code' => 'visible_query_backed_subset_write_not_allowed',
-                'message' => 'Visible query-backed 3-page subset is dry-run only.',
-            ];
-        }
-
         $allowed = array_fill_keys(self::VISIBLE_QUERY_BACKED_3_URLS, true);
         $subset = array_values(array_filter(
             $recommendations,
@@ -587,7 +579,8 @@ final class Mbti64CmsProjectionDraftWriter
         return [
             'mode' => $enabled ? 'visible_query_backed_3' : 'full_88',
             'enabled' => $enabled,
-            'dry_run_only' => $enabled,
+            'dry_run_only' => false,
+            'write_allowed_with_strict_approval' => $enabled,
             'allowed_urls' => $enabled ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
         ];
     }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -93,7 +93,8 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(3, $payload['would_create_revision_count']);
         $this->assertSame('visible_query_backed_3', $payload['subset']['mode']);
         $this->assertTrue($payload['subset']['enabled']);
-        $this->assertTrue($payload['subset']['dry_run_only']);
+        $this->assertFalse($payload['subset']['dry_run_only']);
+        $this->assertTrue($payload['subset']['write_allowed_with_strict_approval']);
 
         $plannedUrls = array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
@@ -108,7 +109,7 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
 
-    public function test_visible_query_backed_three_is_dry_run_only_and_rejects_write_mode(): void
+    public function test_visible_query_backed_three_write_requires_visible_three_approval_token(): void
     {
         $this->seedAllTargets();
         [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
@@ -121,9 +122,80 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertFalse($payload['ok']);
         $this->assertFalse($payload['writes_committed']);
-        $this->assertStringContainsString('dry-run only', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
         $this->assertSame(0, PersonalityProfileRevision::query()->count());
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_visible_query_backed_three_write_creates_only_approved_variant_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFJ-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--visible-query-backed-3'] = true;
+        $options['--operator-approved'] = 'MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('visible_query_backed_3', $payload['subset']['mode']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(3, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $createdUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($createdUrls);
+        $expectedUrls = self::VISIBLE_QUERY_BACKED_3_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $createdUrls);
+
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json);
+        }
+    }
+
+    public function test_visible_query_backed_three_second_write_is_idempotent_for_same_source_hash(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--visible-query-backed-3'] = true;
+        $options['--operator-approved'] = 'MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01';
+
+        $firstExit = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(3, $payload['skipped_existing_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(3, PersonalityProfileVariantRevision::query()->count());
     }
 
     public function test_visible_query_backed_three_fails_closed_when_allowlisted_url_is_missing(): void


### PR DESCRIPTION
## What changed
- Allows `personality:mbti64-cms-projection-draft --visible-query-backed-3` to write only the fixed 3 query-backed MBTI64 URLs when the stricter approval token is provided.
- Adds the approval token `MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01` while keeping the full 88-page approval gate unchanged.
- Keeps the fixed allowlist locked to:
  - `/en/personality/enfj-a`
  - `/zh/personality/intp-a`
  - `/zh/personality/esfp-a`
- Preserves full package and QA validation before the visible-3 subset is filtered.
- Extends focused command tests for missing approval, successful 3-row write, idempotency, and unchanged live profile/variant surfaces.

## Why
Production already has a visible-3 dry-run path, but write mode failed closed. This patch adds a bounded write contract so a later explicitly approved production task can create exactly 3 CMS draft revisions without opening arbitrary URL subsets.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only these files changed:
  - `backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php`
  - `backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php`
  - `backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php`

## Intentionally deferred
- No production dry-run was executed in this PR.
- No CMS production write, live promotion, publish, index/search, sitemap/llms, frontend, scoring, result-route, payment, account, history, share, or private-report change.
- Next production dry-run still requires explicit read-only SSH authorization.
