### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-AUTHORIZED-ARTIFACT-01

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json
+++ b/backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_import_human_approval.v0.1",
+  "approval_id": "riasec_result_page_v2_production_import_approval_2026_06_22_01",
+  "approval_type": "production_import",
+  "decision": "GO",
+  "approved_by": "刘福威",
+  "approver_role": "owner",
+  "approved_at": "2026-06-22T11:05:00Z",
+  "approval_channel": "chatgpt_codex_thread",
+  "approval_evidence_url_or_ref": "current_codex_thread_2026-06-22",
+  "deployed_backend_sha": "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9",
+  "source_release_snapshot_id": "riasec_result_page_v2_rc_0_1",
+  "source_release_snapshot_path": "backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json",
+  "source_release_snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+  "approved_release_snapshot_id": "riasec_result_page_v2_prod_approved_2026_06_22_01",
+  "approved_release_snapshot_path": "backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json",
+  "approved_release_snapshot_sha256": "999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741",
+  "scope": {
+    "tenant_ids": [
+      "single_owner_global"
+    ],
+    "form_codes": [
+      "riasec_60",
+      "riasec_140"
+    ],
+    "locales": [
+      "zh-CN"
+    ],
+    "allowlist": [
+      "owner_manual_import_only"
+    ],
+    "percentage": 0,
+    "max_percentage": 0
+  },
+  "rollback_kill_switch_confirmed": true,
+  "kill_switch_ref": "riasec_result_page_v2.production_emergency_disabled",
+  "post_deploy_smoke_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+  "private_payload_leak_ack": true,
+  "staging_only_rejection_ack": true,
+  "rollout_remains_separately_gated_ack": true,
+  "authorization_source": {
+    "operator_confirmation_text": "确认使用以上最小授权块，执行 approved snapshot artifact PR；不 import、不写 CMS、不改 runtime、不 rollout。",
+    "codex_filled_human_identity_or_scope": false
+  },
+  "negative_guarantees": {
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_performed": false,
+    "production_rollout_enabled": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "codex_approved_production_rollout": false
+  },
+  "go_no_go": {
+    "production_approved_snapshot_generated": true,
+    "ready_for_import_gate_dry_run": true,
+    "production_import_executed": false,
+    "cms_write_allowed_by_this_artifact": false,
+    "runtime_change_allowed_by_this_artifact": false,
+    "production_rollout_allowed_by_this_artifact": false
+  }
+}

