### PR TITLE
SEO-AGENT-GSC-DRAFT-PUBLISH-GATE-READINESS-01 Add draft publish gate readiness

### DIFF
--- a/backend/app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php
+++ b/backend/app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class SeoAgentGscDraftPublishGateReadinessCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-gsc-draft-publish-gate-readiness.v1';
+
+    private const WRITE_SCHEMA_VERSION = 'seo-agent-controlled-cms-draft-write.v1';
+
+    private const READBACK_SCHEMA_VERSION = 'seo-agent-cms-draft-readback-qa.v1';
+
+    private const CLAIM_RISK_SCHEMA_VERSION = 'seo-agent-article-draft-claim-risk-qa.v1';
+
+    private const PREVIEW_RUNTIME_SCHEMA_VERSION = 'seo-agent-article-draft-preview-runtime-qa.v1';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'token',
+        'cookie',
+        'session',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:gsc-draft-publish-gate-readiness
+        {--write-evidence= : Path to seo-agent-controlled-cms-draft-write.v1 JSON artifact}
+        {--readback-qa=* : Path to one or more seo-agent-cms-draft-readback-qa.v1 artifacts}
+        {--claim-risk-qa=* : Path to one or more seo-agent-article-draft-claim-risk-qa.v1 artifacts}
+        {--preview-runtime-qa=* : Path to one or more seo-agent-article-draft-preview-runtime-qa.v1 artifacts}
+        {--artifact-dir= : Directory for sanitized publish gate readiness evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only publish gate readiness evidence for SEO Agent GSC CMS drafts; does not publish.';
+
+    public function handle(): int
+    {
+        $writePath = $this->readablePath((string) $this->option('write-evidence'));
+        if ($writePath === null) {
+            return $this->finish($this->failureSummary('write_evidence_unreadable'));
+        }
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $loaded = $this->loadArtifacts([
+            'write_evidence' => [$writePath],
+            'readback_qa' => (array) $this->option('readback-qa'),
+            'claim_risk_qa' => (array) $this->option('claim-risk-qa'),
+            'preview_runtime_qa' => (array) $this->option('preview-runtime-qa'),
+        ]);
+        if (($loaded['issue'] ?? null) !== null) {
+            return $this->finish($this->failureSummary((string) $loaded['issue'], (array) ($loaded['extra'] ?? [])));
+        }
+
+        $writeEvidence = $loaded['artifacts']['write_evidence'][0]['payload'] ?? null;
+        if (! is_array($writeEvidence) || ($writeEvidence['schema_version'] ?? null) !== self::WRITE_SCHEMA_VERSION) {
+            return $this->finish($this->failureSummary('write_evidence_schema_invalid'));
+        }
+        if (($writeEvidence['status'] ?? null) !== 'success' || (bool) ($writeEvidence['execute'] ?? false) !== true) {
+            return $this->finish($this->failureSummary('write_evidence_not_success_execute'));
+        }
+
+        $evidence = $this->evidence($loaded['artifacts'], $writeEvidence, hash_file('sha256', $writePath) ?: '');
+        $artifactRef = $this->writeArtifact(
+            $artifactDir,
+            'seo-agent-gsc-draft-publish-gate-readiness-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
+            $evidence
+        );
+
+        return $this->finish([
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => (string) ($evidence['status'] ?? 'unknown'),
+            'draft_count' => (int) ($evidence['draft_count'] ?? 0),
+            'publish_ready_count' => (int) ($evidence['publish_ready_count'] ?? 0),
+            'artifact' => $artifactRef,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $artifacts
+     * @param  array<string, mixed>  $writeEvidence
+     * @return array<string, mixed>
+     */
+    private function evidence(array $artifacts, array $writeEvidence, string $writeEvidenceSha): array
+    {
+        $readback = $this->indexByTarget($artifacts['readback_qa'] ?? []);
+        $claimRisk = $this->indexByTarget($artifacts['claim_risk_qa'] ?? []);
+        $preview = $this->indexByTarget($artifacts['preview_runtime_qa'] ?? []);
+        $drafts = [];
+        foreach ((array) ($writeEvidence['affected_refs'] ?? []) as $ref) {
+            if (! is_array($ref) || (string) ($ref['target_model'] ?? '') !== 'article') {
+                continue;
+            }
+            $drafts[] = $this->draftVerdict($ref, $readback, $claimRisk, $preview, $writeEvidenceSha);
+        }
+        $readyCount = count(array_filter($drafts, static fn (array $draft): bool => ($draft['gate_status'] ?? '') === 'publish_ready'));
+        $blockedCount = count(array_filter($drafts, static fn (array $draft): bool => ($draft['gate_status'] ?? '') === 'blocked'));
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $blockedCount > 0 ? 'blocked' : ($readyCount === count($drafts) && $drafts !== [] ? 'publish_ready' : 'review_required'),
+            'draft_count' => count($drafts),
+            'publish_ready_count' => $readyCount,
+            'draft_verdicts' => $drafts,
+            'approval_boundary' => [
+                'draft_write_is_separate_from_publish' => true,
+                'publish_is_separate_from_url_truth_sitemap_indexnow_search' => true,
+                'no_publish_phrase_emitted_when_qa_missing_or_failing' => true,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $ref
+     * @param  array<string, array<string, mixed>>  $readback
+     * @param  array<string, array<string, mixed>>  $claimRisk
+     * @param  array<string, array<string, mixed>>  $preview
+     * @return array<string, mixed>
+     */
+    private function draftVerdict(array $ref, array $readback, array $claimRisk, array $preview, string $writeEvidenceSha): array
+    {
+        $target = (string) ($ref['subject_ref'] ?? '');
+        $revisionId = (int) ($ref['revision_id'] ?? 0);
+        $issues = [];
+        foreach (['readback_qa' => $readback, 'claim_risk_qa' => $claimRisk, 'preview_runtime_qa' => $preview] as $label => $index) {
+            if (! isset($index[$target])) {
+                $issues[] = $label.'_missing';
+            }
+        }
+        if (isset($readback[$target]) && (($readback[$target]['status'] ?? null) !== 'success' || (int) ($readback[$target]['mismatch_count'] ?? count((array) ($readback[$target]['mismatches'] ?? []))) !== 0)) {
+            $issues[] = 'readback_qa_not_passing';
+        }
+        if (isset($claimRisk[$target]) && (($claimRisk[$target]['status'] ?? null) !== 'success' || (int) ($claimRisk[$target]['critical_finding_count'] ?? 0) !== 0)) {
+            $issues[] = 'claim_risk_qa_not_passing';
+        }
+        if (isset($preview[$target]) && (($preview[$target]['status'] ?? null) !== 'success' || (bool) ($preview[$target]['ok'] ?? false) !== true)) {
+            $issues[] = 'preview_runtime_qa_not_passing';
+        }
+
+        $status = $issues === [] ? 'publish_ready' : 'review_required';
+
+        return [
+            'subject_ref' => $target,
+            'revision_id' => $revisionId,
+            'gate_status' => $status,
+            'issues' => $issues,
+            'readback_qa_status' => (string) ($readback[$target]['status'] ?? 'missing'),
+            'claim_risk_qa_status' => (string) ($claimRisk[$target]['status'] ?? 'missing'),
+            'preview_runtime_qa_status' => (string) ($preview[$target]['status'] ?? 'missing'),
+            'publish_approval_phrase' => $status === 'publish_ready'
+                ? 'I explicitly approve production CMS publish canary for '.$target.' revision '.$revisionId.' using write evidence sha256 '.$writeEvidenceSha.'; no URL Truth, no sitemap, no IndexNow, no search, no indexing, no scheduler.'
+                : null,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $artifacts
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexByTarget(array $artifacts): array
+    {
+        $out = [];
+        foreach ($artifacts as $artifact) {
+            $payload = $artifact['payload'] ?? [];
+            if (is_array($payload) && (string) ($payload['target'] ?? '') !== '') {
+                $out[(string) $payload['target']] = $payload;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string, list<string>>  $pathsByKind
+     * @return array<string, mixed>
+     */
+    private function loadArtifacts(array $pathsByKind): array
+    {
+        $expectedSchemas = [
+            'write_evidence' => self::WRITE_SCHEMA_VERSION,
+            'readback_qa' => self::READBACK_SCHEMA_VERSION,
+            'claim_risk_qa' => self::CLAIM_RISK_SCHEMA_VERSION,
+            'preview_runtime_qa' => self::PREVIEW_RUNTIME_SCHEMA_VERSION,
+        ];
+        $artifacts = [];
+        foreach ($pathsByKind as $kind => $paths) {
+            $artifacts[$kind] = [];
+            foreach ($paths as $rawPath) {
+                $path = $this->readablePath((string) $rawPath);
+                if ($path === null) {
+                    return ['issue' => $kind.'_artifact_unreadable'];
+                }
+                $raw = (string) file_get_contents($path);
+                $forbidden = $this->forbiddenStringsPresent($raw);
+                if ($forbidden !== []) {
+                    return ['issue' => 'forbidden_input_field_present', 'extra' => ['forbidden_matches' => $forbidden]];
+                }
+                $payload = json_decode($raw, true);
+                if (! is_array($payload)) {
+                    return ['issue' => $kind.'_json_invalid'];
+                }
+                if (($payload['schema_version'] ?? null) !== $expectedSchemas[$kind]) {
+                    return ['issue' => $kind.'_schema_invalid'];
+                }
+                $artifacts[$kind][] = [
+                    'path' => $path,
+                    'payload' => $payload,
+                    'sha256' => hash_file('sha256', $path) ?: '',
+                ];
+            }
+        }
+
+        return ['artifacts' => $artifacts];
+    }
+
+    private function readablePath(string $rawPath): ?string
+    {
+        $path = trim($rawPath);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/gsc-draft-publish-gate-readiness');
+        }
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        if (! is_dir($dir) && ! mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            return null;
+        }
+
+        return is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $payload): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($payload, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function writeArtifact(string $dir, string $filename, array $payload): array
+    {
+        $path = rtrim($dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded)) {
+            throw new RuntimeException('Failed to encode publish gate readiness artifact.');
+        }
+        file_put_contents($path, $encoded."\n");
+
+        return ['path' => $path, 'size_bytes' => filesize($path) ?: 0, 'sha256' => hash_file('sha256', $path) ?: ''];
+    }
+
+    /**
+     * @return array<string, false>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'sitemap_submission' => false,
+            'indexnow_submit' => false,
+            'search_channel_submit' => false,
+            'indexing_request' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'external_model_api_call' => false,
+            'live_gsc_api_call' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'issues' => [$issue],
+            ...$extra,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->line(sprintf('%s %s', $summary['schema_version'] ?? self::SCHEMA_VERSION, $summary['status'] ?? 'unknown'));
+        }
+
+        return (bool) ($summary['ok'] ?? false) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -201,6 +201,7 @@ use App\Console\Commands\SeoAgentGscCohortHandoffCommand;
 use App\Console\Commands\SeoAgentGscBatchDraftQaSupportCommand;
 use App\Console\Commands\SeoAgentGscOpportunityAutoDraftCommand;
 use App\Console\Commands\SeoAgentGscPostPublishFeedbackCommand;
+use App\Console\Commands\SeoAgentGscDraftPublishGateReadinessCommand;
 use App\Console\Commands\SeoAgentGscRemainingCandidateBatchPlanCommand;
 use App\Console\Commands\SeoAgentL5aContentPagePublishCanaryCommand;
 use App\Console\Commands\SeoAgentL5aIndexnowSubmitCanaryCommand;
@@ -438,6 +439,7 @@ class Kernel extends ConsoleKernel
         SeoAgentGscBatchDraftQaSupportCommand::class,
         SeoAgentGscOpportunityAutoDraftCommand::class,
         SeoAgentGscPostPublishFeedbackCommand::class,
+        SeoAgentGscDraftPublishGateReadinessCommand::class,
         SeoAgentGscRemainingCandidateBatchPlanCommand::class,
         SeoAgentPostPublishIndexnowAutoCommand::class,
         SeoAgentPostPublishSearchSubmitCommand::class,

--- a/backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json
+++ b/backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json
@@ -1,0 +1,42 @@
+{
+  "version": "seo-agent-gsc-draft-publish-gate-readiness.v1",
+  "command": "php artisan seo-agent:gsc-draft-publish-gate-readiness",
+  "purpose": "Read-only publish gate readiness evidence for SEO Agent CMS drafts.",
+  "input_schemas": [
+    "seo-agent-controlled-cms-draft-write.v1",
+    "seo-agent-cms-draft-readback-qa.v1",
+    "seo-agent-article-draft-claim-risk-qa.v1",
+    "seo-agent-article-draft-preview-runtime-qa.v1"
+  ],
+  "verdicts": [
+    "publish_ready",
+    "review_required",
+    "blocked"
+  ],
+  "approval_policy": {
+    "emit_publish_phrase_only_when_all_required_qa_present_and_passing": true,
+    "publish_separate_from_draft_write": true,
+    "url_truth_sitemap_indexnow_search_separate_from_publish": true
+  },
+  "mutates_database": false,
+  "mutates_cms": false,
+  "publishes_content": false,
+  "writes_url_truth": false,
+  "submits_sitemap": false,
+  "submits_indexnow": false,
+  "submits_search": false,
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "sitemap_submission": false,
+    "indexnow_submit": false,
+    "search_channel_submit": false,
+    "indexing_request": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "external_model_api_call": false,
+    "live_gsc_api_call": false
+  }
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentGscDraftPublishGateReadinessTest extends TestCase
+{
+    #[Test]
+    public function it_marks_a_draft_publish_ready_only_when_all_required_qa_is_present_and_passing(): void
+    {
+        $target = 'article:41:en';
+        $revisionId = 68;
+        $write = $this->writeEvidence($target, $revisionId);
+        $readback = $this->artifact('seo-agent-cms-draft-readback-qa.v1', $target, ['status' => 'success', 'mismatch_count' => 0]);
+        $claim = $this->artifact('seo-agent-article-draft-claim-risk-qa.v1', $target, ['status' => 'success', 'critical_finding_count' => 0]);
+        $preview = $this->artifact('seo-agent-article-draft-preview-runtime-qa.v1', $target, ['status' => 'success', 'ok' => true]);
+
+        $exitCode = Artisan::call('seo-agent:gsc-draft-publish-gate-readiness', [
+            '--write-evidence' => $write,
+            '--readback-qa' => [$readback],
+            '--claim-risk-qa' => [$claim],
+            '--preview-runtime-qa' => [$preview],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('publish_ready', $summary['status'] ?? null);
+        $this->assertSame(1, $summary['publish_ready_count'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame('publish_ready', data_get($artifact, 'draft_verdicts.0.gate_status'));
+        $this->assertStringContainsString('I explicitly approve production CMS publish canary for article:41:en revision 68', (string) data_get($artifact, 'draft_verdicts.0.publish_approval_phrase'));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.cms_publish', true));
+        $this->assertFalse((bool) data_get($artifact, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    #[Test]
+    public function it_does_not_emit_a_publish_phrase_when_required_qa_is_missing_or_failing(): void
+    {
+        $target = 'article:41:en';
+        $write = $this->writeEvidence($target, 68);
+        $readback = $this->artifact('seo-agent-cms-draft-readback-qa.v1', $target, ['status' => 'success', 'mismatch_count' => 0]);
+
+        $exitCode = Artisan::call('seo-agent:gsc-draft-publish-gate-readiness', [
+            '--write-evidence' => $write,
+            '--readback-qa' => [$readback],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('review_required', $summary['status'] ?? null);
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertNull(data_get($artifact, 'draft_verdicts.0.publish_approval_phrase'));
+        $this->assertContains('claim_risk_qa_missing', data_get($artifact, 'draft_verdicts.0.issues', []));
+        $this->assertContains('preview_runtime_qa_missing', data_get($artifact, 'draft_verdicts.0.issues', []));
+    }
+
+    #[Test]
+    public function it_fails_closed_for_invalid_schema_and_forbidden_inputs(): void
+    {
+        $badWrite = $this->writeJson('bad-write-', ['schema_version' => 'wrong']);
+
+        $exitCode = Artisan::call('seo-agent:gsc-draft-publish-gate-readiness', [
+            '--write-evidence' => $badWrite,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('write_evidence_schema_invalid', $summary['issues'] ?? []);
+
+        $forbidden = $this->writeJson('forbidden-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'raw_query' => 'blocked',
+        ]);
+        $exitCode = Artisan::call('seo-agent:gsc-draft-publish-gate-readiness', [
+            '--write-evidence' => $forbidden,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('forbidden_input_field_present', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function generated_contract_documents_publish_gate_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json'));
+
+        $this->assertSame('seo-agent-gsc-draft-publish-gate-readiness.v1', $contract['version'] ?? null);
+        $this->assertContains('publish_ready', $contract['verdicts'] ?? []);
+        $this->assertTrue((bool) data_get($contract, 'approval_policy.emit_publish_phrase_only_when_all_required_qa_present_and_passing'));
+        $this->assertFalse((bool) ($contract['publishes_content'] ?? true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_submit', true));
+    }
+
+    private function writeEvidence(string $target, int $revisionId): string
+    {
+        return $this->writeJson('seo-agent-controlled-cms-draft-write-', [
+            'schema_version' => 'seo-agent-controlled-cms-draft-write.v1',
+            'status' => 'success',
+            'execute' => true,
+            'package_sha256' => hash('sha256', 'package'),
+            'affected_refs' => [
+                ['target_model' => 'article', 'subject_ref' => $target, 'revision_id' => $revisionId],
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    private function artifact(string $schema, string $target, array $extra): string
+    {
+        return $this->writeJson('qa-artifact-', [
+            'schema_version' => $schema,
+            'target' => $target,
+            ...$extra,
+        ]);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-gsc-draft-publish-gate-readiness-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1252,6 +1252,20 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_agent_gsc_draft_publish_gate_readiness_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoAgentGscDraftPublishGateReadinessCommand;',
+            '+        SeoAgentGscDraftPublishGateReadinessCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_agent_runtime_seo_qa_readonly_scanner_files(): void
     {
         $changed = [
@@ -4522,6 +4536,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentGscDraftPublishGateReadinessFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentAutoRollbackGuardFile($file)) {
                 continue;
             }
@@ -5254,6 +5272,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoAgentGscPostPublishFeedbackOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscRemainingCandidateBatchPlanOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscBatchDraftQaSupportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoAgentGscDraftPublishGateReadinessOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentAutoRollbackGuardOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentPriorityQueueSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentGscOpportunityAutoDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6073,6 +6092,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentGscBatchDraftQaSupportCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentGscDraftPublishGateReadinessFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php',
         ], true);
     }
 
@@ -8113,6 +8139,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bSeoAgentGscBatchDraftQaSupportCommand\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoAgentGscDraftPublishGateReadinessOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoAgentGscDraftPublishGateReadinessCommand\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-23T00:10:00+08:00",
+  "updated_at": "2026-06-23T00:13:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -313,7 +313,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-draft-publish-gate-readiness-01",
     "base": "main",
-    "status": "local_checks_passed_with_external_sidecar",
+    "status": "pr_open",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-DRAFT-PUBLISH-GATE-READINESS-01 Add draft publish gate readiness",
     "depends_on": [
@@ -347,8 +347,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "782a36301566bfe76c568b7cc0cf6311f66fc779",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2321",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -364,6 +364,12 @@
         "from": "planned",
         "to": "local_checks_passed_with_external_sidecar",
         "notes": "Implemented read-only GSC draft publish gate readiness command and focused tests; broad Pint external blocker unchanged."
+      },
+      {
+        "at": "2026-06-23T00:13:00+08:00",
+        "from": "local_checks_passed_with_external_sidecar",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2321."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T23:57:00+08:00",
+  "updated_at": "2026-06-23T00:10:00+08:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -239,7 +239,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-batch-draft-qa-support-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01 Add batch draft QA support",
     "depends_on": [
@@ -270,14 +270,18 @@
           "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
         ],
         "notes": "Focused PR-H tests, existing single-target readback QA compatibility, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
+      },
+      "github_final": {
+        "status": "pass",
+        "evidence": "GitHub PR #2319 merged with merge commit fde84de2ecc92cbfbb0991ae20e86a837c4b7078; origin/main contains the merge commit and remote branch was pruned/deleted."
       }
     },
     "failure_reason": null,
-    "commit_sha": "71d6bff76e870b2ab0602a0244828994f6432e24",
+    "commit_sha": "fde84de2ecc92cbfbb0991ae20e86a837c4b7078",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2319",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T15:44:24Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-22T22:35:00+08:00",
@@ -296,6 +300,12 @@
         "from": "local_checks_passed_with_external_sidecar",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2319."
+      },
+      {
+        "at": "2026-06-23T00:10:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "PR #2319 squash-merged; origin/main contains merge commit fde84de2ecc92cbfbb0991ae20e86a837c4b7078; local PR-H branch deleted after switching worktree to detached origin/main."
       }
     ]
   },
@@ -303,7 +313,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-agent-gsc-draft-publish-gate-readiness-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed_with_external_sidecar",
     "train_scope": "seo_agent_gsc_draft_canary_closeout",
     "title": "SEO-AGENT-GSC-DRAFT-PUBLISH-GATE-READINESS-01 Add draft publish gate readiness",
     "depends_on": [
@@ -315,8 +325,25 @@
         "evidence": "User explicitly authorized SEO-AGENT-GSC-DRAFT-CANARY-CLOSEOUT-TRAIN-01 and PR-E through PR-I manifest/state initialization."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01."
+        "status": "pass",
+        "evidence": "SEO-AGENT-GSC-BATCH-DRAFT-QA-SUPPORT-01 merged via GitHub PR #2319 at 2026-06-22T15:44:24Z; origin/main contains merge commit fde84de2ecc92cbfbb0991ae20e86a837c4b7078."
+      },
+      "scope_validation": {
+        "status": "pass_with_external_sidecar",
+        "evidence": "Changed files are confined to PR-I command/test/doc registration, BigFive runtime-freeze classifier allowance for this SEO Agent command, and closeout train metadata."
+      },
+      "local": {
+        "status": "pass_with_external_pint_blocker",
+        "commands": [
+          "cd backend && php artisan list | rg 'seo-agent:gsc-draft-publish-gate-readiness'",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscDraftPublishGateReadinessTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsPublishCanaryTest --display-warnings",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_draft_publish_gate_readiness' --display-warnings",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json >/dev/null",
+          "cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel"
+        ],
+        "notes": "Focused PR-I tests, existing publish canary compatibility, BigFive runtime-freeze classifier coverage, scoped Pint, and JSON contract parse passed. Broad Pint still fails only on the existing files recorded in docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md."
       }
     },
     "failure_reason": null,
@@ -331,6 +358,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO Agent GSC draft canary closeout /goal."
+      },
+      {
+        "at": "2026-06-23T00:10:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed_with_external_sidecar",
+        "notes": "Implemented read-only GSC draft publish gate readiness command and focused tests; broad Pint external blocker unchanged."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24021,6 +24021,7 @@ prs:
       - backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json
       - backend/tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php
       - backend/tests/Feature/SeoIntel/SeoAgentCmsPublishCanaryTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train-state.json
     do_not:
       - Publish content.
@@ -24030,6 +24031,7 @@ prs:
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscDraftPublishGateReadinessTest
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsPublishCanaryTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=seo_agent_gsc_draft_publish_gate_readiness
       - cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel
       - python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json >/dev/null
       - git diff --check


### PR DESCRIPTION
## What changed
- Added backend-only `seo-agent:gsc-draft-publish-gate-readiness` read-only Artisan command.
- Consumes controlled CMS draft write evidence plus readback QA, claim-risk QA, and preview/runtime QA artifacts.
- Emits per-draft `publish_ready`, `review_required`, or `blocked` verdicts.
- Emits an exact publish approval phrase only when all required QA evidence is present and passing.
- Keeps publish execution, URL Truth, sitemap, IndexNow, search/indexing, scheduler, and queue actions separate.
- Registered the command, added generated contract docs, focused feature tests, and BigFive runtime-freeze classifier coverage.
- Reconciled PR-H merge facts and recorded PR-I local validation in the PR train state ledger.

## Why
After draft write/readback/claim-risk/preview QA, publish readiness needs an explicit evidence gate before any production publish approval can be requested.

## Validation
- `cd backend && php artisan list | rg 'seo-agent:gsc-draft-publish-gate-readiness'`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscDraftPublishGateReadinessTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsPublishCanaryTest --display-warnings`\n- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_agent_gsc_draft_publish_gate_readiness' --display-warnings`\n- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentGscDraftPublishGateReadinessCommand.php tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`\n- `python3 -m json.tool backend/docs/seo/generated/seo-agent-gsc-draft-publish-gate-readiness.v1.json >/dev/null`\n- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`\n- `git diff --check`\n- `git diff --cached --check`\n\nBroad Pint note: `cd backend && vendor/bin/pint --test app/Console/Commands tests/Feature/SeoIntel` still fails only on existing files outside PR-I scope, already recorded in `docs/codex/sidecar/20260622-seo-agent-closeout-external-pint-blocker.md`.\n\n## Intentionally deferred\n- No production CMS draft write.\n- No publish execution.\n- No URL Truth write.\n- No sitemap, IndexNow, search/indexing submission.\n- No scheduler, queue worker, external model API, or live GSC API action.