### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-AUTHORIZED-SNAPSHOT-01

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_import_gate_dry_run_authorized_snapshot.v0.1",
+  "task_id": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-AUTHORIZED-SNAPSHOT-01",
+  "created_date": "2026-06-22",
+  "record_type": "production_import_gate_dry_run_authorized_snapshot",
+  "scope": "docs_artifact_only_read_only",
+  "decision": "GO_FOR_IMPORT_EXECUTION_AUTHORIZATION_ONLY",
+  "dry_run_status": "pass_read_only",
+  "approved_snapshot": {
+    "snapshot_id": "riasec_result_page_v2_prod_approved_2026_06_22_01",
+    "path": "backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json",
+    "sha256": "999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741",
+    "production_use_allowed": true,
+    "ready_for_production_import": true,
+    "ready_for_production_rollout": false,
+    "production_rollout_enabled": false,
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false
+  },
+  "approval_evidence": {
+    "approval_id": "riasec_result_page_v2_production_import_approval_2026_06_22_01",
+    "path": "backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json",
+    "sha256": "1fecb849e2ee47d2234631ad10614e327463928be2a390a0836552acdff23095",
+    "approval_type": "production_import",
+    "decision": "GO",
+    "approved_by": "刘福威",
+    "approved_at": "2026-06-22T11:05:00Z",
+    "ready_for_import_gate_dry_run": true,
+    "production_import_executed": false,
+    "production_rollout_allowed_by_this_artifact": false
+  },
+  "source_snapshot": {
+    "snapshot_id": "riasec_result_page_v2_rc_0_1",
+    "path": "backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json",
+    "sha256": "4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853",
+    "source_rc_snapshot_modified": false
+  },
+  "dry_run_check_matrix": {
+    "manifest": "PASS_approved_snapshot_artifact_present",
+    "sha256": "PASS_approved_snapshot_and_approval_evidence_hashes_match",
+    "release_snapshot": "PASS_production_approved_snapshot_ready_for_import",
+    "approval_evidence": "PASS_human_import_approval_evidence_present",
+    "safety": "PASS_no_mutation_and_no_runtime_change",
+    "no_private_payload_leak": "PASS_forbidden_public_payload_fields_absent_from_dry_run_inputs",
+    "staging_only_rejection": "PASS_acknowledged_and_not_reclassified",
+    "rollout_separation": "PASS_import_approval_does_not_authorize_rollout"
+  },
+  "commands_reviewed": {
+    "snapshot_field_check": "jq -e '<approved snapshot predicates>' backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json",
+    "approval_field_check": "jq -e '<approval evidence predicates>' backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json",
+    "forbidden_field_scan": "rg for attempt_id/user_id/raw_score/score_vector/dimension_vector/percentile/selector_trace/private path/token/secret/share_block keys",
+    "hash_check": "shasum -a 256 approved snapshot and approval evidence"
+  },
+  "explicit_non_actions": {
+    "cms_write_performed": false,
+    "production_import_performed": false,
+    "production_import_command_run": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_performed": false,
+    "production_rollout_enabled": false,
+    "production_gate_enabled": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "frontend_fallback_added": false,
+    "codex_approved_production_rollout": false
+  },
+  "go_no_go": {
+    "import_gate_dry_run_passed_for_authorized_snapshot": true,
+    "ready_for_separate_import_execution_authorization": true,
+    "production_import_allowed_without_second_authorization": false,
+    "cms_production_write_allowed_now": false,
+    "runtime_production_enablement_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "import_approval_counts_as_rollout_approval": false
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-import-gate-dry-run-authorized-snapshot-2026-06-22.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-import-gate-dry-run-authorized-snapshot-2026-06-22.md
@@ -1,0 +1,79 @@
+# RIASEC Result Page V2 Production Import Gate Dry-Run For Authorized Snapshot
+
+Date: 2026-06-22
+
+Task: `RIASEC-RESULT-V2-PRODUCTION-IMPORT-GATE-DRY-RUN-AUTHORIZED-SNAPSHOT-01`
+
+Scope: docs/artifact-only and read-only production import gate dry-run for `riasec_result_page_v2_prod_approved_2026_06_22_01`. This PR does not write CMS data, execute production import, change runtime code, mutate environment variables, open production rollout, or treat import approval as rollout approval.
+
+## Verdict
+
+Production import gate dry-run result for the authorized snapshot: `PASS_READ_ONLY`.
+
+This means the approved snapshot can be used as input to a separate production import execution authorization task.
+
+This does not authorize production import execution by itself.
+
+## Inputs Reviewed
+
+| Input | Path / reference | Result |
+| --- | --- | --- |
+| Approved snapshot | `backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json` | Present and ready for production import dry-run. |
+| Approved snapshot SHA256 | `999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741` | Matches file. |
+| Approval evidence | `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json` | Present, `decision=GO`, import-only. |
+| Approval evidence SHA256 | `1fecb849e2ee47d2234631ad10614e327463928be2a390a0836552acdff23095` | Matches file. |
+| Source RC snapshot | `backend/content_assets/riasec/result_page_v2/releases/v0_1/riasec_result_page_v2_release_snapshot_rc_0_1.json` | Unmodified. |
+| Source RC snapshot SHA256 | `4e5b7a3c356324bbd854ad2a3c8586caf07f0e05fee6bb26ab56af5c29f4b853` | Matches source record. |
+| Import gate policy | `backend/content_assets/riasec/result_page_v2/governance/production_import_gate_v0_1/riasec_result_page_v2_production_import_gate_policy_v0_1.json` | Fail-closed policy reviewed. |
+
+## Dry-Run Check Matrix
+
+| Gate check | Result | Evidence |
+| --- | --- | --- |
+| `manifest` | `PASS` | Approved snapshot artifact is present and references the matching approval evidence. |
+| `sha256` | `PASS` | Approved snapshot and approval evidence hashes match expected values. |
+| `release_snapshot` | `PASS` | Approved snapshot has `production_use_allowed=true` and `ready_for_production_import=true`. |
+| `approval_evidence` | `PASS` | Human import approval evidence is present with `decision=GO`. |
+| `safety` | `PASS` | No CMS write, import command, runtime change, or environment change occurred. |
+| `no_private_payload_leak` | `PASS` | Forbidden public payload fields were absent from the dry-run input artifacts. |
+| `staging_only_rejection` | `PASS` | Staging-only rejection is acknowledged and no staging-only artifact is reclassified. |
+| `rollout_separation` | `PASS` | Approval is import-only; rollout remains separately gated and disabled. |
+
+## Commands Reviewed
+
+```bash
+jq -e '<approved snapshot predicates>' backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json
+jq -e '<approval evidence predicates>' backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json
+rg '<forbidden public payload field keys>' backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json
+shasum -a 256 backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json
+```
+
+## Explicit Non-Actions
+
+This dry-run did not:
+
+- write CMS data;
+- execute production import;
+- run a production import command;
+- modify the RC snapshot;
+- enable runtime;
+- mutate environment variables;
+- open production import execution;
+- open production rollout;
+- mark staging-only assets as production-ready;
+- add frontend fallback;
+- approve production activation beyond dry-run readiness.
+
+## Go / No-Go
+
+| Decision | Result |
+| --- | --- |
+| Import gate dry-run passed for authorized snapshot | `YES` |
+| Ready for separate import execution authorization | `YES` |
+| Production import allowed without second authorization | `NO` |
+| CMS production write allowed now | `NO` |
+| Runtime production enablement allowed now | `NO` |
+| Production rollout allowed now | `NO` |
+| Import approval counts as rollout approval | `NO` |
+
+Next safe step: request a separate explicit production import execution authorization. Without that second authorization, no CMS write or import command is allowed.


### PR DESCRIPTION
## What changed

- Added a read-only production import gate dry-run report for `riasec_result_page_v2_prod_approved_2026_06_22_01`.
- Added a JSON QA artifact recording manifest/hash/approval/safety/no-leak/staging-only rejection/rollout separation checks.

## Why

The production-approved snapshot artifact now exists. This PR validates that approved snapshot as an input to a future, separately authorized production import execution task.

## Validation commands

- `jq empty backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json`
- `git diff --check`
- `jq -e '.go_no_go.import_gate_dry_run_passed_for_authorized_snapshot == true and .go_no_go.ready_for_separate_import_execution_authorization == true and .go_no_go.production_import_allowed_without_second_authorization == false and .go_no_go.cms_production_write_allowed_now == false and .go_no_go.production_rollout_allowed_now == false' backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json`
- Scope validation: only the dry-run docs/report files changed.

## Intentionally deferred

- No CMS write.
- No production import execution.
- No runtime or environment changes.
- No production rollout.
- Import approval is not treated as rollout approval.
