### PR TITLE
Enneagram: add sanitized readiness artifact run

### DIFF
--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/control_packet.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/control_packet.json
@@ -1,0 +1,113 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "control_packet",
+    "content_authority": "backend",
+    "scale": "ENNEAGRAM",
+    "surface": "private_result_page",
+    "candidate_contract": {
+        "baseline_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+        "runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+        "payload_count": 630,
+        "out_of_launch_scope_must_equal": [
+            "1R-I",
+            "1R-J"
+        ],
+        "launch_scope_batches": [
+            "1R-A",
+            "1R-B",
+            "1R-C",
+            "1R-D",
+            "1R-E",
+            "1R-F",
+            "1R-G",
+            "1R-H"
+        ]
+    },
+    "source_ledger_contract": {
+        "schema_version": "fap.enneagram.result_page.source_ledger.v0.1",
+        "default_relative_dir": "content_assets/enneagram/result_page/source_ledger",
+        "required_source_ids": [
+            "enneagram_v2_runtime_registry",
+            "enneagram_e105_compiled_questions",
+            "enneagram_fc144_compiled_questions",
+            "phase8b_candidate_baseline_a9fd",
+            "batch_1r_a_asset_stream",
+            "batch_1r_b_asset_stream",
+            "batch_1r_c_asset_stream",
+            "batch_1r_d_asset_stream",
+            "batch_1r_e_asset_stream",
+            "batch_1r_f_asset_stream",
+            "batch_1r_g_asset_stream",
+            "batch_1r_h_asset_stream",
+            "fc144_boundary_policy",
+            "forbidden_claim_policy"
+        ],
+        "allowed_source_labels": [
+            "runtime_contract",
+            "compiled_question_contract",
+            "candidate_baseline",
+            "asset_stream_contract",
+            "policy_contract"
+        ]
+    },
+    "agent_batches": [
+        {
+            "batch_id": "ENNEAGRAM-RESULT-AGENT-CONTROL-PACKET-01",
+            "state": "merged_ready",
+            "allowed_output": "docs, control packet, readiness artifacts",
+            "generation_allowed": false
+        },
+        {
+            "batch_id": "ENNEAGRAM-RESULT-SOURCE-LEDGER-01",
+            "state": "scaffold_only",
+            "allowed_output": "source ledger and validator harness artifacts",
+            "generation_allowed": false
+        },
+        {
+            "batch_id": "ENNEAGRAM-RESULT-PILOT-ASSET-BATCH-01",
+            "state": "blocked_until_validator_and_ledger_pass",
+            "allowed_output": "small candidate draft only after explicit PR authorization",
+            "generation_allowed": false
+        },
+        {
+            "batch_id": "ENNEAGRAM-RESULT-CANDIDATE-EXPORT-QA-01",
+            "state": "blocked_until_candidate_dir_is_provided",
+            "allowed_output": "Phase8B/Phase8D2B reports only",
+            "generation_allowed": false
+        }
+    ],
+    "allowed_actions": [
+        "read existing docs and code",
+        "write run-scoped readiness artifacts",
+        "write source ledger templates",
+        "validate a provided Phase8B candidate directory without import or activation",
+        "prepare small candidate drafts only in a future explicitly authorized PR"
+    ],
+    "forbidden_actions": [
+        "bulk content generation in this PR",
+        "candidate payload creation in this PR",
+        "production activation",
+        "content_pack_activations write",
+        "runtime registry switch",
+        "production import",
+        "frontend-side result copy fallback",
+        "fap-web runtime changes",
+        "sitemap or llms exposure",
+        "public SEO profile generation",
+        "private result identifier export"
+    ],
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/forbidden_claim_report.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/forbidden_claim_report.json
@@ -1,0 +1,40 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "forbidden_claim_report",
+    "runtime_use": "not_runtime",
+    "production_use_allowed": false,
+    "candidate_dir": {
+        "provided": false,
+        "path": null
+    },
+    "forbidden_claim_families": [
+        "diagnosis_clinical_treatment",
+        "hiring_employment_screening",
+        "final_typing_you_are_this_type",
+        "fixed_type_certainty",
+        "e105_fc144_score_comparison",
+        "fc144_more_accurate_or_replacement_result",
+        "success_salary_performance_prediction",
+        "private_result_identifier_path_or_vector_leakage"
+    ],
+    "status": {
+        "forbidden_claim_zero": true
+    },
+    "hit_count": 0,
+    "hits": [],
+    "truncated": false,
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/go_no_go.md
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/go_no_go.md
@@ -1,0 +1,21 @@
+# Enneagram Result Page Agent Go / No-Go
+
+- verdict: SOURCE_LEDGER_VALIDATOR_SCAFFOLD_ONLY
+- candidate_generation_allowed: false
+- ready_for_generation: false
+- ready_for_import: false
+- ready_for_activation: false
+- source_ledger_valid: true
+- candidate_dir_provided: false
+- candidate_contract_valid: true
+- expected_candidate_manifest_sha256: `a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0`
+- expected_runtime_registry_manifest_sha256: `ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f`
+- expected_payload_count: 630
+- runtime_registry_matches_expected: true
+- no bulk content generated
+- no candidate payloads created
+- no import
+- no production write
+- no activation
+- no runtime switch
+- no frontend fallback

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/metadata_leakage_report.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/metadata_leakage_report.json
@@ -1,0 +1,35 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "metadata_leakage_report",
+    "runtime_use": "not_runtime",
+    "production_use_allowed": false,
+    "candidate_dir": {
+        "provided": false,
+        "path": null
+    },
+    "blocked_field_families": [
+        "private_result_identifier_path_or_vector_leakage",
+        "editorial_or_qa_working_notes",
+        "internal_source_selection_metadata"
+    ],
+    "status": {
+        "leakage_zero": true
+    },
+    "hit_count": 0,
+    "hits": [],
+    "truncated": false,
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/readiness_inventory.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/readiness_inventory.json
@@ -1,0 +1,54 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "readiness_inventory",
+    "runtime_use": "staging_only",
+    "production_use_allowed": false,
+    "candidate_dir": {
+        "provided": false,
+        "path": null,
+        "required_files": [
+            "candidate_manifest.json",
+            "candidate_hashes.json",
+            "rollback_plan.md",
+            "import_diff_summary.json",
+            "replacement_additive_map.json",
+            "source_mapping_report.json",
+            "legacy_residual_scan.json",
+            "fc144_boundary_report.json",
+            "phase8b_summary.json",
+            "candidate_payloads_manifest.json",
+            "candidate_payload_hashes.json",
+            "candidate_payload_source_mapping.json",
+            "candidate_payloads/"
+        ],
+        "missing_required_files": []
+    },
+    "repo_contracts": {
+        "export_command": "php artisan enneagram:export-production-equivalent-candidate-payloads --candidate-dir=<candidate> --output-dir=<tmp> --json",
+        "inactive_import_command": "php artisan enneagram:import-inactive-candidate-release --candidate-dir=<candidate> --output-dir=<tmp> --json",
+        "activation_command": "php artisan enneagram:activate-registry-release --release-id=<inactive_release_id>",
+        "activation_allowed_in_this_program": false
+    },
+    "runtime_registry": {
+        "manifest_path": "content_packs/ENNEAGRAM/v2/registry/manifest.json",
+        "actual_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+        "expected_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+        "matches_expected": true
+    },
+    "expected_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "expected_payload_count": 630,
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/safety_policy.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/safety_policy.json
@@ -1,0 +1,29 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "safety_policy",
+    "forbidden_claim_families": [
+        "diagnosis_clinical_treatment",
+        "hiring_employment_screening",
+        "final_typing_you_are_this_type",
+        "fixed_type_certainty",
+        "e105_fc144_score_comparison",
+        "fc144_more_accurate_or_replacement_result",
+        "success_salary_performance_prediction",
+        "private_result_identifier_path_or_vector_leakage"
+    ],
+    "blocked_public_payload_field_families": [
+        "private_result_identifier_path_or_vector_leakage",
+        "editorial_or_qa_working_notes",
+        "internal_source_selection_metadata"
+    ],
+    "fc144_boundary_rules": [
+        "FC144 may be suggested as a second lens, not a more accurate final type.",
+        "E105 and FC144 scores must not be directly compared.",
+        "No final typing, retyping, diagnostic, hiring, or certainty claims."
+    ],
+    "source_mapping_rules": [
+        "Every candidate payload must map to one approved source batch and source asset checksum.",
+        "Fallback, blocked, duplicate selection, and branch provenance mismatch counts must be zero.",
+        "Machine-local private paths must be redacted from public reports."
+    ]
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/source_ledger_inventory.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/source_ledger_inventory.json
@@ -1,0 +1,115 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "source_ledger_inventory",
+    "source_ledger": {
+        "schema_version": "fap.enneagram.result_page.source_ledger.v0.1",
+        "exists": true,
+        "valid": true,
+        "source_ledger_dir": "<backend>/content_assets/enneagram/result_page/source_ledger",
+        "primary_ledger_path": "<backend>/content_assets/enneagram/result_page/source_ledger/source_ledger.json",
+        "allowed_source_labels": [
+            "runtime_contract",
+            "compiled_question_contract",
+            "candidate_baseline",
+            "asset_stream_contract",
+            "policy_contract"
+        ],
+        "required_source_ids": [
+            "enneagram_v2_runtime_registry",
+            "enneagram_e105_compiled_questions",
+            "enneagram_fc144_compiled_questions",
+            "phase8b_candidate_baseline_a9fd",
+            "batch_1r_a_asset_stream",
+            "batch_1r_b_asset_stream",
+            "batch_1r_c_asset_stream",
+            "batch_1r_d_asset_stream",
+            "batch_1r_e_asset_stream",
+            "batch_1r_f_asset_stream",
+            "batch_1r_g_asset_stream",
+            "batch_1r_h_asset_stream",
+            "fc144_boundary_policy",
+            "forbidden_claim_policy"
+        ],
+        "required_source_ids_present": [
+            "batch_1r_a_asset_stream",
+            "batch_1r_b_asset_stream",
+            "batch_1r_c_asset_stream",
+            "batch_1r_d_asset_stream",
+            "batch_1r_e_asset_stream",
+            "batch_1r_f_asset_stream",
+            "batch_1r_g_asset_stream",
+            "batch_1r_h_asset_stream",
+            "enneagram_e105_compiled_questions",
+            "enneagram_fc144_compiled_questions",
+            "enneagram_v2_runtime_registry",
+            "fc144_boundary_policy",
+            "forbidden_claim_policy",
+            "phase8b_candidate_baseline_a9fd"
+        ],
+        "label_counts": {
+            "runtime_contract": 1,
+            "compiled_question_contract": 2,
+            "candidate_baseline": 1,
+            "asset_stream_contract": 8,
+            "policy_contract": 2
+        },
+        "candidate_baseline_hash": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+        "runtime_registry_hash": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+        "expected_payload_count": 630,
+        "launch_scope": [
+            "1R-A",
+            "1R-B",
+            "1R-C",
+            "1R-D",
+            "1R-E",
+            "1R-F",
+            "1R-G",
+            "1R-H"
+        ],
+        "out_of_launch_scope": [
+            "1R-I",
+            "1R-J"
+        ],
+        "negative_guarantees": {
+            "cms_write_performed": false,
+            "runtime_change_performed": false,
+            "frontend_fallback_allowed": false,
+            "activation_happened": false
+        },
+        "errors": [],
+        "files": [
+            {
+                "relative_path": "content_assets/enneagram/result_page/source_ledger/README.md",
+                "sha256": "8fe122399955c6cf0f6ba50c0ba3c673e022c4050918b58a694fddf9e5fa3c8c",
+                "size": 1868,
+                "json_valid": true
+            },
+            {
+                "relative_path": "content_assets/enneagram/result_page/source_ledger/source_ledger.json",
+                "sha256": "bf2aba1d2d93cc487334b12a48dc29bffd5961aba1113034bb6805b1b401cda1",
+                "size": 23413,
+                "json_valid": true
+            },
+            {
+                "relative_path": "content_assets/enneagram/result_page/source_ledger/source_ledger_template_v0_1.json",
+                "sha256": "ae4f693d377141b77a2e215a6de98a948f0f3cfd73df6b8c46a47cdd9c3c42df",
+                "size": 3051,
+                "json_valid": true
+            }
+        ]
+    },
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/source_mapping_contract_report.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/source_mapping_contract_report.json
@@ -1,0 +1,30 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "source_mapping_contract_report",
+    "runtime_use": "not_runtime",
+    "production_use_allowed": false,
+    "candidate_dir": {
+        "provided": false,
+        "path": null
+    },
+    "status": {
+        "source_mapping_zero_failures": true,
+        "payload_source_mapping_present": null
+    },
+    "issue_count": 0,
+    "issues": [],
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/validation_commands.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/validation_commands.json
@@ -1,0 +1,33 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "validation_commands",
+    "local_pr_validation": [
+        "php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php",
+        "php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php",
+        "cd backend && php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi",
+        "cd backend && php artisan enneagram:result-page-agent audit --run-id=smoke --artifact-dir=<tmpdir> --json",
+        "cd backend && php artisan enneagram:result-page-agent audit --run-id=smoke-strict --artifact-dir=<tmpdir> --strict --json",
+        "git diff --check"
+    ],
+    "future_candidate_export_gate": [
+        "cd backend && PHASE8B_CANDIDATE_DIR=<candidate-dir> PHASE8B1_OUTPUT_DIR=<tmp-output> php artisan enneagram:export-production-equivalent-candidate-payloads --json",
+        "assert phase8b1_summary.json verdict starts with PASS_",
+        "assert total_payload_count == 630",
+        "assert metadata_leak_count == 0",
+        "assert source_mapping_failure_count == 0",
+        "assert fc144_boundary_violation_count == 0"
+    ],
+    "future_inactive_import_gate": [
+        "cd backend && PHASE8B_CANDIDATE_DIR=<candidate-dir> PHASE8D2B_OUTPUT_DIR=<tmp-output> php artisan enneagram:import-inactive-candidate-release --json",
+        "assert phase8d2b_summary.json verdict == PASS_FOR_PHASE_8D_3_ACTIVATION_ROLLBACK_GATE",
+        "assert activation_happened == false",
+        "assert production_import_happened == false",
+        "assert candidate_payload_count == 630"
+    ],
+    "deferred": [
+        "production activation",
+        "runtime registry switch",
+        "fap-web rendered QA",
+        "bulk asset generation"
+    ]
+}

