### PR TITLE
FA30-API-05: Centralize six-scale smoke attempt analytics exclusion

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -11,6 +11,13 @@ use Illuminate\Support\Facades\DB;
 
 final class AnalyticsFunnelDailyBuilder
 {
+    private readonly AnalyticsTrafficExclusionPolicy $trafficExclusionPolicy;
+
+    public function __construct(?AnalyticsTrafficExclusionPolicy $trafficExclusionPolicy = null)
+    {
+        $this->trafficExclusionPolicy = $trafficExclusionPolicy ?? new AnalyticsTrafficExclusionPolicy;
+    }
+
     private const SUBMISSION_SUCCESS_STATES = [
         'succeeded',
         'success',
@@ -262,7 +269,7 @@ final class AnalyticsFunnelDailyBuilder
         foreach (array_chunk($attemptIds, 500) as $attemptChunk) {
             $query = DB::table('attempts')
                 ->whereIn('id', $attemptChunk)
-                ->select('id', 'org_id', 'scale_code', 'locale');
+                ->select('id', 'anon_id', 'org_id', 'scale_code', 'locale');
 
             if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
                 $query->addSelect('scale_code_v2');
@@ -276,7 +283,7 @@ final class AnalyticsFunnelDailyBuilder
 
             foreach ($query->get() as $row) {
                 $attemptId = trim((string) ($row->id ?? ''));
-                if ($attemptId === '') {
+                if ($attemptId === '' || $this->trafficExclusionPolicy->isExcludedAttemptRow($row)) {
                     continue;
                 }
 

--- a/backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php
+++ b/backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+final class AnalyticsTrafficExclusionPolicy
+{
+    /**
+     * @return list<string>
+     */
+    private function configuredAttemptIds(): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) config('analytics.smoke_attempt_exclusion.attempt_ids', [])
+        ), static fn (string $value): bool => $value !== '')));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredAnonPrefixes(): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): string => strtolower(trim((string) $value)),
+            (array) config('analytics.smoke_attempt_exclusion.anon_id_prefixes', [])
+        ), static fn (string $value): bool => $value !== '')));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function configuredTrafficQualityLabels(): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): string => strtolower(trim((string) $value)),
+            (array) config('analytics.smoke_attempt_exclusion.traffic_quality_labels', [])
+        ), static fn (string $value): bool => $value !== '')));
+    }
+
+    public function isExcludedAttemptRow(object $attempt): bool
+    {
+        return $this->isExcludedAttemptId($attempt->id ?? null)
+            || $this->hasExcludedProbePrefix($attempt->anon_id ?? null);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function isExcludedSeoConversionEvent(object $event, array $meta): bool
+    {
+        $seoConversion = is_array($meta['seo_conversion'] ?? null) ? $meta['seo_conversion'] : [];
+
+        return $this->isExcludedAttemptId($event->attempt_id ?? null)
+            || $this->isExcludedAttemptId($meta['attempt_id'] ?? null)
+            || $this->isExcludedAttemptId($seoConversion['attempt_id'] ?? null)
+            || $this->hasExcludedProbePrefix($event->anon_id ?? null)
+            || $this->hasExcludedProbePrefix($event->session_id ?? null)
+            || $this->hasExcludedProbePrefix($event->request_id ?? null)
+            || $this->hasExcludedProbePrefix($seoConversion['anon_id'] ?? null)
+            || $this->hasExcludedProbePrefix($seoConversion['session_id'] ?? null)
+            || $this->hasExcludedProbePrefix($seoConversion['request_id'] ?? null)
+            || $this->hasTrafficQualityExclusion($meta)
+            || $this->hasTrafficQualityExclusion($seoConversion);
+    }
+
+    public function isExcludedAttemptId(mixed $value): bool
+    {
+        $attemptId = trim((string) $value);
+        if ($attemptId === '') {
+            return false;
+        }
+
+        return in_array($attemptId, $this->configuredAttemptIds(), true);
+    }
+
+    public function hasExcludedProbePrefix(mixed $value): bool
+    {
+        $candidate = strtolower(trim((string) $value));
+        if ($candidate === '') {
+            return false;
+        }
+
+        foreach ($this->configuredAnonPrefixes() as $prefix) {
+            if (str_starts_with($candidate, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function hasTrafficQualityExclusion(array $payload): bool
+    {
+        foreach ([
+            'traffic_quality',
+            'trafficQuality',
+            'traffic_quality_label',
+            'trafficQualityLabel',
+            'quality',
+            'run_mode',
+            'runMode',
+            'source',
+            'probe',
+            'smoke',
+        ] as $key) {
+            if (! array_key_exists($key, $payload)) {
+                continue;
+            }
+
+            $value = $payload[$key];
+            if (is_bool($value) && $value === true && in_array($key, ['probe', 'smoke'], true)) {
+                return true;
+            }
+
+            if (in_array(strtolower(trim((string) $value)), $this->configuredTrafficQualityLabels(), true)) {
+                return true;
+            }
+        }
+
+        foreach (['is_probe', 'isProbe', 'is_smoke', 'isSmoke', 'codex_probe', 'codexProbe'] as $key) {
+            if (($payload[$key] ?? false) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Services/Analytics/SeoConversionDailyBuilder.php
+++ b/backend/app/Services/Analytics/SeoConversionDailyBuilder.php
@@ -39,6 +39,13 @@ final class SeoConversionDailyBuilder
         'history',
     ];
 
+    private readonly AnalyticsTrafficExclusionPolicy $trafficExclusionPolicy;
+
+    public function __construct(?AnalyticsTrafficExclusionPolicy $trafficExclusionPolicy = null)
+    {
+        $this->trafficExclusionPolicy = $trafficExclusionPolicy ?? new AnalyticsTrafficExclusionPolicy;
+    }
+
     /**
      * @param  list<int>  $orgIds
      * @return array{rows:list<array<string,mixed>>,attempted_rows:int,org_scope:list<int>,from:string,to:string,skipped_rows:int}
@@ -66,6 +73,10 @@ final class SeoConversionDailyBuilder
             }
 
             $meta = $this->decodeJson($event->meta_json ?? null);
+            if ($this->trafficExclusionPolicy->isExcludedSeoConversionEvent($event, $meta)) {
+                continue;
+            }
+
             $seoConversion = is_array($meta['seo_conversion'] ?? null) ? $meta['seo_conversion'] : [];
             $dimensions = $this->resolveDimensions($seoConversion, $event);
             if ($dimensions === null) {
@@ -178,7 +189,7 @@ final class SeoConversionDailyBuilder
         $query = DB::table('events')
             ->whereBetween('occurred_at', [$from, $to])
             ->whereRaw('lower(event_code) in ('.$placeholders.')', $eventCodes)
-            ->select(['id', 'org_id', 'event_code', 'session_id', 'meta_json', 'occurred_at', 'locale']);
+            ->select(['id', 'org_id', 'event_code', 'anon_id', 'session_id', 'request_id', 'attempt_id', 'meta_json', 'occurred_at', 'locale']);
 
         if ($orgIds !== []) {
             $query->whereIn('org_id', $orgIds);

--- a/backend/config/analytics.php
+++ b/backend/config/analytics.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'smoke_attempt_exclusion' => [
+        /*
+         * Production smoke attempts are operational probes, not growth signals.
+         * Keep the default empty so deploy/runtime config can provide exact ids
+         * without hardcoding live attempt identifiers in the repository.
+         */
+        'attempt_ids' => array_values(array_filter(array_map(
+            static fn (string $value): string => trim($value),
+            explode(',', (string) env('ANALYTICS_SMOKE_EXCLUDED_ATTEMPT_IDS', ''))
+        ))),
+
+        'anon_id_prefixes' => [
+            'codex_probe_',
+        ],
+
+        'traffic_quality_labels' => [
+            'smoke',
+            'probe',
+            'codex_probe',
+            'internal_smoke',
+            'production_smoke',
+        ],
+    ],
+];

--- a/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
@@ -8,6 +8,7 @@ use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\Concerns\SeedsFunnelAnalyticsScenario;
 use Tests\TestCase;
@@ -88,6 +89,58 @@ final class AnalyticsFunnelDailyBuilderTest extends TestCase
         $this->assertSame(2, (int) ($totals['first_view_attempts'] ?? 0), 'paywall_view must stay outside the main view stage');
         $this->assertSame(2, (int) ($totals['paid_attempts'] ?? 0));
         $this->assertSame(1, (int) ($totals['unlocked_attempts'] ?? 0), 'unlock_success must depend on active grants, not paid order status');
+    }
+
+    public function test_builder_excludes_configured_smoke_attempts_and_codex_probe_anons(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(89);
+        $day = CarbonImmutable::parse($scenario['day'].' 08:00:00');
+        $configuredSmokeAttempt = (string) Str::uuid();
+        $codexProbeAttempt = (string) Str::uuid();
+
+        config([
+            'analytics.smoke_attempt_exclusion.attempt_ids' => [$configuredSmokeAttempt],
+            'analytics.smoke_attempt_exclusion.anon_id_prefixes' => ['codex_probe_'],
+        ]);
+
+        foreach ([
+            [$configuredSmokeAttempt, 'BIG5_OCEAN', 'anon_'.$configuredSmokeAttempt, $day->addHours(5)],
+            [$codexProbeAttempt, 'ENNEAGRAM', 'codex_probe_enneagram_live_result_smoke', $day->addHours(6)],
+        ] as [$attemptId, $scaleCode, $anonId, $createdAt]) {
+            $this->insertAttempt($attemptId, 89, 'en', $createdAt, $createdAt->addMinutes(5));
+            $updates = [
+                'anon_id' => $anonId,
+                'scale_code' => $scaleCode,
+            ];
+            if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+                $updates['scale_code_v2'] = $scaleCode;
+            }
+
+            DB::table('attempts')->where('id', $attemptId)->update($updates);
+            $this->insertAttemptSubmission($attemptId, 89, $createdAt->addMinutes(6));
+            $this->insertResult($attemptId, 89, $createdAt->addMinutes(8));
+            $this->insertEvent(89, 'result_view', $attemptId, $createdAt->addMinutes(10));
+            $this->insertOrder('ord_smoke_'.$attemptId, $attemptId, 89, $createdAt->addMinutes(12), 999, $createdAt->addMinutes(15));
+            $this->insertBenefitGrant($attemptId, 'ord_smoke_'.$attemptId, 89, $createdAt->addMinutes(16));
+            $this->insertReportSnapshot($attemptId, 'ord_smoke_'.$attemptId, 89, $createdAt->addMinutes(20));
+        }
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [89],
+        );
+
+        $rowsByScale = collect($payload['rows'])->groupBy('scale_code');
+        $this->assertFalse($rowsByScale->has('BIG5_OCEAN'));
+        $this->assertFalse($rowsByScale->has('ENNEAGRAM'));
+
+        $mbtiRows = $rowsByScale->get('MBTI');
+        $this->assertNotNull($mbtiRows);
+        $this->assertSame(3, (int) $mbtiRows->sum('started_attempts'));
+        $this->assertSame(3, (int) $mbtiRows->sum('submitted_attempts'));
+        $this->assertSame(2, (int) $mbtiRows->sum('first_view_attempts'));
+        $this->assertSame(2, (int) $mbtiRows->sum('paid_attempts'));
     }
 
     public function test_projection_ready_paid_access_counts_as_report_ready(): void

--- a/backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
@@ -92,6 +92,56 @@ final class SeoConversionDailyBuilderTest extends TestCase
         $this->assertSame(0, (int) $row->start_test_count);
     }
 
+    public function test_refresh_excludes_smoke_and_codex_probe_seo_conversion_events(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-09 11:30:00');
+        $smokeAttemptId = (string) Str::uuid();
+
+        config([
+            'analytics.smoke_attempt_exclusion.attempt_ids' => [$smokeAttemptId],
+            'analytics.smoke_attempt_exclusion.anon_id_prefixes' => ['codex_probe_'],
+        ]);
+
+        $basePayload = [
+            'url' => 'https://fermatmind.com/en/articles/personality-types',
+            'lang' => 'en',
+            'page_type' => 'article',
+            'source_article' => 'personality-types',
+            'target_test' => '/en/tests/big-five-personality-test-ocean-model',
+            'scale_id' => 'BIG5_OCEAN',
+            'form_id' => 'big5_90',
+            'session_id' => 'seo_sess_real_user',
+        ];
+
+        $this->insertSeoEvent(0, 'landing_pv', $day, $basePayload);
+        $this->insertSeoEvent(0, 'start_test', $day->addMinute(), [
+            ...$basePayload,
+            'session_id' => 'codex_probe_big5_live_result_smoke',
+        ]);
+        $this->insertSeoEvent(0, 'complete_test', $day->addMinutes(2), [
+            ...$basePayload,
+            'attempt_id' => $smokeAttemptId,
+            'session_id' => 'seo_sess_configured_smoke',
+        ]);
+        $this->insertSeoEvent(0, 'view_result', $day->addMinutes(3), [
+            ...$basePayload,
+            'session_id' => 'seo_sess_traffic_quality_smoke',
+            'traffic_quality' => 'smoke',
+        ]);
+
+        $result = app(SeoConversionDailyBuilder::class)->refresh($day, $day, [], false);
+
+        $this->assertSame(1, (int) ($result['upserted_rows'] ?? 0));
+
+        $row = DB::table('analytics_seo_conversion_daily')->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) $row->landing_pv_count);
+        $this->assertSame(0, (int) $row->start_test_count);
+        $this->assertSame(0, (int) $row->complete_test_count);
+        $this->assertSame(0, (int) $row->view_result_count);
+    }
+
     public function test_refresh_skips_private_urls_before_daily_storage(): void
     {
         $day = CarbonImmutable::parse('2026-06-09 12:00:00');

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4974,6 +4974,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isAnalyticsSmokeExclusionPolicyFile($file)) {
+                continue;
+            }
+
             if ($this->isAnalyticsFunnelOpsReadModelFile($file)) {
                 continue;
             }
