### PR TITLE
fix(seo-agent): support inline article runtime QA

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php
@@ -122,15 +122,19 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
         }
 
         $publishedRevision = null;
+        $publishedRevisionPointer = null;
         if ($article->published_revision_id !== null) {
             $publishedRevision = ArticleRevision::query()->withoutGlobalScopes()
                 ->where('article_id', $articleId)
                 ->whereKey((int) $article->published_revision_id)
                 ->first();
+            $publishedRevisionPointer = ArticleRevision::query()->withoutGlobalScopes()
+                ->whereKey((int) $article->published_revision_id)
+                ->first();
         }
 
         $payload = is_array($revision->payload_json) ? $revision->payload_json : [];
-        $evidence = $this->evidence($writeEvidencePath, $writeEvidence, $writeRef, $article, $revision, $publishedRevision, $payload, $target, $beforeState);
+        $evidence = $this->evidence($writeEvidencePath, $writeEvidence, $writeRef, $article, $revision, $publishedRevision, $publishedRevisionPointer, $payload, $target, $beforeState);
         $artifactRef = $this->writeArtifact(
             $artifactDir,
             'seo-agent-article-draft-preview-runtime-qa-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json',
@@ -191,6 +195,7 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
      * @param  array<string, mixed>  $writeEvidence
      * @param  array<string, mixed>  $writeRef
      * @param  array<string, mixed>|null  $publishedRevision
+     * @param  array<string, mixed>|null  $publishedRevisionPointer
      * @param  array<string, mixed>  $payload
      * @param  array<string, mixed>  $beforeState
      * @return array<string, mixed>
@@ -202,17 +207,24 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
         Article $article,
         ArticleRevision $revision,
         ?ArticleRevision $publishedRevision,
+        ?ArticleRevision $publishedRevisionPointer,
         array $payload,
         string $target,
         array $beforeState
     ): array {
         $article->refresh();
         $afterState = $this->articleState($article);
+        $publicRuntimeMode = $this->publicRuntimeMode($article, $revision, $publishedRevision);
         $findings = $this->qaFindings($writeEvidence, $article, $revision, $publishedRevision, $payload, $target, $beforeState, $afterState);
         $criticalCount = count(array_filter($findings, static fn (array $finding): bool => ($finding['severity'] ?? '') === 'critical'));
+        $warningCount = count(array_filter($findings, static fn (array $finding): bool => ($finding['severity'] ?? '') === 'warning'));
         $status = $criticalCount > 0 ? 'blocked' : 'success';
 
         $isPublishedRevision = (int) ($article->published_revision_id ?? 0) === (int) $revision->id;
+        $publishedRevisionExists = $publishedRevision instanceof ArticleRevision;
+        $publicRuntimeSafe = $publicRuntimeMode !== 'unresolved'
+            && ! $isPublishedRevision
+            && (string) $article->status === 'published';
 
         return [
             'schema_version' => self::SCHEMA_VERSION,
@@ -254,8 +266,12 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
                 'is_indexable' => (bool) $article->is_indexable,
                 'working_revision_id' => $article->working_revision_id ? (int) $article->working_revision_id : null,
                 'published_revision_id' => $article->published_revision_id ? (int) $article->published_revision_id : null,
-                'published_revision_exists' => $publishedRevision instanceof ArticleRevision,
-                'public_runtime_uses_published_revision' => $publishedRevision instanceof ArticleRevision
+                'published_revision_exists' => $publishedRevisionExists,
+                'published_revision_pointer_exists' => $publishedRevisionPointer instanceof ArticleRevision,
+                'published_revision_pointer_article_id' => $publishedRevisionPointer instanceof ArticleRevision ? (int) $publishedRevisionPointer->article_id : null,
+                'public_runtime_source' => $publicRuntimeMode,
+                'public_runtime_safe' => $publicRuntimeSafe,
+                'public_runtime_uses_published_revision' => $publishedRevisionExists
                     && ! $isPublishedRevision
                     && (string) $article->status === 'published',
                 'draft_revision_leaked_to_public_runtime' => $isPublishedRevision,
@@ -271,6 +287,7 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
             ],
             'qa_findings' => $findings,
             'critical_finding_count' => $criticalCount,
+            'warning_finding_count' => $warningCount,
             'negative_guarantees' => $this->negativeGuarantees(),
         ];
     }
