### PR TITLE
ci: retry only fap-api deploy SSH transport failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -367,11 +367,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -404,11 +408,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -507,11 +515,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -541,11 +553,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -584,11 +600,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -647,11 +667,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }
@@ -760,11 +784,15 @@ jobs:
                 return 0
               fi
 
+              if [ "$rc" -ne 255 ]; then
+                return "$rc"
+              fi
+
               if [ "$attempt" -ge "$max_attempts" ]; then
                 return "$rc"
               fi
 
-              echo "SSH attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
+              echo "SSH transport attempt ${attempt}/${max_attempts} failed with exit ${rc}; retrying in ${retry_delay}s" >&2
               sleep "$retry_delay"
             done
           }


### PR DESCRIPTION
## Summary
- keep deploy SSH retry bounded to transport-level failures only
- return remote command failures immediately so existing health/ops retry loops keep their original behavior
- avoid multiplying HTTP/application smoke retries inside SSH retry wrappers

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "workflow_yaml_ok"'`\n- `git diff --check -- .github/workflows/deploy.yml`\n\n## Scope\n- workflow-only hardening follow-up\n- no application code changes\n- no deploy target changes\n- no runtime, SEO, CMS, content, staging data, or production import changes