@@ -7486,6 +7490,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php',
             'backend/app/Services/Analytics/FunnelEventTaxonomy.php',
         ], true);
+    }
+
+    private function isAnalyticsSmokeExclusionPolicyFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php';
     }
 
     private function isAnalyticsFunnelOpsReadModelFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:12:20.759+00:00",
+  "updated_at": "2026-06-22T16:19:48.289+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59065,7 +59065,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-05-analytics-smoke-exclusion",
     "base": "main",
-    "status": "pr_open",
+    "status": "ci_fix_local_validated",
     "train_scope": "fa30_six_scale_smoke_analytics_exclusion",
     "title": "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion",
     "depends_on": [
@@ -59085,20 +59085,21 @@
         "commands": [
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi",
-          "cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "git diff --check"
         ],
-        "evidence": "PASS: cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi (8 warning-only existing file_get_contents warnings, 50 assertions)\nPASS: cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi (5 warning-only existing file_get_contents warnings, 36 assertions)\nPASS: cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php\nPASS: ruby YAML parse for docs/codex/pr-train.yaml\nPASS: python3 -m json.tool docs/codex/pr-train-state.json\nPASS: git diff --check"
+        "evidence": "PASS after CI fix: AnalyticsFunnelDailyBuilderTest (8 warning-only existing file_get_contents warnings, 50 assertions)\nPASS after CI fix: SeoConversionDailyBuilderTest (5 warning-only existing file_get_contents warnings, 36 assertions)\nPASS after CI fix: BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff (1 warning-only existing file_get_contents warning, 3 assertions)\nPASS: Pint for 7 scoped PHP files\nPASS: YAML/JSON parse and git diff --check"
       },
       "scope_validation": {
         "status": "pass",
-        "evidence": "Changed files are limited to FA30-API-05 allowed paths: analytics config/policy, two analytics builders, two focused analytics tests, and docs/codex train metadata."
+        "evidence": "Changed files remain limited to FA30-API-05 allowed paths, including the Big Five runtime freeze classifier test update needed to classify the analytics smoke exclusion policy as analytics-only support."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2324 opened; GitHub checks pending."
+        "status": "retry_pending",
+        "evidence": "Initial PR CI failed only on verify-bigfive because the new analytics policy support file was classified as Big Five runtime drift. The current-scope fix updates the freeze classifier and passed local reproduction; retry pending after push."
       }
     },
     "failure_reason": null,
