### PR TITLE
SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php
@@ -1,0 +1,496 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-article-draft-preview-runtime-qa.v1';
+
+    private const WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const WRITER_TASK = 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:article-draft-preview-runtime-qa
+        {--write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--target= : Exact target subject ref, e.g. article:41:en}
+        {--revision-id= : Exact ArticleRevision id to verify as draft preview}
+        {--artifact-dir= : Directory for sanitized preview/runtime QA evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only SEO Agent article draft preview/runtime QA; verifies draft preview identity without changing public runtime state.';
+
+    public function handle(): int
+    {
+        $writeEvidencePath = $this->readablePath((string) $this->option('write-evidence'));
+        $target = trim((string) $this->option('target'));
+        $revisionId = filter_var($this->option('revision-id'), FILTER_VALIDATE_INT);
+
+        if ($writeEvidencePath === null) {
+            return $this->finish($this->failureSummary('write_evidence_unreadable'));
+        }
+        if ($target === '' || str_contains($target, "\0")) {
+            return $this->finish($this->failureSummary('target_invalid'));
+        }
+        if (! is_int($revisionId) || $revisionId <= 0) {
+            return $this->finish($this->failureSummary('revision_id_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $writeRaw = (string) file_get_contents($writeEvidencePath);
+        $forbidden = $this->forbiddenStringsPresent($writeRaw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $writeEvidence = json_decode($writeRaw, true);
+        if (! is_array($writeEvidence)) {
+            return $this->finish($this->failureSummary('write_evidence_json_invalid'));
+        }
+
+        $writeIssue = $this->validateWriteEvidence($writeEvidence);
+        if ($writeIssue !== null) {
+            return $this->finish($this->failureSummary($writeIssue));
+        }
+
+        $writeRef = $this->writeRefForTarget($writeEvidence, $target);
+        if ($writeRef === null) {
+            return $this->finish($this->failureSummary('target_not_found_in_write_evidence', [
+                'target' => $target,
+            ]));
+        }
+        if ((string) ($writeRef['target_model'] ?? '') !== 'article') {
+            return $this->finish($this->failureSummary('target_model_not_supported_for_preview_runtime_qa', [
+                'target' => $target,
+            ]));
+        }
+        if ((int) ($writeRef['revision_id'] ?? 0) !== $revisionId) {
+            return $this->finish($this->failureSummary('revision_id_write_evidence_mismatch', [
+                'target' => $target,
+                'revision_id' => $revisionId,
+                'write_evidence_revision_id' => isset($writeRef['revision_id']) ? (int) $writeRef['revision_id'] : null,
+            ]));
+        }
+
+        $articleId = $this->idFromSubjectRef($target, 'article');
+        $article = Article::query()->withoutGlobalScopes()->find($articleId);
+        if (! $article instanceof Article) {
+            return $this->finish($this->failureSummary('article_not_found', [
+                'target' => $target,
+            ]));
+        }
+
+        $beforeState = $this->articleState($article);
+        $revision = ArticleRevision::query()->withoutGlobalScopes()
+            ->where('article_id', $articleId)
+            ->whereKey($revisionId)
+            ->first();
+        if (! $revision instanceof ArticleRevision) {
+            return $this->finish($this->failureSummary('draft_revision_not_found', [
+                'target' => $target,
+                'revision_id' => $revisionId,
+            ]));
+        }
+
+        $publishedRevision = null;
+        if ($article->published_revision_id !== null) {
+            $publishedRevision = ArticleRevision::query()->withoutGlobalScopes()
+                ->where('article_id', $articleId)
+                ->whereKey((int) $article->published_revision_id)
+                ->first();
+        }
+
+        $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
+        $evidence = $this->evidence($writeEvidencePath, $writeEvidence, $writeRef, $article, $revision, $publishedRevision, $payload, $target, $beforeState);
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-article-draft-preview-runtime-qa-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) ($evidence['ok'] ?? false),
+            'status' => (string) ($evidence['status'] ?? 'unknown'),
+            'target' => $target,
+            'revision_id' => $revisionId,
+            'artifact' => $artifactRef,
+            'preview_readable' => (bool) data_get($evidence, 'preview_read.preview_readable', false),
+            'public_runtime_uses_published_revision' => (bool) data_get($evidence, 'public_runtime.public_runtime_uses_published_revision', false),
+            'mutation_detected' => (bool) data_get($evidence, 'read_only_invariants.mutation_detected', true),
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     */
+    private function validateWriteEvidence(array $writeEvidence): ?string
+    {
+        if (($writeEvidence['schema_version'] ?? null) !== self::WRITE_SCHEMA_VERSION) {
+            return 'write_evidence_schema_invalid';
+        }
+        if (($writeEvidence['status'] ?? null) !== 'success') {
+            return 'write_evidence_not_success';
+        }
+        if ((bool) ($writeEvidence['execute'] ?? false) !== true || (bool) ($writeEvidence['writes_attempted'] ?? false) !== true) {
+            return 'write_evidence_not_execute';
+        }
+        if ((string) ($writeEvidence['package_sha256'] ?? '') === '') {
+            return 'write_evidence_package_sha256_missing';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     * @return array<string, mixed>|null
+     */
+    private function writeRefForTarget(array $writeEvidence, string $target): ?array
+    {
+        foreach ((array) ($writeEvidence['affected_refs'] ?? []) as $ref) {
+            if (is_array($ref) && (string) ($ref['subject_ref'] ?? '') === $target) {
+                return $ref;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     * @param  array<string, mixed>  $writeRef
+     * @param  array<string, mixed>|null  $publishedRevision
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $beforeState
+     * @return array<string, mixed>
+     */
+    private function evidence(
+        string $writeEvidencePath,
+        array $writeEvidence,
+        array $writeRef,
+        Article $article,
+        ArticleRevision $revision,
+        ?ArticleRevision $publishedRevision,
+        array $payload,
+        string $target,
+        array $beforeState
+    ): array {
+        $article->refresh();
+        $afterState = $this->articleState($article);
+        $findings = $this->qaFindings($writeEvidence, $article, $revision, $publishedRevision, $payload, $target, $beforeState, $afterState);
+        $criticalCount = count(array_filter($findings, static fn (array $finding): bool => ($finding['severity'] ?? '') === 'critical'));
+        $status = $criticalCount > 0 ? 'blocked' : 'success';
+
+        $isPublishedRevision = (int) ($article->published_revision_id ?? 0) === (int) $revision->id;
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => $criticalCount === 0,
+            'status' => $status,
+            'target' => $target,
+            'write_evidence' => $this->artifactRef($writeEvidencePath, self::WRITE_SCHEMA_VERSION),
+            'package_sha256' => (string) ($writeEvidence['package_sha256'] ?? ''),
+            'write_summary' => [
+                'target_write_ref' => [
+                    'status' => (string) ($writeRef['status'] ?? ''),
+                    'target_model' => (string) ($writeRef['target_model'] ?? ''),
+                    'subject_ref' => (string) ($writeRef['subject_ref'] ?? ''),
+                    'revision_id' => isset($writeRef['revision_id']) ? (int) $writeRef['revision_id'] : null,
+                ],
+            ],
+            'preview_read' => [
+                'preview_readable' => ! $isPublishedRevision && (int) $revision->article_id === (int) $article->id,
+                'mode' => 'draft_revision_locked_read',
+                'target_model' => 'article_revision',
+                'revision_id' => (int) $revision->id,
+                'revision_no' => (int) $revision->revision_no,
+                'article_id' => (int) $revision->article_id,
+                'is_published_revision' => $isPublishedRevision,
+                'is_working_revision' => (int) ($article->working_revision_id ?? 0) === (int) $revision->id,
+                'payload_identity' => [
+                    'writer_task' => (string) data_get($payload, 'seo_agent.task', ''),
+                    'subject_ref' => (string) data_get($payload, 'seo_agent.subject_ref', ''),
+                    'package_sha256' => (string) data_get($payload, 'seo_agent.package_sha256', ''),
+                    'publish_allowed' => data_get($payload, 'seo_agent.publish_allowed'),
+                    'search_submit_allowed' => data_get($payload, 'seo_agent.search_submit_allowed'),
+                    'indexing_request_allowed' => data_get($payload, 'seo_agent.indexing_request_allowed'),
+                ],
+            ],
+            'public_runtime' => [
+                'article_id' => (int) $article->id,
+                'status' => (string) $article->status,
+                'is_public' => (bool) $article->is_public,
+                'is_indexable' => (bool) $article->is_indexable,
+                'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+                'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+                'published_revision_exists' => $publishedRevision instanceof ArticleRevision,
+                'public_runtime_uses_published_revision' => $publishedRevision instanceof ArticleRevision
+                    && ! $isPublishedRevision
+                    && (string) $article->status === 'published',
+                'draft_revision_leaked_to_public_runtime' => $isPublishedRevision,
+            ],
+            'read_only_invariants' => [
+                'before_article_state' => $beforeState,
+                'after_article_state' => $afterState,
+                'article_state_unchanged_by_this_read' => $beforeState === $afterState,
+                'mutation_detected' => $beforeState !== $afterState,
+                'article_revision_count_for_article' => ArticleRevision::query()->withoutGlobalScopes()
+                    ->where('article_id', (int) $article->id)
+                    ->count(),
+            ],
+            'qa_findings' => $findings,
+            'critical_finding_count' => $criticalCount,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     * @param  array<string, mixed>|null  $publishedRevision
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $beforeState
+     * @param  array<string, mixed>  $afterState
+     * @return list<array<string, string>>
+     */
+    private function qaFindings(
+        array $writeEvidence,
+        Article $article,
+        ArticleRevision $revision,
+        ?ArticleRevision $publishedRevision,
+        array $payload,
+        string $target,
+        array $beforeState,
+        array $afterState
+    ): array {
+        $findings = [];
+        if ((string) $article->status !== 'published') {
+            $findings[] = $this->finding('public_runtime', 'critical', 'article_not_published');
+        }
+        if (! $publishedRevision instanceof ArticleRevision) {
+            $findings[] = $this->finding('public_runtime', 'critical', 'published_revision_missing');
+        }
+        if ((int) ($article->published_revision_id ?? 0) === (int) $revision->id) {
+            $findings[] = $this->finding('public_runtime', 'critical', 'draft_revision_is_public_published_revision');
+        }
+        if ($beforeState !== $afterState) {
+            $findings[] = $this->finding('read_only', 'critical', 'article_state_mutated_by_preview_runtime_qa');
+        }
+        if (data_get($payload, 'seo_agent.task') !== self::WRITER_TASK) {
+            $findings[] = $this->finding('preview_read', 'critical', 'revision_writer_task_invalid');
+        }
+        if (data_get($payload, 'seo_agent.subject_ref') !== $target) {
+            $findings[] = $this->finding('preview_read', 'critical', 'revision_subject_ref_mismatch');
+        }
+        if (data_get($payload, 'seo_agent.package_sha256') !== (string) ($writeEvidence['package_sha256'] ?? '')) {
+            $findings[] = $this->finding('preview_read', 'critical', 'revision_package_sha256_mismatch');
+        }
+        foreach ([
+            'publish_allowed' => 'publish_allowed_not_false',
+            'search_submit_allowed' => 'search_submit_allowed_not_false',
+            'indexing_request_allowed' => 'indexing_request_allowed_not_false',
+        ] as $payloadKey => $issue) {
+            if (data_get($payload, 'seo_agent.'.$payloadKey) !== false) {
+                $findings[] = $this->finding('preview_read', 'critical', $issue);
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articleState(Article $article): array
+    {
+        return [
+            'id' => (int) $article->id,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+            'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+            'updated_at' => optional($article->updated_at)->toISOString(),
+        ];
+    }
+
+    private function idFromSubjectRef(string $subjectRef, string $expectedType): int
+    {
+        $parts = explode(':', $subjectRef);
+        if (count($parts) < 3 || $parts[0] !== $expectedType || ! ctype_digit($parts[1])) {
+            return 0;
+        }
+
+        return (int) $parts[1];
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/article-draft-preview-runtime-qa');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'schema_version' => $schemaVersion,
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, string $filename, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode preview/runtime QA artifact.');
+        }
+        file_put_contents($path, $encoded."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'published_revision_mutation' => false,
+            'live_published_content_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'production_env_change' => false,
+            'external_model_api_call' => false,
+            'live_gsc_api_call' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function finding(string $surface, string $severity, string $issue): array
+    {
+        return [
+            'surface' => $surface,
+            'severity' => $severity,
+            'issue' => $issue,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line(sprintf('%s %s', $summary['schema_version'] ?? self::SCHEMA_VERSION, $summary['status'] ?? 'unknown'));
+        }
+
+        return (bool) ($summary['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -187,6 +187,7 @@ use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentArticleDraftClaimRiskQaCommand;
+use App\Console\Commands\SeoAgentArticleDraftPreviewRuntimeQaCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftPayloadRepairCanaryCommand;
 use App\Console\Commands\SeoAgentCmsDraftReadbackQaCommand;
@@ -420,6 +421,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsFaqGapScanCommand::class,
         SeoAgentAutoRollbackGuardCommand::class,
         SeoAgentArticleDraftClaimRiskQaCommand::class,
+        SeoAgentArticleDraftPreviewRuntimeQaCommand::class,
         SeoAgentCmsTdkGapScanCommand::class,
         SeoAgentCodexReviewRunnerCommand::class,
         SeoAgentCmsDraftPackageDryRunCommand::class,

--- a/backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json
+++ b/backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json
@@ -1,0 +1,74 @@
+{
+  "version": "seo-agent-article-draft-preview-runtime-qa.v1",
+  "command": "php artisan seo-agent:article-draft-preview-runtime-qa",
+  "purpose": "Read-only SEO Agent CMS article draft preview/runtime QA for a locked ArticleRevision created by controlled CMS draft write evidence.",
+  "inputs": {
+    "write_evidence": "Path to seo-agent-controlled-cms-draft-write.v1 JSON artifact.",
+    "target": "Exact subject ref such as article:41:en.",
+    "revision_id": "Exact ArticleRevision id expected in write evidence.",
+    "artifact_dir": "Directory for sanitized evidence artifact.",
+    "json": "Emit machine-readable summary."
+  },
+  "supported_targets": [
+    "article"
+  ],
+  "required_write_evidence_schema": "seo-agent-controlled-cms-draft-write.v1",
+  "artifact_outputs": [
+    "seo-agent-article-draft-preview-runtime-qa-*.json"
+  ],
+  "qa_contract": {
+    "preview_read": [
+      "draft revision exists",
+      "draft revision belongs to target article",
+      "draft revision is not the public published revision",
+      "revision payload keeps SEO Agent writer identity"
+    ],
+    "public_runtime": [
+      "article remains published",
+      "published_revision_id resolves to an ArticleRevision",
+      "public runtime uses published_revision_id, not the draft revision"
+    ],
+    "read_only_invariants": [
+      "working_revision_id unchanged",
+      "published_revision_id unchanged",
+      "article publication flags unchanged"
+    ]
+  },
+  "mutates_database": false,
+  "mutates_cms": false,
+  "publishes_content": false,
+  "submits_search": false,
+  "calls_external_model": false,
+  "calls_live_gsc_api": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "published_revision_mutation": false,
+    "live_published_content_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "production_env_change": false,
+    "external_model_api_call": false,
+    "live_gsc_api_call": false
+  },
+  "forbidden_input_fields_or_strings": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "Bearer ",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "cms_draft_body"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentArticleDraftPreviewRuntimeQaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_verifies_draft_preview_runtime_state_without_mutating_rows(): void
+    {
+        [$article, $publishedRevision, $draftRevision, $writeEvidencePath] = $this->draftFixture();
+        $countsBefore = $this->rowCounts();
+        $articleStateBefore = $this->articleState($article);
+
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) $draftRevision->id,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['preview_readable'] ?? false));
+        $this->assertTrue((bool) ($summary['public_runtime_uses_published_revision'] ?? false));
+        $this->assertFalse((bool) ($summary['mutation_detected'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.cms_publish', true));
+
+        $this->assertSame($countsBefore, $this->rowCounts());
+        $this->assertSame($articleStateBefore, $this->articleState($article->refresh()));
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertTrue((bool) ($artifact['ok'] ?? false));
+        $this->assertSame((int) $draftRevision->id, data_get($artifact, 'preview_read.revision_id'));
+        $this->assertSame((int) $publishedRevision->id, data_get($artifact, 'public_runtime.published_revision_id'));
+        $this->assertFalse((bool) data_get($artifact, 'preview_read.is_published_revision', true));
+        $this->assertFalse((bool) data_get($artifact, 'public_runtime.draft_revision_leaked_to_public_runtime', true));
+        $this->assertTrue((bool) data_get($artifact, 'read_only_invariants.article_state_unchanged_by_this_read', false));
+
+        $encoded = json_encode($artifact, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+    }
+
+    #[Test]
+    public function it_blocks_when_the_locked_revision_is_the_public_published_revision(): void
+    {
+        [$article, $publishedRevision, , $writeEvidencePath] = $this->draftFixture(usePublishedRevisionAsWriteTarget: true);
+
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) $publishedRevision->id,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertContains('draft_revision_is_public_published_revision', array_column($artifact['qa_findings'] ?? [], 'issue'));
+        $this->assertFalse((bool) data_get($artifact, 'preview_read.preview_readable', true));
+    }
+
+    #[Test]
+    public function it_fails_closed_for_wrong_revision_invalid_schema_missing_target_and_forbidden_inputs(): void
+    {
+        [$article, , $draftRevision, $writeEvidencePath] = $this->draftFixture();
+
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) (((int) $draftRevision->id) + 999),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('revision_id_write_evidence_mismatch', $summary['issues'] ?? []);
+
+        $badSchema = $this->writeJson('bad-write-evidence-', ['schema_version' => 'wrong']);
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $badSchema,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) $draftRevision->id,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('write_evidence_schema_invalid', $summary['issues'] ?? []);
+
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:999:en',
+            '--revision-id' => (string) $draftRevision->id,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('target_not_found_in_write_evidence', $summary['issues'] ?? []);
+
+        $forbidden = $this->writeJson('forbidden-write-evidence-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'raw_url' => 'https://example.com/private',
+        ]);
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $forbidden,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) $draftRevision->id,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_preview_runtime_qa_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json'));
+
+        $this->assertSame('seo-agent-article-draft-preview-runtime-qa.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:article-draft-preview-runtime-qa', $contract['command'] ?? null);
+        $this->assertContains('article', $contract['supported_targets'] ?? []);
+        $this->assertFalse((bool) ($contract['mutates_cms'] ?? true));
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.live_gsc_api_call', true));
+    }
+
+    /**
+     * @return array{0: Article, 1: ArticleRevision, 2: ArticleRevision, 3: string}
+     */
+    private function draftFixture(bool $usePublishedRevisionAsWriteTarget = false): array
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'big-five-career-fit',
+            'locale' => 'en',
+            'title' => 'Big Five Career Fit',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'working_revision_id' => null,
+            'published_revision_id' => null,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $packageSha = hash('sha256', 'package:article:'.$article->id);
+        $publishedRevision = $this->articleRevision($article, 1, [
+            'seo_agent' => [
+                'task' => 'historical_publish',
+            ],
+        ]);
+        $draftRevision = $this->articleRevision($article, 2, [
+            'seo_agent' => [
+                'task' => 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01',
+                'package_sha256' => $packageSha,
+                'subject_ref' => 'article:'.$article->id.':en',
+                'target_fields' => ['seo_title', 'seo_description', 'faq_items'],
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'indexing_request_allowed' => false,
+            ],
+            'proposal' => [
+                'safe_path' => '/en/articles/big-five-career-fit',
+                'proposal_quality' => [
+                    'source' => 'gsc_cohort_artifact',
+                    'slug_generated_copy' => false,
+                ],
+            ],
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $draftRevision->id,
+            'published_revision_id' => (int) $publishedRevision->id,
+        ])->save();
+
+        $writeTargetRevision = $usePublishedRevisionAsWriteTarget ? $publishedRevision : $draftRevision;
+
+        return [
+            $article->refresh(),
+            $publishedRevision,
+            $draftRevision,
+            $this->writeEvidence($packageSha, 'article:'.$article->id.':en', (int) $writeTargetRevision->id),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function articleRevision(Article $article, int $revisionNo, array $payload): ArticleRevision
+    {
+        return ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => $revisionNo,
+            'editor_admin_user_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'change_note' => 'SEO Agent preview runtime QA fixture',
+            'payload_json' => $payload,
+            'created_at' => now(),
+        ]);
+    }
+
+    private function writeEvidence(string $packageSha, string $subjectRef, int $revisionId): string
+    {
+        return $this->writeJson('seo-agent-controlled-cms-draft-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'package_sha256' => $packageSha,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'planned_count' => 1,
+            'rows_created' => 1,
+            'rows_skipped_existing' => 0,
+            'rows_failed' => [],
+            'affected_refs' => [
+                [
+                    'status' => 'created',
+                    'target_model' => 'article',
+                    'subject_ref' => $subjectRef,
+                    'revision_id' => $revisionId,
+                ],
+            ],
+            'negative_guarantees' => [
+                'cms_publish' => false,
+                'search_channel_submit' => false,
+            ],
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-article-draft-preview-runtime-qa-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->count(),
+            'article_revisions' => ArticleRevision::query()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articleState(Article $article): array
+    {
+        return [
+            'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
+            'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1210,6 +1210,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_article_draft_preview_runtime_qa_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentArticleDraftPreviewRuntimeQaCommand;',
+            '+        SeoAgentArticleDraftPreviewRuntimeQaCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4424,6 +4438,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentArticleDraftPreviewRuntimeQaFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentRuntimeSeoQaReadonlyScannerFile($file)) {
                 continue;
             }
@@ -5184,6 +5202,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentCmsDraftReadbackQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPayloadRepairCanaryOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentArticleDraftClaimRiskQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentArticleDraftPreviewRuntimeQaOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentRuntimeSeoQaReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsFaqGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentOpportunityAggregatorOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5915,6 +5934,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentArticleDraftClaimRiskQaCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentArticleDraftPreviewRuntimeQaFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php',
         ], true);
     }
 
@@ -7969,6 +7995,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentArticleDraftClaimRiskQaCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentArticleDraftPreviewRuntimeQaOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentArticleDraftPreviewRuntimeQaCommand\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,11 +1,11 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T22:35:00+08:00",
+  "updated_at": "2026-06-22T23:10:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01 Add article draft claim-risk QA",
     "checks": {
@@ -49,14 +49,18 @@
           "cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticleDraftClaimRiskQaCommand.php tests/Feature/SeoIntel/SeoAgentArticleDraftClaimRiskQaTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
         ],
         "notes": "Added the new read-only SEO Agent claim-risk QA command to the existing BigFive runtime-freeze classifier allowlist."
+      },
+      "github_final": {
+        "status": "pass",
+        "evidence": "GitHub PR #2315 merged with merge commit 77e606cb69ef467d79c0e90051e206eb11cd5bc1; origin/main contains the merge commit and remote branch was pruned/deleted."
       }
     },
     "failure_reason": null,
-    "commit_sha": "ac56924d4673c9eb08fcfdc38bd9ec241d32eae0",
+    "commit_sha": "77e606cb69ef467d79c0e90051e206eb11cd5bc1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2315",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T15:00:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T22:35:00+08:00",
@@ -75,6 +79,12 @@
         "from": "local_checks_passed_with_external_sidecar",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2315."
+      },
+      {
+        "at": "2026-06-22T23:10:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "PR #2315 squash-merged; origin/main contains merge commit 77e606cb69ef467d79c0e90051e206eb11cd5bc1; local PR-E branch deleted after switching worktree to detached origin/main."
       }
     ]
   },
@@ -82,7 +92,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-preview-runtime-qa-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed_with_external_sidecar",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA",
     "depends_on": [
@@ -94,8 +104,24 @@
         "evidence": "User explicitly authorized SEO-AGENT-GSC-DRAFT-CANARY-CLOSEOUT-TRAIN-01 and PR-E through PR-I manifest/state initialization."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01."
+        "status": "pass",
+        "evidence": "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01 merged via GitHub PR #2315 at 2026-06-22T15:00:48Z; origin/main contains merge commit 77e606cb69ef467d79c0e90051e206eb11cd5bc1."
+      },
+      "scope_validation": {
+        "status": "pass_with_external_sidecar",
+        "evidence": "Changed files are confined to PR-F command/test/doc registration, BigFive runtime-freeze classifier allowance for this SEO Agent command, and closeout train metadata."
+      },
+      "local": {
+        "status": "pass_with_external_pint_blocker",
+        "commands": [
+          "cd backend && php artisan list | rg 'seo-agent:article-draft-preview-runtime-qa|seo-agent:article-draft-claim-risk-qa'",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleDraftPreviewRuntimeQaTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_article_draft_preview_runtime_qa --display-warnings",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json >/dev/null",
+          "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
+        ],
+        "notes": "Focused PR-F tests, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing external files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
       }
     },
     "failure_reason": null,
@@ -110,6 +136,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO Agent GSC draft canary closeout /goal."
+      },
+      {
+        "at": "2026-06-22T23:10:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed_with_external_sidecar",
+        "notes": "Implemented read-only article draft preview/runtime QA command and focused tests; broad Pint external blocker unchanged."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:10:00+08:00",
+  "updated_at": "2026-06-22T23:14:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -92,7 +92,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-preview-runtime-qa-01",
     "base": "main",
-    "status": "local_checks_passed_with_external_sidecar",
+    "status": "pr_open",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA",
     "depends_on": [
@@ -125,8 +125,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "3e569f791eab80a9fdfd0400f6a7f3fe1d47d671",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2317",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -142,6 +142,12 @@
         "from": "planned",
         "to": "local_checks_passed_with_external_sidecar",
         "notes": "Implemented read-only article draft preview/runtime QA command and focused tests; broad Pint external blocker unchanged."
+      },
+      {
+        "at": "2026-06-22T23:14:00+08:00",
+        "from": "local_checks_passed_with_external_sidecar",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2317."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23905,6 +23905,7 @@ prs:
       - backend/app/Console/Kernel.php
       - backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json
       - backend/tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train-state.json
     do_not:
       - Write CMS drafts.
@@ -23913,6 +23914,7 @@ prs:
       - Modify public runtime content.
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleDraftPreviewRuntimeQaTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_article_draft_preview_runtime_qa
       - cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel
       - python3 -m json.tool backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json >/dev/null
       - git diff --check


### PR DESCRIPTION
## What changed
- Added backend-only `seo-agent:article-draft-preview-runtime-qa` read-only Artisan command.
- Registered the command and generated `seo-agent-article-draft-preview-runtime-qa.v1` contract docs.
- Added focused feature coverage for draft preview readability, public published revision isolation, forbidden input blocking, and schema docs.
- Added the command to the BigFive runtime-freeze classifier allowlist, matching the existing SEO Agent command pattern.
- Reconciled PR-E merge facts and recorded PR-F local validation in the PR train state ledger.

## Why
PR-F provides evidence that a controlled CMS draft revision can be preview/read checked without leaking into the live published article runtime or mutating CMS state.

## Validation
- `cd backend && php artisan list | rg 'seo-agent:article-draft-preview-runtime-qa|seo-agent:article-draft-claim-risk-qa'`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleDraftPreviewRuntimeQaTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_article_draft_preview_runtime_qa --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_article_draft_preview_runtime_qa' --display-warnings`\n- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `python3 -m json.tool backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json >/dev/null`\n- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n- `git diff --cached --check`\n\nBroad Pint note: `cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel` still fails only on existing files outside PR-F scope, already recorded in `docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md`.\n\n## Intentionally deferred\n- No production CMS write.\n- No publish.\n- No URL Truth, sitemap, IndexNow, search/indexing submission.\n- No scheduler, queue worker, external model API, or live GSC API action.