### PR TITLE
FA30-API-04: Add free-assessment GSC live-smoke evidence contract

### DIFF
--- a/backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json
+++ b/backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json
@@ -1,0 +1,139 @@
+{
+  "version": "free-assessment-gsc-live-smoke-evidence-contract.v1",
+  "task": "FA30-API-04",
+  "type": "gsc_readonly_live_smoke_evidence_contract",
+  "channel": "gsc",
+  "surface_group": "free_assessment_landings",
+  "site_property": {
+    "host": "fermatmind.com",
+    "property_scope": "sc-domain:fermatmind.com",
+    "property_hash": "63c1b1d353301bf50bad716597fe04c209c7d0ff70e327981bd5463743f9bd60"
+  },
+  "authority_boundary": {
+    "gsc_is_feedback_readiness_source": true,
+    "backend_url_truth_remains_authority": true,
+    "cms_publication_state_remains_authority": true,
+    "sitemap_llms_canonical_remain_backend_authority": true,
+    "gsc_is_content_authority": false,
+    "gsc_is_url_truth_authority": false,
+    "gsc_creates_urls": false,
+    "gsc_overrides_indexability": false
+  },
+  "allowed_live_smoke": {
+    "api": "google_search_console_searchanalytics_query",
+    "method": "read_only_searchanalytics",
+    "requires_explicit_live_read_gate": true,
+    "requires_safe_secret_channel": true,
+    "requires_dry_run": true,
+    "requires_no_write": true,
+    "max_row_limit": 250,
+    "recommended_window_days": 28,
+    "dimensions": [
+      "query",
+      "page"
+    ],
+    "evidence_format": "sanitized_hash_and_aggregate_only"
+  },
+  "free_assessment_surfaces": [
+    {
+      "scale_code": "MBTI",
+      "locale": "en",
+      "canonical_path": "/en/tests/mbti-personality-test-16-personality-types",
+      "canonical_url_hash": "4403609d40ab1dd5684e31ed159a60ca3652c3f6b84d33834e6093126412361a",
+      "expected_page_type": "test_landing_page"
+    },
+    {
+      "scale_code": "BIG5_OCEAN",
+      "locale": "en",
+      "canonical_path": "/en/tests/big-five-personality-test-ocean-model",
+      "canonical_url_hash": "6c9851d9ac655fcfa99275135cda32b4d0a992bd5af89ceb485d84e2d1faa56a",
+      "expected_page_type": "test_landing_page"
+    },
+    {
+      "scale_code": "RIASEC",
+      "locale": "en",
+      "canonical_path": "/en/tests/holland-career-interest-test-riasec",
+      "canonical_url_hash": "d42216023e19cd6460175c11a409665ad40db7ab0a6528177ad6bda81f500c3a",
+      "expected_page_type": "test_landing_page"
+    },
+    {
+      "scale_code": "IQ_RAVEN",
+      "locale": "en",
+      "canonical_path": "/en/tests/iq-test-intelligence-quotient-assessment",
+      "canonical_url_hash": "74fa5ffb0d5a86e51eb32f99cd3a7953976afab6182406394d6d1fb53bca90ca",
+      "expected_page_type": "test_landing_page"
+    },
+    {
+      "scale_code": "EQ_60",
+      "locale": "en",
+      "canonical_path": "/en/tests/eq-test-emotional-intelligence-assessment",
+      "canonical_url_hash": "32ab11ef5071c48447b54c6796cbd12aa2d19e1ea87f8f76d0002989bffcc09f",
+      "expected_page_type": "test_landing_page"
+    },
+    {
+      "scale_code": "ENNEAGRAM",
+      "locale": "en",
+      "canonical_path": "/en/tests/enneagram-personality-test-nine-types",
+      "canonical_url_hash": "c3e98d608640476f418e135abd71ce5ac594c5b2b1e1e07979eb3b5567a807c9",
+      "expected_page_type": "test_landing_page"
+    }
+  ],
+  "required_evidence_fields": [
+    "run_id",
+    "observed_at",
+    "date_window",
+    "row_limit",
+    "dimensions",
+    "surface_count",
+    "matched_surface_count",
+    "rows_seen",
+    "data_quality_gate",
+    "safe_row_preview",
+    "canonical_url_hash",
+    "query_hash",
+    "query_display_masked"
+  ],
+  "forbidden_evidence_fields": [
+    "raw_query",
+    "raw_url",
+    "access_token",
+    "service_account_json",
+    "private_key",
+    "client_email",
+    "credential_path",
+    "cookie",
+    "session",
+    "email",
+    "order_id",
+    "attempt_id",
+    "payment_id",
+    "raw_ip"
+  ],
+  "negative_guarantees": {
+    "live_api_call_in_this_pr": false,
+    "db_writes": false,
+    "seo_gsc_daily_import": false,
+    "cms_write": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "gsc_url_inspection_request_indexing": false,
+    "gsc_sitemap_submit": false,
+    "baidu_call": false,
+    "indexnow_call": false,
+    "scheduler_enabled": false,
+    "queue_worker_enabled": false,
+    "production_env_edited": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "canonical_changed": false,
+    "noindex_changed": false,
+    "jsonld_changed": false
+  },
+  "acceptance": {
+    "go_status": "contract_ready",
+    "future_live_smoke_must_report": "GO_or_NO_GO",
+    "future_live_smoke_must_not_submit_urls": true,
+    "future_live_smoke_must_not_publish_or_import": true
+  },
+  "next_task": "FA30-WEB-05"
+}

