### PR TITLE
FA30-API-03: Add Batch 2 readback and review ledger authority

### DIFF
--- a/backend/app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php
+++ b/backend/app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Content\Batch2ResultPageReadbackReviewLedger;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class Batch2ResultPageReadbackReviewLedgerCommand extends Command
+{
+    protected $signature = 'result-page:batch2-readback-review-ledger
+        {--run-id= : Stable run identifier for the artifact directory}
+        {--artifact-dir= : Optional artifact root; defaults to backend/artifacts/result_page_batch2_readback_review_ledger}
+        {--bigfive-candidate-dir= : Optional Big Five candidate batch directory}
+        {--enneagram-source-ledger-dir= : Optional Enneagram source ledger directory}
+        {--enneagram-public-payload-json= : Optional Enneagram public payload JSON}
+        {--strict : Return non-zero when the Batch 2 readback/review ledger is blocked}
+        {--json : Emit machine-readable summary}';
+
+    protected $description = 'Run the backend-only Batch 2 readback/review ledger authority check without runtime or CMS writes.';
+
+    public function handle(Batch2ResultPageReadbackReviewLedger $ledger): int
+    {
+        try {
+            $payloadJson = trim((string) $this->option('enneagram-public-payload-json'));
+            $enneagramPublicPayload = null;
+            if ($payloadJson !== '') {
+                $enneagramPublicPayload = json_decode($payloadJson, true);
+                if (! is_array($enneagramPublicPayload)) {
+                    $this->error('enneagram-public-payload-json must decode to an object');
+
+                    return self::FAILURE;
+                }
+            }
+
+            $summary = $ledger->run([
+                'run_id' => trim((string) $this->option('run-id')),
+                'artifact_dir' => trim((string) $this->option('artifact-dir')),
+                'bigfive_candidate_dir' => trim((string) $this->option('bigfive-candidate-dir')),
+                'enneagram_source_ledger_dir' => trim((string) $this->option('enneagram-source-ledger-dir')),
+                'enneagram_public_payload' => $enneagramPublicPayload,
+            ]);
+
+            $this->render($summary);
+
+            return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function render(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($summary['status'] ?? 'unknown'));
+        $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
+        $this->line('artifact_dir='.(string) ($summary['artifact_dir'] ?? ''));
+        $this->line('go_no_go='.(string) data_get($summary, 'summary.go_no_go', ''));
+        $this->line('production_go_no_go='.(string) data_get($summary, 'summary.production_go_no_go', ''));
+        $this->line('next_allowed_pr='.(string) data_get($summary, 'summary.next_allowed_pr', ''));
+        $this->line('authority_state='.(string) data_get($summary, 'summary.authority_state', ''));
+        $this->line('bigfive_status='.(string) data_get($summary, 'summary.bigfive_status', ''));
+        $this->line('enneagram_status='.(string) data_get($summary, 'summary.enneagram_status', ''));
+
+        foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {
+            $this->line('artifact['.$filename.']='.(string) data_get($artifact, 'relative_path', ''));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            $this->line('error='.(string) $error);
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -19,6 +19,7 @@ use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\ArticleUpdateTranslationGroupId;
 use App\Console\Commands\ArticleWeeklySeoObservationExport;
 use App\Console\Commands\Batch2ResultPageDryRunGateCommand;
+use App\Console\Commands\Batch2ResultPageReadbackReviewLedgerCommand;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
@@ -249,6 +250,7 @@ class Kernel extends ConsoleKernel
         OpsHealthzSnapshot::class,
         ArchiveColdData::class,
         Batch2ResultPageDryRunGateCommand::class,
+        Batch2ResultPageReadbackReviewLedgerCommand::class,
         PaymentsPruneEvents::class,
         SeedScaleRegistry::class,
         SyncScaleSlugs::class,

--- a/backend/app/Services/Content/Batch2ResultPageReadbackReviewLedger.php
+++ b/backend/app/Services/Content/Batch2ResultPageReadbackReviewLedger.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Services\BigFive\ResultPageV2\AssetAgent\BigFiveResultPageV2AssetAgent;
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageAgentReadiness;
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPageContentBatchAutomation;
+use Illuminate\Support\Facades\File;
+
+final class Batch2ResultPageReadbackReviewLedger
+{
+    public const SCHEMA_VERSION = 'fap.result_page.batch2_readback_review_ledger.v0.1';
+
+    public const DEFAULT_ARTIFACT_RELATIVE_DIR = 'artifacts/result_page_batch2_readback_review_ledger';
+
+    public const DEFAULT_BIGFIVE_CANDIDATE_RELATIVE_DIR = 'content_assets/big5/result_page_v2/agent_runs/candidate_batch_001';
+
+    public const NEXT_ALLOWED_PR = 'FA30-WEB-02';
+
+    public function __construct(
+        private readonly BigFiveResultPageV2AssetAgent $bigFiveAgent,
+        private readonly EnneagramResultPageAgentReadiness $enneagramReadiness,
+        private readonly EnneagramResultPageContentBatchAutomation $enneagramAutomation,
+    ) {}
+
+    /**
+     * @param  array{
+     *     run_id?:string,
+     *     artifact_dir?:string,
+     *     bigfive_candidate_dir?:string,
+     *     enneagram_source_ledger_dir?:string,
+     *     enneagram_public_payload?:array<string,mixed>|null
+     * }  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options = []): array
+    {
+        $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'batch2-readback-review-ledger'));
+        $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
+        $bigFiveCandidateDir = $this->absolutePathOrDefault(
+            (string) ($options['bigfive_candidate_dir'] ?? ''),
+            base_path(self::DEFAULT_BIGFIVE_CANDIDATE_RELATIVE_DIR)
+        );
+        $enneagramSourceLedgerDir = trim((string) ($options['enneagram_source_ledger_dir'] ?? ''));
+        $enneagramPublicPayload = is_array($options['enneagram_public_payload'] ?? null)
+            ? (array) $options['enneagram_public_payload']
+            : null;
+
+        $this->ensureDirectory($artifactDir);
+
+        $bigFive = $this->bigFiveAgent->stageCandidates([
+            'run_id' => 'bigfive-review',
+            'artifact_dir' => $artifactDir.'/bigfive',
+            'candidate_dir' => $bigFiveCandidateDir,
+            'allow_staging_write' => false,
+        ]);
+        $bigFiveReviewManifest = $this->readOptionalJson($bigFiveCandidateDir.'/review_manifest.json');
+
+        $enneagramReadiness = $this->enneagramReadiness->audit(array_filter([
+            'run_id' => 'enneagram-readiness',
+            'artifact_dir' => $artifactDir.'/enneagram-readiness',
+            'source_ledger_dir' => $enneagramSourceLedgerDir !== '' ? $enneagramSourceLedgerDir : null,
+            'strict' => false,
+        ], static fn (mixed $value): bool => $value !== null));
+
+        $enneagramBatch = $this->enneagramAutomation->evaluate([
+            'run_id' => 'enneagram-readback',
+            'artifact_dir' => $artifactDir.'/enneagram-batch',
+            'public_payload' => $enneagramPublicPayload,
+            'strict' => false,
+        ]);
+
+        $errors = [];
+        if (($bigFive['ok'] ?? false) !== true) {
+            $errors[] = 'bigfive_readback_review_blocked';
+        }
+        if ((bool) data_get($bigFive, 'summary.staging_write_performed', false)) {
+            $errors[] = 'bigfive_staging_write_performed';
+        }
+        if ((bool) data_get($enneagramReadiness, 'summary.source_ledger_valid', false) !== true) {
+            $errors[] = 'enneagram_source_ledger_invalid';
+        }
+        if (($enneagramBatch['ok'] ?? false) !== true) {
+            $errors[] = 'enneagram_readback_review_blocked';
+        }
+        if ((bool) data_get($enneagramBatch, 'summary.bulk_generation_allowed', true)) {
+            $errors[] = 'enneagram_bulk_generation_allowed';
+        }
+        if ((bool) data_get($enneagramBatch, 'summary.production_execution_allowed_for_agent', true)) {
+            $errors[] = 'enneagram_production_execution_allowed';
+        }
+
+        $ok = $errors === [];
+        $status = $ok ? 'success' : 'blocked';
+
+        $report = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => 'batch2_result_page_readback_review_ledger',
+            'run_id' => $runId,
+            'runtime_use' => 'not_runtime',
+            'production_use_allowed' => false,
+            'ready_for_pilot' => false,
+            'ready_for_runtime' => false,
+            'ready_for_production' => false,
+            'authority_state' => 'backend_readback_review_authority_only',
+            'next_allowed_pr' => self::NEXT_ALLOWED_PR,
+            'go_no_go' => $ok ? 'GO_FOR_FA30-WEB-02_FRONTEND_RUNTIME_QA_ONLY' : 'NO_GO_CURRENT_PR_BLOCKED',
+            'production_go_no_go' => 'NO_GO',
+            'bigfive' => [
+                'status' => ($bigFive['ok'] ?? false) === true ? 'pass' : 'blocked',
+                'candidate_dir' => $this->relativeOrRawPath($bigFiveCandidateDir),
+                'review_manifest' => [
+                    'present' => $bigFiveReviewManifest !== null,
+                    'human_reviewed' => (bool) ($bigFiveReviewManifest['human_reviewed'] ?? false),
+                    'review_status' => (string) ($bigFiveReviewManifest['review_status'] ?? ''),
+                    'runtime_use' => (string) ($bigFiveReviewManifest['runtime_use'] ?? ''),
+                    'production_use_allowed' => (bool) ($bigFiveReviewManifest['production_use_allowed'] ?? false),
+                    'ready_for_pilot' => (bool) ($bigFiveReviewManifest['ready_for_pilot'] ?? false),
+                    'ready_for_runtime' => (bool) ($bigFiveReviewManifest['ready_for_runtime'] ?? false),
+                    'ready_for_production' => (bool) ($bigFiveReviewManifest['ready_for_production'] ?? false),
+                    'reviewed_by' => $this->nullableString($bigFiveReviewManifest['reviewed_by'] ?? null),
+                    'reviewed_at' => $this->nullableString($bigFiveReviewManifest['reviewed_at'] ?? null),
+                ],
+                'summary' => [
+                    'selector_candidate_count' => (int) data_get($bigFive, 'summary.selector_candidate_count', 0),
+                    'content_candidate_count' => (int) data_get($bigFive, 'summary.content_candidate_count', 0),
+                    'validation_error_count' => (int) data_get($bigFive, 'summary.validation_error_count', 0),
+                    'review_error_count' => (int) data_get($bigFive, 'summary.review_error_count', 0),
+                    'leak_hit_count' => (int) data_get($bigFive, 'summary.leak_hit_count', 0),
+                    'staging_write_performed' => (bool) data_get($bigFive, 'summary.staging_write_performed', false),
+                ],
+                'readback_authority' => [
+                    'authority_layer' => 'review_manifest_and_candidate_validation',
+                    'frontend_fallback_allowed' => false,
+                    'public_runtime_allowed' => false,
+                    'production_write_allowed' => false,
+                ],
+                'negative_guarantees' => $this->booleanMap((array) ($bigFive['negative_guarantees'] ?? [])),
+                'artifacts' => $this->artifactMap((array) ($bigFive['artifacts'] ?? [])),
+            ],
+            'enneagram' => [
+                'status' => ((bool) data_get($enneagramReadiness, 'summary.source_ledger_valid', false) === true
+                    && ($enneagramBatch['ok'] ?? false) === true) ? 'pass' : 'blocked',
+                'source_ledger' => [
+                    'valid' => (bool) data_get($enneagramReadiness, 'summary.source_ledger_valid', false),
+                    'candidate_dir_provided' => (bool) data_get($enneagramReadiness, 'summary.candidate_dir_provided', false),
+                    'candidate_contract_valid' => (bool) data_get($enneagramReadiness, 'summary.candidate_contract_valid', false),
+                    'ready_for_generation' => (bool) data_get($enneagramReadiness, 'summary.ready_for_generation', false),
+                    'ready_for_import' => (bool) data_get($enneagramReadiness, 'summary.ready_for_import', false),
+                    'ready_for_activation' => (bool) data_get($enneagramReadiness, 'summary.ready_for_activation', false),
+                ],
+                'batch_summary' => [
+                    'payload_count' => (int) data_get($enneagramBatch, 'summary.payload_count', 0),
+                    'bulk_generation_allowed' => (bool) data_get($enneagramBatch, 'summary.bulk_generation_allowed', true),
+                    'source_mapping_zero_failures' => (bool) data_get($enneagramBatch, 'summary.source_mapping_zero_failures', false),
+                    'metadata_leakage_zero' => (bool) data_get($enneagramBatch, 'summary.metadata_leakage_zero', false),
+                    'forbidden_claim_zero' => (bool) data_get($enneagramBatch, 'summary.forbidden_claim_zero', false),
+                    'fc144_boundary_zero' => (bool) data_get($enneagramBatch, 'summary.fc144_boundary_zero', false),
+                    'production_execution_allowed_for_agent' => (bool) data_get($enneagramBatch, 'summary.production_execution_allowed_for_agent', true),
+                ],
+                'readback_authority' => [
+                    'authority_layer' => 'source_ledger_and_batch_reports',
+                    'frontend_fallback_allowed' => false,
+                    'public_runtime_allowed' => false,
+                    'production_write_allowed' => false,
+                ],
+                'negative_guarantees' => [
+                    'readiness' => $this->booleanMap((array) ($enneagramReadiness['negative_guarantees'] ?? [])),
+                    'batch' => $this->booleanMap((array) ($enneagramBatch['negative_guarantees'] ?? [])),
+                ],
+                'artifacts' => [
+                    'readiness' => $this->artifactMap((array) ($enneagramReadiness['artifacts'] ?? [])),
+                    'batch' => $this->artifactMap((array) ($enneagramBatch['artifacts'] ?? [])),
+                ],
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+            'error_count' => count($errors),
+            'errors' => $errors,
+        ];
+
+        $artifacts = [
+            'batch2_result_page_readback_review_ledger_report.json' => $this->writeJson(
+                $artifactDir.'/batch2_result_page_readback_review_ledger_report.json',
+                $report
+            ),
+        ];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $ok,
+            'status' => $status,
+            'run_id' => $runId,
+            'artifact_dir' => $this->relativeOrRawPath($artifactDir),
+            'artifacts' => $artifacts,
+            'summary' => [
+                'go_no_go' => $report['go_no_go'],
+                'production_go_no_go' => $report['production_go_no_go'],
+                'next_allowed_pr' => self::NEXT_ALLOWED_PR,
+                'bigfive_status' => data_get($report, 'bigfive.status'),
+                'enneagram_status' => data_get($report, 'enneagram.status'),
+                'authority_state' => $report['authority_state'],
+            ],
+            'errors' => $errors,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,string>
+     */
+    private function writeJson(string $path, array $payload): array
+    {
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'relative_path' => $this->relativeOrRawPath($path),
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $artifacts
+     * @return array<string,string>
+     */
+    private function artifactMap(array $artifacts): array
+    {
+        $mapped = [];
+        foreach ($artifacts as $name => $artifact) {
+            if (! is_array($artifact)) {
+                continue;
+            }
+            $mapped[(string) $name] = (string) ($artifact['relative_path'] ?? data_get($artifact, 'path', ''));
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  array<string,mixed>  $values
+     * @return array<string,bool>
+     */
+    private function booleanMap(array $values): array
+    {
+        $mapped = [];
+        foreach ($values as $key => $value) {
+            $mapped[(string) $key] = (bool) $value;
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'bigfive_staging_write_happened' => false,
+            'enneagram_bulk_generation_happened' => false,
+            'candidate_import_happened' => false,
+            'production_activation_happened' => false,
+            'runtime_switch_happened' => false,
+            'production_write_happened' => false,
+            'frontend_change_happened' => false,
+        ];
+    }
+
+    private function artifactDir(string $root, string $runId): string
+    {
+        $artifactRoot = trim($root) !== '' ? rtrim($root, DIRECTORY_SEPARATOR) : base_path(self::DEFAULT_ARTIFACT_RELATIVE_DIR);
+
+        return $artifactRoot.DIRECTORY_SEPARATOR.$runId;
+    }
+
+    private function absolutePathOrDefault(string $value, string $default): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return $default;
+        }
+
+        return str_starts_with($value, DIRECTORY_SEPARATOR) ? $value : base_path($value);
+    }
+
+    private function relativeOrRawPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $base)) {
+            return substr($path, strlen($base));
+        }
+
+        return $path;
+    }
+
+    private function sanitizeSlug(string $value): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_.-]+/', '-', trim($value)) ?: '';
+
+        return trim($sanitized, '-') ?: 'batch2-readback-review-ledger';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            File::makeDirectory($path, 0777, true);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function readOptionalJson(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/backend/tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php
+++ b/backend/tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+final class Batch2ResultPageReadbackReviewLedgerCommandTest extends TestCase
+{
+    public function test_command_reports_batch2_readback_review_ledger_authority_without_writes(): void
+    {
+        $root = $this->tempDir('batch2-result-page-readback-review-ledger');
+
+        try {
+            $this->artisan('result-page:batch2-readback-review-ledger', [
+                '--run-id' => 'batch2-readback',
+                '--artifact-dir' => $root,
+                '--strict' => true,
+                '--json' => true,
+            ])->assertExitCode(0);
+
+            $report = $this->readJson($root.'/batch2-readback/batch2_result_page_readback_review_ledger_report.json');
+
+            $this->assertSame('fap.result_page.batch2_readback_review_ledger.v0.1', $report['schema_version'] ?? null);
+            $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+            $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+            $this->assertFalse((bool) ($report['ready_for_runtime'] ?? true));
+            $this->assertFalse((bool) ($report['ready_for_production'] ?? true));
+            $this->assertSame('backend_readback_review_authority_only', $report['authority_state'] ?? null);
+            $this->assertSame('GO_FOR_FA30-WEB-02_FRONTEND_RUNTIME_QA_ONLY', $report['go_no_go'] ?? null);
+            $this->assertSame('NO_GO', $report['production_go_no_go'] ?? null);
+            $this->assertSame('FA30-WEB-02', $report['next_allowed_pr'] ?? null);
+
+            $this->assertSame('pass', data_get($report, 'bigfive.status'));
+            $this->assertTrue((bool) data_get($report, 'bigfive.review_manifest.present', false));
+            $this->assertTrue((bool) data_get($report, 'bigfive.review_manifest.human_reviewed', false));
+            $this->assertSame('approved_for_staging', data_get($report, 'bigfive.review_manifest.review_status'));
+            $this->assertSame('staging_only', data_get($report, 'bigfive.review_manifest.runtime_use'));
+            $this->assertFalse((bool) data_get($report, 'bigfive.review_manifest.production_use_allowed', true));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.validation_error_count'));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.review_error_count'));
+            $this->assertSame(0, data_get($report, 'bigfive.summary.leak_hit_count'));
+            $this->assertFalse((bool) data_get($report, 'bigfive.summary.staging_write_performed', true));
+
+            $this->assertSame('pass', data_get($report, 'enneagram.status'));
+            $this->assertTrue((bool) data_get($report, 'enneagram.source_ledger.valid', false));
+            $this->assertFalse((bool) data_get($report, 'enneagram.source_ledger.ready_for_generation', true));
+            $this->assertFalse((bool) data_get($report, 'enneagram.source_ledger.ready_for_import', true));
+            $this->assertFalse((bool) data_get($report, 'enneagram.source_ledger.ready_for_activation', true));
+            $this->assertSame(1, data_get($report, 'enneagram.batch_summary.payload_count'));
+            $this->assertFalse((bool) data_get($report, 'enneagram.batch_summary.bulk_generation_allowed', true));
+            $this->assertTrue((bool) data_get($report, 'enneagram.batch_summary.source_mapping_zero_failures', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.batch_summary.metadata_leakage_zero', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.batch_summary.forbidden_claim_zero', false));
+            $this->assertTrue((bool) data_get($report, 'enneagram.batch_summary.fc144_boundary_zero', false));
+            $this->assertFalse((bool) data_get($report, 'enneagram.batch_summary.production_execution_allowed_for_agent', true));
+
+            foreach ([
+                'bigfive_staging_write_happened',
+                'enneagram_bulk_generation_happened',
+                'candidate_import_happened',
+                'production_activation_happened',
+                'runtime_switch_happened',
+                'production_write_happened',
+                'frontend_change_happened',
+            ] as $guarantee) {
+                $this->assertFalse((bool) data_get($report, 'negative_guarantees.'.$guarantee, true), $guarantee);
+            }
+
+            $artifactBlob = (string) file_get_contents($root.'/batch2-readback/batch2_result_page_readback_review_ledger_report.json');
+            foreach (['attempt_id', 'raw_score', 'percentile', 'fixed_type', 'user_confirmed_type', 'type_code'] as $forbiddenToken) {
+                $this->assertStringNotContainsString($forbiddenToken, $artifactBlob);
+            }
+        } finally {
+            $this->deleteDirectory($root);
+        }
+    }
+
+    public function test_command_rejects_invalid_enneagram_payload_json(): void
+    {
+        $this->artisan('result-page:batch2-readback-review-ledger', [
+            '--enneagram-public-payload-json' => '{bad',
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(1);
+    }
+
+    private function tempDir(string $prefix): string
+    {
+        $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(4));
+        mkdir($path, 0777, true);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3011,6 +3011,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_batch2_result_page_readback_review_ledger_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Content/Batch2ResultPageReadbackReviewLedger.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\Batch2ResultPageReadbackReviewLedgerCommand;',
+            '+        Batch2ResultPageReadbackReviewLedgerCommand::class,',
+        ];
+
+        $blocked = [
+            'backend/app/Services/BigFive/ResultPageV2/BigFiveResultPageV2Transformer.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+        $this->assertSame($blocked, $this->mbtiImpactingRuntimeChanges($blocked, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_enneagram_result_page_rendered_qa_smoke_harness_scaffold(): void
     {
         $changed = [
@@ -5038,6 +5059,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBatch2ResultPageReadbackReviewLedgerFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramResultPageRenderedQaSmokeHarnessFile($file)) {
                 continue;
             }
@@ -5166,6 +5191,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramResultPageContentBatchAutomationOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageCandidateStagingHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBatch2ResultPageDryRunGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBatch2ResultPageReadbackReviewLedgerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageRenderedQaSmokeHarnessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageReportSidecarIssueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramResultPageProductionManualGateRunbookOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -7139,6 +7165,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ], true);
     }
 
+    private function isBatch2ResultPageReadbackReviewLedgerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php',
+            'backend/app/Services/Content/Batch2ResultPageReadbackReviewLedger.php',
+        ], true);
+    }
+
     private function isEnneagramResultPageRenderedQaSmokeHarnessFile(string $file): bool
     {
         return in_array($file, [
@@ -8460,6 +8494,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $allowed = [
             'use App\\Console\\Commands\\Batch2ResultPageDryRunGateCommand;',
             '        Batch2ResultPageDryRunGateCommand::class,',
+        ];
+        $normalized = array_map(
+            static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,
+            $changedLines,
+        );
+
+        return $changedLines !== [] && array_values($normalized) === $allowed;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBatch2ResultPageReadbackReviewLedgerOnly(array $changedLines): bool
+    {
+        $allowed = [
+            'use App\\Console\\Commands\\Batch2ResultPageReadbackReviewLedgerCommand;',
+            '        Batch2ResultPageReadbackReviewLedgerCommand::class,',
         ];
         $normalized = array_map(
             static fn (string $line): string => str_starts_with($line, '+') ? substr($line, 1) : $line,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -58629,7 +58629,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-03-readback-review-ledger",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "fa30_batch2_backend_readback_review_ledger",
     "title": "FA30-API-03: Add Batch 2 readback and review ledger authority",
     "depends_on": [
@@ -58662,12 +58662,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #2309 opened on head 9cea70b51d2837edd78df1ca2debdbb55635a571. Required GitHub checks have started on the Batch 2 readback/review ledger scope."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9cea70b51d2837edd78df1ca2debdbb55635a571",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2309",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -58681,6 +58681,11 @@
         "at": "2026-06-22T20:31:00Z",
         "status": "local_validated",
         "note": "Added a backend-only Batch 2 readback/review ledger that reuses Big Five candidate review-manifest validation plus Enneagram source-ledger readiness and content-batch evaluation. Targeted feature/runtime-freeze tests, Pint, YAML/JSON parse, and diff checks passed."
+      },
+      {
+        "at": "2026-06-22T20:36:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2309 on head 9cea70b51d2837edd78df1ca2debdbb55635a571 after local validation and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -58555,7 +58555,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-02-batch2-dry-run-gate",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "fa30_batch2_backend_dry_run_gate",
     "title": "FA30-API-02: Add Batch 2 Big Five and Enneagram dry-run gate",
     "depends_on": [
@@ -58587,16 +58587,16 @@
         "evidence": "Changed files are limited to the new Batch2ResultPageDryRunGate command/service/test, backend/app/Console/Kernel.php registration, BigFiveResultPageV2CoreBodyPreviewTest allowlist coverage, and docs/codex metadata including FA30-API-01 merge reconciliation. No runtime route/controller files, deploy files, frontend files, candidate assets, staging writes, or Batch 2 readback/review ledger authority files changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2306 opened on head 6c3d2d301c8f8e9fbc3235e665708acd7865ab9a. Required GitHub checks have started on the Batch 2 dry-run gate scope."
+        "status": "pass",
+        "evidence": "PR #2306 required GitHub checks passed on head ddeed58fa9dc1675684bf6be1b4fc7669df2a25e; GitHub reports merge commit 05fe5f13b95b5bfeaa244ae3dd6f3c94153dc993 and origin/main contains it."
       }
     },
     "failure_reason": null,
-    "commit_sha": "6c3d2d301c8f8e9fbc3235e665708acd7865ab9a",
+    "commit_sha": "ddeed58fa9dc1675684bf6be1b4fc7669df2a25e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2306",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T12:05:49Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T13:58:00Z",
@@ -58612,6 +58612,75 @@
         "at": "2026-06-22T14:13:30Z",
         "status": "pr_open",
         "note": "Opened PR #2306 on head 6c3d2d301c8f8e9fbc3235e665708acd7865ab9a after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T20:05:30Z",
+        "status": "ready_to_merge",
+        "note": "GitHub required checks passed on head ddeed58fa9dc1675684bf6be1b4fc7669df2a25e, changed files remained inside the dry-run gate scope, and the PR title/body were re-reviewed before merge."
+      },
+      {
+        "at": "2026-06-22T20:07:00Z",
+        "status": "merged",
+        "note": "PR #2306 merged at 2026-06-22T12:05:49Z with merge commit 05fe5f13b95b5bfeaa244ae3dd6f3c94153dc993. origin/main contains the merge commit, the remote branch is deleted, and the local task worktree/branch were cleaned up."
+      }
+    ]
+  },
+  "FA30-API-03": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-03-readback-review-ledger",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "fa30_batch2_backend_readback_review_ledger",
+    "title": "FA30-API-03: Add Batch 2 readback and review ledger authority",
+    "depends_on": [
+      "FA30-API-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly ordered FA30-API-03 third in the FA30 train and previously authorized manifest/state entries for FA30-WEB-01, FA30-API-01, FA30-API-02, FA30-API-03, and FA30-WEB-02."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FA30-API-02 is merged on GitHub as PR #2306, and origin/main contains merge commit 05fe5f13b95b5bfeaa244ae3dd6f3c94153dc993."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageReadbackReviewLedgerCommandTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_readback_review_ledger --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php app/Services/Content/Batch2ResultPageReadbackReviewLedger.php tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check"
+        ],
+        "evidence": "Batch2ResultPageReadbackReviewLedgerCommandTest passed with a combined authority report that keeps Big Five review-manifest and Enneagram source-ledger/content-batch checks read-only. The runtime-freeze allowlist test for batch2_result_page_readback_review_ledger passed. Targeted Pint, YAML parse, JSON parse, and git diff checks passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the new Batch2ResultPageReadbackReviewLedger command/service/test, backend/app/Console/Kernel.php registration, BigFiveResultPageV2CoreBodyPreviewTest allowlist coverage, and docs/codex metadata including FA30-API-02 merge reconciliation. No routes, controllers, middleware, migrations, deploy files, frontend files, runtime gates, CMS writes, or candidate import/activation flows changed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T20:14:00Z",
+        "status": "in_progress",
+        "note": "Started clean-worktree implementation from latest origin/main after FA30-API-02 merged. Scope is limited to a backend-only Batch 2 readback/review ledger authority report plus docs/codex metadata."
+      },
+      {
+        "at": "2026-06-22T20:31:00Z",
+        "status": "local_validated",
+        "note": "Added a backend-only Batch 2 readback/review ledger that reuses Big Five candidate review-manifest validation plus Enneagram source-ledger readiness and content-batch evaluation. Targeted feature/runtime-freeze tests, Pint, YAML/JSON parse, and diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -26928,3 +26928,44 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: FA30-API-03
+    repo: fap-api
+    depends_on:
+      - FA30-API-02
+    branch: codex/fa30-api-03-readback-review-ledger
+    title: "FA30-API-03: Add Batch 2 readback and review ledger authority"
+    train_scope: fa30_batch2_backend_readback_review_ledger
+    status: user_authorized
+    scope:
+      - Add a backend-only Batch 2 readback/review ledger entrypoint that consolidates Big Five review-manifest authority with Enneagram source-ledger and content-batch readback evidence.
+      - Reuse the existing Big Five staging candidate validator, Enneagram source-ledger readiness audit, and Enneagram content-batch evaluator instead of introducing runtime or CMS write flows.
+      - Emit a combined authority report whose GO path advances only to FA30-WEB-02 frontend runtime QA work.
+      - Keep production activation, runtime switches, frontend rendering changes, CMS writes, and staging/import execution blocked.
+    allowed_paths:
+      - backend/app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/Content/Batch2ResultPageReadbackReviewLedger.php
+      - backend/tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Perform staging writes, candidate imports, activation, rollout, runtime switches, or frontend changes in this PR.
+      - Introduce controller, route, middleware, or DB migration changes in this PR.
+      - Generate new Big Five or Enneagram content assets in this PR.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageReadbackReviewLedgerCommandTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_readback_review_ledger --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php app/Services/Content/Batch2ResultPageReadbackReviewLedger.php tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- added `result-page:batch2-readback-review-ledger` as a backend-only Batch 2 authority entrypoint
- consolidated Big Five review-manifest validation with Enneagram source-ledger readiness and content-batch readback evidence into one combined report
- updated the Big Five runtime-freeze allowlist for the new command/service pair
- reconciled `FA30-API-02` as merged in `docs/codex/pr-train-state.json` and added the manifest/state entry for `FA30-API-03`

## Why
- `FA30-WEB-02` needs one explicit backend authority surface for Batch 2 instead of inferring readiness from separate Big Five and Enneagram artifacts
- this keeps readback and review status fail-closed on backend-owned manifests and ledgers without introducing runtime switches, CMS writes, or staging/import execution

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Batch2ResultPageReadbackReviewLedgerCommandTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=batch2_result_page_readback_review_ledger --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/Batch2ResultPageReadbackReviewLedgerCommand.php app/Services/Content/Batch2ResultPageReadbackReviewLedger.php tests/Feature/Console/Batch2ResultPageReadbackReviewLedgerCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- frontend runtime harness and browser-side Batch 2 QA belong to `FA30-WEB-02`
- any runtime gate changes, CMS writes, staging writes, candidate imports, or production activation remain out of scope

## Repository rule impact
- no content authority change: Batch 2 authority remains backend-owned and read-only in this PR