--- a/backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json
+++ b/backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_approved_snapshot.v0.1",
+  "snapshot_id": "riasec_result_page_v2_prod_approved_2026_06_22_01",
+  "source_snapshot_id": "riasec_result_page_v2_rc_0_1",
+  "source_snapshot_path": "backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json",
+  "source_snapshot_sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+  "deployed_backend_sha": "ce029ebf6baf8a1eb7dc3164d7ad121ea91054e9",
+  "production_use_allowed": true,
+  "ready_for_production_import": true,
+  "ready_for_production_rollout": false,
+  "production_rollout_enabled": false,
+  "runtime_use": "production_import_candidate",
+  "cms_write_performed": false,
+  "production_import_performed": false,
+  "runtime_change_performed": false,
+  "environment_change_performed": false,
+  "approval_evidence_ref": "backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json",
+  "approval_summary": {
+    "approval_type": "production_import",
+    "decision": "GO",
+    "approved_by": "刘福威",
+    "approver_role": "owner",
+    "approved_at": "2026-06-22T11:05:00Z",
+    "approval_channel": "chatgpt_codex_thread",
+    "approval_evidence_url_or_ref": "current_codex_thread_2026-06-22"
+  },
+  "approved_scope": {
+    "tenant_ids": [
+      "single_owner_global"
+    ],
+    "form_codes": [
+      "riasec_60",
+      "riasec_140"
+    ],
+    "locales": [
+      "zh-CN"
+    ],
+    "allowlist": [
+      "owner_manual_import_only"
+    ],
+    "percentage": 0,
+    "max_percentage": 0
+  },
+  "safety_acknowledgements": {
+    "rollback_kill_switch_confirmed": true,
+    "kill_switch_ref": "riasec_result_page_v2.production_emergency_disabled",
+    "post_deploy_smoke_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+    "private_payload_leak_ack": true,
+    "staging_only_rejection_ack": true,
+    "rollout_remains_separately_gated_ack": true
+  },
+  "evidence_refs": [
+    "PR #2285",
+    "PR #2286",
+    "PR #2288",
+    "PR #2289",
+    "PR #2290",
+    "PR #2292",
+    "PR #2293",
+    "PR #2294",
+    "PR #2295",
+    "PR #2297"
+  ],
+  "negative_guarantees": {
+    "source_rc_snapshot_modified": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_performed": false,
+    "production_rollout_enabled": false,
+    "staging_only_assets_marked_production_ready": false,
+    "codex_approved_production_rollout": false
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-approved-snapshot-authorized-artifact-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-approved-snapshot-authorized-artifact-2026-06-22.md
@@ -1,0 +1,94 @@
+# RIASEC Result Page V2 Production-Approved Snapshot Authorized Artifact
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-PRODUCTION-APPROVED-SNAPSHOT-AUTHORIZED-ARTIFACT-01`
+
+Scope: docs/artifact-only authorized production-approved snapshot packaging. This PR creates a new production-approved snapshot artifact and a matching human approval evidence artifact. It does not modify the original RC snapshot, import CMS data, write production content, change runtime code, mutate environment variables, open production gates, or enable production rollout.
+
+## Verdict
+
+Production-approved snapshot artifact generated: `YES`.
+
+Production import executed: `NO`.
+
+Production rollout approved: `NO`.
+
+Reason: the operator confirmed the minimal authorization block for approved snapshot artifact packaging only, with explicit boundaries: no import, no CMS write, no runtime change, and no rollout.
+
+## Authorization Record
+
+| Field | Value |
+| --- | --- |
+| Approval type | `production_import` |
+| Decision | `GO` |
+| Approved by | `刘福威` |
+| Approver role | `owner` |
+| Approved at | `2026-06-22T11:05:00Z` |
+| Approval channel | `chatgpt_codex_thread` |
+| Approval evidence ref | `current_codex_thread_2026-06-22` |
+| Operator confirmation | `确认使用以上最小授权块，执行 approved snapshot artifact PR；不 import、不写 CMS、不改 runtime、不 rollout。` |
+
+## Snapshot Artifacts
+
+| Artifact | Path | SHA256 |
+| --- | --- | --- |
+| Source RC snapshot | `backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json` | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` |
+| Production-approved snapshot | `backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json` | `999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741` |
+| Human approval evidence | `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json` | `1fecb849e2ee47d2234631ad10614e327463928be2a390a0836552acdff23095` |
+
+The original `riasec_result_page_v2_rc_0_1` snapshot was not modified.
+
+## Approved Scope
+
+| Field | Value |
+| --- | --- |
+| Tenant ids | `single_owner_global` |
+| Form codes | `riasec_60`, `riasec_140` |
+| Locales | `zh-CN` |
+| Allowlist | `owner_manual_import_only` |
+| Percentage | `0` |
+| Max percentage | `0` |
+
+This scope makes the approved snapshot eligible for the next import gate dry-run only. It does not authorize import execution or rollout.
+
+## Safety Acknowledgements
+
+| Check | Result |
+| --- | --- |
+| Rollback / kill switch confirmed | `true` |
+| Kill switch ref | `riasec_result_page_v2.production_emergency_disabled` |
+| Post-deploy smoke procedure id | `riasec_result_page_v2_post_deploy_smoke_v0_1` |
+| Private payload leak acknowledged | `true` |
+| Staging-only rejection acknowledged | `true` |
+| Rollout remains separately gated | `true` |
+
+## Explicit Non-Actions
+
+This PR did not:
+
+- modify `riasec_result_page_v2_rc_0_1`;
+- import CMS data;
+- write production content;
+- run a production import command;
+- enable runtime;
+- mutate environment variables;
+- open production import gate;
+- approve production rollout;
+- enable production rollout;
+- mark staging-only assets as production-ready;
+- approve production activation beyond artifact packaging.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Generate production-approved snapshot artifact | `GO` |
+| Use artifact as input to import gate dry-run | `GO` |
+| Execute production import now | `NO` |
+| Allow CMS production write now | `NO` |
+| Allow runtime production enablement now | `NO` |
+| Allow production rollout now | `NO` |
+| Treat import approval as rollout approval | `NO` |
+
+Next safe step: run a production import gate dry-run against `riasec_result_page_v2_prod_approved_2026_06_22_01`. That next step must still perform no CMS writes unless a separate import execution authorization is provided after the dry-run passes.


### PR DESCRIPTION
## What changed

- Added a production-approved RIASEC Result Page V2 snapshot artifact for `riasec_result_page_v2_prod_approved_2026_06_22_01`.
- Added matching human approval evidence using the confirmed minimal authorization block.
- Added a docs decision record for the authorized artifact packaging.

## Why

The previous approved snapshot artifact PR correctly emitted `NO-GO` because no complete human authorization existed. The operator has now confirmed the minimal authorization block for artifact packaging only, so this PR records the approved snapshot as an input for the next import gate dry-run.

## Validation commands

- `jq empty backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json`
- `git diff --check`
- `shasum -a 256 backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json`
- Scope validation: only the authorized artifact doc, approval evidence JSON, and production-approved snapshot JSON changed.

## Intentionally deferred

- No CMS import or CMS write.
- No production import execution.
- No runtime or environment change.
- No production rollout approval or rollout enablement.
- No modification to the original RC snapshot.