--- a/backend/tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php
+++ b/backend/tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class FreeAssessmentGscLiveSmokeEvidenceContractTest extends TestCase
+{
+    #[Test]
+    public function contract_covers_the_six_free_assessment_landings_without_raw_gsc_outputs(): void
+    {
+        $artifact = $this->artifact();
+        $surfaces = $artifact['free_assessment_surfaces'] ?? null;
+
+        $this->assertSame('free-assessment-gsc-live-smoke-evidence-contract.v1', $artifact['version'] ?? null);
+        $this->assertSame('FA30-API-04', $artifact['task'] ?? null);
+        $this->assertSame('gsc', $artifact['channel'] ?? null);
+        $this->assertSame('free_assessment_landings', $artifact['surface_group'] ?? null);
+        $this->assertIsArray($surfaces);
+        $this->assertCount(6, $surfaces);
+
+        $this->assertSameCanonicalSurfaces([
+            'MBTI' => '/en/tests/mbti-personality-test-16-personality-types',
+            'BIG5_OCEAN' => '/en/tests/big-five-personality-test-ocean-model',
+            'RIASEC' => '/en/tests/holland-career-interest-test-riasec',
+            'IQ_RAVEN' => '/en/tests/iq-test-intelligence-quotient-assessment',
+            'EQ_60' => '/en/tests/eq-test-emotional-intelligence-assessment',
+            'ENNEAGRAM' => '/en/tests/enneagram-personality-test-nine-types',
+        ], $surfaces);
+
+        foreach ($artifact['forbidden_evidence_fields'] ?? [] as $forbiddenField) {
+            $this->assertNotContains($forbiddenField, $artifact['required_evidence_fields'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function contract_locks_readonly_searchanalytics_and_no_submission_boundaries(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('google_search_console_searchanalytics_query', data_get($artifact, 'allowed_live_smoke.api'));
+        $this->assertSame('read_only_searchanalytics', data_get($artifact, 'allowed_live_smoke.method'));
+        $this->assertTrue((bool) data_get($artifact, 'allowed_live_smoke.requires_explicit_live_read_gate'));
+        $this->assertTrue((bool) data_get($artifact, 'allowed_live_smoke.requires_safe_secret_channel'));
+        $this->assertTrue((bool) data_get($artifact, 'allowed_live_smoke.requires_dry_run'));
+        $this->assertTrue((bool) data_get($artifact, 'allowed_live_smoke.requires_no_write'));
+        $this->assertSame(250, data_get($artifact, 'allowed_live_smoke.max_row_limit'));
+        $this->assertSame(['query', 'page'], data_get($artifact, 'allowed_live_smoke.dimensions'));
+
+        foreach ([
+            'gsc_is_content_authority',
+            'gsc_is_url_truth_authority',
+            'gsc_creates_urls',
+            'gsc_overrides_indexability',
+        ] as $flag) {
+            $this->assertFalse((bool) data_get($artifact, 'authority_boundary.'.$flag, true), $flag.' must remain false');
+        }
+
+        foreach ($artifact['negative_guarantees'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function future_live_smoke_evidence_must_be_sanitized_hash_and_aggregate_only(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'run_id',
+            'observed_at',
+            'date_window',
+            'row_limit',
+            'dimensions',
+            'surface_count',
+            'matched_surface_count',
+            'rows_seen',
+            'data_quality_gate',
+            'safe_row_preview',
+            'canonical_url_hash',
+            'query_hash',
+            'query_display_masked',
+        ] as $field) {
+            $this->assertContains($field, $artifact['required_evidence_fields'] ?? []);
+        }
+
+        foreach ([
+            'raw_query',
+            'raw_url',
+            'access_token',
+            'service_account_json',
+            'private_key',
+            'client_email',
+            'credential_path',
+            'cookie',
+            'session',
+            'email',
+            'order_id',
+            'attempt_id',
+            'payment_id',
+            'raw_ip',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_evidence_fields'] ?? []);
+        }
+
+        $this->assertSame('contract_ready', data_get($artifact, 'acceptance.go_status'));
+        $this->assertSame('GO_or_NO_GO', data_get($artifact, 'acceptance.future_live_smoke_must_report'));
+        $this->assertTrue((bool) data_get($artifact, 'acceptance.future_live_smoke_must_not_submit_urls'));
+        $this->assertTrue((bool) data_get($artifact, 'acceptance.future_live_smoke_must_not_publish_or_import'));
+        $this->assertSame('FA30-WEB-05', $artifact['next_task'] ?? null);
+    }
+
+    /**
+     * @param  array<string,string>  $expected
+     * @param  list<array<string,mixed>>  $surfaces
+     */
+    private function assertSameCanonicalSurfaces(array $expected, array $surfaces): void
+    {
+        $actual = [];
+        foreach ($surfaces as $surface) {
+            $scaleCode = (string) ($surface['scale_code'] ?? '');
+            $path = (string) ($surface['canonical_path'] ?? '');
+
+            $this->assertSame('en', $surface['locale'] ?? null);
+            $this->assertSame('test_landing_page', $surface['expected_page_type'] ?? null);
+            $this->assertSame(
+                hash('sha256', 'https://fermatmind.com'.$path),
+                $surface['canonical_url_hash'] ?? null
+            );
+
+            $actual[$scaleCode] = $path;
+        }
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:39:26.087+00:00",
+  "updated_at": "2026-06-22T16:45:26.941+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59211,7 +59211,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-04-gsc-live-smoke-evidence",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "fa30_free_assessment_gsc_live_smoke_evidence_contract",
     "title": "FA30-API-04: Add free-assessment GSC live-smoke evidence contract",
     "depends_on": [
@@ -59243,12 +59243,12 @@
         "evidence": "Changed files are limited to FA30-API-04 allowed paths: generated free-assessment GSC evidence contract, focused PHPUnit contract test, and docs/codex metadata. No live GSC call, URL submission, search queue, CMS write, import, sitemap, llms, canonical, noindex, JSON-LD, deploy, scheduler, or queue change."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2327 opened; GitHub checks pending."
+        "status": "pass",
+        "evidence": "PR #2327 GitHub checks passed: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS."
       }
     },
     "failure_reason": null,
-    "commit_sha": "46514420d056b2442dd847fc546825c48d9127b4",
+    "commit_sha": "b12cff68782136210ade74b83e2f8ce8706282ae",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2327",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -59268,6 +59268,11 @@
         "at": "2026-06-22T16:39:26.087+00:00",
         "status": "pr_open",
         "note": "Opened PR #2327 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-22T16:45:26.941+00:00",
+        "status": "ready_to_merge",
+        "note": "All PR #2327 GitHub checks passed and scope was revalidated; ready for squash merge when final metadata commit checks pass."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:26:25.862+00:00",
+  "updated_at": "2026-06-22T16:38:32.073+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59126,7 +59126,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-05-analytics-smoke-exclusion",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged_cleanup_complete",
     "train_scope": "fa30_six_scale_smoke_analytics_exclusion",
     "title": "FA30-API-05: Centralize six-scale smoke attempt analytics exclusion",
     "depends_on": [
@@ -59160,15 +59160,15 @@
       },
       "github": {
         "status": "pass",
-        "evidence": "PR #2324 GitHub checks passed after current-scope verify-bigfive classifier fix: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS."
+        "evidence": "PR #2324 merged via squash. GitHub reported merge commit 413e06c499be146ddd9bda87dc9f56b4793a4fd5; origin/main contains it; local main synced to origin/main; remote branch deleted; local task branch deleted after squash merge."
       }
     },
     "failure_reason": null,
     "commit_sha": "258c20a92a67495c188b4da700cc2bc8d0a4ecd7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2324",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T16:32:27Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-23T00:00:00+08:00",
@@ -59199,6 +59199,70 @@
         "at": "2026-06-22T16:26:25.862+00:00",
         "status": "ready_to_merge",
         "note": "All PR #2324 GitHub checks passed and scope was revalidated; ready for squash merge when final metadata commit checks pass."
+      },
+      {
+        "at": "2026-06-22T16:37:20.369+00:00",
+        "status": "merged_cleanup_complete",
+        "note": "Reconciled after PR #2324 merge: origin/main contains merge commit 413e06c499be146ddd9bda87dc9f56b4793a4fd5, local main is synced and clean, remote branch is deleted, and local task branch was deleted."
+      }
+    ]
+  },
+  "FA30-API-04": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-04-gsc-live-smoke-evidence",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "fa30_free_assessment_gsc_live_smoke_evidence_contract",
+    "title": "FA30-API-04: Add free-assessment GSC live-smoke evidence contract",
+    "depends_on": [
+      "FA30-API-05"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided FA30-API-04 id, title, scope, and authorized manifest/state updates in the FA30-NON-AGENT-PR-TRAIN-01 /goal request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FA30-API-05 merged as PR #2324 at 2026-06-22T16:32:27Z; origin/main contains merge commit 413e06c499be146ddd9bda87dc9f56b4793a4fd5."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FreeAssessmentGscLiveSmokeEvidenceContractTest --no-ansi",
+          "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check"
+        ],
+        "evidence": "PASS: FreeAssessmentGscLiveSmokeEvidenceContractTest (3 warning-only file_get_contents warnings, 107 assertions)\nPASS: Pint for FreeAssessmentGscLiveSmokeEvidenceContractTest.php\nPASS: JSON parse for free-assessment GSC live-smoke evidence contract\nPASS: YAML parse for docs/codex/pr-train.yaml\nPASS: JSON parse for docs/codex/pr-train-state.json\nPASS: git diff --check"
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to FA30-API-04 allowed paths: generated free-assessment GSC evidence contract, focused PHPUnit contract test, and docs/codex metadata. No live GSC call, URL submission, search queue, CMS write, import, sitemap, llms, canonical, noindex, JSON-LD, deploy, scheduler, or queue change."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": ""
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-22T16:37:20.369+00:00",
+        "status": "in_progress",
+        "note": "Started from clean origin/main worktree. Scope is limited to a docs/generated free-assessment GSC live-smoke evidence contract, focused PHPUnit contract, and docs/codex metadata. No live GSC API call, URL submission, indexing request, CMS write, search queue enqueue, import, sitemap, llms, canonical, noindex, JSON-LD, deploy, scheduler, queue, or fap-web scope is allowed."
+      },
+      {
+        "at": "2026-06-22T16:38:32.073+00:00",
+        "status": "local_validated",
+        "note": "Rebased onto latest origin/main, reran focused PHPUnit/Pint/JSON/YAML/diff checks, and validated path scope."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-22T16:38:32.073+00:00",
+  "updated_at": "2026-06-22T16:39:26.087+00:00",
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",
@@ -59211,7 +59211,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-04-gsc-live-smoke-evidence",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "fa30_free_assessment_gsc_live_smoke_evidence_contract",
     "title": "FA30-API-04: Add free-assessment GSC live-smoke evidence contract",
     "depends_on": [
@@ -59244,12 +59244,12 @@
       },
       "github": {
         "status": "pending",
-        "evidence": ""
+        "evidence": "PR #2327 opened; GitHub checks pending."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "46514420d056b2442dd847fc546825c48d9127b4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2327",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -59263,6 +59263,11 @@
         "at": "2026-06-22T16:38:32.073+00:00",
         "status": "local_validated",
         "note": "Rebased onto latest origin/main, reran focused PHPUnit/Pint/JSON/YAML/diff checks, and validated path scope."
+      },
+      {
+        "at": "2026-06-22T16:39:26.087+00:00",
+        "status": "pr_open",
+        "note": "Opened PR #2327 after local validation and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24326,6 +24326,46 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: FA30-API-04
+    repo: fap-api
+    depends_on:
+      - FA30-API-05
+    branch: codex/fa30-api-04-gsc-live-smoke-evidence
+    title: "FA30-API-04: Add free-assessment GSC live-smoke evidence contract"
+    train_scope: fa30_free_assessment_gsc_live_smoke_evidence_contract
+    status: user_authorized
+    scope:
+      - Add a read-only GSC live-smoke evidence contract for FermatMind free assessment landing pages.
+      - Cover the six public assessment surfaces with backend-authoritative canonical paths and sanitized URL hashes.
+      - Require future live-smoke evidence to be sanitized hash/aggregate only and to report GO/NO-GO without URL submission.
+      - Keep this PR as docs/generated plus PHPUnit contract only; do not activate live GSC reads, URL inspection, indexing, queueing, CMS writes, or search submissions.
+    allowed_paths:
+      - backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json
+      - backend/tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute live Google Search Console API calls in this PR.
+      - Submit URLs, request indexing, enqueue Search Channel records, import GSC rows, or write seo_gsc_daily rows.
+      - Change CMS publication state, sitemap, llms, canonical, noindex, JSON-LD, runtime routes, scheduler, queue, deploy, or environment configuration.
+      - Implement FA30-WEB-05, FA30-API-08, FA30-WEB-07, or any frontend scope.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FreeAssessmentGscLiveSmokeEvidenceContractTest --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php
+      - python3 -m json.tool backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG5-RESULT-SOURCE-LEDGER-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added a generated read-only GSC live-smoke evidence contract for six FermatMind free assessment landing pages.
- Added a focused PHPUnit contract test covering canonical surface coverage, sanitized evidence fields, URL hashes, and no-submit/no-write boundaries.
- Added authorized FA30-API-04 manifest/state entries and reconciled FA30-API-05 post-merge ledger facts.

## Why
Future production GSC live-smoke evidence should be consistent and safe: Search Analytics only, hash/aggregate evidence only, GO/NO-GO reporting, and no URL inspection indexing requests or Search Channel submission.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FreeAssessmentGscLiveSmokeEvidenceContractTest --no-ansi`
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/FreeAssessmentGscLiveSmokeEvidenceContractTest.php`
- `python3 -m json.tool backend/docs/seo/generated/free-assessment-gsc-live-smoke-evidence-contract.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

Note: the PHPUnit contract passes with warning-only `file_get_contents` warnings.

## Intentionally deferred
- No live Google Search Console API call in this PR.
- No URL inspection, indexing request, sitemap submit, or Search Channel submission.
- No CMS write, GSC row import, queue enqueue, scheduler, deployment, or environment config change.
- No sitemap, llms, canonical, noindex, JSON-LD, runtime route, or fap-web changes.
- Does not implement FA30-WEB-05, FA30-API-08, or FA30-WEB-07.

## Repository rule impact
No content authority change. Backend/CMS URL Truth remains authority; GSC remains feedback/readiness evidence only.