--- a/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/validator_harness_report.json
+++ b/backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/validator_harness_report.json
@@ -1,0 +1,61 @@
+{
+    "schema_version": "fap.enneagram.result_page.agent_readiness.v1",
+    "task": "validator_harness_report",
+    "runtime_use": "not_runtime",
+    "production_use_allowed": false,
+    "candidate_dir": {
+        "provided": false,
+        "path": null,
+        "missing_candidate_dir_is_failure": false
+    },
+    "candidate_contract": {
+        "valid": true,
+        "expected_candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+        "expected_runtime_registry_manifest_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+        "expected_payload_count": 630,
+        "launch_scope": [
+            "1R-A",
+            "1R-B",
+            "1R-C",
+            "1R-D",
+            "1R-E",
+            "1R-F",
+            "1R-G",
+            "1R-H"
+        ],
+        "out_of_launch_scope_must_equal": [
+            "1R-I",
+            "1R-J"
+        ]
+    },
+    "checks": {
+        "source_ledger_valid": true,
+        "candidate_dir_provided": false,
+        "candidate_required_artifacts_present": true,
+        "candidate_manifest_hash_matches": null,
+        "runtime_registry_hash_matches": null,
+        "candidate_payload_count_matches": null,
+        "out_of_launch_scope_matches": null,
+        "source_mapping_zero_failures": true,
+        "metadata_leakage_zero": true,
+        "forbidden_claim_zero": true,
+        "legacy_residual_zero": null,
+        "fc144_boundary_zero": null
+    },
+    "error_count": 0,
+    "errors": [],
+    "negative_guarantees": {
+        "runtime_use": "not_runtime",
+        "production_use_allowed": false,
+        "ready_for_generation": false,
+        "ready_for_import": false,
+        "ready_for_runtime": false,
+        "ready_for_production": false,
+        "cms_write_performed": false,
+        "runtime_change_performed": false,
+        "activation_happened": false,
+        "bulk_content_generation_happened": false,
+        "candidate_payload_creation_happened": false,
+        "frontend_fallback_allowed": false
+    }
+}


