### PR TITLE
Enneagram: harden share public-safe contract

### DIFF
--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -509,7 +509,6 @@ class ShareService
                 static fn (array $row): array => [
                     'type' => trim((string) ($row['type'] ?? '')),
                     'candidate_role' => trim((string) ($row['candidate_role'] ?? '')),
-                    'display_score' => $row['display_score'] ?? null,
                 ],
                 array_filter($topTypeCards, static fn (mixed $row): bool => is_array($row))
             )),
@@ -517,39 +516,20 @@ class ShareService
                 static fn (array $row): array => [
                     'type' => trim((string) ($row['type'] ?? '')),
                     'rank' => isset($row['rank']) ? (int) $row['rank'] : null,
-                    'display_score' => $row['display_score'] ?? null,
                 ],
                 array_filter($all9Profile, static fn (mixed $row): bool => is_array($row))
             )),
             'confidence_level' => $confidenceLevel !== '' ? $confidenceLevel : null,
             'confidence_label' => $confidenceLabel !== '' ? $confidenceLabel : null,
             'interpretation_scope' => $scope !== '' ? $scope : null,
-            'interpretation_reason' => $classification['interpretation_reason'] ?? data_get($projection, 'classification.interpretation_reason'),
             'close_call_pair' => [
                 'pair_key' => $this->stringOrNull($closeCallPair['pair_key'] ?? null),
                 'type_a' => $this->stringOrNull($closeCallPair['type_a'] ?? null),
                 'type_b' => $this->stringOrNull($closeCallPair['type_b'] ?? null),
             ],
-            'dominance_gap_abs' => data_get($projection, 'classification.dominance_gap_abs'),
-            'dominance_gap_pct' => data_get($projection, 'classification.dominance_gap_pct'),
             'compare_compatibility_group' => data_get($projection, 'methodology.compare_compatibility_group')
                 ?? data_get($snapshotBinding, 'compare_compatibility_group'),
             'cross_form_comparable' => false,
-            'interpretation_context_id' => data_get($reportV2, 'provenance.interpretation_context_id')
-                ?? data_get($projection, 'content_binding.interpretation_context_id')
-                ?? data_get($snapshotBinding, 'interpretation_context_id'),
-            'registry_release_hash' => data_get($reportV2, 'registry.registry_release_hash')
-                ?? data_get($reportV2, 'provenance.registry_release_hash'),
-            'content_release_hash' => data_get($reportV2, 'provenance.content_release_hash')
-                ?? data_get($projection, 'content_binding.content_release_hash')
-                ?? data_get($snapshotBinding, 'content_release_hash'),
-            'content_snapshot_status' => data_get($reportV2, 'provenance.content_snapshot_status')
-                ?? data_get($projection, 'content_binding.content_snapshot_status')
-                ?? data_get($snapshotBinding, 'content_snapshot_status'),
-            'report_schema_version' => data_get($reportV2, 'schema_version')
-                ?? data_get($snapshotBinding, 'report_schema_version'),
-            'projection_version' => data_get($projection, 'algorithmic_meta.projection_version')
-                ?? data_get($snapshotBinding, 'projection_version'),
             'generated_at' => $generatedAt,
             'summary_text' => $shareText,
         ];
@@ -843,8 +823,8 @@ class ShareService
                 ? '我在 FermatMind 的九型结果可以阅读，但系统提示解释边界较宽。它更适合作为初步观察线索，而不是最终定型。'
                 : 'My FermatMind Enneagram result is readable, but the interpretation boundary is wider. It is better used as an observation cue than a final label.',
             default => $locale === 'zh-CN'
-                ? sprintf('我在 FermatMind 的九型结果显示：我最可能是 %s 号。结果清晰度较高，但仍建议把它当成持续观察自己的框架。', $primary !== '' ? $primary : '主候选')
-                : sprintf('My FermatMind Enneagram result suggests I am most likely Type %s. The signal is relatively clear, but it should still be used as a framework for continued self-observation.', $primary !== '' ? $primary : 'A'),
+                ? sprintf('我在 FermatMind 的九型结果显示：当前结果更接近 %s 号倾向。结果清晰度较高，但仍建议把它当成持续观察自己的框架。', $primary !== '' ? $primary : '主候选')
+                : sprintf('My FermatMind Enneagram result currently leans toward Type %s. The signal is relatively clear, but it should still be used as a framework for continued self-observation.', $primary !== '' ? $primary : 'A'),
         };
     }
 
@@ -1223,6 +1203,7 @@ class ShareService
             if ($enneagramPublicSummary !== []) {
                 $payload['enneagram_public_summary_v1'] = $enneagramPublicSummary;
             }