@@ -298,7 +315,11 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
             $findings[] = $this->finding('public_runtime', 'critical', 'article_not_published');
         }
         if (! $publishedRevision instanceof ArticleRevision) {
-            $findings[] = $this->finding('public_runtime', 'critical', 'published_revision_missing');
+            if ($this->publicRuntimeMode($article, $revision, $publishedRevision) === 'article_inline_published_content') {
+                $findings[] = $this->finding('public_runtime', 'warning', 'published_revision_pointer_not_same_article_using_inline_article_content');
+            } else {
+                $findings[] = $this->finding('public_runtime', 'critical', 'published_revision_missing');
+            }
         }
         if ((int) ($article->published_revision_id ?? 0) === (int) $revision->id) {
             $findings[] = $this->finding('public_runtime', 'critical', 'draft_revision_is_public_published_revision');
@@ -326,6 +347,23 @@ final class SeoAgentArticleDraftPreviewRuntimeQaCommand extends Command
         }
 
         return $findings;
+    }
+
+    private function publicRuntimeMode(Article $article, ArticleRevision $draftRevision, ?ArticleRevision $publishedRevision): string
+    {
+        $draftIsPublishedRevision = (int) ($article->published_revision_id ?? 0) === (int) $draftRevision->id;
+        if ($publishedRevision instanceof ArticleRevision && ! $draftIsPublishedRevision) {
+            return 'published_article_revision';
+        }
+
+        if (! $draftIsPublishedRevision
+            && (string) $article->status === 'published'
+            && (trim((string) $article->content_md) !== '' || trim((string) $article->content_html) !== '')
+        ) {
+            return 'article_inline_published_content';
+        }
+
+        return 'unresolved';
     }
 
     /**

--- a/backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json
+++ b/backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json
@@ -25,8 +25,9 @@
     ],
     "public_runtime": [
       "article remains published",
-      "published_revision_id resolves to an ArticleRevision",
-      "public runtime uses published_revision_id, not the draft revision"
+      "published_revision_id resolves to an ArticleRevision for the same article when the revision graph is canonical",
+      "legacy inline-published articles may pass with public_runtime_source=article_inline_published_content when the published_revision_id pointer targets another article but the current Article row remains published and the draft revision is not leaked",
+      "public runtime uses the canonical published revision or inline published Article content, not the draft revision"
     ],
     "read_only_invariants": [
       "working_revision_id unchanged",

--- a/backend/tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php
@@ -33,7 +33,7 @@ final class SeoAgentArticleDraftPreviewRuntimeQaTest extends TestCase
         ]);
 
         $summary = json_decode(trim(Artisan::output()), true);
-        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame(0, $exitCode, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: Artisan::output());
         $this->assertSame('success', $summary['status'] ?? null);
         $this->assertTrue((bool) ($summary['preview_readable'] ?? false));
         $this->assertTrue((bool) ($summary['public_runtime_uses_published_revision'] ?? false));
@@ -78,6 +78,39 @@ final class SeoAgentArticleDraftPreviewRuntimeQaTest extends TestCase
         $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
         $this->assertContains('draft_revision_is_public_published_revision', array_column($artifact['qa_findings'] ?? [], 'issue'));
         $this->assertFalse((bool) data_get($artifact, 'preview_read.preview_readable', true));
+    }
+
+    #[Test]
+    public function it_accepts_legacy_inline_published_articles_when_revision_pointer_targets_another_article(): void
+    {
+        [$article, $foreignRevision, $draftRevision, $writeEvidencePath] = $this->legacyInlinePublishedFixture();
+
+        $exitCode = Artisan::call('seo-agent:article-draft-preview-runtime-qa', [
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => 'article:'.$article->id.':en',
+            '--revision-id' => (string) $draftRevision->id,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['preview_readable'] ?? false));
+        $this->assertFalse((bool) ($summary['public_runtime_uses_published_revision'] ?? true));
+        $this->assertFalse((bool) ($summary['mutation_detected'] ?? true));
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertTrue((bool) ($artifact['ok'] ?? false));
+        $this->assertSame('article_inline_published_content', data_get($artifact, 'public_runtime.public_runtime_source'));
+        $this->assertTrue((bool) data_get($artifact, 'public_runtime.public_runtime_safe', false));
+        $this->assertFalse((bool) data_get($artifact, 'public_runtime.published_revision_exists', true));
+        $this->assertTrue((bool) data_get($artifact, 'public_runtime.published_revision_pointer_exists', false));
+        $this->assertSame((int) $foreignRevision->article_id, data_get($artifact, 'public_runtime.published_revision_pointer_article_id'));
+        $this->assertFalse((bool) data_get($artifact, 'public_runtime.draft_revision_leaked_to_public_runtime', true));
+        $this->assertSame(0, (int) data_get($artifact, 'critical_finding_count'));
+        $this->assertSame(1, (int) data_get($artifact, 'warning_finding_count'));
+        $this->assertContains('published_revision_pointer_not_same_article_using_inline_article_content', array_column($artifact['qa_findings'] ?? [], 'issue'));
     }
 
     #[Test]
@@ -202,6 +235,70 @@ final class SeoAgentArticleDraftPreviewRuntimeQaTest extends TestCase
             $publishedRevision,
             $draftRevision,
             $this->writeEvidence($packageSha, 'article:'.$article->id.':en', (int) $writeTargetRevision->id),
+        ];
+    }
+
+    /**
+     * @return array{0: Article, 1: ArticleRevision, 2: ArticleRevision, 3: string}
+     */
+    private function legacyInlinePublishedFixture(): array
+    {
+        $foreignArticle = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'foreign-article',
+            'locale' => 'en',
+            'title' => 'Foreign Article',
+            'excerpt' => 'Foreign excerpt.',
+            'content_md' => 'Foreign markdown.',
+            'content_html' => '<p>Foreign HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDays(2),
+        ]);
+        $foreignRevision = $this->articleRevision($foreignArticle, 1, [
+            'seo_agent' => [
+                'task' => 'historical_foreign_publish',
+            ],
+        ]);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'legacy-inline-published',
+            'locale' => 'en',
+            'title' => 'Legacy Inline Published',
+            'excerpt' => 'Existing legacy excerpt.',
+            'content_md' => 'Existing legacy article markdown.',
+            'content_html' => '',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'working_revision_id' => (int) $foreignRevision->id,
+            'published_revision_id' => (int) $foreignRevision->id,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $packageSha = hash('sha256', 'package:legacy-inline:'.$article->id);
+        $draftRevision = $this->articleRevision($article, 1, [
+            'seo_agent' => [
+                'task' => 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01',
+                'package_sha256' => $packageSha,
+                'subject_ref' => 'article:'.$article->id.':en',
+                'target_fields' => ['seo_title', 'seo_description', 'faq_items'],
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'indexing_request_allowed' => false,
+            ],
+            'proposal' => [
+                'safe_path' => '/en/articles/legacy-inline-published',
+            ],
+        ]);
+
+        return [
+            $article->refresh(),
+            $foreignRevision,
+            $draftRevision,
+            $this->writeEvidence($packageSha, 'article:'.$article->id.':en', (int) $draftRevision->id),
         ];
     }
 