### PR DESCRIPTION
## What changed
- Ran the existing read-only Enneagram result-page agent audit in strict mode.
- Added sanitized evidence artifacts under `backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23/`.
- Captured control packet, readiness inventory, source ledger inventory, validator harness report, source mapping contract, metadata leakage, forbidden claim, validation commands, safety policy, and go/no-go evidence.

## Evidence summary
- `ok=true`
- `strict_failures=[]`
- `source_ledger_valid=true`
- `candidate_dir_provided=false`
- `candidate_contract_valid=true`
- `candidate_payload_count_expected=630`
- `candidate_generation_allowed=false`
- `ready_for_generation=false`
- `ready_for_import=false`
- `ready_for_activation=false`
- `activation_happened=false`

## Validation
- `php artisan enneagram:result-page-agent audit --run-id=sanitized-readiness-2026-06-23 --artifact-dir=generated/result-page-agents/enneagram --strict --json`
- `rg -n "/Users/rainie|/private/tmp|attempt_id|raw_score|raw_scores|raw_score_vector|private_url|private_path|frontend fallback|activation_happened\": true|candidate_payload_creation_happened\": true|bulk_content_generation_happened\": true" backend/generated/result-page-agents/enneagram/sanitized-readiness-2026-06-23 || true`
  - Only matched the negative guarantee text `no frontend fallback`.
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageAgentReadinessTest.php --no-ansi`
- `php -l backend/app/Console/Commands/EnneagramResultPageAgentReadinessCommand.php`
- `php -l backend/app/Services/Enneagram/Assets/Agent/EnneagramResultPageAgentReadiness.php`
- JSON parse check for all generated JSON artifacts
- `git diff --check`

Note: the readiness unit test passes with existing non-failing PHPUnit warnings.

## Intentionally deferred
- No bulk content generation.
- No candidate payload generation.
- No candidate export/import.
- No runtime switch.
- No production import or activation.
- No CMS writes.
- No frontend changes.
- No staging or production deploy.