+            unset($payload['attempt_id'], $payload['org_id'], $payload['content_package_version']);
         } elseif ($scaleCode === 'RIASEC' && $riasecProjection !== []) {
             $payload['riasec_public_projection_v1'] = $riasecProjection;
             if ($riasecProjectionV2 !== []) {

--- a/backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php
@@ -42,18 +42,50 @@ final class EnneagramShareSummaryContractTest extends TestCase
             ->assertJsonPath('enneagram_public_summary_v1.third_candidate', '9')
             ->assertJsonPath('enneagram_public_summary_v1.interpretation_scope', 'clear')
             ->assertJsonPath('enneagram_public_summary_v1.cross_form_comparable', false)
-            ->assertJsonPath('enneagram_public_summary_v1.report_schema_version', 'enneagram.report.v2')
+            ->assertJsonMissingPath('attempt_id')
+            ->assertJsonMissingPath('org_id')
+            ->assertJsonMissingPath('content_package_version')
             ->assertJsonMissingPath('mbti_public_summary_v1');
 
         $this->assertCount(3, (array) $response->json('enneagram_public_summary_v1.top_types'));
         $this->assertCount(9, (array) $response->json('enneagram_public_summary_v1.all9_profile_mini'));
         $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.compare_compatibility_group'));
-        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.registry_release_hash'));
-        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.projection_version'));
-        $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.interpretation_context_id'));
         $this->assertNotSame('', (string) $response->json('enneagram_public_summary_v1.generated_at'));
-        $this->assertStringContainsString('最可能是 4 号', (string) $response->json('summary'));
+        $this->assertStringContainsString('当前结果更接近 4 号倾向', (string) $response->json('summary'));
+        $this->assertPublicSummaryHasNoForbiddenFields((array) $response->json('enneagram_public_summary_v1'));
         $this->assertSame('4', (string) $response->json('type_code'));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function assertPublicSummaryHasNoForbiddenFields(array $summary): void
+    {
+        $encoded = json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($encoded);
+
+        foreach ([
+            'attempt_id',
+            'display_score',
+            'raw_score',
+            'raw_scores',
+            'raw_score_vector',
+            'dominance_gap_abs',
+            'dominance_gap_pct',
+            'registry_release_hash',
+            'content_release_hash',
+            'content_snapshot_status',
+            'report_schema_version',
+            'projection_version',
+            'interpretation_context_id',
+            'interpretation_reason',
+            'private_metadata',
+            'source_selection_notes',
+            'editor_notes',
+            'qa_notes',
+        ] as $forbiddenField) {
+            $this->assertStringNotContainsString($forbiddenField, $encoded);
+        }
     }
 
     /**

--- a/backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php
@@ -43,7 +43,7 @@ final class EnneagramShareSummaryStateVariantsTest extends TestCase
      */
     public static function stateProvider(): iterable
     {
-        yield 'clear' => ['clear', '最可能是 4 号', null];
+        yield 'clear' => ['clear', '当前结果更接近 4 号倾向', null];
         yield 'close_call' => ['close_call', '可能在 4 号与 5 号之间摇摆', '4_5'];
         yield 'diffuse' => ['diffuse', '呈现分散结构', null];
         yield 'low_quality' => ['low_quality', '解释边界较宽', null];


### PR DESCRIPTION
## What changed
- Tightened the Enneagram public share summary so it no longer emits display scores, dominance gap fields, release/content hashes, schema/projection versions, interpretation context IDs, snapshot status, or interpretation reasons.
- Softened clear-state share copy from final-type language to a current-tendency phrasing.
- Removed Enneagram top-level share response fields that are not needed for public sharing: attempt_id, org_id, and content_package_version.
- Updated Enneagram share contract tests with negative assertions for private/internal fields.

## Why
The Enneagram share surface should be a public-safe summary: type ordering, gentle explanation, and boundary language only. It should not expose score-like values or internal metadata.

## Validation
- php -l backend/app/Services/V0_3/ShareService.php
- php -l backend/tests/Feature/V0_3/EnneagramShareSummaryContractTest.php
- php -l backend/tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php
- php artisan test tests/Feature/V0_3/EnneagramShareSummaryContractTest.php --no-ansi
- php artisan test tests/Feature/V0_3/EnneagramShareSummaryStateVariantsTest.php --no-ansi
- php artisan test --filter EnneagramShare --no-ansi
- git diff --check

## Deferred
- Frontend share card rendering hardening
- Result shell certainty-copy hardening
- PDF/print metadata boundary changes
- Readiness artifact generation
- Evidence bundle rerun
- Production activation