@@ -59122,6 +59123,16 @@
         "at": "2026-06-22T16:12:20.759+00:00",
         "status": "pr_open",
         "note": "Opened PR #2324 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T16:19:48.289+00:00",
+        "status": "github_checks_failed_current_scope",
+        "note": "PR CI verify-bigfive failed on BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff because backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php needed an analytics-only freeze classifier exemption."
+      },
+      {
+        "at": "2026-06-22T16:19:48.289+00:00",
+        "status": "ci_fix_local_validated",
+        "note": "Added the analytics smoke exclusion policy to the Big Five runtime freeze classifier and reran the failed test plus FA30-API-05 analytics suites, Pint, YAML/JSON parsing, and diff check successfully."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:11:02.492+00:00",
+  "updated_at": "2026-06-22T16:12:20.759+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59065,7 +59065,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-05-analytics-smoke-exclusion",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "fa30_six_scale_smoke_analytics_exclusion",
     "title": "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion",
     "depends_on": [
@@ -59098,12 +59098,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": ""
+        "evidence": "PR #2324 opened; GitHub checks pending."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "7a1c1a46d7cd55e075694b7a5f4921ad79f0a7c3",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2324",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -59117,6 +59117,11 @@
         "at": "2026-06-22T16:11:02.492+00:00",
         "status": "local_validated",
         "note": "Local tests, formatting, YAML/JSON parsing, diff check, and path scope validation passed after rebasing onto latest origin/main. PHPUnit warnings were warning-only and did not fail the targeted suites."
+      },
+      {
+        "at": "2026-06-22T16:12:20.759+00:00",
+        "status": "pr_open",
+        "note": "Opened PR #2324 after local validation and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-23T00:13:00+08:00",
+  "updated_at": "2026-06-22T16:11:02.492+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59058,6 +59058,65 @@
         "at": "2026-06-22T20:36:00Z",
         "status": "pr_open",
         "note": "Opened PR #2309 on head 9cea70b51d2837edd78df1ca2debdbb55635a571 after local validation and scope validation passed."
+      }
+    ]
+  },
+  "FA30-API-05": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-05-analytics-smoke-exclusion",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "fa30_six_scale_smoke_analytics_exclusion",
+    "title": "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion",
+    "depends_on": [
+      "FA30-API-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided FA30-API-05 id, title, scope, and authorized manifest/state updates in the FA30-NON-AGENT-PR-TRAIN-01 /goal request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FA30-API-01 is merged on GitHub as PR #2302, and origin/main contains merge commit 82c10c54cd03edd3380325fc0fa627915713d393."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi",
+          "cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check"
+        ],
+        "evidence": "PASS: cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi (8 warning-only existing file_get_contents warnings, 50 assertions)\nPASS: cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi (5 warning-only existing file_get_contents warnings, 36 assertions)\nPASS: cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php\nPASS: ruby YAML parse for docs/codex/pr-train.yaml\nPASS: python3 -m json.tool docs/codex/pr-train-state.json\nPASS: git diff --check"
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to FA30-API-05 allowed paths: analytics config/policy, two analytics builders, two focused analytics tests, and docs/codex train metadata."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": ""
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-23T00:00:00+08:00",
+        "status": "in_progress",
+        "note": "Started from clean origin/main worktree. Scope is limited to analytics smoke/probe exclusion policy, funnel/SEO conversion aggregation use, focused tests, and docs/codex metadata. No production deploy, CMS write, search submission, scheduler, queue, sitemap, llms, canonical, noindex, JSON-LD, payment/order/report runtime, or fap-web scope is allowed."
+      },
+      {
+        "at": "2026-06-22T16:11:02.492+00:00",
+        "status": "local_validated",
+        "note": "Local tests, formatting, YAML/JSON parsing, diff check, and path scope validation passed after rebasing onto latest origin/main. PHPUnit warnings were warning-only and did not fail the targeted suites."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:19:48.289+00:00",
+  "updated_at": "2026-06-22T16:26:25.862+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59065,7 +59065,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-05-analytics-smoke-exclusion",
     "base": "main",
-    "status": "ci_fix_local_validated",
+    "status": "ready_to_merge",
     "train_scope": "fa30_six_scale_smoke_analytics_exclusion",
     "title": "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion",
     "depends_on": [
@@ -59098,12 +59098,12 @@
         "evidence": "Changed files remain limited to FA30-API-05 allowed paths, including the Big Five runtime freeze classifier test update needed to classify the analytics smoke exclusion policy as analytics-only support."
       },
       "github": {
-        "status": "retry_pending",
-        "evidence": "Initial PR CI failed only on verify-bigfive because the new analytics policy support file was classified as Big Five runtime drift. The current-scope fix updates the freeze classifier and passed local reproduction; retry pending after push."
+        "status": "pass",
+        "evidence": "PR #2324 GitHub checks passed after current-scope verify-bigfive classifier fix: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS."
       }
     },
     "failure_reason": null,
