### PR TITLE
MBTI64-CMS-PROJECTION-PROMOTE-VISIBLE-3-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -26,6 +26,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
         {--package= : Path to the MBTI64 pilot V2.1 or agent projection JSON package}
         {--dry-run : Plan promotion without database writes}
         {--write : Promote latest matching revision snapshots to live CMS content fields}
+        {--visible-query-backed-3 : Restrict agent projection promotion planning/write to the approved 3 query-backed visible MBTI64 URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--promote-live-content : Required for --write; confirms live CMS content promotion intent}
@@ -135,6 +136,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
             'no_llms' => (bool) $this->option('no-llms'),
             'no_search_release' => (bool) $this->option('no-search-release'),
             'operator_approved' => (string) $this->option('operator-approved'),
+            'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
         ];
     }
 

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -26,6 +26,12 @@ final class Mbti64CmsRevisionPromotionService
 
     private const AGENT_PROJECTION_VERSION = 'mbti64.agent_expansion_88_recommendations.v1';
 
+    private const VISIBLE_QUERY_BACKED_3_URLS = [
+        'https://fermatmind.com/en/personality/enfj-a',
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfp-a',
+    ];
+
     public function __construct(private readonly Mbti64BackendImportContractPlanner $planner)
     {
     }
@@ -57,7 +63,7 @@ final class Mbti64CmsRevisionPromotionService
      */
     private function buildSummary(array $package, string $sourceSha256, bool $write, array $options): array
     {
-        $contract = $this->promotionContract($package);
+        $contract = $this->promotionContract($package, $options);
         if (($contract['ok'] ?? false) !== true) {
             return array_merge($this->baseSummary($package, $sourceSha256, $write), [
                 'ok' => false,
@@ -140,10 +146,10 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
-    private function promotionContract(array $package): array
+    private function promotionContract(array $package, array $options): array
     {
         if ($this->isAgentProjectionPackage($package)) {
-            return $this->agentProjectionContract($package);
+            return $this->agentProjectionContract($package, $options);
         }
 
         return $this->planner->plan($package);
@@ -163,12 +169,25 @@ final class Mbti64CmsRevisionPromotionService
      * @param  array<string,mixed>  $package
      * @return array<string,mixed>
      */
-    private function agentProjectionContract(array $package): array
+    private function agentProjectionContract(array $package, array $options): array
     {
         $errors = [];
         $warnings = [];
         $summary = is_array($package['summary'] ?? null) ? $package['summary'] : [];
-        $recommendations = $this->recommendations($package);
+        $rawRecommendations = $this->recommendations($package);
+        $recommendations = array_map(
+            static function (array $recommendation, int $index): array {
+                $recommendation['__package_position'] = $index + 1;
+
+                return $recommendation;
+            },
+            $rawRecommendations,
+            array_keys($rawRecommendations)
+        );
+        $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
+        $contractRecommendations = $visibleQueryBacked3
+            ? $this->visibleQueryBacked3Recommendations($recommendations)
+            : $recommendations;
 
         if ((string) ($package['artifact'] ?? '') !== self::AGENT_PROJECTION_ARTIFACT) {
             $errors[] = ['field' => 'artifact', 'code' => 'unsupported_package_artifact', 'message' => 'Unexpected MBTI64 agent projection artifact.'];
@@ -185,9 +204,16 @@ final class Mbti64CmsRevisionPromotionService
         if ((int) ($summary['variant_pages'] ?? -1) !== 58 || (int) ($summary['comparison_pages'] ?? -1) !== 30) {
             $errors[] = ['field' => 'summary', 'code' => 'unexpected_page_type_counts', 'message' => 'Expected 58 variant and 30 comparison recommendations.'];
         }
+        if ($visibleQueryBacked3 && count($contractRecommendations) !== 3) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'visible_query_backed_3_subset_incomplete',
+                'message' => 'Expected exactly the 3 approved query-backed visible MBTI64 recommendations.',
+            ];
+        }
 
         $rows = [];
-        foreach ($recommendations as $index => $recommendation) {
+        foreach ($contractRecommendations as $index => $recommendation) {
             $identity = $this->identityForRecommendation($recommendation);
             if ($identity === null) {
                 $errors[] = [
@@ -201,6 +227,7 @@ final class Mbti64CmsRevisionPromotionService
 
             $rows[] = [
                 'position' => $index + 1,
+                'package_position' => (int) ($recommendation['__package_position'] ?? ($index + 1)),
                 'url' => (string) $identity['url'],
                 'locale' => (string) $identity['locale'],
                 'page_type' => (string) $identity['page_type'],
@@ -219,6 +246,11 @@ final class Mbti64CmsRevisionPromotionService
             'status' => $errors === [] ? 'pass' : 'fail',
             'artifact' => 'MBTI64-CMS-PROJECTION-PROMOTE-88-CONTRACT-PATCH-01',
             'source_kind' => 'mbti64_agent_projection_draft_v1',
+            'subset' => [
+                'mode' => $visibleQueryBacked3 ? 'visible_query_backed_3' : 'full_agent_projection_88',
+                'enabled' => $visibleQueryBacked3,
+                'allowed_urls' => $visibleQueryBacked3 ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
+            ],
             'row_count' => count($rows),
             'variant_row_count' => count(array_filter($rows, static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant')),
             'comparison_row_count' => count(array_filter($rows, static fn (array $row): bool => ($row['page_type'] ?? null) === 'comparison')),
@@ -267,7 +299,8 @@ final class Mbti64CmsRevisionPromotionService
     {
         if (($contract['source_kind'] ?? null) === 'mbti64_agent_projection_draft_v1') {
             $recommendations = $this->recommendations($package);
-            $recommendation = $recommendations[$position - 1] ?? [];
+            $packagePosition = (int) ($contract['rows'][$position - 1]['package_position'] ?? $position);
+            $recommendation = $recommendations[$packagePosition - 1] ?? [];
 
             return is_array($recommendation) ? $recommendation : [];
         }
@@ -288,6 +321,30 @@ final class Mbti64CmsRevisionPromotionService
             is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
             static fn (mixed $item): bool => is_array($item)
         ));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $recommendations
+     * @return list<array<string,mixed>>
+     */
+    private function visibleQueryBacked3Recommendations(array $recommendations): array
+    {
+        $byUrl = [];
+        foreach ($recommendations as $recommendation) {
+            $url = (string) ($recommendation['target_url'] ?? '');
+            if (in_array($url, self::VISIBLE_QUERY_BACKED_3_URLS, true)) {
+                $byUrl[$url] = $recommendation;
+            }
+        }
+
+        $ordered = [];
+        foreach (self::VISIBLE_QUERY_BACKED_3_URLS as $url) {
+            if (isset($byUrl[$url])) {
+                $ordered[] = $byUrl[$url];
+            }
+        }
+
+        return $ordered;
     }
 
     /**

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -267,6 +267,40 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_dry_run_supports_fixed_visible_query_backed_three_subset_without_live_writes(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame('visible_query_backed_3', $payload['contract']['subset']['mode']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['would_promote_count']);
+        $this->assertSame([
+            'https://fermatmind.com/en/personality/enfj-a',
+            'https://fermatmind.com/zh/personality/intp-a',
+            'https://fermatmind.com/zh/personality/esfp-a',
+        ], array_column($payload['rows'], 'url'));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
     {
         $targets = $this->seedProjectionTargets();
@@ -305,6 +339,70 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             ->firstOrFail();
         $this->assertSame('ENFJ-A-VS-ENFJ-T Meaning', $comparison->title);
         $this->assertSame('/en/personality/enfj-a-vs-enfj-t', $comparison->payload_json['url'] ?? null);
+    }
+
+    public function test_write_promotes_only_fixed_visible_query_backed_three_subset(): void
+    {
+        $targets = $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+        $options = $this->promoteWriteOptions($packagePath);
+        $options['--visible-query-backed-3'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertSame('visible_query_backed_3', $payload['contract']['subset']['mode']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['promoted_count']);
+        $this->assertSame(3, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+
+        foreach (['en|ENFJ-A', 'zh-CN|INTP-A', 'zh-CN|ESFP-A'] as $targetKey) {
+            PersonalityProfileVariantSeoMeta::query()
+                ->where('personality_profile_variant_id', (int) $targets[$targetKey]->id)
+                ->firstOrFail();
+        }
+
+        $this->assertNull(PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|ENTJ-A']->id)
+            ->first());
+    }
+
+    public function test_visible_query_backed_three_subset_fails_closed_when_fixed_url_is_missing(): void
+    {
+        $this->seedProjectionTargets();
+        $package = $this->validProjectionPackage();
+        foreach ($package['recommendations'] as &$recommendation) {
+            if (($recommendation['target_url'] ?? null) === 'https://fermatmind.com/en/personality/enfj-a') {
+                $recommendation['target_url'] = 'https://fermatmind.com/en/personality/enfj-x';
+            }
+        }
+        unset($recommendation);
+        [$packagePath] = $this->writeProjectionArtifacts($package, $this->validProjectionQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('visible_query_backed_3_subset_incomplete', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
     public function test_second_agent_projection_write_is_idempotent(): void


### PR DESCRIPTION
## What changed
- Added `--visible-query-backed-3` to `personality:mbti64-cms-revision-promote`.
- Restricted the MBTI64 agent projection promotion contract to the fixed approved 3 visible query-backed URLs when that flag is used:
  - `https://fermatmind.com/en/personality/enfj-a`
  - `https://fermatmind.com/zh/personality/intp-a`
  - `https://fermatmind.com/zh/personality/esfp-a`
- Preserved the existing full 88-row agent projection promotion behavior when the flag is not used.
- Added focused tests for visible-3 dry-run, visible-3 write, and fail-closed missing fixed URL behavior.

## Why
Production dry-run for `MBTI64-CMS-PROJECTION-PROMOTE-VISIBLE-3-DRY-RUN-01` found that the promotion command could only plan the full 88-row agent projection package. This patch adds a fixed subset contract so the next production dry-run can safely plan exactly 3 rows and cannot accidentally promote the full 88-page package.

## Validation
- `php -l backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php`
- `php -l backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php`
- `php -l backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php`
- `cd backend && php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only promotion command, promotion service, and focused command test changed.

## Intentionally deferred
- No production deploy.
- No production promotion write.
- No CMS live content mutation.
- No publish/index/search/sitemap/llms changes.
- No frontend changes.

## Repository rule impact
Backend remains the CMS authority for personality public profile content. This PR only narrows the backend promotion contract for an approved fixed subset; it does not add frontend fallback content or change content ownership.
