### PR TITLE
FA30-API-02: Add Batch 2 Big Five and Enneagram dry-run gate

### DIFF
--- a/backend/app/Console/Commands/Batch2ResultPageDryRunGateCommand.php
+++ b/backend/app/Console/Commands/Batch2ResultPageDryRunGateCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Content\Batch2ResultPageDryRunGate;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class Batch2ResultPageDryRunGateCommand extends Command
+{
+    protected $signature = 'result-page:batch2-dry-run-gate
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/result_page_batch2_dry_run_gate}
+        {--bigfive-candidate-dir= : Optional Big Five candidate batch directory}
+        {--enneagram-public-payload-json= : Optional Enneagram public payload JSON}
+        {--strict : Return non-zero when either Batch 2 dry-run gate is blocked}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Run the backend-only Batch 2 Big Five and Enneagram dry-run gate without production writes.';
+
+    public function handle(Batch2ResultPageDryRunGate $gate): int
+    {
+        try {
+            $payloadJson = trim((string) $this->option('enneagram-public-payload-json'));
+            $enneagramPublicPayload = null;
+            if ($payloadJson !== '') {
+                $enneagramPublicPayload = json_decode($payloadJson, true);
+                if (! is_array($enneagramPublicPayload)) {
+                    $this->error('enneagram-public-payload-json must decode to an object');
+
+                    return self::FAILURE;
+                }
+            }
+
+            $summary = $gate->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'bigfive_candidate_dir' => trim((string) $this->option('bigfive-candidate-dir')),
+                'enneagram_public_payload' => $enneagramPublicPayload,
+                'strict' => (bool) $this->option('strict'),
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('artifact_dir='.(string) ($summary['artifact_dir'] ?? ''));
+        $this->line('go_no_go='.(string) data_get($summary, 'summary.go_no_go', ''));
+        $this->line('production_go_no_go='.(string) data_get($summary, 'summary.production_go_no_go', ''));
+        $this->line('next_allowed_pr='.(string) data_get($summary, 'summary.next_allowed_pr', ''));
+        $this->line('bigfive_status='.(string) data_get($summary, 'summary.bigfive_status', ''));
+        $this->line('enneagram_status='.(string) data_get($summary, 'summary.enneagram_status', ''));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -18,6 +18,7 @@ use App\Console\Commands\ArticleUpdateExistingSeoContentPackage;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\ArticleUpdateTranslationGroupId;
 use App\Console\Commands\ArticleWeeklySeoObservationExport;
+use App\Console\Commands\Batch2ResultPageDryRunGateCommand;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
@@ -247,6 +248,7 @@ class Kernel extends ConsoleKernel
         OpsDeployEvent::class,
         OpsHealthzSnapshot::class,
         ArchiveColdData::class,
+        Batch2ResultPageDryRunGateCommand::class,
         PaymentsPruneEvents::class,
         SeedScaleRegistry::class,
         SyncScaleSlugs::class,

--- a/backend/app/Services/Content/Batch2ResultPageDryRunGate.php
+++ b/backend/app/Services/Content/Batch2ResultPageDryRunGate.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Services\BigFive\ResultPageV2\AssetAgent\BigFiveResultPageV2AssetAgent;
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageContentBatchAutomation;
+use Illuminate\Support\Facades\File;
+
+final class Batch2ResultPageDryRunGate
+{
+    public const SCHEMA_VERSION = 'fap.result_page.batch2_dry_run_gate.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/result_page_batch2_dry_run_gate';
+
+    public const DEFAULT_BIGFIVE_CANDIDATE_RELATIVE_DIR = 'content_assets/big5/result_page_v2/agent_runs/candidate_batch_001';
+
+    public const NEXT_ALLOWED_PR = 'FA30-API-03';
+
+    public function __construct(
+        private readonly BigFiveResultPageV2AssetAgent $bigFiveAgent,
+        private readonly EnneagramResultPageContentBatchAutomation $enneagramAutomation,
+    ) {}
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     bigfive_candidate_dir?:string,
+     *     enneagram_public_payload?:array<string,mixed>|null,
+     *     strict?:bool
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'batch2-dry-run-gate'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $bigFiveCandidateDir = $this->absolutePathOrDefault(
+            (string) ($options['bigfive_candidate_dir'] ?? ''),
+            base_path(self::DEFAULT_BIGFIVE_CANDIDATE_RELATIVE_DIR)
+        );
+        $strict = ($options['strict'] ?? false) === true;
+        $enneagramPublicPayload = is_array($options['enneagram_public_payload'] ?? null)
+            ? (array) $options['enneagram_public_payload']
+            : null;
+
+        $this->ensureDirectory($artifactDir);
+
+        $bigFive = $this->bigFiveAgent->stageCandidates([
+            'run_id' => 'bigfive-stage',
+            'artifact_dir' => $artifactDir.'/bigfive',
+            'candidate_dir' => $bigFiveCandidateDir,
+            'allow_staging_write' => false,
+        ]);
+
+        $enneagram = $this->enneagramAutomation->evaluate([
+            'run_id' => 'enneagram-evaluate',
+            'artifact_dir' => $artifactDir.'/enneagram',
+            'public_payload' => $enneagramPublicPayload,
+            'strict' => $strict,
+        ]);
+
+        $errors = [];
+        if (($bigFive['ok'] ?? false) !== true) {
+            $errors[] = 'bigfive_batch2_dry_run_gate_blocked';
+        }
+        if ((bool) data_get($bigFive, 'summary.staging_write_performed', false)) {
+            $errors[] = 'bigfive_staging_write_performed';
+        }
+        if (($enneagram['ok'] ?? false) !== true) {
+            $errors[] = 'enneagram_batch2_dry_run_gate_blocked';
+        }
+        if ((bool) data_get($enneagram, 'summary.bulk_generation_allowed', true)) {
+            $errors[] = 'enneagram_bulk_generation_allowed';
+        }
+        if ((bool) data_get($enneagram, 'summary.production_execution_allowed_for_agent', true)) {
+            $errors[] = 'enneagram_production_execution_allowed';
+        }
+
+        $ok = $errors === [];
+        $status = $ok ? 'success' : 'blocked';
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'batch2_result_page_dry_run_gate',
+            'run_id' => $runId,
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'next_allowed_pr' => self::NEXT_ALLOWED_PR,
+            'go_no_go' => $ok ? 'GO_FOR_BATCH2_READBACK_REVIEW_LEDGER_ONLY' : 'NO_GO_CURRENT_PR_BLOCKED',
+            'production_go_no_go' => 'NO_GO',
+            'bigfive' => [
+                'status' => ($bigFive['ok'] ?? false) === true ? 'pass' : 'blocked',
+                'candidate_dir' => $this->relativeOrRawPath($bigFiveCandidateDir),
+                'summary' => [
+                    'selector_candidate_count' => (int) data_get($bigFive, 'summary.selector_candidate_count', 0),
+                    'content_candidate_count' => (int) data_get($bigFive, 'summary.content_candidate_count', 0),
+                    'validation_error_count' => (int) data_get($bigFive, 'summary.validation_error_count', 0),
+                    'review_error_count' => (int) data_get($bigFive, 'summary.review_error_count', 0),
+                    'leak_hit_count' => (int) data_get($bigFive, 'summary.leak_hit_count', 0),
+                    'staging_write_performed' => (bool) data_get($bigFive, 'summary.staging_write_performed', false),
+                ],
+                'negative_guarantees' => $this->booleanMap((array) ($bigFive['negative_guarantees'] ?? [])),
+                'artifacts' => $this->artifactMap((array) ($bigFive['artifacts'] ?? [])),
+            ],
+            'enneagram' => [
+                'status' => ($enneagram['ok'] ?? false) === true ? 'pass' : 'blocked',
+                'summary' => [
+                    'payload_count' => (int) data_get($enneagram, 'summary.payload_count', 0),
+                    'bulk_generation_allowed' => (bool) data_get($enneagram, 'summary.bulk_generation_allowed', true),
+                    'source_mapping_zero_failures' => (bool) data_get($enneagram, 'summary.source_mapping_zero_failures', false),
+                    'metadata_leakage_zero' => (bool) data_get($enneagram, 'summary.metadata_leakage_zero', false),
+                    'forbidden_claim_zero' => (bool) data_get($enneagram, 'summary.forbidden_claim_zero', false),
+                    'fc144_boundary_zero' => (bool) data_get($enneagram, 'summary.fc144_boundary_zero', false),
+                    'production_execution_allowed_for_agent' => (bool) data_get($enneagram, 'summary.production_execution_allowed_for_agent', true),
+                ],
+                'negative_guarantees' => $this->booleanMap((array) ($enneagram['negative_guarantees'] ?? [])),
+                'artifacts' => $this->artifactMap((array) ($enneagram['artifacts'] ?? [])),
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'batch2_result_page_dry_run_gate_report.json' => $this->writeJson(
+                $artifactDir.'/batch2_result_page_dry_run_gate_report.json',
+                $report
+            ),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $status,
+            'run_id' => $runId,
+            'artifact_dir' => $this->relativeOrRawPath($artifactDir),
+            'artifacts' => $artifacts,
+            'summary' => [
+                'go_no_go' => $report['go_no_go'],
+                'production_go_no_go' => $report['production_go_no_go'],
+                'next_allowed_pr' => self::NEXT_ALLOWED_PR,
+                'bigfive_status' => data_get($report, 'bigfive.status'),
+                'enneagram_status' => data_get($report, 'enneagram.status'),
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativeOrRawPath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $artifacts
+     * @return array<string,string>
+     */
+    private function artifactMap(array $artifacts): array
+    {
+        $mapped = [];
+        foreach ($artifacts as $name => $artifact) {
+            if (! is_array($artifact)) {
+                continue;
+            }
+            $mapped[(string) $name] = (string) ($artifact['relative_path'] ?? '');
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  array<string,mixed>  $values
+     * @return array<string,bool>
+     */
+    private function booleanMap(array $values): array
+    {
+        $mapped = [];
+        foreach ($values as $key => $value) {
+            $mapped[(string) $key] = (bool) $value;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bigfive_candidate_generation_happened' => false,
+            'bigfive_staging_write_happened' => false,
+            'enneagram_bulk_generation_happened' => false,
+            'candidate_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = trim($root) !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function absolutePathOrDefault(string $value, string $default): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return $default;
+        }
+
+        return str_starts_with($value, DIRECTORY_SEPARATOR) ? $value : base_path($value);
+    }
+
+    private function relativeOrRawPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $path;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'batch2-dry-run-gate';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+}

--- a/backend/tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php
+++ b/backend/tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class Batch2ResultPageDryRunGateCommandTest extends TestCase
+{
+    public function test_command_reports_bigfive_and_enneagram_batch2_dry_run_gate_without_writes(): void
+    {
+        $root = $this->tempDir('batch2-result-page-dry-run-gate');
+
+        try {
+            $this->artisan('result-page:batch2-dry-run-gate', [
+                '--run-id' => 'batch2-gate',
+                '--artifact-dir' => $root,
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/batch2-gate/batch2_result_page_dry_run_gate_report.json');
+
+            $this->assertSame('fap.result_page.batch2_dry_run_gate.v0.1', $report['schema_version'] ?? null);
+            $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($report['ready_for_runtime'] ?? true));
+            $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+            $this->assertSame('GO_FOR_BATCH2_READBACK_REVIEW_LEDGER_ONLY', $report['go_no_go'] ?? null);
+            $this->assertSame('NO_GO', $report['production_go_no_go'] ?? null);
+            $this->assertSame('FA30-API-03', $report['next_allowed_pr'] ?? null);
+
+            $this->assertSame('pass', data_get($report, 'bigfive.status'));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.validation_error_count'));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.review_error_count'));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.leak_hit_count'));
+            $this->assertFalse((bool) data_get($report, 'bigfive.summary.staging_write_performed', true));
+
+            $this->assertSame('pass', data_get($report, 'enneagram.status'));
+            $this->assertSame(1, data_get($report, 'enneagram.summary.payload_count'));
+            $this->assertFalse((bool) data_get($report, 'enneagram.summary.bulk_generation_allowed', true));
+            $this->assertTrue((bool) data_get($report, 'enneagram.summary.source_mapping_zero_failures', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.summary.metadata_leakage_zero', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.summary.forbidden_claim_zero', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.summary.fc144_boundary_zero', false));
+            $this->assertFalse((bool) data_get($report, 'enneagram.summary.production_execution_allowed_for_agent', true));
+
+            foreach ([
+                'bigfive_candidate_generation_happened',
+                'bigfive_staging_write_happened',
+                'enneagram_bulk_generation_happened',
+                'candidate_import_happened',
+                'production_activation_happened',
+                'runtime_switch_happened',
+                'production_write_happened',
+                'frontend_change_happened',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, 'negative_guarantees.'.$guarantee, true), $guarantee);
+            }
+
+            $artifactBlob = (string) file_get_contents($root.'/batch2-gate/batch2_result_page_dry_run_gate_report.json');
+            foreach (['attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $artifactBlob);
+            }
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_command_rejects_invalid_enneagram_payload_json(): void
+    {
+        $this->artisan('result-page:batch2-dry-run-gate', [
+            '--enneagram-public-payload-json' => '{bad',
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2990,6 +2990,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_batch2_result_page_dry_run_gate_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/Batch2ResultPageDryRunGateCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Content/Batch2ResultPageDryRunGate.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\Batch2ResultPageDryRunGateCommand;',
+            '+        Batch2ResultPageDryRunGateCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_rendered_qa_smoke_harness_scaffold(): void
     {
         $changed = [
@@ -5013,6 +5034,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBatch2ResultPageDryRunGateFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageRenderedQaSmokeHarnessFile($file)) {
                 continue;
             }
@@ -5140,6 +5165,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageOpsRunnerOrchestratorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBatch2ResultPageDryRunGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageReportSidecarIssueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageProductionManualGateRunbookOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -7105,6 +7131,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isBatch2ResultPageDryRunGateFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/Batch2ResultPageDryRunGateCommand.php',
+            'backend/app/Services/Content/Batch2ResultPageDryRunGate.php',
+        ], true);
+    }
+
     private function isEnneagramResultPageRenderedQaSmokeHarnessFile(string $file): bool
     {
         return in_array($file, [
@@ -8409,6 +8443,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\EnneagramResultPageCandidateStagingHarnessCommand;',
             '        EnneagramResultPageCandidateStagingHarnessCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBatch2ResultPageDryRunGateOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\Batch2ResultPageDryRunGateCommand;',
+            '        Batch2ResultPageDryRunGateCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -58555,7 +58555,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-02-batch2-dry-run-gate",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "fa30_batch2_backend_dry_run_gate",
     "title": "FA30-API-02: Add Batch 2 Big Five and Enneagram dry-run gate",
     "depends_on": [
@@ -58588,12 +58588,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2306 opened on head 6c3d2d301c8f8e9fbc3235e665708acd7865ab9a. Required GitHub checks have started on the Batch 2 dry-run gate scope."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "6c3d2d301c8f8e9fbc3235e665708acd7865ab9a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2306",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -58607,6 +58607,11 @@
         "at": "2026-06-22T14:10:00Z",
         "status": "local_validated",
         "note": "Added a backend-only result-page Batch 2 dry-run gate that reuses Big Five stageCandidates in no-write mode and Enneagram content-batch evaluate. Targeted feature/runtime-freeze tests, Pint, YAML/JSON parse, and diff checks passed."
+      },
+      {
+        "at": "2026-06-22T14:13:30Z",
+        "status": "pr_open",
+        "note": "Opened PR #2306 on head 6c3d2d301c8f8e9fbc3235e665708acd7865ab9a after local validation and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -58470,7 +58470,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-01-analytics-smoke-exclusion",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "fa30_batch2_backend_ci_boundary",
     "title": "FA30-API-01: Exclude analytics-only backend changes from MBTI smoke",
     "depends_on": [],
@@ -58503,16 +58503,16 @@
         "evidence": "Changed files are limited to .github/workflows/ci.yml, backend/app/Services/Ci/ScaleImpactResolver.php, backend/scripts/ci_verify_mbti.sh, backend/tests/Unit/Ci/ScaleImpactResolverTest.php, and docs/codex PR-train metadata. No Batch 2 dry-run/readback authority files, frontend runtime files, deploy files, or production write paths changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2302 now points at head 8e759f1522e2e9df626c350065e368dc4bb4965b after the scoped verify-bigfive repair. Required GitHub checks are pending again on the updated head."
+        "status": "pass",
+        "evidence": "PR #2302 required GitHub checks passed on head 186ee67162d8ad287c2c6279f51950aca1d73ee2; mergeStateStatus was CLEAN before squash merge, and GitHub reports merge commit 82c10c54cd03edd3380325fc0fa627915713d393."
       }
     },
     "failure_reason": null,
-    "commit_sha": "8e759f1522e2e9df626c350065e368dc4bb4965b",
+    "commit_sha": "186ee67162d8ad287c2c6279f51950aca1d73ee2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2302",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T11:44:35Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T10:58:00Z",
@@ -58538,6 +58538,75 @@
         "at": "2026-06-22T13:08:00Z",
         "status": "pr_open",
         "note": "Pushed scoped verify-bigfive repair commit 8e759f1522e2e9df626c350065e368dc4bb4965b to PR #2302. Waiting for required GitHub checks on the updated head."
+      },
+      {
+        "at": "2026-06-22T13:43:50Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed on head 186ee67162d8ad287c2c6279f51950aca1d73ee2, mergeStateStatus was CLEAN, and PR title/body/scope were re-reviewed before merge."
+      },
+      {
+        "at": "2026-06-22T13:45:30Z",
+        "status": "merged",
+        "note": "PR #2302 merged at 2026-06-22T11:44:35Z with merge commit 82c10c54cd03edd3380325fc0fa627915713d393. origin/main contains the merge commit, the remote branch is deleted, and the local task worktree/branch were cleaned up."
+      }
+    ]
+  },
+  "FA30-API-02": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-02-batch2-dry-run-gate",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "fa30_batch2_backend_dry_run_gate",
+    "title": "FA30-API-02: Add Batch 2 Big Five and Enneagram dry-run gate",
+    "depends_on": [
+      "FA30-API-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly ordered FA30-API-02 second in the FA30 train and previously authorized manifest/state entries for FA30-WEB-01, FA30-API-01, FA30-API-02, FA30-API-03, and FA30-WEB-02."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FA30-API-01 is merged on GitHub as PR #2302, and origin/main contains merge commit 82c10c54cd03edd3380325fc0fa627915713d393."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageDryRunGateCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_dry_run_gate --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageDryRunGateCommand.php app/Services/Content/Batch2ResultPageDryRunGate.php tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check"
+        ],
+        "evidence": "Batch2ResultPageDryRunGateCommandTest passed with the combined Big Five and Enneagram no-write gate report. The runtime-freeze allowlist test for batch2_result_page_dry_run_gate passed. Targeted Pint, YAML parse, JSON parse, and git diff checks passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the new Batch2ResultPageDryRunGate command/service/test, backend/app/Console/Kernel.php registration, BigFiveResultPageV2CoreBodyPreviewTest allowlist coverage, and docs/codex metadata including FA30-API-01 merge reconciliation. No runtime route/controller files, deploy files, frontend files, candidate assets, staging writes, or Batch 2 readback/review ledger authority files changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T13:58:00Z",
+        "status": "in_progress",
+        "note": "Started clean-worktree implementation from latest origin/main after FA30-API-01 merged. Scope is limited to a backend-only Batch 2 Big Five and Enneagram dry-run gate plus docs/codex metadata."
+      },
+      {
+        "at": "2026-06-22T14:10:00Z",
+        "status": "local_validated",
+        "note": "Added a backend-only result-page Batch 2 dry-run gate that reuses Big Five stageCandidates in no-write mode and Enneagram content-batch evaluate. Targeted feature/runtime-freeze tests, Pint, YAML/JSON parse, and diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26887,3 +26887,44 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: FA30-API-02
+    repo: fap-api
+    depends_on:
+      - FA30-API-01
+    branch: codex/fa30-api-02-batch2-dry-run-gate
+    title: "FA30-API-02: Add Batch 2 Big Five and Enneagram dry-run gate"
+    train_scope: fa30_batch2_backend_dry_run_gate
+    status: user_authorized
+    scope:
+      - Add a backend-only Batch 2 dry-run gate entrypoint that evaluates Big Five staged candidate validation and Enneagram content-batch safety without production writes.
+      - Reuse the existing Big Five asset-agent and Enneagram content-batch services instead of introducing parallel content pipelines.
+      - Emit a combined gate report whose GO path advances only to FA30-API-03 readback/review ledger work.
+      - Keep production activation, runtime switches, frontend changes, and staging-write execution blocked.
+    allowed_paths:
+      - backend/app/Console/Commands/Batch2ResultPageDryRunGateCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/Content/Batch2ResultPageDryRunGate.php
+      - backend/tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate new Big Five candidate assets or Enneagram bulk content in this PR.
+      - Perform staging writes, candidate imports, activation, rollout, runtime switches, or frontend changes.
+      - Modify Batch 2 readback/review ledger authority logic in this PR.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageDryRunGateCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_dry_run_gate --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageDryRunGateCommand.php app/Services/Content/Batch2ResultPageDryRunGate.php tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- add a backend-only `result-page:batch2-dry-run-gate` command and service that reuse the existing Big Five candidate staging validator and Enneagram content-batch evaluator
- emit a combined Batch 2 dry-run gate report that stays no-write, no-runtime, and points the train forward only to `FA30-API-03`
- register the command in the Laravel console kernel and extend the Big Five runtime-freeze allowlist for this read-only gate
- add `FA30-API-02` PR-train manifest/state metadata and reconcile `FA30-API-01` as merged/cleaned-up in the state ledger

## Why
Batch 2 needed one explicit backend gate before readback/review ledger work. The existing Big Five and Enneagram dry-run primitives were separate, which left the train without a single authority surface for “can we move to API-03 yet?”. This PR narrows that gap without opening any write or runtime paths.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageDryRunGateCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_dry_run_gate --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageDryRunGateCommand.php app/Services/Content/Batch2ResultPageDryRunGate.php tests/Feature/Console/Batch2ResultPageDryRunGateCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- `FA30-API-03` Batch 2 readback / review ledger authority
- `FA30-WEB-02` frontend runtime QA harness
- any candidate import, activation, rollout, runtime switch, deploy, or frontend change

## Repository rule impact
- no public runtime authority changed
- no CMS write, DB write, candidate import, activation, or deploy behavior changed
- this PR adds only a backend read-only gate that consumes existing Big Five and Enneagram dry-run primitives