-    "commit_sha": "7a1c1a46d7cd55e075694b7a5f4921ad79f0a7c3",
+    "commit_sha": "258c20a92a67495c188b4da700cc2bc8d0a4ecd7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2324",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -59133,6 +59133,11 @@
         "at": "2026-06-22T16:19:48.289+00:00",
         "status": "ci_fix_local_validated",
         "note": "Added the analytics smoke exclusion policy to the Big Five runtime freeze classifier and reran the failed test plus FA30-API-05 analytics suites, Pint, YAML/JSON parsing, and diff check successfully."
+      },
+      {
+        "at": "2026-06-22T16:26:25.862+00:00",
+        "status": "ready_to_merge",
+        "note": "All PR #2324 GitHub checks passed and scope was revalidated; ready for squash merge when final metadata commit checks pass."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24256,6 +24256,7 @@ prs:
       - Add a centralized analytics traffic exclusion policy for configured production smoke attempt ids and codex_probe_ anonymous probe traffic.
       - Apply the exclusion to analytics funnel daily aggregation and SEO conversion daily aggregation without deleting source events or rows.
       - Add focused tests proving configured smoke attempt ids and codex_probe_ traffic do not enter growth metrics.
+      - Keep the Big Five runtime freeze classifier aware that the analytics smoke exclusion policy is analytics-only support, not Big Five runtime surface drift.
     allowed_paths:
       - backend/config/analytics.php
       - backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php
@@ -24263,6 +24264,7 @@ prs:
       - backend/app/Services/Analytics/SeoConversionDailyBuilder.php
       - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
       - backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - generated/pr-train-sidecar-issues/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
@@ -24274,7 +24276,8 @@ prs:
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi
-      - cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi
+      - cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - git diff --check

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24244,6 +24244,49 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: FA30-API-05
+    repo: fap-api
+    depends_on:
+      - FA30-API-01
+    branch: codex/fa30-api-05-analytics-smoke-exclusion
+    title: "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion"
+    train_scope: fa30_six_scale_smoke_analytics_exclusion
+    status: user_authorized
+    scope:
+      - Add a centralized analytics traffic exclusion policy for configured production smoke attempt ids and codex_probe_ anonymous probe traffic.
+      - Apply the exclusion to analytics funnel daily aggregation and SEO conversion daily aggregation without deleting source events or rows.
+      - Add focused tests proving configured smoke attempt ids and codex_probe_ traffic do not enter growth metrics.
+    allowed_paths:
+      - backend/config/analytics.php
+      - backend/app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/app/Services/Analytics/SeoConversionDailyBuilder.php
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Delete production analytics source rows or daily aggregate rows.
+      - Change payment, order, report, result, attempt runtime behavior.
+      - Change scheduler, queue, CMS, sitemap, llms, canonical, noindex, JSON-LD, deploy, or search submission behavior.
+      - Implement FA30-API-04, FA30-API-08, or any fap-web scope.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi
+      - cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG5-RESULT-SOURCE-LEDGER-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added a centralized analytics smoke/probe traffic exclusion policy for configured smoke attempt ids and `codex_probe_` anonymous probe traffic.
- Applied the exclusion to funnel daily aggregation and SEO conversion daily aggregation without deleting source events or rows.
- Added focused coverage proving configured smoke attempts and `codex_probe_` traffic stay out of six-scale growth metrics.
- Kept the Big Five runtime freeze classifier aware that this analytics smoke exclusion policy is analytics-only support, not Big Five runtime surface drift.
- Added the authorized FA30-API-05 manifest/state entries for this scoped train item.

## Why
Production smoke attempts and Codex probe traffic are operational verification signals, not growth analytics. This keeps six-scale smoke activity from polluting funnel and SEO conversion aggregates while preserving source telemetry.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=AnalyticsFunnelDailyBuilderTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi`
- `cd backend && vendor/bin/pint --test config/analytics.php app/Services/Analytics/AnalyticsTrafficExclusionPolicy.php app/Services/Analytics/AnalyticsFunnelDailyBuilder.php app/Services/Analytics/SeoConversionDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

Note: the targeted PHPUnit suites pass with existing warning-only `file_get_contents` warnings.

## Intentionally deferred
- No production deploy.
- No staging deploy wait or manual deploy trigger.
- No CMS publish/import/write.
- No search URL submission.
- No scheduler, queue, sitemap, llms, canonical, noindex, JSON-LD, payment/order/report/result/attempt runtime changes.
- Does not implement FA30-API-04, FA30-API-08, or any fap-web scope.

## Repository rule impact
No content authority or publishing surface changes. This is backend analytics aggregation policy and CI classifier scope only; source events and production data are not mutated.
