### PR TITLE
MBTI64-CMS-PROJECTION-PROMOTE-LIVE-MATCH-DETECTOR-PATCH-01

### DIFF
--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -863,7 +863,11 @@ final class Mbti64CmsRevisionPromotionService
                 ->where('section_key', (string) ($section['section_key'] ?? ''))
                 ->first();
 
-            if (! $live instanceof PersonalityProfileVariantSection || ! $this->modelSubsetMatches($live, $section)) {
+            if (! $live instanceof PersonalityProfileVariantSection) {
+                return false;
+            }
+
+            if (! $this->modelSubsetMatches($live, $section)) {
                 return false;
             }
         }
@@ -881,21 +885,38 @@ final class Mbti64CmsRevisionPromotionService
                 continue;
             }
 
-            $actual = $model->getAttribute($key);
-            if (is_array($value)) {
-                if ($actual !== $value) {
-                    return false;
-                }
-
-                continue;
-            }
-
-            if ($actual !== $value) {
+            if (! $this->liveMatchValueEquals($model->getAttribute($key), $value)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private function liveMatchValueEquals(mixed $actual, mixed $expected): bool
+    {
+        if (is_array($actual) || is_array($expected)) {
+            return $this->canonicalLiveMatchValue($actual) === $this->canonicalLiveMatchValue($expected);
+        }
+
+        return $actual === $expected;
+    }
+
+    private function canonicalLiveMatchValue(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as $key => $nested) {
+            $value[$key] = $this->canonicalLiveMatchValue($nested);
+        }
+
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        return $value;
     }
 
     private function safeSectionKey(string $key): string

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -374,6 +374,48 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             ->first());
     }
 
+    public function test_visible_query_backed_three_subset_is_idempotent_after_write(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+        $options = $this->promoteWriteOptions($packagePath);
+        $options['--visible-query-backed-3'] = true;
+
+        $this->assertSame(0, Artisan::call('personality:mbti64-cms-revision-promote', $options), Artisan::output());
+        $this->reorderOnePromotedVisibleThreeJsonPayload();
+
+        $dryRunExit = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $dryRunPayload = $this->jsonOutput();
+        $this->assertSame(0, $dryRunExit, Artisan::output());
+        $this->assertTrue($dryRunPayload['ok']);
+        $this->assertSame(3, $dryRunPayload['row_count']);
+        $this->assertSame([], array_column(array_filter(
+            $dryRunPayload['rows'],
+            static fn (array $row): bool => ($row['live_matches_revision'] ?? false) !== true
+        ), 'url'));
+        $this->assertSame(0, $dryRunPayload['would_promote_count']);
+        $this->assertSame(3, $dryRunPayload['skipped_existing_count']);
+        $this->assertSame(array_fill(0, 3, 'would_skip_existing'), array_column($dryRunPayload['rows'], 'action'));
+        $this->assertSame(array_fill(0, 3, true), array_column($dryRunPayload['rows'], 'live_matches_revision'));
+
+        $secondWriteExit = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $secondWritePayload = $this->jsonOutput();
+        $this->assertSame(0, $secondWriteExit, Artisan::output());
+        $this->assertTrue($secondWritePayload['ok']);
+        $this->assertFalse($secondWritePayload['writes_committed']);
+        $this->assertSame(0, $secondWritePayload['promoted_count']);
+        $this->assertSame(3, $secondWritePayload['skipped_existing_count']);
+        $this->assertSame(array_fill(0, 3, 'skipped_existing'), array_column($secondWritePayload['rows'], 'action'));
+    }
+
     public function test_visible_query_backed_three_subset_fails_closed_when_fixed_url_is_missing(): void
     {
         $this->seedProjectionTargets();
@@ -679,6 +721,32 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    private function reorderOnePromotedVisibleThreeJsonPayload(): void
+    {
+        $seo = PersonalityProfileVariantSeoMeta::query()->firstOrFail();
+        $seo->jsonld_overrides_json = $this->reverseAssociativeKeys((array) $seo->jsonld_overrides_json);
+        $seo->save();
+
+        $section = PersonalityProfileVariantSection::query()
+            ->where('section_key', 'mbti64_promotion_metadata')
+            ->firstOrFail();
+        $section->payload_json = $this->reverseAssociativeKeys((array) $section->payload_json);
+        $section->save();
+    }
+
+    /**
+     * @param  array<string|int,mixed>  $value
+     * @return array<string|int,mixed>
+     */
+    private function reverseAssociativeKeys(array $value): array
+    {
+        foreach ($value as $key => $nested) {
+            $value[$key] = is_array($nested) ? $this->reverseAssociativeKeys($nested) : $nested;
+        }
+
+        return array_is_list($value) ? $value : array_reverse($value, true);
     }
 
     /**


### PR DESCRIPTION
## What changed
- Fixed MBTI64 CMS revision promotion live-match comparison for JSON payloads by canonicalizing associative array key order before comparison.
- Added a visible-query-backed 3 regression test that promotes once, simulates reordered persisted JSON, and verifies the next dry-run/write skips existing live content instead of planning another promotion.

## Why
Production visible-3 promotion succeeded and public HTML/API reflected the promoted content, but a follow-up dry-run still planned the same 3 rows as `would_promote`. The detector was too strict for persisted JSON object key ordering.

## Validation
- `php artisan test --filter=test_visible_query_backed_three_subset_is_idempotent_after_write tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only `backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php` and `backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php` changed

Note: focused tests emitted warnings in the clean temporary worktree because `.env` was absent; exit code was 0. `ci_verify_mbti.sh` created and cleaned its temporary test `.env`.

## Deferred
- No production deploy.
- No CMS write or promotion.
- No publish/index/sitemap/llms/search queue changes.