### PR TITLE
PRODUCTION-AUTO-DEPLOY-POLICY-GUARD-01

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   TARGET: production
@@ -24,12 +25,123 @@ env:
   SSH_RETRY_DELAY_SECONDS: "10"
 
 jobs:
-  deploy-production:
-    name: Deploy fap-api production
+  policy-guard:
+    name: Production auto-deploy policy guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
+    outputs:
+      auto_deploy_allowed: ${{ steps.evaluate.outputs.auto_deploy_allowed }}
+      deploy_sha: ${{ steps.evaluate.outputs.deploy_sha }}
+      associated_pr: ${{ steps.evaluate.outputs.associated_pr }}
+    steps:
+      - name: Evaluate production auto-deploy policy
+        id: evaluate
+        uses: actions/github-script@v8
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const deploySha = process.env.WORKFLOW_RUN_HEAD_SHA;
+
+            if (!deploySha) {
+              core.setFailed('Production auto-deploy policy failed closed: deploy SHA is empty.');
+              return;
+            }
+
+            core.setOutput('deploy_sha', deploySha);
+
+            const { owner, repo } = context.repo;
+            const associatedPulls = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              { owner, repo, commit_sha: deploySha, per_page: 100 },
+            );
+            const mergedMainPulls = associatedPulls
+              .filter((pull) => pull.base?.ref === 'main' && pull.merged_at)
+              .sort((left, right) => new Date(right.merged_at) - new Date(left.merged_at));
+
+            if (mergedMainPulls.length !== 1) {
+              core.setFailed(
+                `Production auto-deploy policy failed closed: expected exactly one merged main PR for ${deploySha}, found ${mergedMainPulls.length}.`,
+              );
+              return;
+            }
+
+            const pull = mergedMainPulls[0];
+            core.setOutput('associated_pr', String(pull.number));
+            core.info(`Associated PR: #${pull.number} ${pull.title}`);
+
+            const labels = (pull.labels || []).map((label) => String(label.name || '').toLowerCase());
+            const riskyLabelPatterns = [
+              /(^|[-_: ])no[-_: ]?auto[-_: ]?production($|[-_: ])/,
+              /(^|[-_: ])manual[-_: ]?production($|[-_: ])/,
+              /(^|[-_: ])production[-_: ]?manual($|[-_: ])/,
+              /(^|[-_: ])requires[-_: ]?production[-_: ]?approval($|[-_: ])/,
+              /(^|[-_: ])cms($|[-_: ])/,
+              /(^|[-_: ])content($|[-_: ])/,
+              /(^|[-_: ])search($|[-_: ])/,
+              /(^|[-_: ])seo($|[-_: ])/,
+              /(^|[-_: ])sitemap($|[-_: ])/,
+              /(^|[-_: ])llms($|[-_: ])/,
+              /(^|[-_: ])database($|[-_: ])/,
+              /(^|[-_: ])migration(s)?($|[-_: ])/,
+              /(^|[-_: ])queue($|[-_: ])/,
+              /(^|[-_: ])deploy($|[-_: ])/,
+              /(^|[-_: ])secret(s)?($|[-_: ])/,
+            ];
+            const riskyLabels = labels.filter((label) => riskyLabelPatterns.some((pattern) => pattern.test(label)));
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pull.number, per_page: 100 },
+            );
+            const riskyPathPatterns = [
+              /^\.github\/workflows\//,
+              /^\.github\/actions\//,
+              /^deploy\.php$/,
+              /^backend\/scripts\/deploy\//,
+              /^backend\/scripts\/.*(deploy|release|import|publish|search|sitemap|llms|queue)/i,
+              /^backend\/database\//,
+              /^backend\/config\//,
+              /^backend\/content_assets\//,
+              /^content_packages\//,
+              /^backend\/docs\/seo\//,
+              /^backend\/docs\/search\//,
+              /^backend\/app\/Console\/Commands\/.*(Cms|CMS|Search|Seo|SEO|Sitemap|Llms|LLMS|Queue|Import|Publish|Promote)/,
+              /^backend\/app\/Services\/Cms\//,
+              /^backend\/app\/Services\/SeoIntel\//,
+              /^backend\/app\/Services\/Search\//,
+              /^backend\/app\/Services\/Sitemap\//,
+              /^backend\/app\/Services\/Llms\//,
+              /^backend\/app\/Services\/ContentRelease\//,
+              /(^|\/)\.env($|\.|-)/,
+              /(^|\/).*secret.*$/i,
+            ];
+            const riskyFiles = files
+              .map((file) => file.filename)
+              .filter((filename) => riskyPathPatterns.some((pattern) => pattern.test(filename)));
+
+            if (riskyLabels.length > 0 || riskyFiles.length > 0) {
+              core.setOutput('auto_deploy_allowed', 'false');
+              core.setFailed([
+                'Production auto-deploy policy failed closed.',
+                riskyLabels.length > 0 ? `Risk labels: ${riskyLabels.join(', ')}` : 'Risk labels: none',
+                riskyFiles.length > 0 ? `Risk files: ${riskyFiles.join(', ')}` : 'Risk files: none',
+                'Use the manual deploy-readiness path for this change.',
+              ].join('\n'));
+              return;
+            }
+
+            core.setOutput('auto_deploy_allowed', 'true');
+            core.info('Production auto-deploy policy passed for ordinary backend runtime change.');
+
+  deploy-production:
+    name: Deploy fap-api production
+    needs: policy-guard
+    if: ${{ needs.policy-guard.outputs.auto_deploy_allowed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -42,7 +154,7 @@ jobs:
       - name: Checkout deploy revision
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ needs.policy-guard.outputs.deploy_sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -53,7 +165,7 @@ jobs:
       - name: Confirm approved revision is still latest main
         shell: bash
         env:
-          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_SHA: ${{ needs.policy-guard.outputs.deploy_sha }}
         run: |
           set -euo pipefail
           git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
@@ -174,7 +286,7 @@ jobs:
         shell: bash
         env:
           DEPLOYER_NO_INTERACTION: "1"
-          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_SHA: ${{ needs.policy-guard.outputs.deploy_sha }}
         run: |
           set -euo pipefail
           DEPLOY_LOCK_METADATA="$(php -r '
@@ -226,7 +338,7 @@ jobs:
       - name: Verify deployed revision
         shell: bash
         env:
-          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_SHA: ${{ needs.policy-guard.outputs.deploy_sha }}
         run: |
           set -euo pipefail
           ssh_retry() {


### PR DESCRIPTION
## What changed
- Added a pre-deploy `policy-guard` job to the fap-api production deploy workflow.
- The guard reads the merged PR associated with the staging deploy SHA and checks labels plus changed files before the production deploy job can start.
- The production deploy job now depends on the guard and deploys exactly the SHA approved by the guard.

## Why
- Keeps backend production auto-deploy available for ordinary runtime changes after staging success.
- Fails closed for higher-risk changes that must continue through manual deploy-readiness or explicit operator approval.

## Guard behavior
Fail closed when the associated PR has risky labels or files touching workflow/actions, deploy scripts, database/config, CMS/content assets, content packages, SEO/search/sitemap/llms paths, queue/import/publish/promote commands, env/secret-looking files, or related release paths.

This PR itself changes `.github/workflows/deploy-production.yml`, so the first production workflow run after merge is expected to fail closed rather than auto-deploy itself.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-production.yml"); puts "yaml_ok"'`
- `git diff --check`
- Scope validation: only `.github/workflows/**` changed.

Note: `actionlint` is not available locally in this worktree.

## Intentionally deferred
- GitHub `production` Environment reviewer/branch protection settings remain repository settings.
- No production deploy is executed by this PR.

## Repository rule impact
- Workflow-only runtime deploy policy guard.
- No Laravel runtime code changes.
- No CMS import/write/publish/promotion.
- No sitemap/llms mutation.
- No Search Queue enqueue/approve/submit.
- No IndexNow/Baidu/GSC external submission.
