### PR TITLE
SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01 Plan remaining GSC draft candidates

### DIFF
--- a/backend/app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentGscRemainingCandidateBatchPlanCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-gsc-remaining-candidate-batch-plan.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:gsc-remaining-candidate-batch-plan
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--completed-target=article:41:en : Completed target to exclude from the next write batch}
+        {--artifact-dir= : Directory for sanitized batch planning evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only planner for remaining GSC cohort article draft candidates; recommends the next bounded CMS draft write canary batch.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        $completedTarget = trim((string) $this->option('completed-target'));
+
+        if ($packagePath === null) {
+            return $this->finish($this->failureSummary('package_unreadable'));
+        }
+        if ($completedTarget === '' || str_contains($completedTarget, "\0")) {
+            return $this->finish($this->failureSummary('completed_target_invalid'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $raw = (string) file_get_contents($packagePath);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($raw, true);
+        if (! is_array($package)) {
+            return $this->finish($this->failureSummary('package_json_invalid'));
+        }
+
+        $packageIssue = $this->validatePackage($package);
+        if ($packageIssue !== null) {
+            return $this->finish($this->failureSummary($packageIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        $evidence = $this->evidence($packagePath, $package, $packageSha, $completedTarget);
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-remaining-candidate-batch-plan-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) ($evidence['ok'] ?? false),
+            'status' => (string) ($evidence['status'] ?? 'unknown'),
+            'package_sha256' => $packageSha,
+            'remaining_candidate_count' => (int) ($evidence['remaining_candidate_count'] ?? 0),
+            'recommended_limit' => (int) data_get($evidence, 'recommendation.limit', 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true) {
+            return 'package_not_dry_run';
+        }
+        if ((bool) ($package['cms_write_allowed'] ?? true) !== false || (bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array<string, mixed>
+     */
+    private function evidence(string $packagePath, array $package, string $packageSha, string $completedTarget): array
+    {
+        $items = $this->packageItems($package);
+        $articleCandidates = array_values(array_filter(
+            $items,
+            static fn (array $item): bool => (string) ($item['target_model'] ?? $item['subject_type'] ?? '') === 'article'
+                && (string) ($item['source_family'] ?? '') === 'gsc_cohort_artifact'
+        ));
+        $remaining = array_values(array_filter(
+            $articleCandidates,
+            static fn (array $item): bool => (string) ($item['subject_ref'] ?? '') !== $completedTarget
+        ));
+        $ranked = $this->rankedCandidates($remaining);
+        $issues = [];
+        $subjectRefs = array_map(static fn (array $item): string => (string) ($item['subject_ref'] ?? ''), $articleCandidates);
+        if (! in_array($completedTarget, $subjectRefs, true)) {
+            $issues[] = 'completed_target_not_found_in_package';
+        }
+        if (count($remaining) !== 6) {
+            $issues[] = 'remaining_candidate_count_not_expected_6';
+        }
+
+        $recommendation = $this->recommendation($ranked, $packageSha);
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $issues === [] ? 'success' : 'review_required',
+            'issues' => $issues,
+            'package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'package_sha256' => $packageSha,
+            'completed_target_excluded' => $completedTarget,
+            'source_candidate_count' => count($articleCandidates),
+            'remaining_candidate_count' => count($remaining),
+            'remaining_candidates' => $ranked,
+            'recommendation' => $recommendation,
+            'approval_gate' => [
+                'requires_separate_production_cms_draft_write_approval' => true,
+                'exact_future_approval_phrase' => (string) ($recommendation['future_approval_phrase'] ?? ''),
+                'no_publish_covered_by_this_phrase' => true,
+                'no_search_or_indexing_covered_by_this_phrase' => true,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return list<array<string, mixed>>
+     */
+    private function packageItems(array $package): array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        if (! is_array($items)) {
+            return [];
+        }
+
+        return array_values(array_filter($items, static fn (mixed $item): bool => is_array($item)));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     * @return list<array<string, mixed>>
+     */
+    private function rankedCandidates(array $candidates): array
+    {
+        $ranked = array_map(fn (array $candidate): array => $this->candidatePlan($candidate), $candidates);
+        usort($ranked, static function (array $left, array $right): int {
+            return [
+                (int) ($left['sort_keys']['priority_weight'] ?? 99),
+                -1 * (int) ($left['sort_keys']['impressions'] ?? 0),
+                (int) ($left['sort_keys']['risk_weight'] ?? 99),
+                (string) ($left['subject_ref'] ?? ''),
+            ] <=> [
+                (int) ($right['sort_keys']['priority_weight'] ?? 99),
+                -1 * (int) ($right['sort_keys']['impressions'] ?? 0),
+                (int) ($right['sort_keys']['risk_weight'] ?? 99),
+                (string) ($right['subject_ref'] ?? ''),
+            ];
+        });
+
+        foreach ($ranked as $index => $candidate) {
+            $ranked[$index]['rank'] = $index + 1;
+        }
+
+        return $ranked;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function candidatePlan(array $candidate): array
+    {
+        $locale = $this->locale($candidate);
+        $riskFlags = $this->riskFlags($candidate, $locale);
+
+        return [
+            'subject_ref' => (string) ($candidate['subject_ref'] ?? ''),
+            'safe_path' => (string) ($candidate['safe_path'] ?? ''),
+            'locale' => $locale,
+            'severity' => (string) ($candidate['severity'] ?? ''),
+            'metrics' => [
+                'impressions' => $this->metricInt($candidate, 'impressions'),
+                'clicks' => $this->metricInt($candidate, 'clicks'),
+                'ctr_ppm' => $this->metricInt($candidate, 'ctr_ppm'),
+                'average_position' => $this->metricFloat($candidate, 'average_position'),
+            ],
+            'proposal_quality' => [
+                'source' => (string) data_get($candidate, 'proposal_quality.source', ''),
+                'locale_preserved' => (bool) data_get($candidate, 'proposal_quality.locale_preserved', false),
+                'slug_generated_copy' => (bool) data_get($candidate, 'proposal_quality.slug_generated_copy', true),
+                'needs_human_approval' => (bool) data_get($candidate, 'proposal_quality.needs_human_approval', true),
+            ],
+            'risk_flags' => $riskFlags,
+            'review_cautions' => $this->reviewCautions($riskFlags, $locale),
+            'ranking_rationale' => [
+                'priority_first',
+                'higher_gsc_impressions_next',
+                'lower_locale_and_claim_surface_risk_next',
+                'bounded_batch_before_remaining_candidates',
+            ],
+            'sort_keys' => [
+                'priority_weight' => $this->priorityWeight((string) ($candidate['severity'] ?? '')),
+                'impressions' => $this->metricInt($candidate, 'impressions'),
+                'risk_weight' => count($riskFlags),
+            ],
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function riskFlags(array $candidate, string $locale): array
+    {
+        $flags = [];
+        if (in_array($locale, ['zh', 'zh-CN'], true)) {
+            $flags[] = 'zh_tdk_faq_extra_review';
+        }
+        if ((bool) ($candidate['claim_gate_required'] ?? true)) {
+            $flags[] = 'claim_gate_required';
+        }
+        if ((array) ($candidate['proposed_faq_items'] ?? []) !== [] || in_array('faq_items', (array) ($candidate['target_fields'] ?? []), true)) {
+            $flags[] = 'faq_claim_surface';
+        }
+        if ((array) ($candidate['proposed_internal_link_actions'] ?? []) !== []) {
+            $flags[] = 'internal_link_review_required';
+        }
+        if ((bool) data_get($candidate, 'proposal_quality.slug_generated_copy', false)) {
+            $flags[] = 'slug_generated_copy_risk';
+        }
+
+        return array_values(array_unique($flags));
+    }
+
+    /**
+     * @param  list<string>  $riskFlags
+     * @return list<string>
+     */
+    private function reviewCautions(array $riskFlags, string $locale): array
+    {
+        $cautions = [];
+        if (in_array($locale, ['zh', 'zh-CN'], true)) {
+            $cautions[] = 'extra_chinese_tdk_and_faq_review_required';
+        }
+        if (in_array('faq_claim_surface', $riskFlags, true)) {
+            $cautions[] = 'faq_items_require_claim_risk_review_before_write';
+        }
+        if (in_array('internal_link_review_required', $riskFlags, true)) {
+            $cautions[] = 'internal_link_actions_require_safe_path_review';
+        }
+
+        return $cautions;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $ranked
+     * @return array<string, mixed>
+     */
+    private function recommendation(array $ranked, string $packageSha): array
+    {
+        $topThree = array_slice($ranked, 0, 3);
+        $hasHigherReviewSurface = count(array_filter(
+            $topThree,
+            static fn (array $candidate): bool => in_array('zh_tdk_faq_extra_review', (array) ($candidate['risk_flags'] ?? []), true)
+                || in_array('faq_claim_surface', (array) ($candidate['risk_flags'] ?? []), true)
+        )) > 0;
+        $limit = max(0, min($hasHigherReviewSurface ? 2 : 3, count($ranked)));
+
+        return [
+            'limit' => $limit,
+            'recommended_targets' => array_map(
+                static fn (array $candidate): string => (string) ($candidate['subject_ref'] ?? ''),
+                array_slice($ranked, 0, $limit)
+            ),
+            'reason' => 'Bound the next CMS draft write canary before touching all remaining GSC cohort candidates.',
+            'future_approval_phrase' => 'I explicitly approve production CMS draft write canary for next GSC cohort article batch limit='.$limit.' using dry-run artifact sha256 '.$packageSha.'; no publish, no queue, no search, no indexing, no scheduler.',
+            'requires_separate_approval' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function locale(array $candidate): string
+    {
+        $subjectRef = (string) ($candidate['subject_ref'] ?? '');
+        $parts = explode(':', $subjectRef);
+        if (($parts[2] ?? '') !== '') {
+            return (string) $parts[2];
+        }
+
+        $path = (string) ($candidate['safe_path'] ?? '');
+        if (str_starts_with($path, '/zh/')) {
+            return 'zh-CN';
+        }
+        if (str_starts_with($path, '/en/')) {
+            return 'en';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function metricInt(array $candidate, string $key): int
+    {
+        $value = data_get($candidate, 'metrics.'.$key, $candidate[$key] ?? 0);
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function metricFloat(array $candidate, string $key): ?float
+    {
+        $value = data_get($candidate, 'metrics.'.$key, $candidate[$key] ?? null);
+
+        return is_numeric($value) ? (float) $value : null;
+    }
+
+    private function priorityWeight(string $severity): int
+    {
+        return match (strtolower($severity)) {
+            'p0' => 0,
+            'p1' => 1,
+            'p2' => 2,
+            'p3' => 3,
+            default => 9,
+        };
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/gsc-remaining-candidate-batch-plan');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'schema_version' => $schemaVersion,
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, string $filename, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode remaining candidate batch plan artifact.');
+        }
+        file_put_contents($path, $encoded."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'sitemap_submission' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'external_model_api_call' => false,
+            'live_gsc_api_call' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line(sprintf('%s %s', $summary['schema_version'] ?? self::SCHEMA_VERSION, $summary['status'] ?? 'unknown'));
+        }
+
+        return (bool) ($summary['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -200,6 +200,7 @@ use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentGscCohortHandoffCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentGscPostPublishFeedbackCommand;
+use App\Console\Commands\SeoAgentGscRemainingCandidateBatchPlanCommand;
 use App\Console\Commands\SeoAgentL5aContentPagePublishCanaryCommand;
 use App\Console\Commands\SeoAgentL5aIndexnowSubmitCanaryCommand;
 use App\Console\Commands\SeoAgentOpportunityAggregateCommand;
@@ -435,6 +436,7 @@ class Kernel extends ConsoleKernel
         SeoAgentGscCohortHandoffCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentGscPostPublishFeedbackCommand::class,
+        SeoAgentGscRemainingCandidateBatchPlanCommand::class,
         SeoAgentPostPublishIndexnowAutoCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,
         SeoAgentPriorityQueueSchedulerCommand::class,

--- a/backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json
@@ -1,0 +1,71 @@
+{
+  "version": "seo-agent-gsc-remaining-candidate-batch-plan.v1",
+  "command": "php artisan seo-agent:gsc-remaining-candidate-batch-plan",
+  "purpose": "Read-only planner for remaining GSC cohort article candidates after the article:41:en CMS draft write canary.",
+  "input_schema": "seo-agent-cms-draft-package-dry-run.v1",
+  "inputs": {
+    "package": "Path to PR-B CMS draft package dry-run artifact.",
+    "completed_target": "Completed subject ref to exclude; defaults to article:41:en.",
+    "artifact_dir": "Directory for sanitized planning evidence.",
+    "json": "Emit machine-readable summary."
+  },
+  "outputs": [
+    "seo-agent-gsc-remaining-candidate-batch-plan-*.json"
+  ],
+  "planning_policy": {
+    "only_source_family": "gsc_cohort_artifact",
+    "only_target_model": "article",
+    "exclude_completed_target": "article:41:en",
+    "expected_remaining_candidate_count": 6,
+    "recommended_limit": "2 or 3, never all 6",
+    "ranking_inputs": [
+      "priority",
+      "impressions",
+      "locale risk",
+      "TDK quality",
+      "FAQ risk",
+      "internal-link risk",
+      "claim-risk surface"
+    ],
+    "chinese_candidate_caution": "Chinese TDK and FAQ proposals require extra review before any CMS draft write."
+  },
+  "approval_gate": {
+    "cms_draft_write_requires_separate_exact_approval": true,
+    "publish_requires_separate_exact_approval": true,
+    "search_or_indexing_requires_separate_exact_approval": true
+  },
+  "mutates_database": false,
+  "mutates_cms": false,
+  "publishes_content": false,
+  "submits_search": false,
+  "calls_external_model": false,
+  "calls_live_gsc_api": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "sitemap_submission": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "external_model_api_call": false,
+    "live_gsc_api_call": false
+  },
+  "forbidden_input_fields_or_strings": [
+    "raw_url",
+    "raw_query",
+    "credential_path",
+    "service_account_json",
+    "client_email",
+    "private_key",
+    "Bearer ",
+    "token",
+    "cookie",
+    "session",
+    "content_md",
+    "content_html",
+    "cms_draft_body"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscRemainingCandidateBatchPlanTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscRemainingCandidateBatchPlanTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentGscRemainingCandidateBatchPlanTest extends TestCase
+{
+    #[Test]
+    public function it_plans_the_remaining_six_candidates_and_recommends_a_bounded_next_batch(): void
+    {
+        $packagePath = $this->writePackage($this->packageCandidates());
+
+        $exitCode = Artisan::call('seo-agent:gsc-remaining-candidate-batch-plan', [
+            '--package' => $packagePath,
+            '--completed-target' => 'article:41:en',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(6, $summary['remaining_candidate_count'] ?? null);
+        $this->assertContains($summary['recommended_limit'] ?? null, [2, 3]);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('article:41:en', $artifact['completed_target_excluded'] ?? null);
+        $this->assertSame(7, $artifact['source_candidate_count'] ?? null);
+        $this->assertSame(6, $artifact['remaining_candidate_count'] ?? null);
+        $this->assertNotContains('article:41:en', array_column($artifact['remaining_candidates'] ?? [], 'subject_ref'));
+        $this->assertContains('article:42:en', data_get($artifact, 'recommendation.recommended_targets', []));
+        $this->assertContains(data_get($artifact, 'recommendation.limit'), [2, 3]);
+        $this->assertStringContainsString(
+            'I explicitly approve production CMS draft write canary for next GSC cohort article batch limit=',
+            (string) data_get($artifact, 'recommendation.future_approval_phrase')
+        );
+        $this->assertTrue((bool) data_get($artifact, 'approval_gate.requires_separate_production_cms_draft_write_approval'));
+
+        $zhCandidate = collect($artifact['remaining_candidates'] ?? [])
+            ->firstWhere('subject_ref', 'article:44:zh-CN');
+        $this->assertIsArray($zhCandidate);
+        $this->assertContains('extra_chinese_tdk_and_faq_review_required', $zhCandidate['review_cautions'] ?? []);
+        $this->assertContains('zh_tdk_faq_extra_review', $zhCandidate['risk_flags'] ?? []);
+
+        $encoded = json_encode([$summary, $artifact], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($encoded);
+        foreach ($this->forbiddenStrings() as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $encoded, $forbidden);
+        }
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'search_channel_enqueue',
+            'search_channel_submit',
+            'indexing_request',
+            'scheduler_activation',
+            'external_model_api_call',
+            'live_gsc_api_call',
+        ] as $field) {
+            $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.'.$field, true), $field);
+        }
+    }
+
+    #[Test]
+    public function it_returns_review_required_when_the_package_does_not_contain_exactly_six_remaining_candidates(): void
+    {
+        $packagePath = $this->writePackage(array_slice($this->packageCandidates(), 0, 4));
+
+        $exitCode = Artisan::call('seo-agent:gsc-remaining-candidate-batch-plan', [
+            '--package' => $packagePath,
+            '--completed-target' => 'article:41:en',
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('review_required', $summary['status'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertContains('remaining_candidate_count_not_expected_6', $artifact['issues'] ?? []);
+    }
+
+    #[Test]
+    public function it_fails_closed_for_invalid_schema_and_forbidden_fields(): void
+    {
+        $invalidSchema = $this->writeJson('seo-agent-cms-draft-package-', ['schema_version' => 'wrong']);
+
+        $exitCode = Artisan::call('seo-agent:gsc-remaining-candidate-batch-plan', [
+            '--package' => $invalidSchema,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_schema_invalid', $summary['issues'] ?? []);
+
+        $forbidden = $this->writePackage([
+            [
+                ...$this->candidate('article:41:en', 'p1', 10, 'en'),
+                'raw_query' => 'blocked',
+            ],
+        ]);
+        $exitCode = Artisan::call('seo-agent:gsc-remaining-candidate-batch-plan', [
+            '--package' => $forbidden,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_remaining_candidate_batch_plan_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json'));
+
+        $this->assertSame('seo-agent-gsc-remaining-candidate-batch-plan.v1', $contract['version'] ?? null);
+        $this->assertSame('seo-agent-cms-draft-package-dry-run.v1', $contract['input_schema'] ?? null);
+        $this->assertSame(6, data_get($contract, 'planning_policy.expected_remaining_candidate_count'));
+        $this->assertFalse((bool) ($contract['mutates_cms'] ?? true));
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function packageCandidates(): array
+    {
+        return [
+            $this->candidate('article:41:en', 'p1', 31, 'en'),
+            $this->candidate('article:42:en', 'p1', 28, 'en'),
+            $this->candidate('article:43:en', 'p2', 19, 'en'),
+            $this->candidate('article:44:zh-CN', 'p2', 25, 'zh-CN'),
+            $this->candidate('article:45:zh-CN', 'p2', 12, 'zh-CN'),
+            $this->candidate('article:46:en', 'p3', 18, 'en'),
+            $this->candidate('article:47:zh-CN', 'p3', 10, 'zh-CN'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function candidate(string $subjectRef, string $severity, int $impressions, string $locale): array
+    {
+        $slug = str_replace(':', '-', $subjectRef);
+
+        return [
+            'source_id' => hash('sha256', $subjectRef),
+            'source_family' => 'gsc_cohort_artifact',
+            'subject_type' => 'article',
+            'target_model' => 'article',
+            'subject_ref' => $subjectRef,
+            'safe_path' => ($locale === 'en' ? '/en/articles/' : '/zh/articles/').$slug,
+            'severity' => $severity,
+            'target_fields' => ['seo_title', 'seo_description', 'faq_items'],
+            'proposed_seo_title' => $locale === 'en'
+                ? 'Careful Career Reflection | FermatMind'
+                : '谨慎理解职业选择 | FermatMind',
+            'proposed_seo_description' => $locale === 'en'
+                ? 'Review personality and career signals without overclaiming outcomes.'
+                : '用谨慎方式理解人格与职业信号，避免过度承诺。',
+            'proposed_faq_items' => [
+                [
+                    'question' => $locale === 'en' ? 'Can this predict career outcomes?' : '这能预测职业结果吗？',
+                    'answer' => $locale === 'en' ? 'No. It supports reflection only.' : '不能。它只辅助自我反思。',
+                ],
+            ],
+            'proposed_internal_link_actions' => ['Add internal link review target to /en/tests/big-five-personality-test'],
+            'proposal_quality' => [
+                'source' => 'gsc_cohort_artifact',
+                'locale_preserved' => true,
+                'slug_generated_copy' => false,
+                'needs_human_approval' => true,
+            ],
+            'metrics' => [
+                'impressions' => $impressions,
+                'clicks' => 0,
+                'ctr_ppm' => 0,
+                'average_position' => 3.2,
+            ],
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $candidates
+     */
+    private function writePackage(array $candidates): string
+    {
+        return $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'run_mode' => 'cms_draft_package_dry_run',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'draft_brief_count' => count($candidates),
+            'draft_briefs' => $candidates,
+            'proposal_count' => count($candidates),
+            'proposal_items' => $candidates,
+            'claim_gate_required' => true,
+            'human_approval_required' => true,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-gsc-remaining-candidate-batch-plan-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStrings(): array
+    {
+        return [
+            'raw_url',
+            'raw_query',
+            'credential_path',
+            'client_email',
+            'private_key',
+            'Bearer ',
+            'content_md',
+            'content_html',
+            'cms_draft_body',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1224,6 +1224,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_remaining_candidate_batch_plan_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentGscRemainingCandidateBatchPlanCommand;',
+            '+        SeoAgentGscRemainingCandidateBatchPlanCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4486,6 +4500,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentGscRemainingCandidateBatchPlanFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentAutoRollbackGuardFile($file)) {
                 continue;
             }
@@ -5216,6 +5234,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentPostPublishSearchSubmitOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscPostPublishFeedbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentGscRemainingCandidateBatchPlanOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPriorityQueueSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6021,6 +6040,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscPostPublishFeedbackCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentGscRemainingCandidateBatchPlanFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php',
         ], true);
     }
 
@@ -8017,6 +8043,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentArticleDraftPreviewRuntimeQaCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentGscRemainingCandidateBatchPlanOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentGscRemainingCandidateBatchPlanCommand\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:14:00+08:00",
+  "updated_at": "2026-06-22T23:33:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -92,7 +92,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-preview-runtime-qa-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 Add article draft preview runtime QA",
     "depends_on": [
@@ -122,14 +122,18 @@
           "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
         ],
         "notes": "Focused PR-F tests, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing external files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
+      },
+      "github_final": {
+        "status": "pass",
+        "evidence": "GitHub PR #2317 merged with merge commit e7281b97466f1bf37ffe2fe84c53104577ddffc3; origin/main contains the merge commit and remote branch was pruned/deleted."
       }
     },
     "failure_reason": null,
-    "commit_sha": "3e569f791eab80a9fdfd0400f6a7f3fe1d47d671",
+    "commit_sha": "e7281b97466f1bf37ffe2fe84c53104577ddffc3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2317",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T15:14:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T22:35:00+08:00",
@@ -148,6 +152,12 @@
         "from": "local_checks_passed_with_external_sidecar",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2317."
+      },
+      {
+        "at": "2026-06-22T23:33:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "PR #2317 squash-merged; origin/main contains merge commit e7281b97466f1bf37ffe2fe84c53104577ddffc3; local PR-F branch deleted after switching worktree to detached origin/main."
       }
     ]
   },
@@ -155,7 +165,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-remaining-candidate-batch-plan-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed_with_external_sidecar",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01 Plan remaining GSC draft candidates",
     "depends_on": [
@@ -167,8 +177,25 @@
         "evidence": "User explicitly authorized SEO-AGENT-GSC-DRAFT-CANARY-CLOSEOUT-TRAIN-01 and PR-E through PR-I manifest/state initialization."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01."
+        "status": "pass",
+        "evidence": "SEO-AGENT-ARTICLE41-DRAFT-PREVIEW-RUNTIME-QA-01 merged via GitHub PR #2317 at 2026-06-22T15:14:48Z; origin/main contains merge commit e7281b97466f1bf37ffe2fe84c53104577ddffc3."
+      },
+      "scope_validation": {
+        "status": "pass_with_external_sidecar",
+        "evidence": "Changed files are confined to PR-G command/test/doc registration, BigFive runtime-freeze classifier allowance for this SEO Agent command, and closeout train metadata."
+      },
+      "local": {
+        "status": "pass_with_external_pint_blocker",
+        "commands": [
+          "cd backend && php artisan list | rg 'seo-agent:gsc-remaining-candidate-batch-plan'",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscRemainingCandidateBatchPlanTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_gsc_remaining_candidate_batch_plan --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_remaining_candidate_batch_plan' --display-warnings",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php tests/Feature/SeoIntel/SeoAgentGscRemainingCandidateBatchPlanTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json >/dev/null",
+          "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
+        ],
+        "notes": "Focused PR-G tests, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
       }
     },
     "failure_reason": null,
@@ -183,6 +210,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO Agent GSC draft canary closeout /goal."
+      },
+      {
+        "at": "2026-06-22T23:33:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed_with_external_sidecar",
+        "notes": "Implemented read-only remaining GSC candidate batch planner and focused tests; broad Pint external blocker unchanged."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:33:00+08:00",
+  "updated_at": "2026-06-22T23:37:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -165,7 +165,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-remaining-candidate-batch-plan-01",
     "base": "main",
-    "status": "local_checks_passed_with_external_sidecar",
+    "status": "pr_open",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01 Plan remaining GSC draft candidates",
     "depends_on": [
@@ -199,8 +199,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "78eace54790e2057269482e377eab1604123d0b2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2318",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -216,6 +216,12 @@
         "from": "planned",
         "to": "local_checks_passed_with_external_sidecar",
         "notes": "Implemented read-only remaining GSC candidate batch planner and focused tests; broad Pint external blocker unchanged."
+      },
+      {
+        "at": "2026-06-22T23:37:00+08:00",
+        "from": "local_checks_passed_with_external_sidecar",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2318."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23943,6 +23943,7 @@ prs:
       - backend/app/Console/Kernel.php
       - backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json
       - backend/tests/Feature/SeoIntel/SeoAgentGscRemainingCandidateBatchPlanTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train-state.json
     do_not:
       - Execute CMS draft writes.
@@ -23950,6 +23951,7 @@ prs:
       - Submit URL Truth, sitemap, IndexNow, or search/indexing requests.
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscRemainingCandidateBatchPlanTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_gsc_remaining_candidate_batch_plan
       - cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel
       - python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json >/dev/null
       - git diff --check


### PR DESCRIPTION
## What changed
- Added backend-only `seo-agent:gsc-remaining-candidate-batch-plan` read-only Artisan command.
- Reads a `seo-agent-cms-draft-package-dry-run.v1` artifact, excludes completed `article:41:en`, ranks remaining GSC cohort article candidates, and recommends a bounded next write canary limit.
- Emits sanitized planning evidence plus an exact future CMS draft write approval phrase.
- Registered the command, added generated contract docs, focused feature tests, and BigFive runtime-freeze classifier coverage.
- Reconciled PR-F merge facts and recorded PR-G local validation in the PR train state ledger.

## Why
After article:41:en passed readback and repair QA, the next step is not another production write yet; it is a reproducible planner for the remaining six article candidates so the next canary stays bounded to limit=2 or limit=3.

## Validation
- `cd backend && php artisan list | rg 'seo-agent:gsc-remaining-candidate-batch-plan'`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscRemainingCandidateBatchPlanTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_gsc_remaining_candidate_batch_plan --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_remaining_candidate_batch_plan' --display-warnings`\n- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php tests/Feature/SeoIntel/SeoAgentGscRemainingCandidateBatchPlanTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-remaining-candidate-batch-plan.v1.json >/dev/null`\n- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n- `git diff --cached --check`\n\nBroad Pint note: `cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel` still fails only on existing files outside PR-G scope, already recorded in `docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md`.\n\n## Intentionally deferred\n- No production CMS draft write.\n- No publish.\n- No URL Truth, sitemap, IndexNow, search/indexing submission.\n- No scheduler, queue worker, external model API, or live GSC API action.