### PR TITLE
Enneagram: simplify production approval gate

### DIFF
--- a/backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php
+++ b/backend/app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPagePendingProductionGateStore;
 use App\Services\Ops\EnneagramRegistryActivationGateService;
 use Illuminate\Console\Command;
 use RuntimeException;
@@ -17,22 +18,43 @@ final class EnneagramActivateInactiveCandidateRelease extends Command
         {--runtime-registry-sha256= : Expected runtime registry manifest SHA256}
         {--output-dir= : Report output directory}
         {--actor=ops : Operator label recorded in release snapshots}
+        {--use-pending-gate : Load locked release/hash contract from the singleton pending production gate}
+        {--approval-phrase= : Exact human approval phrase for the pending gate}
         {--json : Emit JSON summary}';
 
     protected $description = 'Activate a validated ENNEAGRAM inactive candidate release with exact hash and release-id confirmations.';
 
     public function __construct(
         private readonly EnneagramRegistryActivationGateService $activationGateService,
+        private readonly EnneagramResultPagePendingProductionGateStore $pendingGateStore,
     ) {
         parent::__construct();
     }
 
     public function handle(): int
     {
-        $releaseId = trim((string) $this->option('release-id'));
-        $confirmReleaseId = trim((string) $this->option('confirm-release-id'));
-        $candidateManifestSha256 = trim((string) $this->option('candidate-manifest-sha256'));
-        $runtimeRegistrySha256 = trim((string) $this->option('runtime-registry-sha256'));
+        $usePendingGate = (bool) $this->option('use-pending-gate');
+        $pendingGateId = null;
+        if ($usePendingGate) {
+            try {
+                $pendingGate = $this->pendingGateStore->consume(trim((string) $this->option('approval-phrase')));
+            } catch (RuntimeException $e) {
+                $this->components->error($e->getMessage());
+
+                return self::FAILURE;
+            }
+
+            $pendingGateId = $pendingGate['pending_gate_id'];
+            $releaseId = $pendingGate['release_id'];
+            $confirmReleaseId = $pendingGate['confirm_release_id'];
+            $candidateManifestSha256 = $pendingGate['candidate_manifest_sha256'];
+            $runtimeRegistrySha256 = $pendingGate['runtime_registry_sha256'];
+        } else {
+            $releaseId = trim((string) $this->option('release-id'));
+            $confirmReleaseId = trim((string) $this->option('confirm-release-id'));
+            $candidateManifestSha256 = trim((string) $this->option('candidate-manifest-sha256'));
+            $runtimeRegistrySha256 = trim((string) $this->option('runtime-registry-sha256'));
+        }
         $outputDir = trim((string) $this->option('output-dir'));
         if ($outputDir === '') {
             $outputDir = $this->readOutputDirFromEnvironment();
@@ -77,6 +99,11 @@ final class EnneagramActivateInactiveCandidateRelease extends Command
                 $outputDir,
                 trim((string) $this->option('actor')),
             );
+            if ($usePendingGate && $pendingGateId !== null) {
+                $this->pendingGateStore->markActivated($pendingGateId, $releaseId, $summary);
+                $summary['pending_gate_id'] = $pendingGateId;
+                $summary['pending_gate_consumed'] = true;
+            }
         } catch (RuntimeException $e) {
             $this->components->error($e->getMessage());
 

--- a/backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php
+++ b/backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php
@@ -15,6 +15,9 @@ final class EnneagramResultPageProductionManualGateCommand extends Command
         {--run-id=production-manual-gate : Stable run identifier for the artifact directory}
         {--artifact-dir= : Optional artifact root}
         {--contract-path= : Optional runbook contract path}
+        {--evidence-dir= : Evidence report directory required before writing a pending activation gate}
+        {--write-pending-gate : Write the singleton pending production activation gate}
+        {--pending-gate-ttl-minutes=120 : Pending activation gate expiry window in minutes}
         {--release-id= : Exact inactive release id}
         {--confirm-release-id= : Repeat exact inactive release id}
         {--candidate-manifest-sha256= : Exact candidate manifest SHA256}
@@ -39,6 +42,9 @@ final class EnneagramResultPageProductionManualGateCommand extends Command
                 'run_id' => trim((string) $this->option('run-id')),
                 'artifact_dir' => trim((string) $this->option('artifact-dir')),
                 'contract_path' => trim((string) $this->option('contract-path')),
+                'evidence_dir' => trim((string) $this->option('evidence-dir')),
+                'write_pending_gate' => (bool) $this->option('write-pending-gate'),
+                'pending_gate_ttl_minutes' => (int) $this->option('pending-gate-ttl-minutes'),
                 'release_id' => trim((string) $this->option('release-id')),
                 'confirm_release_id' => trim((string) $this->option('confirm-release-id')),
                 'candidate_manifest_sha256' => trim((string) $this->option('candidate-manifest-sha256')),
@@ -73,6 +79,7 @@ final class EnneagramResultPageProductionManualGateCommand extends Command
         $this->line('run_id='.(string) ($summary['run_id'] ?? ''));
         $this->line('release_id='.(string) data_get($summary, 'summary.release_id', ''));
         $this->line('manual_approval_packet_valid='.(((bool) data_get($summary, 'summary.manual_approval_packet_valid', false)) ? 'true' : 'false'));
+        $this->line('pending_gate_written='.(((bool) data_get($summary, 'summary.pending_gate_written', false)) ? 'true' : 'false'));
         $this->line('production_execution_allowed_for_agent='.(((bool) data_get($summary, 'summary.production_execution_allowed_for_agent', true)) ? 'true' : 'false'));
 
         foreach ((array) ($summary['artifacts'] ?? []) as $filename => $artifact) {

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPagePendingProductionGateStore.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPagePendingProductionGateStore.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Enneagram\Assets\Agent;
+
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class EnneagramResultPagePendingProductionGateStore
+{
+    public const SCHEMA_VERSION = 'fap.enneagram.result_page.pending_production_activation_gate.v0.1';
+
+    public const APPROVAL_PHRASE = '我同意';
+
+    public const DEFAULT_TTL_MINUTES = 120;
+
+    public const DEFAULT_RELATIVE_PATH = 'private/content_releases/ENNEAGRAM/v2/pending_production_activation_gate.json';
+
+    private const REQUIRED_GREEN_EVIDENCE_GATES = [
+        'candidate_export_staging_import',
+        'web_rendered_qa',
+        'api_smoke',
+        'rollback_simulation',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $approvalPacket
+     * @return array<string,mixed>
+     */
+    public function write(array $approvalPacket, string $runId, string $evidenceDir, int $ttlMinutes = self::DEFAULT_TTL_MINUTES): array
+    {
+        $ttlMinutes = max(1, $ttlMinutes);
+        $evidence = $this->evidenceInventory($evidenceDir);
+        $errors = array_values(array_unique(array_merge(
+            $this->approvalPacketErrors($approvalPacket),
+            (array) ($evidence['errors'] ?? []),
+        )));
+
+        if ($errors !== []) {
+            throw new RuntimeException('Pending production gate is not valid: '.implode(', ', $errors));
+        }
+
+        $issuedAt = now();
+        $expiresAt = $issuedAt->copy()->addMinutes($ttlMinutes);
+        $releaseId = (string) ($approvalPacket['release_id'] ?? '');
+        $candidateManifestSha256 = (string) ($approvalPacket['candidate_manifest_sha256'] ?? '');
+        $runtimeRegistrySha256 = (string) ($approvalPacket['runtime_registry_sha256'] ?? '');
+        $rollbackWindow = (string) ($approvalPacket['rollback_window'] ?? '');
+        $pendingGateId = hash('sha256', implode('|', [
+            $releaseId,
+            $candidateManifestSha256,
+            $runtimeRegistrySha256,
+            $rollbackWindow,
+            $issuedAt->toIso8601String(),
+        ]));
+
+        $packet = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'status' => 'pending',
+            'pending_gate_id' => $pendingGateId,
+            'single_pending_gate' => true,
+            'approval_phrase' => self::APPROVAL_PHRASE,
+            'run_id' => $runId,
+            'issued_at' => $issuedAt->toIso8601String(),
+            'expires_at' => $expiresAt->toIso8601String(),
+            'ttl_minutes' => $ttlMinutes,
+            'locked_contract' => [
+                'release_id' => $releaseId,
+                'confirm_release_id' => $releaseId,
+                'candidate_manifest_sha256' => $candidateManifestSha256,
+                'runtime_registry_sha256' => $runtimeRegistrySha256,
+                'rollback_window' => $rollbackWindow,
+                'post_activation_smoke_acknowledged' => (bool) ($approvalPacket['post_activation_smoke_acknowledged'] ?? false),
+            ],
+            'evidence_bundle' => $evidence,
+            'authorization_scope' => [
+                'phrase_authorizes_only_this_pending_gate' => true,
+                'permanent_authorization' => false,
+                'agent_may_decide_production_rollout' => false,
+                'chat_may_override_locked_release_or_hashes' => false,
+            ],
+            'negative_guarantees' => [
+                'production_activation_happened' => false,
+                'production_rollback_happened' => false,
+                'runtime_switch_happened' => false,
+                'bulk_content_generation_happened' => false,
+                'frontend_change_happened' => false,
+            ],
+        ];
+
+        $path = $this->path();
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($packet, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'written' => true,
+            'path' => self::DEFAULT_RELATIVE_PATH,
+            'sha256' => hash_file('sha256', $path) ?: '',
+            'pending_gate_id' => $pendingGateId,
+            'expires_at' => $expiresAt->toIso8601String(),
+            'approval_phrase' => self::APPROVAL_PHRASE,
+            'locked_contract' => $packet['locked_contract'],
+        ];
+    }
+
+    /**
+     * @return array{pending_gate_id:string,release_id:string,confirm_release_id:string,candidate_manifest_sha256:string,runtime_registry_sha256:string,rollback_window:string}
+     */
+    public function consume(string $approvalPhrase): array
+    {
+        if ($approvalPhrase !== self::APPROVAL_PHRASE) {
+            throw new RuntimeException('Pending production gate approval phrase mismatch.');
+        }
+
+        $packet = $this->readPendingPacket();
+        $errors = $this->pendingPacketErrors($packet);
+        if ($errors !== []) {
+            throw new RuntimeException('Pending production gate is not executable: '.implode(', ', $errors));
+        }
+
+        $locked = (array) ($packet['locked_contract'] ?? []);
+        $releaseId = (string) ($locked['release_id'] ?? '');
+
+        return [
+            'pending_gate_id' => (string) ($packet['pending_gate_id'] ?? ''),
+            'release_id' => $releaseId,
+            'confirm_release_id' => $releaseId,
+            'candidate_manifest_sha256' => (string) ($locked['candidate_manifest_sha256'] ?? ''),
+            'runtime_registry_sha256' => (string) ($locked['runtime_registry_sha256'] ?? ''),
+            'rollback_window' => (string) ($locked['rollback_window'] ?? ''),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $activationSummary
+     */
+    public function markActivated(string $pendingGateId, string $releaseId, array $activationSummary): void
+    {
+        $packet = $this->readPendingPacket();
+        if (($packet['pending_gate_id'] ?? null) !== $pendingGateId) {
+            throw new RuntimeException('Pending production gate id mismatch after activation.');
+        }
+
+        $locked = (array) ($packet['locked_contract'] ?? []);
+        if (($locked['release_id'] ?? null) !== $releaseId) {
+            throw new RuntimeException('Pending production gate release id mismatch after activation.');
+        }
+
+        $packet['status'] = 'activated';
+        $packet['activated_at'] = now()->toIso8601String();
+        $packet['activation_summary'] = [
+            'verdict' => (string) ($activationSummary['verdict'] ?? ''),
+            'release_id' => (string) ($activationSummary['release_id'] ?? ''),
+            'rollback_target_release_id' => (string) ($activationSummary['rollback_target_release_id'] ?? ''),
+        ];
+        $packet['negative_guarantees']['production_activation_happened'] = true;
+
+        File::put($this->path(), json_encode($packet, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+    }
+
+    public function delete(): void
+    {
+        File::delete($this->path());
+    }
+
+    private function path(): string
+    {
+        return storage_path('app/'.self::DEFAULT_RELATIVE_PATH);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readPendingPacket(): array
+    {
+        $path = $this->path();
+        if (! is_file($path)) {
+            throw new RuntimeException('Pending production gate file not found.');
+        }
+
+        $decoded = json_decode((string) File::get($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Pending production gate file is not valid JSON.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $approvalPacket
+     * @return list<string>
+     */
+    private function approvalPacketErrors(array $approvalPacket): array
+    {
+        $errors = [];
+        if (($approvalPacket['valid'] ?? null) !== true) {
+            $errors[] = 'manual_approval_packet_not_valid';
+        }
+        foreach (['release_id', 'candidate_manifest_sha256', 'runtime_registry_sha256', 'rollback_window'] as $field) {
+            if (trim((string) ($approvalPacket[$field] ?? '')) === '') {
+                $errors[] = 'manual_approval_packet_missing:'.$field;
+            }
+        }
+        if (($approvalPacket['post_activation_smoke_acknowledged'] ?? null) !== true) {
+            $errors[] = 'post_activation_smoke_acknowledgement_missing';
+        }
+        if (($approvalPacket['production_execution_allowed_for_agent'] ?? true) !== false) {
+            $errors[] = 'agent_production_execution_must_remain_false';
+        }
+        if (($approvalPacket['manual_human_approval_required'] ?? null) !== true) {
+            $errors[] = 'manual_human_approval_required_missing';
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @param  array<string,mixed>  $packet
+     * @return list<string>
+     */
+    private function pendingPacketErrors(array $packet): array
+    {
+        $errors = [];
+        if (($packet['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            $errors[] = 'schema_version_mismatch';
+        }
+        if (($packet['status'] ?? null) !== 'pending') {
+            $errors[] = 'pending_gate_not_pending';
+        }
+        if (($packet['single_pending_gate'] ?? null) !== true) {
+            $errors[] = 'single_pending_gate_must_be_true';
+        }
+        if (($packet['approval_phrase'] ?? null) !== self::APPROVAL_PHRASE) {
+            $errors[] = 'approval_phrase_not_locked';
+        }
+        if (strtotime((string) ($packet['expires_at'] ?? '')) <= time()) {
+            $errors[] = 'pending_gate_expired';
+        }
+        $locked = (array) ($packet['locked_contract'] ?? []);
+        if (($locked['release_id'] ?? '') === '' || ($locked['candidate_manifest_sha256'] ?? '') === '' || ($locked['runtime_registry_sha256'] ?? '') === '') {
+            $errors[] = 'locked_contract_incomplete';
+        }
+        if (($locked['confirm_release_id'] ?? null) !== ($locked['release_id'] ?? null)) {
+            $errors[] = 'locked_confirm_release_id_mismatch';
+        }
+        if (($locked['post_activation_smoke_acknowledged'] ?? null) !== true) {
+            $errors[] = 'locked_post_activation_smoke_acknowledgement_missing';
+        }
+        if (($packet['authorization_scope']['phrase_authorizes_only_this_pending_gate'] ?? null) !== true) {
+            $errors[] = 'phrase_scope_not_single_gate';
+        }
+        if (($packet['authorization_scope']['permanent_authorization'] ?? true) !== false) {
+            $errors[] = 'permanent_authorization_must_be_false';
+        }
+        if (($packet['authorization_scope']['agent_may_decide_production_rollout'] ?? true) !== false) {
+            $errors[] = 'agent_rollout_decision_must_be_false';
+        }
+        if (($packet['evidence_bundle']['all_green'] ?? null) !== true) {
+            $errors[] = 'evidence_bundle_not_green';
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function evidenceInventory(string $evidenceDir): array
+    {
+        $evidenceDir = rtrim(trim($evidenceDir), DIRECTORY_SEPARATOR);
+        if ($evidenceDir === '') {
+            return [
+                'provided' => false,
+                'all_green' => false,
+                'gate_status' => [],
+                'reports' => [],
+                'errors' => ['evidence_dir_missing'],
+            ];
+        }
+        if (! is_dir($evidenceDir)) {
+            return [
+                'provided' => true,
+                'relative_path' => $this->redactPath($evidenceDir),
+                'all_green' => false,
+                'gate_status' => [],
+                'reports' => [],
+                'errors' => ['evidence_dir_not_found'],
+            ];
+        }
+
+        $reports = [];
+        $gateStatus = [];
+        $errors = [];
+        foreach (File::glob($evidenceDir.'/*.json') ?: [] as $path) {
+            $payload = $this->readJson($path);
+            $gate = $this->gateName($path, $payload);
+            if ($gate === null) {
+                continue;
+            }
+
+            $passing = $this->isPassingReport($payload);
+            $gateStatus[$gate] = $passing ? 'pass' : 'fail';
+            if (! $passing) {
+                $errors[] = 'evidence_gate_failed:'.$gate;
+            }
+            $reports[] = [
+                'relative_path' => $this->redactPath($path),
+                'sha256' => hash_file('sha256', $path) ?: '',
+                'gate' => $gate,
+                'ok' => $passing,
+            ];
+        }
+
+        foreach (self::REQUIRED_GREEN_EVIDENCE_GATES as $gate) {
+            if (($gateStatus[$gate] ?? null) !== 'pass') {
+                $errors[] = 'evidence_gate_missing_or_not_green:'.$gate;
+            }
+        }
+
+        return [
+            'provided' => true,
+            'relative_path' => $this->redactPath($evidenceDir),
+            'all_green' => $errors === [],
+            'required_green_gates' => self::REQUIRED_GREEN_EVIDENCE_GATES,
+            'gate_status' => $gateStatus,
+            'reports' => $reports,
+            'errors' => array_values(array_unique($errors)),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) File::get($path), true);
+        if (! is_array($decoded)) {
+            return ['ok' => false, 'status' => 'invalid_json'];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function gateName(string $path, array $payload): ?string
+    {
+        $rawGate = strtolower((string) ($payload['gate'] ?? pathinfo($path, PATHINFO_FILENAME)));
+        $filename = strtolower(pathinfo($path, PATHINFO_FILENAME));
+        $source = $rawGate.' '.$filename;
+
+        if (str_contains($source, 'candidate_export_staging_import') || str_contains($source, 'candidate_staging') || str_contains($source, 'staging_import')) {
+            return 'candidate_export_staging_import';
+        }
+        if (str_contains($source, 'web_rendered_qa') || str_contains($source, 'phase8c') || str_contains($source, 'rendered_qa')) {
+            return 'web_rendered_qa';
+        }
+        if (str_contains($source, 'api_smoke')) {
+            return 'api_smoke';
+        }
+        if (str_contains($source, 'rollback_simulation')) {
+            return 'rollback_simulation';
+        }
+
+        return in_array($rawGate, self::REQUIRED_GREEN_EVIDENCE_GATES, true) ? $rawGate : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function isPassingReport(array $payload): bool
+    {
+        if (array_key_exists('ok', $payload)) {
+            return $payload['ok'] === true;
+        }
+
+        $status = strtolower((string) ($payload['status'] ?? ''));
+        if (in_array($status, ['success', 'pass', 'passed'], true)) {
+            return true;
+        }
+
+        $verdict = strtoupper((string) ($payload['verdict'] ?? ''));
+
+        return str_starts_with($verdict, 'PASS');
+    }
+
+    private function redactPath(string $path): string
+    {
+        $base = rtrim(base_path(), DIRECTORY_SEPARATOR);
+        if (str_starts_with($path, $base)) {
+            return 'backend'.substr($path, strlen($base));
+        }
+
+        return basename($path);
+    }
+}

--- a/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php
+++ b/backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php
@@ -21,11 +21,18 @@ final class EnneagramResultPageProductionManualGateRunbook
 
     public const EXPECTED_RUNTIME_REGISTRY_SHA256 = 'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f';
 
+    public function __construct(
+        private readonly EnneagramResultPagePendingProductionGateStore $pendingGateStore,
+    ) {}
+
     /**
      * @param  array{
      *     run_id?:string,
      *     artifact_dir?:string,
      *     contract_path?:string,
+     *     evidence_dir?:string,
+     *     write_pending_gate?:bool,
+     *     pending_gate_ttl_minutes?:int,
      *     release_id?:string,
      *     confirm_release_id?:string,
      *     candidate_manifest_sha256?:string,
@@ -41,6 +48,9 @@ final class EnneagramResultPageProductionManualGateRunbook
         $runId = $this->sanitizeSlug((string) ($options['run_id'] ?? 'production-manual-gate'));
         $artifactDir = $this->artifactDir((string) ($options['artifact_dir'] ?? ''), $runId);
         $contractPath = $this->contractPath((string) ($options['contract_path'] ?? ''));
+        $evidenceDir = trim((string) ($options['evidence_dir'] ?? ''));
+        $writePendingGate = ($options['write_pending_gate'] ?? false) === true;
+        $pendingGateTtlMinutes = (int) ($options['pending_gate_ttl_minutes'] ?? EnneagramResultPagePendingProductionGateStore::DEFAULT_TTL_MINUTES);
         $releaseId = trim((string) ($options['release_id'] ?? ''));
         $confirmReleaseId = trim((string) ($options['confirm_release_id'] ?? ''));
         $candidateManifestSha256 = trim((string) ($options['candidate_manifest_sha256'] ?? ''));
@@ -68,6 +78,25 @@ final class EnneagramResultPageProductionManualGateRunbook
             $contractErrors,
             $strict ? (array) ($approvalPacket['errors'] ?? []) : [],
         )));
+        $pendingGate = [
+            'requested' => $writePendingGate,
+            'written' => false,
+            'approval_phrase' => EnneagramResultPagePendingProductionGateStore::APPROVAL_PHRASE,
+            'ttl_minutes' => $pendingGateTtlMinutes,
+        ];
+        if ($writePendingGate) {
+            try {
+                $pendingGate = array_merge($pendingGate, $this->pendingGateStore->write(
+                    $approvalPacket,
+                    $runId,
+                    $evidenceDir,
+                    $pendingGateTtlMinutes,
+                ));
+            } catch (RuntimeException $exception) {
+                $errors[] = $exception->getMessage();
+                $pendingGate['error'] = $exception->getMessage();
+            }
+        }
 
         $report = [
             'schema_version' => self::SCHEMA_VERSION,
@@ -80,6 +109,7 @@ final class EnneagramResultPageProductionManualGateRunbook
                 'errors' => $contractErrors,
             ],
             'manual_approval_packet' => $approvalPacket,
+            'pending_production_activation_gate' => $pendingGate,
             'rollback_window' => $rollbackWindowPlan,
             'post_activation_smoke_plan' => $postActivationSmokePlan,
             'negative_guarantees' => $this->negativeGuarantees(),
@@ -111,6 +141,9 @@ final class EnneagramResultPageProductionManualGateRunbook
                 'production_manual_gate_required' => true,
                 'post_activation_smoke_plan_ready' => true,
                 'rollback_window_recorded' => $rollbackWindow !== '',
+                'pending_gate_written' => (bool) ($pendingGate['written'] ?? false),
+                'pending_gate_expires_at' => $pendingGate['expires_at'] ?? null,
+                'approval_phrase_required' => EnneagramResultPagePendingProductionGateStore::APPROVAL_PHRASE,
             ],
             'errors' => $errors,
             'negative_guarantees' => $this->negativeGuarantees(),

--- a/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramRegistryActivationCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console;
 
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPagePendingProductionGateStore;
 use App\Services\Enneagram\Assets\EnneagramInactiveCandidateReleaseImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -85,6 +86,45 @@ final class EnneagramRegistryActivationCommandTest extends TestCase
         $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')->where('pack_id', 'ENNEAGRAM')->where('pack_version', 'v2')->value('release_id'));
     }
 
+    public function test_inactive_candidate_activation_command_can_consume_pending_gate_with_simple_approval_phrase(): void
+    {
+        $fixture = $this->importInactiveFixture('inactive_candidate_activation_command_pending_gate');
+        $pendingGate = $this->writePendingGateForFixture($fixture, 'activation-pending-gate');
+        $outputDir = $fixture['output_dir'].'/inactive_candidate_activate_pending_gate';
+
+        $this->artisan('enneagram:activate-inactive-candidate-release', [
+            '--use-pending-gate' => true,
+            '--approval-phrase' => EnneagramResultPagePendingProductionGateStore::APPROVAL_PHRASE,
+            '--output-dir' => $outputDir,
+            '--actor' => 'activation_pending_gate_test',
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $summary = json_decode((string) File::get($outputDir.'/phase8d3_activation_summary.json'), true);
+        $this->assertSame('PASS_PRODUCTION_ACTIVATION_COMPLETED', $summary['verdict'] ?? null);
+        $this->assertTrue($summary['production_activation_happened'] ?? false);
+        $this->assertSame($fixture['release_id'], DB::table('content_pack_activations')->where('pack_id', 'ENNEAGRAM')->where('pack_version', 'v2')->value('release_id'));
+
+        $packet = json_decode((string) File::get(storage_path('app/'.EnneagramResultPagePendingProductionGateStore::DEFAULT_RELATIVE_PATH)), true);
+        $this->assertSame($pendingGate['pending_gate_id'], $packet['pending_gate_id'] ?? null);
+        $this->assertSame('activated', $packet['status'] ?? null);
+    }
+
+    public function test_inactive_candidate_activation_command_rejects_pending_gate_without_exact_approval_phrase(): void
+    {
+        $fixture = $this->importInactiveFixture('inactive_candidate_activation_command_pending_gate_bad_phrase');
+        $this->writePendingGateForFixture($fixture, 'activation-pending-gate-bad-phrase');
+
+        $this->artisan('enneagram:activate-inactive-candidate-release', [
+            '--use-pending-gate' => true,
+            '--approval-phrase' => '同意',
+            '--output-dir' => $fixture['output_dir'].'/inactive_candidate_activate_pending_gate_bad_phrase',
+            '--json' => true,
+        ])->assertExitCode(1);
+
+        $this->assertFalse(DB::table('content_pack_activations')->exists());
+    }
+
     public function test_inactive_candidate_activation_command_fails_closed_on_hash_mismatch(): void
     {
         $fixture = $this->importInactiveFixture('inactive_candidate_activation_command_hash_mismatch');
@@ -124,6 +164,35 @@ final class EnneagramRegistryActivationCommandTest extends TestCase
             'output_dir' => $outputDir,
             'contracts' => $contracts,
         ];
+    }
+
+    /**
+     * @param  array{release_id:string,output_dir:string,contracts:array{candidate_manifest_sha256:string,runtime_registry_manifest_sha256:string}}  $fixture
+     * @return array<string,mixed>
+     */
+    private function writePendingGateForFixture(array $fixture, string $runId): array
+    {
+        $evidenceDir = storage_path('framework/testing/enneagram_activation_command/'.$runId.'/evidence');
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        foreach (['candidate_export_staging_import', 'web_rendered_qa', 'api_smoke', 'rollback_simulation'] as $gate) {
+            File::put($evidenceDir.'/'.$gate.'.json', json_encode(['gate' => $gate, 'ok' => true], JSON_PRETTY_PRINT));
+        }
+
+        $store = app(EnneagramResultPagePendingProductionGateStore::class);
+        $store->delete();
+
+        return $store->write([
+            'valid' => true,
+            'release_id' => $fixture['release_id'],
+            'confirm_release_id' => $fixture['release_id'],
+            'candidate_manifest_sha256' => $fixture['contracts']['candidate_manifest_sha256'],
+            'runtime_registry_sha256' => $fixture['contracts']['runtime_registry_manifest_sha256'],
+            'rollback_window' => '60 minutes after activation',
+            'post_activation_smoke_acknowledged' => true,
+            'production_execution_allowed_for_agent' => false,
+            'manual_human_approval_required' => true,
+        ], $runId, $evidenceDir, 120);
     }
 
     /**

--- a/backend/tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php
+++ b/backend/tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console;
 
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPagePendingProductionGateStore;
 use App\Services\Enneagram\Assets\Agent\EnneagramResultPageProductionManualGateRunbook;
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 final class EnneagramResultPageProductionManualGateCommandTest extends TestCase
@@ -24,5 +26,36 @@ final class EnneagramResultPageProductionManualGateCommandTest extends TestCase
             '--strict' => true,
             '--json' => true,
         ])->assertExitCode(0);
+    }
+
+    public function test_production_manual_gate_command_can_write_pending_gate_from_green_evidence_bundle(): void
+    {
+        $evidenceDir = sys_get_temp_dir().'/enneagram-production-manual-gate-command-evidence';
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        app(EnneagramResultPagePendingProductionGateStore::class)->delete();
+
+        foreach (['candidate_export_staging_import', 'web_rendered_qa', 'api_smoke', 'rollback_simulation'] as $gate) {
+            File::put($evidenceDir.'/'.$gate.'.json', json_encode(['gate' => $gate, 'ok' => true], JSON_PRETTY_PRINT));
+        }
+
+        $this->artisan('enneagram:result-page-production-manual-gate', [
+            'action' => 'audit',
+            '--run-id' => 'command-manual-pending-gate',
+            '--artifact-dir' => sys_get_temp_dir().'/enneagram-production-manual-gate-command-pending',
+            '--evidence-dir' => $evidenceDir,
+            '--write-pending-gate' => true,
+            '--pending-gate-ttl-minutes' => 120,
+            '--release-id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            '--confirm-release-id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            '--candidate-manifest-sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            '--runtime-registry-sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            '--rollback-window' => '60 minutes after activation',
+            '--post-activation-smoke-acknowledged' => true,
+            '--strict' => true,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $this->assertFileExists(storage_path('app/'.EnneagramResultPagePendingProductionGateStore::DEFAULT_RELATIVE_PATH));
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3083,6 +3083,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php',
             'backend/app/Console/Kernel.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPagePendingProductionGateStore.php',
             'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php',
             'backend/content_assets/enneagram/result_page/production_manual_gate/README.md',
             'backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json',
@@ -7197,6 +7198,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php',
+            'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPagePendingProductionGateStore.php',
             'backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php',
             'backend/content_assets/enneagram/result_page/production_manual_gate/README.md',
             'backend/content_assets/enneagram/result_page/production_manual_gate/production_manual_gate_contract_v0_1.json',

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Enneagram\Assets;
 
+use App\Services\Enneagram\Assets\Agent\EnneagramResultPagePendingProductionGateStore;
 use App\Services\Enneagram\Assets\Agent\EnneagramResultPageProductionManualGateRunbook;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -36,6 +37,72 @@ final class EnneagramResultPageProductionManualGateRunbookTest extends TestCase
         $packet = $this->readJson($artifactRoot.'/manual-pass/manual_approval_packet.json');
         $this->assertFalse((bool) data_get($packet, 'production_execution_allowed_for_agent', true));
         $this->assertTrue((bool) data_get($packet, 'manual_human_approval_required', false));
+    }
+
+    public function test_manual_gate_writes_single_pending_gate_from_green_evidence_bundle(): void
+    {
+        $artifactRoot = storage_path('framework/testing/production_manual_gate_artifacts/pending_gate');
+        $evidenceDir = storage_path('framework/testing/production_manual_gate_evidence/pass');
+        File::deleteDirectory($artifactRoot);
+        File::deleteDirectory($evidenceDir);
+        File::ensureDirectoryExists($evidenceDir);
+        app(EnneagramResultPagePendingProductionGateStore::class)->delete();
+
+        foreach (['candidate_export_staging_import', 'web_rendered_qa', 'api_smoke', 'rollback_simulation'] as $gate) {
+            File::put($evidenceDir.'/'.$gate.'.json', json_encode(['gate' => $gate, 'ok' => true], JSON_PRETTY_PRINT));
+        }
+
+        $summary = app(EnneagramResultPageProductionManualGateRunbook::class)->run([
+            'run_id' => 'manual-pending-gate',
+            'artifact_dir' => $artifactRoot,
+            'evidence_dir' => $evidenceDir,
+            'write_pending_gate' => true,
+            'pending_gate_ttl_minutes' => 120,
+            'release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'confirm_release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'candidate_manifest_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => '60 minutes after activation',
+            'post_activation_smoke_acknowledged' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertTrue((bool) data_get($summary, 'summary.pending_gate_written', false));
+        $this->assertSame(EnneagramResultPagePendingProductionGateStore::APPROVAL_PHRASE, data_get($summary, 'summary.approval_phrase_required'));
+
+        $packet = $this->readJson(storage_path('app/'.EnneagramResultPagePendingProductionGateStore::DEFAULT_RELATIVE_PATH));
+        $this->assertSame('pending', $packet['status'] ?? null);
+        $this->assertTrue((bool) ($packet['single_pending_gate'] ?? false));
+        $this->assertSame('我同意', $packet['approval_phrase'] ?? null);
+        $this->assertSame(EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID, data_get($packet, 'locked_contract.release_id'));
+        $this->assertTrue((bool) data_get($packet, 'authorization_scope.phrase_authorizes_only_this_pending_gate', false));
+        $this->assertFalse((bool) data_get($packet, 'authorization_scope.permanent_authorization', true));
+        $this->assertFalse((bool) data_get($packet, 'authorization_scope.agent_may_decide_production_rollout', true));
+    }
+
+    public function test_manual_gate_refuses_pending_gate_without_green_evidence_bundle(): void
+    {
+        $artifactRoot = storage_path('framework/testing/production_manual_gate_artifacts/pending_gate_missing_evidence');
+        File::deleteDirectory($artifactRoot);
+        app(EnneagramResultPagePendingProductionGateStore::class)->delete();
+
+        $summary = app(EnneagramResultPageProductionManualGateRunbook::class)->run([
+            'run_id' => 'manual-pending-gate-no-evidence',
+            'artifact_dir' => $artifactRoot,
+            'write_pending_gate' => true,
+            'release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'confirm_release_id' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RELEASE_ID,
+            'candidate_manifest_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_CANDIDATE_MANIFEST_SHA256,
+            'runtime_registry_sha256' => EnneagramResultPageProductionManualGateRunbook::EXPECTED_RUNTIME_REGISTRY_SHA256,
+            'rollback_window' => '60 minutes after activation',
+            'post_activation_smoke_acknowledged' => true,
+            'strict' => true,
+        ]);
+
+        $this->assertFalse((bool) ($summary['ok'] ?? true));
+        $this->assertStringContainsString('evidence_dir_missing', implode("\n", $summary['errors'] ?? []));
+        $this->assertFileDoesNotExist(storage_path('app/'.EnneagramResultPagePendingProductionGateStore::DEFAULT_RELATIVE_PATH));
     }
 
     public function test_manual_gate_fails_closed_on_release_mismatch(): void


### PR DESCRIPTION
## Summary
- Adds a singleton pending Enneagram production activation gate store with a 2-hour default TTL.
- Lets the production manual gate command write a pending gate only after exact packet validation plus green evidence reports.
- Lets the activation command consume that pending gate with the simple phrase `我同意`, while release id, candidate hash, runtime hash, and rollback window remain locked by the stored packet.
- Adds the narrow BigFive runtime-freeze allowlist entry for this Enneagram pending-gate scaffold.

## Why
This keeps production rollout manual, but removes the need for a solo operator to repeat long hashes in chat. The agent still cannot decide production rollout: it can only execute after a valid pending gate exists and the human phrase authorizes that current gate.

## Validation
- `php -l` on changed command/service/test files
- `./vendor/bin/pint --test app/Services/Enneagram/Assets/Agent/EnneagramResultPagePendingProductionGateStore.php app/Services/Enneagram/Assets/Agent/EnneagramResultPageProductionManualGateRunbook.php app/Console/Commands/EnneagramResultPageProductionManualGateCommand.php app/Console/Commands/EnneagramActivateInactiveCandidateRelease.php tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php tests/Feature/Console/EnneagramRegistryActivationCommandTest.php`
- `./vendor/bin/pint --test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php tests/Feature/Console/EnneagramResultPageProductionManualGateCommandTest.php tests/Feature/Console/EnneagramRegistryActivationCommandTest.php --no-ansi`
- `php artisan test --filter "BigFiveResultPageV2CoreBodyPreviewTest|EnneagramResultPageProductionManualGate|EnneagramRegistryActivation" --no-ansi`
- `php artisan route:list --no-ansi`
- `git diff --check`

`php artisan migrate --pretend --no-ansi` was attempted but blocked by the local temp worktree `.env` MySQL connection (`Access denied for user root@localhost`). No migrations are changed in this PR.

## Intentionally deferred
- No production activation.
- No production import.
- No runtime switch.
- No candidate payload generation.
- No frontend changes.