### PR TITLE
Enable AI Impact preview detail shell fallback

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\API\V0_5\Career;
 
 use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
+use App\Services\Career\AiImpactAssets\CareerAiImpactPreviewDetailShellBuilder;
 use App\Services\Career\Bundles\CareerCnProxyPublicOwnerSurfaceBuilder;
 use App\Services\Career\PublicCareerAuthorityResponseCache;
 use Illuminate\Http\JsonResponse;
@@ -18,6 +19,7 @@ final class CareerJobDetailController extends Controller
     public function __construct(
         private readonly PublicCareerAuthorityResponseCache $responseCache,
         private readonly CareerCnProxyPublicOwnerSurfaceBuilder $cnProxySurfaceBuilder,
+        private readonly CareerAiImpactPreviewDetailShellBuilder $aiImpactPreviewDetailShellBuilder,
     ) {}
 
     public function show(Request $request, string $slug): JsonResponse
@@ -29,6 +31,11 @@ final class CareerJobDetailController extends Controller
             $cnProxySurface = $this->cnProxySurfaceBuilder->buildBySlug($slug, $publicLocale);
             if ($cnProxySurface !== null) {
                 return response()->json($cnProxySurface);
+            }
+
+            $aiImpactPreviewShell = $this->aiImpactPreviewDetailShellBuilder->build($slug, $publicLocale);
+            if ($aiImpactPreviewShell !== null) {
+                return response()->json($aiImpactPreviewShell);
             }
 
             return $this->notFoundResponse('career job detail bundle unavailable.');

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactPreviewDetailShellBuilder.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactPreviewDetailShellBuilder.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Career\AiImpactAssets;
+
+final class CareerAiImpactPreviewDetailShellBuilder
+{
+    /**
+     * @var list<string>
+     */
+    private const COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
+    public function __construct(
+        private readonly CareerAiImpactAssetPreviewService $previewService,
+    ) {}
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function build(string $slug, string $locale): ?array
+    {
+        $normalizedSlug = $this->normalizeSlug($slug);
+        $normalizedLocale = $this->normalizeLocale($locale);
+        if ($normalizedSlug === '' || $normalizedLocale === null) {
+            return null;
+        }
+
+        $asset = $this->previewService->previewAsset($normalizedSlug, $normalizedLocale);
+        if ($asset === null) {
+            return null;
+        }
+
+        $previewPayload = $this->previewService->publicPayload($asset);
+        if (($previewPayload['preview'] ?? false) !== true || ! is_array($previewPayload['ai_impact_asset_v1'] ?? null)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $aiImpact */
+        $aiImpact = $previewPayload['ai_impact_asset_v1'];
+        $occupation = is_array($aiImpact['occupation'] ?? null) ? $aiImpact['occupation'] : [];
+        $titleEn = $this->nonEmptyString($occupation['title_en'] ?? null) ?? $this->titleFromSlug($normalizedSlug);
+        $titleZh = $this->nonEmptyString($occupation['title_zh'] ?? null) ?? $titleEn;
+        $title = $normalizedLocale === 'zh-CN' ? $titleZh : $titleEn;
+        $displayLocale = $normalizedLocale === 'zh-CN' ? 'zh' : 'en';
+        $path = '/'.$displayLocale.'/career/jobs/'.$normalizedSlug;
+        $summary = $this->nonEmptyString($aiImpact['summary'] ?? null)
+            ?? ($displayLocale === 'zh'
+                ? $title.' 的 AI 影响预览已通过后端 reader-safe 投影读取。'
+                : $title.' AI impact preview is available through the reader-safe backend projection.');
+
+        return [
+            'bundle_kind' => 'career_job_detail',
+            'bundle_version' => 'ai_impact_preview_detail_shell.v1',
+            'identity' => [
+                'canonical_slug' => $normalizedSlug,
+            ],
+            'titles' => [
+                'canonical_en' => $titleEn,
+                'canonical_zh' => $titleZh,
+            ],
+            'locale_policy' => [
+                'requested_locale' => $normalizedLocale,
+                'resolved_locale' => $normalizedLocale,
+            ],
+            'truth_layer' => [
+                'summary' => $summary,
+                'source_refs' => ['career_ai_impact_asset_preview'],
+            ],
+            'trust_manifest' => [
+                'status' => 'restricted_preview_shell',
+                'authority' => 'career_ai_impact_asset_preview',
+            ],
+            'warnings' => [[
+                'code' => 'detail_bundle_preview_shell',
+                'message' => 'Career detail shell is restricted to AI Impact staging preview page readiness.',
+            ]],
+            'claim_permissions' => $this->claimPermissions(),
+            'seo_contract' => $this->seoContract($path, $title),
+            'seo_authority_v1' => [
+                'seo_surface_v1' => $this->seoContract($path, $title),
+                'jsonld' => [],
+            ],
+            'structured_data' => [],
+            'display_surface_v1' => $this->displaySurface($normalizedSlug, $displayLocale, $path, $title, $summary, $aiImpact),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function displaySurface(string $slug, string $locale, string $path, string $title, string $summary, array $aiImpact): array
+    {
+        return [
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'subject' => [
+                'canonical_slug' => $slug,
+            ],
+            'claim_permissions' => $this->claimPermissions(),
+            'component_order' => self::COMPONENT_ORDER,
+            'sources' => $this->displaySources(is_array($aiImpact['sources'] ?? null) ? $aiImpact['sources'] : []),
+            'support_components' => [
+                'boundary_notice' => [
+                    $locale => [
+                        $locale === 'zh'
+                            ? '该页面承载 AI 影响预览模块；AI 分数不是个人职业结果预测。'
+                            : 'This page carries the AI Impact preview module; the AI score is not an individual career outcome forecast.',
+                    ],
+                ],
+                'review_validity' => [
+                    'last_reviewed' => '2026-06-22',
+                ],
+            ],
+            'page' => [
+                $locale => [
+                    'path' => $path,
+                    'hero' => [
+                        'h1' => $title,
+                        'quick_answer' => $summary,
+                        'primary_cta' => [
+                            'label' => $locale === 'zh' ? '测我的职业兴趣是否匹配' : 'Check my career interest fit',
+                            'href' => '/'.$locale.'/tests/holland-career-interest-test-riasec',
+                        ],
+                    ],
+                    'sections' => [[
+                        'id' => 'ai_impact_preview_anchor',
+                        'component' => 'AIImpactTable',
+                        'heading' => $locale === 'zh' ? 'AI 影响' : 'AI Impact',
+                        'score' => $this->scoreLabel($aiImpact),
+                        'body' => $summary,
+                        'fermat_view' => 'FermatMind AI Impact preview',
+                    ]],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function claimPermissions(): array
+    {
+        return [
+            'integrity_state' => 'restricted',
+            'allow_strong_claim' => false,
+            'allow_ai_strategy' => true,
+            'allow_salary_comparison' => false,
+            'allow_market_signal' => false,
+            'allow_local_proxy_wage' => false,
+            'blocked_claims' => ['preview_detail_shell_restricted'],
+            'warnings' => ['Restricted AI Impact preview shell; no salary, SEO schema, or production-import claims.'],
+            'evidence_basis' => [
+                'salary' => 'missing',
+                'ai_exposure' => 'central_score',
+                'market_signal' => 'missing',
+                'crosswalk' => 'missing',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function seoContract(string $path, string $title): array
+    {
+        return [
+            'canonical_path' => $path,
+            'title' => $title,
+            'robots' => 'noindex,nofollow',
+            'indexable' => false,
+            'jsonld_allowed' => false,
+            'sitemap_allowed' => false,
+            'llms_allowed' => false,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sources
+     * @return array<string, array<string, string>>
+     */
+    private function displaySources(array $sources): array
+    {
+        $displaySources = [];
+        foreach ($sources as $index => $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $name = $this->nonEmptyString($source['name'] ?? null);
+            $url = $this->nonEmptyString($source['url'] ?? null);
+            if ($name === null || $url === null) {
+                continue;
+            }
+
+            $displaySources['ai_impact_source_'.($index + 1)] = [
+                'label' => $name,
+                'url' => $url,
+                'usage' => 'AI Impact preview source.',
+            ];
+        }
+
+        return $displaySources;
+    }
+
+    private function scoreLabel(array $aiImpact): string
+    {
+        $score = $aiImpact['ai_exposure_score']['score_1_to_10'] ?? null;
+        if (is_int($score) || is_float($score) || (is_string($score) && is_numeric($score))) {
+            return (string) $score.'/10';
+        }
+
+        return '';
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    private function normalizeLocale(string $locale): ?string
+    {
+        $normalized = strtolower(trim($locale));
+
+        return match ($normalized) {
+            'en' => 'en',
+            'zh', 'zh-cn', 'zh_cn' => 'zh-CN',
+            default => null,
+        };
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function titleFromSlug(string $slug): string
+    {
+        return implode(' ', array_map(
+            static fn (string $part): string => ucfirst($part),
+            array_filter(explode('-', $slug), static fn (string $part): bool => $part !== '')
+        ));
+    }
+}

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -765,6 +765,155 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertStringContainsString('不是个人职业结果预测', $asset['items']['reader_boundary']['body']);
     }
 
+    public function test_ai_impact_preview_asset_can_provide_restricted_detail_shell_when_bundle_is_missing(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', ['emergency-medicine-physicians']);
+        $occupation = $this->seedOccupation('emergency-medicine-physicians');
+        $row = $this->assetRow('emergency-medicine-physicians', 'en');
+        $row['occupation']['title_en'] = 'Emergency Medicine Physicians';
+        $row['occupation']['title_zh'] = '急诊医学医师';
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'emergency-medicine-physicians',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $this->assertNotNull(
+            app(\App\Services\Career\AiImpactAssets\CareerAiImpactPreviewDetailShellBuilder::class)
+                ->build('emergency-medicine-physicians', 'en')
+        );
+
+        $response = $this->getJson('/api/v0.5/career/jobs/emergency-medicine-physicians?locale=en')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'emergency-medicine-physicians')
+            ->assertJsonPath('display_surface_v1.surface_version', 'display.surface.v1')
+            ->assertJsonPath('display_surface_v1.status', 'ready_for_pilot')
+            ->assertJsonPath('display_surface_v1.subject.canonical_slug', 'emergency-medicine-physicians')
+            ->assertJsonPath('display_surface_v1.page.en.path', '/en/career/jobs/emergency-medicine-physicians')
+            ->assertJsonPath('seo_contract.indexable', false)
+            ->assertJsonPath('seo_contract.jsonld_allowed', false);
+
+        $encoded = json_encode($response->json(), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('evidence_id', $encoded);
+        $this->assertStringNotContainsString('row_hash', $encoded);
+        $this->assertStringNotContainsString('source_id', $encoded);
+        $this->assertStringNotContainsString('search_projection', $encoded);
+
+        $this->getJson('/api/v0.5/career/jobs/emergency-medicine-physicians/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ai_impact_asset_v1.slug', 'emergency-medicine-physicians');
+    }
+
+    public function test_ai_impact_preview_detail_shell_fails_closed_when_disabled_or_not_allowlisted(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', false);
+        Config::set('career_ai_impact_assets.preview_slugs', ['emergency-medicine-physicians']);
+        $occupation = $this->seedOccupation('emergency-medicine-physicians');
+        $row = $this->assetRow('emergency-medicine-physicians', 'en');
+
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'career_job_slug' => 'emergency-medicine-physicians',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $row,
+            'sources_json' => $row['sources'],
+            'evidence_used_json' => $row['evidence_used'],
+            'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+            'audit_fields_json' => $row['audit_fields'],
+            'asset_row_hash' => $row['audit_fields']['row_hash'],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/emergency-medicine-physicians?locale=en')
+            ->assertNotFound();
+
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        CareerJobAiImpactAsset::query()
+            ->where('career_job_slug', 'emergency-medicine-physicians')
+            ->where('locale', 'en')
+            ->update(['preview_allowlisted' => false]);
+
+        $this->getJson('/api/v0.5/career/jobs/emergency-medicine-physicians?locale=en')
+            ->assertNotFound();
+    }
+
+    public function test_ai_impact_preview_detail_shell_covers_preview_slugs_without_standard_detail_bundles(): void
+    {
+        $slugs = [
+            'emergency-medicine-physicians',
+            'pharmacists',
+            'diagnostic-medical-sonographers',
+            'medical-and-clinical-laboratory-technologists',
+            'genetic-counselors',
+            'physicians-and-surgeons',
+            'aviation-inspectors',
+            'aircraft-and-avionics-equipment-mechanics-and-technicians',
+            'judicial-law-clerks',
+            'military-careers',
+            'first-line-supervisors-of-air-crew-members',
+            'first-line-supervisors-of-weapons-specialists-crew-members',
+            'school-and-career-counselors',
+            'special-education-teachers-elementary-school',
+            'multimedia-artists-and-animators',
+            'police-and-sheriff-s-patrol-officers',
+            'heavy-and-tractor-trailer-truck-drivers',
+            'construction-and-building-inspectors',
+            'information-security-analysts',
+            'computer-systems-engineers-architects',
+        ];
+
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', $slugs);
+
+        foreach ($slugs as $slug) {
+            $occupation = $this->seedOccupation($slug);
+            foreach (['zh-CN', 'en'] as $locale) {
+                $row = $this->assetRow($slug, $locale);
+                CareerJobAiImpactAsset::query()->create([
+                    'occupation_id' => $occupation->id,
+                    'career_job_slug' => $slug,
+                    'locale' => $locale,
+                    'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                    'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                    'preview_allowlisted' => true,
+                    'asset_payload_json' => $row,
+                    'sources_json' => $row['sources'],
+                    'evidence_used_json' => $row['evidence_used'],
+                    'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+                    'audit_fields_json' => $row['audit_fields'],
+                    'asset_row_hash' => $row['audit_fields']['row_hash'],
+                ]);
+            }
+        }
+
+        foreach ($slugs as $slug) {
+            $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=zh-CN')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.page.zh.path', '/zh/career/jobs/'.$slug);
+
+            $this->getJson('/api/v0.5/career/jobs/'.$slug.'?locale=en')
+                ->assertOk()
+                ->assertJsonPath('identity.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.subject.canonical_slug', $slug)
+                ->assertJsonPath('display_surface_v1.page.en.path', '/en/career/jobs/'.$slug);
+        }
+    }
+
     public function test_preview_api_fails_closed_when_disabled_or_not_allowlisted(): void
     {
         Config::set('career_ai_impact_assets.staging_preview_enabled', false);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -207,6 +207,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_ai_impact_preview_route_readiness_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactPreviewDetailShellBuilder.php',
+            'backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_detail_ready_1048_audit_scanner_changes(): void
     {
         $changed = [
@@ -4160,6 +4171,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCareerAiImpactPreviewRouteReadinessFile($file)) {
+                continue;
+            }
+
             if ($this->isCmsArticleReportCorrectnessFile($file)) {
                 continue;
             }
@@ -5336,6 +5351,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCareerCliArtifactPathGuardFile(string $file): bool
     {
         return $file === 'backend/app/Services/Career/CareerCliArtifactPathGuard.php';
+    }
+
+    private function isCareerAiImpactPreviewRouteReadinessFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php',
+            'backend/app/Services/Career/AiImpactAssets/CareerAiImpactPreviewDetailShellBuilder.php',
+            'backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php',
+        ], true);
     }
 
     private function isCmsArticleReportCorrectnessFile(string $file): bool


### PR DESCRIPTION
## Summary

This is a narrow backend route-readiness repair for the AI Impact v5 staging preview flow.

Some staging preview slugs already have reader-safe AI Impact preview assets, but their standard career job detail bundle is unavailable. The frontend career page fails before it can request and render the AI Impact preview block, so those pages return 404 even though the AI Impact asset API itself is ready.

This PR adds a restricted backend detail-shell fallback for that exact condition:

- standard career job detail bundle is missing
- AI Impact v5 preview asset exists for the requested slug/locale
- staging preview is enabled
- the row is preview allowlisted

If any of those conditions fail, the endpoint remains fail-closed.

## What Changed

- Added `CareerAiImpactPreviewDetailShellBuilder` to build a restricted reader-safe detail shell from the existing AI Impact preview asset.
- Wired `CareerJobDetailController` to use that fallback only after the normal detail bundle and CN proxy fallback both fail.
- Added feature tests covering:
  - restricted detail shell for an allowlisted AI Impact preview slug with no standard detail bundle
  - fail-closed behavior when preview is disabled or the row is not allowlisted
  - all 20 known preview slugs that had AI Impact preview API readiness but lacked detail page authority

## Boundaries

- No AI Impact asset edits.
- No AI Impact re-import.
- No staging writes.
- No production import.
- No frontend fallback content.
- No sitemap, llms, canonical, noindex, JSON-LD, or SEO runtime changes.

## Validation

- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`

## Deferred

After this PR is merged and deployed to staging, rerun the same 50-slug staging page/editorial QA. The previous live staging rerun still showed 20 slug / 40 page 404 because this backend fix was not deployed yet.