### PR DESCRIPTION
## Summary
- Makes `seo-agent:article-draft-preview-runtime-qa` compatible with legacy inline-published Article rows where `published_revision_id` points at an ArticleRevision from another article.
- Keeps canonical same-article published revision validation unchanged.
- Emits explicit evidence fields for `public_runtime_source`, pointer existence, pointer article id, and `public_runtime_safe`; records the legacy pointer mismatch as a warning instead of a critical blocker when current Article content remains published and the SEO Agent draft is not public.

## Why
Production dry-run QA for `article:34`, `article:37`, and `article:41` found `published_revision_missing`. Read-only production diagnosis showed the `published_revision_id` values resolve to ArticleRevision rows, but those rows belong to other articles. The live article content is held on the Article row itself, and the SEO Agent drafts were preview-readable without changing or leaking into public runtime.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleDraftPreviewRuntimeQaTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentGscDraftPublishGateReadinessTest`
- `cd backend && php artisan list --raw | rg '^seo-agent:article-draft-preview-runtime-qa'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticleDraftPreviewRuntimeQaCommand.php tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-article-draft-preview-runtime-qa.v1.json >/dev/null`
- `git diff --check && git diff --cached --check`

Note: the two focused PHPUnit runs returned exit code 0 with existing warning output from the local test environment; no assertions failed.

## Intentionally deferred
- No production deploy.
- No production CMS write.
- No CMS publish.
- No URL Truth, sitemap, IndexNow, search/indexing, scheduler, queue worker, external model, or live GSC action.
- Production preview/runtime QA rerun is deferred until this PR is merged and deployed under a separate exact deploy approval.

## Repository rule impact
This is a read-only SEO Agent QA compatibility change. It does not change content ownership, publishing SOP, public content APIs, media handling, sitemap/llms enumeration, or frontend fallback behavior.
