### PR TITLE
PR-D: Add SEO Agent CMS draft payload repair canary

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
@@ -1,0 +1,743 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-cms-draft-payload-repair-canary.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const WRITER_TASK = 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01';
+
+    private const TASK = 'SEO-AGENT-CMS-DRAFT-PAYLOAD-REPAIR-CANARY-01';
+
+    private const ALLOWED_MISMATCHES = [
+        'proposal.proposed_internal_link_actions',
+        'proposal.proposal_quality',
+    ];
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:cms-draft-payload-repair-canary
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--write-evidence= : Path to the old seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--target= : Exact article subject_ref, e.g. article:41:en}
+        {--artifact-dir= : Directory for repair and compatible write evidence artifacts}
+        {--confirm-package-sha256= : Required package sha256 for execute mode}
+        {--confirm-repair= : Exact confirmation phrase for execute mode}
+        {--execute : Actually append one repaired ArticleRevision draft}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Append one repaired SEO Agent article draft revision when an old draft payload only missed optional proposal quality fields.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        if ($packagePath === null) {
+            return $this->finish($this->failureSummary('package_unreadable'));
+        }
+
+        $writeEvidencePath = $this->readablePath((string) $this->option('write-evidence'));
+        if ($writeEvidencePath === null) {
+            return $this->finish($this->failureSummary('write_evidence_unreadable'));
+        }
+
+        $target = trim((string) $this->option('target'));
+        if ($target === '') {
+            return $this->finish($this->failureSummary('target_required'));
+        }
+
+        $packageRaw = (string) file_get_contents($packagePath);
+        $writeRaw = (string) file_get_contents($writeEvidencePath);
+        $forbidden = array_values(array_unique(array_merge(
+            $this->forbiddenStringsPresent($packageRaw),
+            $this->forbiddenStringsPresent($writeRaw)
+        )));
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($packageRaw, true);
+        if (! is_array($package)) {
+            return $this->finish($this->failureSummary('package_json_invalid'));
+        }
+
+        $writeEvidence = json_decode($writeRaw, true);
+        if (! is_array($writeEvidence)) {
+            return $this->finish($this->failureSummary('write_evidence_json_invalid'));
+        }
+
+        $validationIssue = $this->validateInputs($package, $writeEvidence);
+        if ($validationIssue !== null) {
+            return $this->finish($this->failureSummary($validationIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $confirmedSha = trim((string) $this->option('confirm-package-sha256'));
+        if ($confirmedSha !== '' && $confirmedSha !== $packageSha) {
+            return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $proposal = $this->proposalForTarget($package, $target);
+        if ($proposal === null) {
+            return $this->finish($this->failureSummary('target_not_found_in_package', [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $articleId = $this->articleIdFromTarget($target);
+        if ($articleId === null) {
+            return $this->finish($this->failureSummary('unsupported_or_invalid_target', [
+                'target' => $target,
+            ]));
+        }
+
+        $writeRef = $this->writeRefForTarget($writeEvidence, $target);
+        if ($writeRef === null) {
+            return $this->finish($this->failureSummary('target_not_found_in_write_evidence', [
+                'target' => $target,
+            ]));
+        }
+
+        $article = Article::query()->withoutGlobalScopes()->find($articleId);
+        if (! $article instanceof Article) {
+            return $this->finish($this->failureSummary('article_not_found', [
+                'target' => $target,
+            ]));
+        }
+
+        $oldRevision = $this->oldRevision($articleId, $writeRef);
+        if (! $oldRevision instanceof ArticleRevision) {
+            return $this->finish($this->failureSummary('old_revision_not_found', [
+                'target' => $target,
+            ]));
+        }
+
+        $targetFields = $this->targetFields($proposal);
+        if (! $this->revisionCoreMatches($oldRevision, $packageSha, $target, $targetFields)) {
+            return $this->finish($this->failureSummary('old_revision_identity_mismatch', [
+                'target' => $target,
+            ]));
+        }
+
+        $comparisons = $this->comparisons($proposal, is_array($oldRevision->payload_json) ? $oldRevision->payload_json : []);
+        $mismatches = array_values(array_map(
+            static fn (array $row): string => (string) ($row['field'] ?? ''),
+            array_filter($comparisons, static fn (array $row): bool => ($row['matched'] ?? false) !== true)
+        ));
+        sort($mismatches);
+        $allowed = self::ALLOWED_MISMATCHES;
+        sort($allowed);
+
+        if ($mismatches === []) {
+            return $this->finish($this->failureSummary('old_revision_already_clean', [
+                'target' => $target,
+                'package_sha256' => $packageSha,
+            ]));
+        }
+        if ($mismatches !== $allowed) {
+            return $this->finish($this->failureSummary('mismatch_set_not_repairable', [
+                'target' => $target,
+                'package_sha256' => $packageSha,
+                'mismatches' => $mismatches,
+                'allowed_mismatches' => $allowed,
+            ]));
+        }
+        if ($this->matchingCleanRepairExists($articleId, $packageSha, $target, $proposal, (int) $oldRevision->id)) {
+            return $this->finish($this->failureSummary('repaired_revision_already_exists', [
+                'target' => $target,
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $execute = (bool) $this->option('execute');
+        $confirmationPhrase = $this->requiredConfirmationPhrase($target, $packageSha);
+        if (! $execute) {
+            $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $target, $article, $oldRevision, null, $mismatches, [
+                'ok' => true,
+                'status' => 'planned',
+                'dry_run' => true,
+                'execute' => false,
+                'would_append_revision' => true,
+                'required_confirmation_phrase' => $confirmationPhrase,
+            ]);
+            $artifact = $this->writeArtifact($this->artifactDir(), 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
+
+            return $this->finish([
+                ...$evidence,
+                'artifact' => $artifact,
+            ]);
+        }
+
+        if ($confirmedSha !== $packageSha) {
+            return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $confirmationPhrase,
+            ]));
+        }
+        if ((string) $this->option('confirm-repair') !== $confirmationPhrase) {
+            return $this->finish($this->failureSummary('confirm_repair_phrase_mismatch', [
+                'package_sha256' => $packageSha,
+                'required_confirmation_phrase' => $confirmationPhrase,
+            ]));
+        }
+
+        try {
+            $newRevision = DB::transaction(fn (): ArticleRevision => $this->appendRepairRevision($article, $oldRevision, $proposal, $packageSha, $targetFields));
+        } catch (RuntimeException $exception) {
+            return $this->finish($this->failureSummary($exception->getMessage(), [
+                'target' => $target,
+                'package_sha256' => $packageSha,
+            ]));
+        }
+
+        $artifactDir = $this->artifactDir();
+        $compatibleWriteEvidence = $this->compatibleWriteEvidence($packageSha, $target, (int) $newRevision->id);
+        $compatibleArtifact = $this->writeArtifact($artifactDir, 'seo-agent-controlled-cms-draft-write-repair-', $compatibleWriteEvidence);
+        $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $target, $article, $oldRevision, $newRevision, $mismatches, [
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'would_append_revision' => false,
+            'rows_created' => 1,
+            'compatible_write_evidence' => $compatibleArtifact,
+        ]);
+        $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
+
+        return $this->finish([
+            ...$evidence,
+            'artifact' => $artifact,
+        ]);
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<string, mixed>  $writeEvidence
+     */
+    private function validateInputs(array $package, array $writeEvidence): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true
+            || (bool) ($package['cms_write_allowed'] ?? true) !== false
+            || (bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_boundary_invalid';
+        }
+        if (($writeEvidence['schema_version'] ?? null) !== self::WRITE_SCHEMA_VERSION) {
+            return 'write_evidence_schema_invalid';
+        }
+        if ((bool) ($writeEvidence['execute'] ?? false) !== true
+            || (bool) ($writeEvidence['writes_attempted'] ?? false) !== true) {
+            return 'write_evidence_not_execute';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array<string, mixed>|null
+     */
+    private function proposalForTarget(array $package, string $target): ?array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return null;
+        }
+
+        foreach ($items as $item) {
+            if (is_array($item) && (string) ($item['subject_ref'] ?? '') === $target) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function articleIdFromTarget(string $target): ?int
+    {
+        $parts = explode(':', $target);
+        if (($parts[0] ?? '') !== 'article' || ! isset($parts[1]) || ! ctype_digit($parts[1])) {
+            return null;
+        }
+
+        return (int) $parts[1];
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     * @return array<string, mixed>|null
+     */
+    private function writeRefForTarget(array $writeEvidence, string $target): ?array
+    {
+        foreach ((array) ($writeEvidence['affected_refs'] ?? []) as $ref) {
+            if (is_array($ref) && (string) ($ref['subject_ref'] ?? '') === $target) {
+                return $ref;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeRef
+     */
+    private function oldRevision(int $articleId, array $writeRef): ?ArticleRevision
+    {
+        $revisionId = $writeRef['revision_id'] ?? null;
+        if (! is_int($revisionId) && (! is_string($revisionId) || ! ctype_digit($revisionId))) {
+            return null;
+        }
+
+        return ArticleRevision::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->whereKey((int) $revisionId)
+            ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return list<string>
+     */
+    private function targetFields(array $proposal): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map('strval', (array) ($proposal['target_fields'] ?? [])),
+            static fn (string $field): bool => $field !== ''
+        )));
+    }
+
+    /**
+     * @param  list<string>  $targetFields
+     */
+    private function revisionCoreMatches(ArticleRevision $revision, string $packageSha, string $target, array $targetFields): bool
+    {
+        $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+        $actual = array_values(array_map('strval', (array) data_get($payload, 'seo_agent.target_fields', [])));
+        sort($actual);
+        $expected = $targetFields;
+        sort($expected);
+
+        return data_get($payload, 'seo_agent.task') === self::WRITER_TASK
+            && data_get($payload, 'seo_agent.package_sha256') === $packageSha
+            && data_get($payload, 'seo_agent.subject_ref') === $target
+            && $actual === $expected;
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function comparisons(array $proposal, array $payload): array
+    {
+        $rows = [
+            $this->comparison('seo_agent.task', self::WRITER_TASK, data_get($payload, 'seo_agent.task')),
+            $this->comparison('seo_agent.subject_ref', (string) ($proposal['subject_ref'] ?? ''), data_get($payload, 'seo_agent.subject_ref')),
+            $this->comparison('seo_agent.target_fields', $this->sortedStrings((array) ($proposal['target_fields'] ?? [])), $this->sortedStrings((array) data_get($payload, 'seo_agent.target_fields', []))),
+            $this->comparison('proposal.safe_path', (string) ($proposal['safe_path'] ?? ''), data_get($payload, 'proposal.safe_path')),
+            $this->comparison('proposal.proposed_seo_title', $proposal['proposed_seo_title'] ?? null, data_get($payload, 'proposal.proposed_seo_title')),
+            $this->comparison('proposal.proposed_seo_description', $proposal['proposed_seo_description'] ?? null, data_get($payload, 'proposal.proposed_seo_description')),
+            $this->comparison('proposal.proposed_faq_items', $proposal['proposed_faq_items'] ?? [], data_get($payload, 'proposal.proposed_faq_items', [])),
+        ];
+
+        if (array_key_exists('proposed_internal_link_actions', $proposal)) {
+            $rows[] = $this->comparison(
+                'proposal.proposed_internal_link_actions',
+                $proposal['proposed_internal_link_actions'] ?? [],
+                data_get($payload, 'proposal.proposed_internal_link_actions', [])
+            );
+        }
+
+        if (array_key_exists('proposal_quality', $proposal)) {
+            $rows[] = $this->comparison(
+                'proposal.proposal_quality',
+                $proposal['proposal_quality'] ?? [],
+                data_get($payload, 'proposal.proposal_quality', [])
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  mixed  $expected
+     * @param  mixed  $actual
+     * @return array<string, mixed>
+     */
+    private function comparison(string $field, $expected, $actual): array
+    {
+        $normalizedExpected = $this->canonicalComparableValue($expected);
+        $normalizedActual = $this->canonicalComparableValue($actual);
+
+        return [
+            'field' => $field,
+            'matched' => $normalizedExpected === $normalizedActual,
+            'expected_hash' => hash('sha256', json_encode($normalizedExpected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+            'actual_hash' => hash('sha256', json_encode($normalizedActual, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function matchingCleanRepairExists(int $articleId, string $packageSha, string $target, array $proposal, int $oldRevisionId): bool
+    {
+        $targetFields = $this->targetFields($proposal);
+
+        return ArticleRevision::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->where('id', '!=', $oldRevisionId)
+            ->get()
+            ->contains(function (ArticleRevision $revision) use ($packageSha, $target, $proposal, $targetFields): bool {
+                $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+
+                return $this->revisionCoreMatches($revision, $packageSha, $target, $targetFields)
+                    && array_filter($this->comparisons($proposal, $payload), static fn (array $row): bool => ($row['matched'] ?? false) !== true) === [];
+            });
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  list<string>  $targetFields
+     */
+    private function appendRepairRevision(Article $article, ArticleRevision $oldRevision, array $proposal, string $packageSha, array $targetFields): ArticleRevision
+    {
+        $freshOldRevision = ArticleRevision::query()
+            ->withoutGlobalScopes()
+            ->whereKey((int) $oldRevision->id)
+            ->lockForUpdate()
+            ->first();
+        if (! $freshOldRevision instanceof ArticleRevision) {
+            throw new RuntimeException('old_revision_not_found');
+        }
+
+        $revisionNo = ((int) ArticleRevision::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', (int) $article->org_id)
+            ->where('article_id', (int) $article->id)
+            ->lockForUpdate()
+            ->max('revision_no')) + 1;
+
+        return ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => $revisionNo,
+            'editor_admin_user_id' => null,
+            'title' => (string) $freshOldRevision->title,
+            'excerpt' => $freshOldRevision->excerpt,
+            'content_md' => (string) $freshOldRevision->content_md,
+            'content_html' => $freshOldRevision->content_html,
+            'change_note' => 'SEO Agent controlled draft payload repair canary',
+            'payload_json' => $this->revisionPayload($proposal, $packageSha, $targetFields),
+            'created_at' => Carbon::now('UTC'),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  list<string>  $targetFields
+     * @return array<string, mixed>
+     */
+    private function revisionPayload(array $proposal, string $packageSha, array $targetFields): array
+    {
+        return [
+            'seo_agent' => [
+                'task' => self::WRITER_TASK,
+                'package_sha256' => $packageSha,
+                'subject_ref' => (string) ($proposal['subject_ref'] ?? ''),
+                'target_fields' => $targetFields,
+                'claim_gate_required' => true,
+                'human_approval_required' => true,
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'indexing_request_allowed' => false,
+                'repair_task' => self::TASK,
+            ],
+            'proposal' => [
+                'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+                'proposed_seo_title' => $proposal['proposed_seo_title'] ?? null,
+                'proposed_seo_description' => $proposal['proposed_seo_description'] ?? null,
+                'proposed_faq_items' => $proposal['proposed_faq_items'] ?? [],
+                'proposed_canonical_path' => $proposal['proposed_canonical_path'] ?? null,
+                'proposed_indexability' => $proposal['proposed_indexability'] ?? null,
+                'proposed_internal_link_actions' => $proposal['proposed_internal_link_actions'] ?? [],
+                'proposal_quality' => $proposal['proposal_quality'] ?? [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function compatibleWriteEvidence(string $packageSha, string $target, int $revisionId): array
+    {
+        return [
+            'schema_version' => self::WRITE_SCHEMA_VERSION,
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'approval_mode' => 'exact_human_confirmation',
+            'repair_source_task' => self::TASK,
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'planned_count' => 1,
+            'rows_created' => 1,
+            'rows_skipped_existing' => 0,
+            'rows_failed' => [],
+            'affected_refs' => [
+                [
+                    'status' => 'created',
+                    'target_model' => 'article',
+                    'subject_ref' => $target,
+                    'revision_id' => $revisionId,
+                ],
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $mismatches
+     * @param  array<string, mixed>  $state
+     * @return array<string, mixed>
+     */
+    private function repairEvidence(
+        string $packagePath,
+        string $writeEvidencePath,
+        string $packageSha,
+        string $target,
+        Article $article,
+        ArticleRevision $oldRevision,
+        ?ArticleRevision $newRevision,
+        array $mismatches,
+        array $state
+    ): array {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            ...$state,
+            'target' => $target,
+            'package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'old_write_evidence' => $this->artifactRef($writeEvidencePath, self::WRITE_SCHEMA_VERSION),
+            'package_sha256' => $packageSha,
+            'repair_policy' => [
+                'mode' => 'append_article_revision',
+                'allowed_mismatches' => self::ALLOWED_MISMATCHES,
+                'copy_body_from_previous_draft_revision' => true,
+                'mutate_old_revision' => false,
+            ],
+            'old_revision' => [
+                'revision_id' => (int) $oldRevision->id,
+                'revision_no' => (int) $oldRevision->revision_no,
+                'is_published_revision' => (int) ($article->published_revision_id ?? 0) === (int) $oldRevision->id,
+            ],
+            'new_revision' => [
+                'revision_id' => $newRevision instanceof ArticleRevision ? (int) $newRevision->id : null,
+                'revision_no' => $newRevision instanceof ArticleRevision ? (int) $newRevision->revision_no : null,
+                'is_published_revision' => $newRevision instanceof ArticleRevision
+                    ? (int) ($article->published_revision_id ?? 0) === (int) $newRevision->id
+                    : false,
+            ],
+            'article_state' => [
+                'article_id' => (int) $article->id,
+                'locale' => (string) $article->locale,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+                'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+                'published_revision_unchanged' => true,
+            ],
+            'mismatches_repaired' => $mismatches,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    private function requiredConfirmationPhrase(string $target, string $packageSha): string
+    {
+        return 'I explicitly approve '.self::TASK.' to append 1 repaired CMS draft revision for '.$target.' from package sha256 '.$packageSha.'; no publish, no queue, no search, no indexing, no scheduler.';
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/cms-draft-payload-repair-canary');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, string $prefix, array $payload): array
+    {
+        $path = rtrim($dir, '/').'/'.$prefix.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $this->artifactRef($path, (string) ($payload['schema_version'] ?? ''));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'path' => $path,
+            'size' => is_file($path) ? filesize($path) : null,
+            'sha256' => is_file($path) ? hash_file('sha256', $path) : null,
+            'schema_version' => $schemaVersion,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return mixed
+     */
+    private function canonicalComparableValue($value)
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+        if (array_is_list($value)) {
+            return array_map(fn ($item) => $this->canonicalComparableValue($item), $value);
+        }
+
+        ksort($value);
+
+        return array_map(fn ($item) => $this->canonicalComparableValue($item), $value);
+    }
+
+    /**
+     * @param  list<mixed>  $values
+     * @return list<string>
+     */
+    private function sortedStrings(array $values): array
+    {
+        $strings = array_values(array_map('strval', $values));
+        sort($strings);
+
+        return $strings;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_started' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -185,6 +185,7 @@ use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
+use App\Console\Commands\SeoAgentCmsDraftPayloadRepairCanaryCommand;
 use App\Console\Commands\SeoAgentCmsDraftReadbackQaCommand;
 use App\Console\Commands\SeoAgentCmsDraftWriteCommand;
 use App\Console\Commands\SeoAgentCmsFaqGapScanCommand;
@@ -416,6 +417,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,
+        SeoAgentCmsDraftPayloadRepairCanaryCommand::class,
         SeoAgentCmsDraftReadbackQaCommand::class,
         SeoAgentCmsDraftWriteCommand::class,
         SeoAgentCmsPublishAutoCanaryCommand::class,

--- a/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
@@ -1,0 +1,56 @@
+{
+  "version": "seo-agent-cms-draft-payload-repair-canary.v1",
+  "task": "SEO-AGENT-CMS-DRAFT-PAYLOAD-REPAIR-CANARY-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:cms-draft-payload-repair-canary",
+  "input_schemas": [
+    "seo-agent-cms-draft-package-dry-run.v1",
+    "seo-agent-controlled-cms-draft-write.v1"
+  ],
+  "output_schema": "seo-agent-cms-draft-payload-repair-canary.v1",
+  "default_mode": "dry_run_plan",
+  "execute_requires": [
+    "--execute",
+    "--confirm-package-sha256=<sha256>",
+    "--confirm-repair=<exact phrase>"
+  ],
+  "supported_targets": [
+    "article"
+  ],
+  "repair_mode": "append_article_revision",
+  "compatible_write_evidence_schema": "seo-agent-controlled-cms-draft-write.v1",
+  "allowed_mismatches": [
+    "proposal.proposed_internal_link_actions",
+    "proposal.proposal_quality"
+  ],
+  "copies_body_from_previous_draft_revision": true,
+  "mutates_old_revision": false,
+  "publishes_content": false,
+  "mutates_published_revision": false,
+  "search_submit_allowed": false,
+  "indexing_request_allowed": false,
+  "forbidden_input": [
+    "raw_url",
+    "raw_query",
+    "credentials",
+    "cookies",
+    "tokens",
+    "content_html",
+    "content_md",
+    "cms_draft_body"
+  ],
+  "negative_guarantees": {
+    "cms_publish": false,
+    "published_revision_mutation": false,
+    "live_published_content_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_started": false,
+    "production_env_change": false,
+    "external_model_api_call": false
+  },
+  "next_step": "After execute, pass the emitted compatible write evidence path to seo-agent:cms-draft-readback-qa and require ok=true before any further draft write canary."
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentCmsDraftPayloadRepairCanaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_plans_one_repair_without_writing_rows(): void
+    {
+        [$article, $proposal, $packagePath, $sha, $oldRevision, $writeEvidencePath] = $this->oldDraftMissingOptionalFields();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['dry_run'] ?? false));
+        $this->assertTrue((bool) ($summary['would_append_revision'] ?? false));
+        $this->assertSame($sha, $summary['package_sha256'] ?? null);
+        $this->assertSame((int) $oldRevision->id, data_get($summary, 'old_revision.revision_id'));
+        $this->assertNull(data_get($summary, 'new_revision.revision_id'));
+        $this->assertSame([
+            'proposal.proposal_quality',
+            'proposal.proposed_internal_link_actions',
+        ], $summary['mismatches_repaired'] ?? null);
+        $this->assertStringContainsString($proposal['subject_ref'], (string) ($summary['required_confirmation_phrase'] ?? ''));
+        $this->assertSame($countsBefore, $this->rowCounts());
+        $this->assertSame((int) $article->published_revision_id, Article::query()->findOrFail((int) $article->id)->published_revision_id);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('planned', $artifact['status'] ?? null);
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_publish', true));
+    }
+
+    #[Test]
+    public function execute_appends_repaired_revision_and_readback_qa_succeeds_with_compatible_evidence(): void
+    {
+        [$article, $proposal, $packagePath, $sha, $oldRevision, $writeEvidencePath] = $this->oldDraftMissingOptionalFields();
+        $oldPayload = $oldRevision->payload_json;
+        $phrase = $this->approvalPhrase($proposal['subject_ref'], $sha);
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--confirm-package-sha256' => $sha,
+            '--confirm-repair' => $phrase,
+            '--artifact-dir' => $artifactDir,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertFalse((bool) ($summary['dry_run'] ?? true));
+        $this->assertSame(1, $summary['rows_created'] ?? null);
+        $this->assertSame(2, ArticleRevision::query()->where('article_id', (int) $article->id)->count());
+
+        $oldRevision->refresh();
+        $this->assertSame($oldPayload, $oldRevision->payload_json);
+
+        $newRevision = ArticleRevision::query()->findOrFail((int) data_get($summary, 'new_revision.revision_id'));
+        $this->assertSame(((int) $oldRevision->revision_no) + 1, (int) $newRevision->revision_no);
+        $this->assertSame((string) $oldRevision->content_md, (string) $newRevision->content_md);
+        $this->assertSame($proposal['proposed_internal_link_actions'], data_get($newRevision->payload_json, 'proposal.proposed_internal_link_actions'));
+        $this->assertSame('gsc_cohort_artifact', data_get($newRevision->payload_json, 'proposal.proposal_quality.source'));
+        $this->assertSame('SEO-AGENT-CMS-DRAFT-PAYLOAD-REPAIR-CANARY-01', data_get($newRevision->payload_json, 'seo_agent.repair_task'));
+
+        $freshArticle = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+        $this->assertSame((int) $article->published_revision_id, (int) $freshArticle->published_revision_id);
+        $this->assertSame((int) $article->working_revision_id, (int) $freshArticle->working_revision_id);
+
+        $compatibleEvidencePath = (string) data_get($summary, 'compatible_write_evidence.path');
+        $compatibleEvidence = $this->readJson($compatibleEvidencePath);
+        $this->assertSame('seo-agent-controlled-cms-draft-write.v1', $compatibleEvidence['schema_version'] ?? null);
+        $this->assertSame((int) $newRevision->id, data_get($compatibleEvidence, 'affected_refs.0.revision_id'));
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $packagePath,
+            '--write-evidence' => $compatibleEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $sha,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $readback = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $readback['status'] ?? null);
+        $this->assertSame(0, $readback['mismatch_count'] ?? null);
+    }
+
+    #[Test]
+    public function it_blocks_mismatch_sets_outside_optional_payload_fields(): void
+    {
+        [, $proposal, $packagePath, , , $writeEvidencePath] = $this->oldDraftMissingOptionalFields([
+            'proposed_seo_title' => 'Different title',
+        ]);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('mismatch_set_not_repairable', $summary['issues'] ?? []);
+        $this->assertContains('proposal.proposed_seo_title', $summary['mismatches'] ?? []);
+    }
+
+    #[Test]
+    public function it_blocks_invalid_inputs_missing_article_already_clean_and_forbidden_fields(): void
+    {
+        [$article, $proposal, $packagePath, $sha, $oldRevision, $writeEvidencePath] = $this->oldDraftMissingOptionalFields();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--confirm-package-sha256' => str_repeat('0', 64),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_sha256_confirmation_mismatch', $summary['issues'] ?? []);
+
+        $badSchema = $this->writeJson('bad-package-', ['schema_version' => 'wrong']);
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $badSchema,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_schema_invalid', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:999:en',
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('target_not_found_in_package', $summary['issues'] ?? []);
+
+        $forbiddenPackage = $this->writeJson('forbidden-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'proposal_items' => [
+                ['subject_ref' => $proposal['subject_ref'], 'raw_query' => 'blocked'],
+            ],
+        ]);
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $forbiddenPackage,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+
+        $oldRevision->forceFill([
+            'payload_json' => $this->revisionPayload($proposal, $sha, includeOptionalProposalFields: true),
+        ])->save();
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('old_revision_already_clean', $summary['issues'] ?? []);
+
+        $this->assertSame(1, ArticleRevision::query()->where('article_id', (int) $article->id)->count());
+    }
+
+    #[Test]
+    public function generated_contract_documents_payload_repair_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json'));
+
+        $this->assertSame('seo-agent-cms-draft-payload-repair-canary.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:cms-draft-payload-repair-canary', $contract['command'] ?? null);
+        $this->assertSame('append_article_revision', $contract['repair_mode'] ?? null);
+        $this->assertFalse((bool) ($contract['mutates_old_revision'] ?? true));
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $oldProposalOverrides
+     * @return array{0: Article, 1: array<string, mixed>, 2: string, 3: string, 4: ArticleRevision, 5: string}
+     */
+    private function oldDraftMissingOptionalFields(array $oldProposalOverrides = []): array
+    {
+        $article = $this->article();
+        $proposal = $this->proposal((int) $article->id);
+        $packagePath = $this->writePackage([$proposal]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $oldProposal = [
+            ...$proposal,
+            ...$oldProposalOverrides,
+        ];
+        $oldRevision = $this->articleRevision($article, $oldProposal, $sha, includeOptionalProposalFields: false);
+        $writeEvidencePath = $this->writeEvidence($sha, $proposal['subject_ref'], (int) $oldRevision->id);
+
+        return [$article, $proposal, $packagePath, $sha, $oldRevision, $writeEvidencePath];
+    }
+
+    private function article(): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'big-five-career-fit',
+            'locale' => 'en',
+            'title' => 'Big Five Career Fit',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'working_revision_id' => 101,
+            'published_revision_id' => 100,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function proposal(int $articleId): array
+    {
+        return [
+            'source_id' => hash('sha256', 'article'.$articleId),
+            'source_family' => 'gsc_cohort_artifact',
+            'target_model' => 'article',
+            'subject_type' => 'article',
+            'subject_ref' => 'article:'.$articleId.':en',
+            'safe_path' => '/en/articles/big-five-career-fit',
+            'severity' => 'p1',
+            'target_fields' => ['seo_title', 'seo_description', 'faq_items'],
+            'proposed_seo_title' => 'Big Five Career Fit | FermatMind',
+            'proposed_seo_description' => 'Review Big Five career fit patterns with careful, non-diagnostic guidance.',
+            'proposed_faq_items' => [
+                [
+                    'question' => 'Can Big Five scores predict career success?',
+                    'answer' => 'No. They can support reflection, but they do not guarantee outcomes.',
+                ],
+            ],
+            'proposed_internal_link_actions' => [
+                'Add internal link to /en/tests/big-five-personality-test',
+            ],
+            'proposal_quality' => [
+                'source' => 'gsc_cohort_artifact',
+                'locale_preserved' => true,
+                'slug_generated_copy' => false,
+                'needs_human_approval' => true,
+            ],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function writePackage(array $proposals): string
+    {
+        return $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'run_mode' => 'cms_draft_package_dry_run',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'draft_brief_count' => count($proposals),
+            'draft_briefs' => $proposals,
+            'proposal_count' => count($proposals),
+            'proposal_items' => $proposals,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ]);
+    }
+
+    private function writeEvidence(string $packageSha, string $subjectRef, int $revisionId): string
+    {
+        return $this->writeJson('seo-agent-controlled-cms-draft-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'planned_count' => 1,
+            'rows_created' => 1,
+            'rows_skipped_existing' => 0,
+            'rows_failed' => [],
+            'affected_refs' => [
+                [
+                    'status' => 'created',
+                    'target_model' => 'article',
+                    'subject_ref' => $subjectRef,
+                    'revision_id' => $revisionId,
+                ],
+            ],
+            'negative_guarantees' => [
+                'cms_publish' => false,
+                'search_channel_submit' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function articleRevision(Article $article, array $proposal, string $packageSha, bool $includeOptionalProposalFields): ArticleRevision
+    {
+        return ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => 2,
+            'editor_admin_user_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'change_note' => 'SEO Agent controlled draft proposal',
+            'payload_json' => $this->revisionPayload($proposal, $packageSha, $includeOptionalProposalFields),
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function revisionPayload(array $proposal, string $packageSha, bool $includeOptionalProposalFields): array
+    {
+        $proposalPayload = [
+            'safe_path' => $proposal['safe_path'],
+            'proposed_seo_title' => $proposal['proposed_seo_title'],
+            'proposed_seo_description' => $proposal['proposed_seo_description'],
+            'proposed_faq_items' => $proposal['proposed_faq_items'],
+            'proposed_canonical_path' => null,
+            'proposed_indexability' => null,
+        ];
+        if ($includeOptionalProposalFields) {
+            $proposalPayload['proposed_internal_link_actions'] = $proposal['proposed_internal_link_actions'];
+            $proposalPayload['proposal_quality'] = $proposal['proposal_quality'];
+        }
+
+        return [
+            'seo_agent' => [
+                'task' => 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01',
+                'package_sha256' => $packageSha,
+                'subject_ref' => $proposal['subject_ref'],
+                'target_fields' => $proposal['target_fields'],
+                'claim_gate_required' => true,
+                'human_approval_required' => true,
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'indexing_request_allowed' => false,
+            ],
+            'proposal' => $proposalPayload,
+        ];
+    }
+
+    private function approvalPhrase(string $target, string $sha): string
+    {
+        return 'I explicitly approve SEO-AGENT-CMS-DRAFT-PAYLOAD-REPAIR-CANARY-01 to append 1 repaired CMS draft revision for '.$target.' from package sha256 '.$sha.'; no publish, no queue, no search, no indexing, no scheduler.';
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-cms-draft-payload-repair-canary-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->count(),
+            'article_revisions' => ArticleRevision::query()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1173,6 +1173,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_cms_draft_payload_repair_canary_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentCmsDraftPayloadRepairCanaryCommand;',
+            '+        SeoAgentCmsDraftPayloadRepairCanaryCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4332,6 +4346,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentCmsDraftPayloadRepairCanaryFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentRuntimeSeoQaReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5082,6 +5100,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentControlledCmsDraftWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftReadbackQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentCmsDraftPayloadRepairCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5792,6 +5811,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentCmsDraftReadbackQaCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentCmsDraftPayloadRepairCanaryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php',
         ], true);
     }
 
@@ -7785,6 +7811,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\b(SeoAgentCmsDraftReadbackQaCommand|EnneagramResultPageReportSidecarIssueCommand)\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentCmsDraftPayloadRepairCanaryOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentCmsDraftPayloadRepairCanaryCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-agent:cms-draft-payload-repair-canary` for the article:41:en-style repair case where an old SEO Agent draft revision only missed `proposed_internal_link_actions` and `proposal_quality`.
- The command defaults to dry-run, validates old package/write evidence, appends one repaired `article_revisions` row only with exact execute confirmation, and emits compatible `seo-agent-controlled-cms-draft-write.v1` evidence for existing readback QA.
- Added generated contract docs and focused feature coverage.

## Why
- Existing `seo-agent:cms-draft-write` intentionally skips duplicate `package_sha256 + target_fields` drafts, so it cannot self-heal revision payloads created before PR-C preserved optional proposal quality fields.

## Validation
- `php artisan list | rg seo-agent:cms-draft-payload-repair-canary`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php`
- `vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentControlledCmsDraftWriterTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php`
- `vendor/bin/pint --test app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php`
- `python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No production repair execute in this PR.
- No CMS publish, search/indexing submit, scheduler/queue activation, external model call, or GSC call.
- Remaining article candidates stay blocked until article:41:en repair execute and readback QA pass under separate approvals.

## Repository rule impact
- Backend CMS remains the authority layer. This PR adds a controlled backend-only draft repair command; it does not change content ownership or publishing SOP.