### PR TITLE
Enneagram: harden PDF metadata boundary

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2661,7 +2661,7 @@ class AttemptReadController extends Controller
         $variant = (string) ($generated['variant'] ?? $variant);
         $locked = (bool) ($generated['locked'] ?? $locked);
 
-        return response($pdfBinary, 200, [
+        $responseHeaders = [
             'Content-Type' => 'application/pdf',
             'Content-Disposition' => $disposition.'; filename="'.$fileName.'"',
             'Cache-Control' => 'private, no-store',
@@ -2682,7 +2682,22 @@ class AttemptReadController extends Controller
             'X-Cross-Form-Comparable' => is_bool($pdfMetadata['cross_form_comparable'] ?? null)
                 ? (($pdfMetadata['cross_form_comparable'] ?? false) ? 'true' : 'false')
                 : '',
-        ]);
+        ];
+
+        if (strtoupper((string) ($attempt->scale_code ?? '')) === 'ENNEAGRAM') {
+            foreach ([
+                'X-Report-Schema-Version',
+                'X-Projection-Version',
+                'X-Report-Engine-Version',
+                'X-Interpretation-Context-Id',
+                'X-Content-Release-Hash',
+                'X-Content-Snapshot-Status',
+            ] as $internalHeader) {
+                unset($responseHeaders[$internalHeader]);
+            }
+        }
+
+        return response($pdfBinary, 200, $responseHeaders);
     }
 
     /**

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -418,12 +418,15 @@ final class ReportPdfDocumentService
         string $qualityLevel,
         array $sections
     ): string {
+        $normalizedScale = strtoupper($scaleCode);
         $lines = [
-            'Attempt ID: '.$attemptId,
-            'Scale: '.strtoupper($scaleCode),
+            'Scale: '.$normalizedScale,
             'Variant: '.strtolower($variant),
             'Locked: '.($locked ? 'true' : 'false'),
         ];
+        if ($normalizedScale !== 'ENNEAGRAM') {
+            array_unshift($lines, 'Attempt ID: '.$attemptId);
+        }
 
         if ($normsStatus !== '') {
             $lines[] = 'Norms Status: '.strtoupper($normsStatus);

--- a/backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php
+++ b/backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php
@@ -40,9 +40,9 @@ final class EnneagramPdfMetadataContractTest extends TestCase
         $response->assertHeader('X-Pdf-Surface-Version', 'enneagram.pdf_surface.v1');
         $response->assertHeader('X-Report-Form-Code', $formCode);
         $response->assertHeader('X-Report-Form-Label', $expectedLabel);
-        $response->assertHeader('X-Report-Schema-Version', 'enneagram.report.v2');
-        $response->assertHeader('X-Projection-Version', 'enneagram_projection.v2');
         $response->assertHeader('X-Cross-Form-Comparable', 'false');
+        $this->assertEnneagramPdfHeadersArePublicSafe($response->headers->all());
+        $this->assertEnneagramPdfBodyIsPublicSafe((string) $response->getContent(), $attemptId);
         $this->assertStringContainsString(
             sprintf('fermatmind-enneagram-%s-%s.pdf', $expectedSlug, now()->format('Y-m-d')),
             (string) $response->headers->get('Content-Disposition')
@@ -60,7 +60,52 @@ final class EnneagramPdfMetadataContractTest extends TestCase
         $this->assertSame($expectedLabel, $metadata['form_label']);
         $this->assertSame(false, $metadata['cross_form_comparable']);
         $this->assertNotSame('', (string) $metadata['filename_hint']);
+        $this->assertSame('enneagram.report.v2', $metadata['report_schema_version']);
+        $this->assertSame('enneagram_projection.v2', $metadata['projection_version']);
+        $this->assertNotSame('', (string) $metadata['interpretation_context_id']);
+        $this->assertNotSame('', (string) $metadata['content_release_hash']);
+        $this->assertNotSame('', (string) $metadata['content_snapshot_status']);
         $this->assertNotEmpty((array) $metadata['snapshot_binding_v1']);
+    }
+
+    /**
+     * @param  array<string,list<string|null>>  $headers
+     */
+    private function assertEnneagramPdfHeadersArePublicSafe(array $headers): void
+    {
+        foreach ([
+            'x-report-schema-version',
+            'x-projection-version',
+            'x-report-engine-version',
+            'x-interpretation-context-id',
+            'x-content-release-hash',
+            'x-content-snapshot-status',
+        ] as $header) {
+            $this->assertArrayNotHasKey($header, $headers, $header);
+        }
+    }
+
+    private function assertEnneagramPdfBodyIsPublicSafe(string $pdfBinary, string $attemptId): void
+    {
+        foreach ([
+            $attemptId,
+            'Attempt ID:',
+            'raw_score',
+            'raw_scores',
+            'raw_score_vector',
+            'score_vector',
+            'schema_version',
+            'report_schema_version',
+            'projection_version',
+            'interpretation_context_id',
+            'content_release_hash',
+            'content_snapshot_status',
+            'sha256:',
+            'enneagram.report.v2',
+            'enneagram_projection.v2',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $pdfBinary, $forbidden);
+        }
     }
 
     /**


### PR DESCRIPTION
## What changed
- Enneagram PDF responses now keep public-safe headers only: scale, variant, lock state, PDF surface version, form code/label, filename hint, compare group, and cross-form comparable.
- Enneagram PDF responses no longer expose schema/projection/engine/context/release hash/snapshot headers.
- Enneagram PDF body no longer writes the attempt id.
- Added negative coverage for headers/body: no attempt id, raw scores/vectors, internal hash/context/schema/projection/status leakage in user-facing PDF response.

## Why
Enneagram PDF/print surfaces should be user-facing report artifacts, not metadata/debug surfaces. Internal schema, projection, release hash, interpretation context, and snapshot state remain available in server-side metadata for logs/audit, but are not sent to the user-facing PDF response.

## Validation
- `php -l backend/app/Services/Report/Pdf/ReportPdfDocumentService.php`
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
- `php -l backend/tests/Feature/Report/EnneagramPdfMetadataContractTest.php`
- `php artisan test tests/Feature/Report/EnneagramPdfMetadataContractTest.php --no-ansi`
- `php artisan test tests/Feature/Report/EnneagramPdfDeliveryTest.php --no-ansi`
- `php artisan test --filter EnneagramPdf --no-ansi`
- `git diff --check`

Note: the Enneagram PDF tests pass with existing PHPUnit warnings from the PDF generator path; they are non-failing locally.

## Intentionally deferred
- No candidate changes.
- No runtime switch.
- No production import or activation.
- No CMS writes.
- No frontend changes.
- No staging or production deploy.