### PR TITLE
SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01 Add batch draft QA support

### DIFF
--- a/backend/app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentGscBatchDraftQaSupportCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-gsc-batch-draft-qa-support.v1';
+
+    private const PACKAGE_SCHEMA_VERSION = 'seo-agent-cms-draft-package-dry-run.v1';
+
+    private const WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:gsc-batch-draft-qa-support
+        {--package= : Path to a seo-agent-cms-draft-package-dry-run.v1 JSON artifact}
+        {--write-evidence= : Path to a seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--target=* : Optional subject_ref filter; may be repeated}
+        {--artifact-dir= : Directory for sanitized batch QA evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only batch QA summarizer for GSC cohort CMS draft write evidence; keeps single-target readback QA compatible.';
+
+    public function handle(): int
+    {
+        $packagePath = $this->readablePath((string) $this->option('package'));
+        $writeEvidencePath = $this->readablePath((string) $this->option('write-evidence'));
+        if ($packagePath === null) {
+            return $this->finish($this->failureSummary('package_unreadable'));
+        }
+        if ($writeEvidencePath === null) {
+            return $this->finish($this->failureSummary('write_evidence_unreadable'));
+        }
+
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $packageRaw = (string) file_get_contents($packagePath);
+        $writeRaw = (string) file_get_contents($writeEvidencePath);
+        $forbidden = array_values(array_unique(array_merge(
+            $this->forbiddenStringsPresent($packageRaw),
+            $this->forbiddenStringsPresent($writeRaw),
+        )));
+        if ($forbidden !== []) {
+            return $this->finish($this->failureSummary('forbidden_input_field_present', [
+                'forbidden_matches' => $forbidden,
+            ]));
+        }
+
+        $package = json_decode($packageRaw, true);
+        $writeEvidence = json_decode($writeRaw, true);
+        if (! is_array($package)) {
+            return $this->finish($this->failureSummary('package_json_invalid'));
+        }
+        if (! is_array($writeEvidence)) {
+            return $this->finish($this->failureSummary('write_evidence_json_invalid'));
+        }
+        $packageIssue = $this->validatePackage($package);
+        if ($packageIssue !== null) {
+            return $this->finish($this->failureSummary($packageIssue));
+        }
+        $writeIssue = $this->validateWriteEvidence($writeEvidence);
+        if ($writeIssue !== null) {
+            return $this->finish($this->failureSummary($writeIssue));
+        }
+
+        $packageSha = hash_file('sha256', $packagePath) ?: '';
+        if ((string) ($writeEvidence['package_sha256'] ?? '') !== $packageSha) {
+            return $this->finish($this->failureSummary('write_evidence_package_sha256_mismatch', [
+                'package_sha256' => $packageSha,
+                'write_evidence_package_sha256' => (string) ($writeEvidence['package_sha256'] ?? ''),
+            ]));
+        }
+
+        $evidence = $this->evidence($packagePath, $writeEvidencePath, $package, $writeEvidence, $packageSha);
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-batch-draft-qa-support-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => (bool) ($evidence['ok'] ?? false),
+            'status' => (string) ($evidence['status'] ?? 'unknown'),
+            'target_count' => (int) ($evidence['target_count'] ?? 0),
+            'mismatch_count' => (int) ($evidence['mismatch_count'] ?? 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function validatePackage(array $package): ?string
+    {
+        if (($package['schema_version'] ?? null) !== self::PACKAGE_SCHEMA_VERSION) {
+            return 'package_schema_invalid';
+        }
+        if ((bool) ($package['dry_run'] ?? false) !== true || (bool) ($package['cms_write_allowed'] ?? true) !== false || (bool) ($package['execution_permission'] ?? true) !== false) {
+            return 'package_execution_boundary_invalid';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $writeEvidence
+     */
+    private function validateWriteEvidence(array $writeEvidence): ?string
+    {
+        if (($writeEvidence['schema_version'] ?? null) !== self::WRITE_SCHEMA_VERSION) {
+            return 'write_evidence_schema_invalid';
+        }
+        if (($writeEvidence['status'] ?? null) !== 'success') {
+            return 'write_evidence_not_success';
+        }
+        if ((bool) ($writeEvidence['execute'] ?? false) !== true || (bool) ($writeEvidence['writes_attempted'] ?? false) !== true) {
+            return 'write_evidence_not_execute';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<string, mixed>  $writeEvidence
+     * @return array<string, mixed>
+     */
+    private function evidence(string $packagePath, string $writeEvidencePath, array $package, array $writeEvidence, string $packageSha): array
+    {
+        $targets = array_values(array_filter(array_map('strval', (array) $this->option('target'))));
+        $proposals = $this->proposalsByTarget($package);
+        $refs = array_values(array_filter((array) ($writeEvidence['affected_refs'] ?? []), static function (mixed $ref) use ($targets): bool {
+            if (! is_array($ref)) {
+                return false;
+            }
+            if ((string) ($ref['target_model'] ?? '') !== 'article') {
+                return false;
+            }
+
+            return $targets === [] || in_array((string) ($ref['subject_ref'] ?? ''), $targets, true);
+        }));
+        $targetVerdicts = array_map(fn (array $ref): array => $this->targetVerdict($ref, $proposals, $packageSha), $refs);
+        $mismatchCount = array_sum(array_map(static fn (array $verdict): int => count((array) ($verdict['mismatches'] ?? [])), $targetVerdicts));
+        $findingCount = array_sum(array_map(static fn (array $verdict): int => count((array) ($verdict['qa_findings'] ?? [])), $targetVerdicts));
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $mismatchCount === 0 && $findingCount === 0 ? 'success' : 'review_required',
+            'package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'write_evidence' => $this->artifactRef($writeEvidencePath, self::WRITE_SCHEMA_VERSION),
+            'package_sha256' => $packageSha,
+            'target_count' => count($targetVerdicts),
+            'mismatch_count' => $mismatchCount,
+            'qa_finding_count' => $findingCount,
+            'target_verdicts' => $targetVerdicts,
+            'post_approval_command_sequence' => [
+                'run seo-agent:cms-draft-readback-qa for each affected target when single-target detail is needed',
+                'run seo-agent:article-draft-claim-risk-qa for each draft revision before publish readiness',
+                'run seo-agent:article-draft-preview-runtime-qa for each draft revision before publish readiness',
+                'do not publish until a separate publish gate readiness artifact passes',
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $ref
+     * @param  array<string, array<string, mixed>>  $proposals
+     * @return array<string, mixed>
+     */
+    private function targetVerdict(array $ref, array $proposals, string $packageSha): array
+    {
+        $target = (string) ($ref['subject_ref'] ?? '');
+        $proposal = $proposals[$target] ?? null;
+        $revisionId = (int) ($ref['revision_id'] ?? 0);
+        $articleId = $this->idFromSubjectRef($target);
+        $article = $articleId > 0 ? Article::query()->withoutGlobalScopes()->find($articleId) : null;
+        $revision = $articleId > 0 && $revisionId > 0
+            ? ArticleRevision::query()->withoutGlobalScopes()->where('article_id', $articleId)->whereKey($revisionId)->first()
+            : null;
+        $payload = $revision instanceof ArticleRevision && is_array($revision->payload_json) ? $revision->payload_json : [];
+        $mismatches = [];
+        $matched = [];
+        $findings = [];
+
+        if (! is_array($proposal)) {
+            $findings[] = 'proposal_missing_for_target';
+        }
+        if (! $article instanceof Article) {
+            $findings[] = 'article_missing_for_target';
+        }
+        if (! $revision instanceof ArticleRevision) {
+            $findings[] = 'draft_revision_missing_for_target';
+        }
+        if (data_get($payload, 'seo_agent.package_sha256') !== $packageSha) {
+            $findings[] = 'revision_package_sha256_mismatch';
+        }
+        if (data_get($payload, 'seo_agent.subject_ref') !== $target) {
+            $findings[] = 'revision_subject_ref_mismatch';
+        }
+
+        foreach ($this->proposalFieldMap() as $field => $payloadPath) {
+            $expected = is_array($proposal) ? ($proposal[$field] ?? null) : null;
+            $actual = data_get($payload, $payloadPath);
+            if ($this->canonical($expected) === $this->canonical($actual)) {
+                $matched[] = $payloadPath;
+            } else {
+                $mismatches[] = 'field_mismatch:'.$payloadPath;
+            }
+        }
+
+        return [
+            'subject_ref' => $target,
+            'revision_id' => $revisionId,
+            'locale' => $this->locale($target, (string) ($proposal['safe_path'] ?? '')),
+            'safe_path' => (string) ($proposal['safe_path'] ?? ''),
+            'matched_fields' => $matched,
+            'mismatches' => $mismatches,
+            'qa_findings' => $findings,
+            'proposal_quality' => is_array($proposal) ? ($proposal['proposal_quality'] ?? []) : [],
+            'internal_link_actions' => is_array($proposal) ? ($proposal['proposed_internal_link_actions'] ?? []) : [],
+            'claim_risk_handoff_status' => (bool) ($proposal['claim_gate_required'] ?? true) ? 'required_pending' : 'not_required',
+            'preview_runtime_handoff_status' => 'required_pending',
+            'public_runtime_published_revision_id' => $article instanceof Article && $article->published_revision_id ? (int) $article->published_revision_id : null,
+            'execution_permission' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array<string, array<string, mixed>>
+     */
+    private function proposalsByTarget(array $package): array
+    {
+        $items = $package['proposal_items'] ?? $package['draft_briefs'] ?? [];
+        $out = [];
+        foreach ((array) $items as $item) {
+            if (is_array($item) && (string) ($item['subject_ref'] ?? '') !== '') {
+                $out[(string) $item['subject_ref']] = $item;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function proposalFieldMap(): array
+    {
+        return [
+            'proposed_seo_title' => 'proposal.proposed_seo_title',
+            'proposed_seo_description' => 'proposal.proposed_seo_description',
+            'proposed_faq_items' => 'proposal.proposed_faq_items',
+            'proposed_internal_link_actions' => 'proposal.proposed_internal_link_actions',
+            'proposal_quality' => 'proposal.proposal_quality',
+        ];
+    }
+
+    private function idFromSubjectRef(string $subjectRef): int
+    {
+        $parts = explode(':', $subjectRef);
+
+        return ($parts[0] ?? '') === 'article' && ctype_digit($parts[1] ?? '') ? (int) $parts[1] : 0;
+    }
+
+    private function locale(string $subjectRef, string $safePath): string
+    {
+        $parts = explode(':', $subjectRef);
+        if (($parts[2] ?? '') !== '') {
+            return (string) $parts[2];
+        }
+
+        return str_starts_with($safePath, '/zh/') ? 'zh-CN' : (str_starts_with($safePath, '/en/') ? 'en' : '');
+    }
+
+    private function canonical(mixed $value): string
+    {
+        return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION) ?: '';
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/gsc-batch-draft-qa-support');
+        }
+
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactRef(string $path, string $schemaVersion): array
+    {
+        return [
+            'schema_version' => $schemaVersion,
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, string $filename, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode GSC batch draft QA artifact.');
+        }
+        file_put_contents($path, $encoded."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'external_model_api_call' => false,
+            'live_gsc_api_call' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line(sprintf('%s %s', $summary['schema_version'] ?? self::SCHEMA_VERSION, $summary['status'] ?? 'unknown'));
+        }
+
+        return (bool) ($summary['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -198,6 +198,7 @@ use App\Console\Commands\SeoAgentCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentCmsTdkGapScanCommand;
 use App\Console\Commands\SeoAgentCodexReviewRunnerCommand;
 use App\Console\Commands\SeoAgentGscCohortHandoffCommand;
+use App\Console\Commands\SeoAgentGscBatchDraftQaSupportCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentGscPostPublishFeedbackCommand;
 use App\Console\Commands\SeoAgentGscRemainingCandidateBatchPlanCommand;
@@ -434,6 +435,7 @@ class Kernel extends ConsoleKernel
         SeoAgentL5aContentPagePublishCanaryCommand::class,
         SeoAgentL5aIndexnowSubmitCanaryCommand::class,
         SeoAgentGscCohortHandoffCommand::class,
+        SeoAgentGscBatchDraftQaSupportCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentGscPostPublishFeedbackCommand::class,
         SeoAgentGscRemainingCandidateBatchPlanCommand::class,

--- a/backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json
@@ -1,0 +1,53 @@
+{
+  "version": "seo-agent-gsc-batch-draft-qa-support.v1",
+  "command": "php artisan seo-agent:gsc-batch-draft-qa-support",
+  "purpose": "Read-only batch post-write QA summarizer for GSC cohort CMS draft write evidence.",
+  "inputs": {
+    "package": "Path to seo-agent-cms-draft-package-dry-run.v1 JSON artifact.",
+    "write_evidence": "Path to seo-agent-controlled-cms-draft-write.v1 JSON artifact.",
+    "target": "Optional repeated subject_ref filter.",
+    "artifact_dir": "Directory for sanitized batch QA evidence.",
+    "json": "Emit machine-readable summary."
+  },
+  "supported_targets": [
+    "article"
+  ],
+  "output_fields": [
+    "target_verdicts",
+    "matched_fields",
+    "mismatches",
+    "qa_findings",
+    "locale",
+    "proposal_quality",
+    "internal_link_actions",
+    "claim_risk_handoff_status"
+  ],
+  "compatibility": {
+    "single_target_readback_qa_unchanged": true,
+    "batch_write_evidence_supported": true
+  },
+  "post_approval_command_sequence": [
+    "run seo-agent:cms-draft-readback-qa for each affected target when single-target detail is needed",
+    "run seo-agent:article-draft-claim-risk-qa for each draft revision before publish readiness",
+    "run seo-agent:article-draft-preview-runtime-qa for each draft revision before publish readiness",
+    "do not publish until a separate publish gate readiness artifact passes"
+  ],
+  "mutates_database": false,
+  "mutates_cms": false,
+  "publishes_content": false,
+  "submits_search": false,
+  "calls_external_model": false,
+  "calls_live_gsc_api": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "external_model_api_call": false,
+    "live_gsc_api_call": false
+  }
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscBatchDraftQaSupportTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscBatchDraftQaSupportTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentGscBatchDraftQaSupportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_summarizes_multiple_written_article_drafts_without_mutating_rows(): void
+    {
+        [$packagePath, $writeEvidencePath] = $this->batchFixture();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:gsc-batch-draft-qa-support', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame(2, $summary['target_count'] ?? null);
+        $this->assertSame(0, $summary['mismatch_count'] ?? null);
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame(2, $artifact['target_count'] ?? null);
+        $this->assertCount(2, $artifact['target_verdicts'] ?? []);
+        $this->assertContains('proposal.proposed_internal_link_actions', data_get($artifact, 'target_verdicts.0.matched_fields', []));
+        $this->assertContains('proposal.proposal_quality', data_get($artifact, 'target_verdicts.0.matched_fields', []));
+        $this->assertSame('required_pending', data_get($artifact, 'target_verdicts.0.claim_risk_handoff_status'));
+        $this->assertSame('gsc_cohort_artifact', data_get($artifact, 'target_verdicts.0.proposal_quality.source'));
+        $this->assertNotEmpty(data_get($artifact, 'target_verdicts.0.internal_link_actions'));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_write', true));
+    }
+
+    #[Test]
+    public function it_reports_per_target_mismatches_without_breaking_single_target_readback_qa(): void
+    {
+        [$packagePath, $writeEvidencePath, $first] = $this->batchFixture(mismatchFirst: true);
+
+        $exitCode = Artisan::call('seo-agent:gsc-batch-draft-qa-support', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => [$first],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('review_required', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['target_count'] ?? null);
+        $this->assertGreaterThanOrEqual(1, $summary['mismatch_count'] ?? 0);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertContains('field_mismatch:proposal.proposed_seo_title', data_get($artifact, 'target_verdicts.0.mismatches', []));
+    }
+
+    #[Test]
+    public function it_fails_closed_for_invalid_schema_package_sha_mismatch_and_forbidden_inputs(): void
+    {
+        [$packagePath, $writeEvidencePath] = $this->batchFixture();
+        $invalid = $this->writeJson('bad-package-', ['schema_version' => 'wrong']);
+
+        $exitCode = Artisan::call('seo-agent:gsc-batch-draft-qa-support', [
+            '--package' => $invalid,
+            '--write-evidence' => $writeEvidencePath,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('package_schema_invalid', $summary['issues'] ?? []);
+
+        $badWrite = $this->writeEvidence('bad-sha', []);
+        $exitCode = Artisan::call('seo-agent:gsc-batch-draft-qa-support', [
+            '--package' => $packagePath,
+            '--write-evidence' => $badWrite,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('write_evidence_package_sha256_mismatch', $summary['issues'] ?? []);
+
+        $forbidden = $this->writeJson('forbidden-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'raw_query' => 'blocked',
+        ]);
+        $exitCode = Artisan::call('seo-agent:gsc-batch-draft-qa-support', [
+            '--package' => $packagePath,
+            '--write-evidence' => $forbidden,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_batch_draft_qa_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json'));
+
+        $this->assertSame('seo-agent-gsc-batch-draft-qa-support.v1', $contract['version'] ?? null);
+        $this->assertContains('target_verdicts', $contract['output_fields'] ?? []);
+        $this->assertTrue((bool) data_get($contract, 'compatibility.single_target_readback_qa_unchanged'));
+        $this->assertFalse((bool) ($contract['mutates_cms'] ?? true));
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}
+     */
+    private function batchFixture(bool $mismatchFirst = false): array
+    {
+        $articleA = $this->article('article-a', 'en');
+        $articleB = $this->article('article-b', 'zh-CN');
+        $proposalA = $this->proposal((int) $articleA->id, 'en');
+        $proposalB = $this->proposal((int) $articleB->id, 'zh-CN');
+        $packagePath = $this->writePackage([$proposalA, $proposalB]);
+        $sha = hash_file('sha256', $packagePath) ?: '';
+        $revisionA = $this->revision($articleA, $proposalA, $sha, $mismatchFirst);
+        $revisionB = $this->revision($articleB, $proposalB, $sha);
+        $writeEvidencePath = $this->writeEvidence($sha, [
+            ['target_model' => 'article', 'subject_ref' => $proposalA['subject_ref'], 'revision_id' => (int) $revisionA->id],
+            ['target_model' => 'article', 'subject_ref' => $proposalB['subject_ref'], 'revision_id' => (int) $revisionB->id],
+        ]);
+
+        return [$packagePath, $writeEvidencePath, $proposalA['subject_ref']];
+    }
+
+    private function article(string $slug, string $locale): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $slug,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'content_html' => '<p>Existing HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_revision_id' => 100,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function proposal(int $articleId, string $locale): array
+    {
+        return [
+            'source_family' => 'gsc_cohort_artifact',
+            'subject_type' => 'article',
+            'target_model' => 'article',
+            'subject_ref' => 'article:'.$articleId.':'.$locale,
+            'safe_path' => $locale === 'en' ? '/en/articles/article-a' : '/zh/articles/article-b',
+            'proposed_seo_title' => $locale === 'en' ? 'Article A | FermatMind' : '文章 B | FermatMind',
+            'proposed_seo_description' => $locale === 'en' ? 'Careful description.' : '谨慎的中文描述。',
+            'proposed_faq_items' => [['question' => 'Question?', 'answer' => 'Answer.']],
+            'proposed_internal_link_actions' => ['Add internal link to /en/tests/big-five-personality-test'],
+            'proposal_quality' => [
+                'source' => 'gsc_cohort_artifact',
+                'locale_preserved' => true,
+                'slug_generated_copy' => false,
+                'needs_human_approval' => true,
+            ],
+            'claim_gate_required' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     */
+    private function revision(Article $article, array $proposal, string $sha, bool $mismatch = false): ArticleRevision
+    {
+        return ArticleRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'revision_no' => 2,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'payload_json' => [
+                'seo_agent' => [
+                    'package_sha256' => $sha,
+                    'subject_ref' => $proposal['subject_ref'],
+                ],
+                'proposal' => [
+                    'proposed_seo_title' => $mismatch ? 'Wrong title' : $proposal['proposed_seo_title'],
+                    'proposed_seo_description' => $proposal['proposed_seo_description'],
+                    'proposed_faq_items' => $proposal['proposed_faq_items'],
+                    'proposed_internal_link_actions' => $proposal['proposed_internal_link_actions'],
+                    'proposal_quality' => $proposal['proposal_quality'],
+                ],
+            ],
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $proposals
+     */
+    private function writePackage(array $proposals): string
+    {
+        return $this->writeJson('seo-agent-cms-draft-package-', [
+            'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
+            'dry_run' => true,
+            'cms_write_allowed' => false,
+            'execution_permission' => false,
+            'draft_brief_count' => count($proposals),
+            'draft_briefs' => $proposals,
+            'proposal_items' => $proposals,
+        ]);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $refs
+     */
+    private function writeEvidence(string $sha, array $refs): string
+    {
+        return $this->writeJson('seo-agent-controlled-cms-draft-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'status' => 'success',
+            'execute' => true,
+            'writes_attempted' => true,
+            'package_sha256' => $sha,
+            'affected_refs' => $refs,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-gsc-batch-draft-qa-support-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->count(),
+            'article_revisions' => ArticleRevision::query()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1238,6 +1238,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_batch_draft_qa_support_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentGscBatchDraftQaSupportCommand;',
+            '+        SeoAgentGscBatchDraftQaSupportCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4504,6 +4518,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentGscBatchDraftQaSupportFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentAutoRollbackGuardFile($file)) {
                 continue;
             }
@@ -5235,6 +5253,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentPostPublishIndexnowAutoOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscPostPublishFeedbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscRemainingCandidateBatchPlanOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentGscBatchDraftQaSupportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPriorityQueueSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6047,6 +6066,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscRemainingCandidateBatchPlanCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentGscBatchDraftQaSupportFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php',
         ], true);
     }
 
@@ -8065,6 +8091,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentGscRemainingCandidateBatchPlanCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentGscBatchDraftQaSupportOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentGscBatchDraftQaSupportCommand\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:37:00+08:00",
+  "updated_at": "2026-06-22T23:52:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -165,7 +165,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-remaining-candidate-batch-plan-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01 Plan remaining GSC draft candidates",
     "depends_on": [
@@ -196,14 +196,18 @@
           "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
         ],
         "notes": "Focused PR-G tests, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
+      },
+      "github_final": {
+        "status": "pass",
+        "evidence": "GitHub PR #2318 merged with merge commit 16d3905871b9402f43d124ca9b69a7effae74fbb; origin/main contains the merge commit and remote branch was pruned/deleted."
       }
     },
     "failure_reason": null,
-    "commit_sha": "78eace54790e2057269482e377eab1604123d0b2",
+    "commit_sha": "16d3905871b9402f43d124ca9b69a7effae74fbb",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2318",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T15:31:01Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T22:35:00+08:00",
@@ -222,6 +226,12 @@
         "from": "local_checks_passed_with_external_sidecar",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2318."
+      },
+      {
+        "at": "2026-06-22T23:52:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "PR #2318 squash-merged; origin/main contains merge commit 16d3905871b9402f43d124ca9b69a7effae74fbb; local PR-G branch deleted after switching worktree to detached origin/main."
       }
     ]
   },
@@ -229,7 +239,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-batch-draft-qa-support-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed_with_external_sidecar",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01 Add batch draft QA support",
     "depends_on": [
@@ -241,8 +251,25 @@
         "evidence": "User explicitly authorized SEO-AGENT-GSC-DRAFT-CANARY-CLOSEOUT-TRAIN-01 and PR-E through PR-I manifest/state initialization."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01."
+        "status": "pass",
+        "evidence": "SEO-AGENT-GSC-REMAINING-CANDIDATE-BATCH-PLAN-01 merged via GitHub PR #2318 at 2026-06-22T15:31:01Z; origin/main contains merge commit 16d3905871b9402f43d124ca9b69a7effae74fbb."
+      },
+      "scope_validation": {
+        "status": "pass_with_external_sidecar",
+        "evidence": "Changed files are confined to PR-H command/test/doc registration, BigFive runtime-freeze classifier allowance for this SEO Agent command, and closeout train metadata."
+      },
+      "local": {
+        "status": "pass_with_external_pint_blocker",
+        "commands": [
+          "cd backend && php artisan list | rg 'seo-agent:gsc-batch-draft-qa-support'",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscBatchDraftQaSupportTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsDraftReadbackQaTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_batch_draft_qa_support' --display-warnings",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php tests/Feature/SeoIntel/SeoAgentGscBatchDraftQaSupportTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json >/dev/null",
+          "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
+        ],
+        "notes": "Focused PR-H tests, existing single-target readback QA compatibility, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
       }
     },
     "failure_reason": null,
@@ -257,6 +284,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO Agent GSC draft canary closeout /goal."
+      },
+      {
+        "at": "2026-06-22T23:52:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed_with_external_sidecar",
+        "notes": "Implemented read-only batch draft QA support and focused tests; broad Pint external blocker unchanged."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:52:00+08:00",
+  "updated_at": "2026-06-22T23:57:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -239,7 +239,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-batch-draft-qa-support-01",
     "base": "main",
-    "status": "local_checks_passed_with_external_sidecar",
+    "status": "pr_open",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01 Add batch draft QA support",
     "depends_on": [
@@ -273,8 +273,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "71d6bff76e870b2ab0602a0244828994f6432e24",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2319",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -290,6 +290,12 @@
         "from": "planned",
         "to": "local_checks_passed_with_external_sidecar",
         "notes": "Implemented read-only batch draft QA support and focused tests; broad Pint external blocker unchanged."
+      },
+      {
+        "at": "2026-06-22T23:57:00+08:00",
+        "from": "local_checks_passed_with_external_sidecar",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2319."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23981,6 +23981,7 @@ prs:
       - backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json
       - backend/tests/Feature/SeoIntel/SeoAgentGscBatchDraftQaSupportTest.php
       - backend/tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train-state.json
     do_not:
       - Execute CMS draft writes.
@@ -23990,6 +23991,7 @@ prs:
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscBatchDraftQaSupportTest
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsDraftReadbackQaTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_gsc_batch_draft_qa_support
       - cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel
       - python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json >/dev/null
       - git diff --check


### PR DESCRIPTION
## What changed
- Added backend-only `seo-agent:gsc-batch-draft-qa-support` read-only Artisan command.
- Summarizes multi-target controlled CMS draft write evidence against the dry-run package.
- Reports per target matched fields, mismatches, locale, proposal quality, internal-link actions, and claim-risk handoff status.
- Keeps existing single-target `seo-agent:cms-draft-readback-qa` compatible and unchanged.
- Registered the command, added generated contract docs, focused feature tests, and BigFive runtime-freeze classifier coverage.
- Reconciled PR-G merge facts and recorded PR-H local validation in the PR train state ledger.

## Why
The next GSC cohort write canary should be limit=2 or limit=3, so post-write evidence needs batch-level QA without losing per-target readback detail or accidentally changing publish behavior.

## Validation
- `cd backend && php artisan list | rg 'seo-agent:gsc-batch-draft-qa-support'`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscBatchDraftQaSupportTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsDraftReadbackQaTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_batch_draft_qa_support' --display-warnings`\n- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php tests/Feature/SeoIntel/SeoAgentGscBatchDraftQaSupportTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-batch-draft-qa-support.v1.json >/dev/null`\n- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n- `git diff --cached --check`\n\nBroad Pint note: `cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel` still fails only on existing files outside PR-H scope, already recorded in `docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md`.\n\n## Intentionally deferred\n- No production CMS draft write.\n- No publish.\n- No URL Truth, sitemap, IndexNow, search/indexing submission.\n- No scheduler, queue worker, external model API, or live GSC API action.