### PR TITLE
Enneagram: add controlled pilot observation plan

### DIFF
--- a/backend/content_assets/enneagram/result_page/controlled_pilot_observation/v0_1/README.md
+++ b/backend/content_assets/enneagram/result_page/controlled_pilot_observation/v0_1/README.md
@@ -1,0 +1,37 @@
+# Enneagram Controlled Pilot Observation v0.1
+
+Status: `OBSERVATION_PLAN_ONLY`
+
+This directory defines the post-activation observation plan for the Enneagram result page. It is not an activation artifact and does not authorize production rollout.
+
+The plan starts only after the manual production gate and post-activation smoke have passed for the exact inactive release:
+
+- `enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4`
+
+## Observation Windows
+
+- D1
+- D7
+- D14
+- D28
+
+## Metrics
+
+- share clicks
+- retest starts and completions
+- Big Five cross-test clicks
+- MBTI cross-test clicks
+- PDF and share errors
+- claim gate hits
+
+## Boundaries
+
+- No production activation in this plan.
+- No production rollback in this plan.
+- No runtime switch in this plan.
+- No CMS writes.
+- No SEO expansion.
+- No sitemap, IndexNow, or search submission.
+- No public exposure of attempt ids, raw scores, score vectors, private report payloads, internal hashes, source traces, or selector metadata.
+
+Operational expansion remains blocked until the D1, D7, D14, and D28 evidence is reviewed.

--- a/backend/content_assets/enneagram/result_page/controlled_pilot_observation/v0_1/controlled_pilot_observation_plan_v0_1.json
+++ b/backend/content_assets/enneagram/result_page/controlled_pilot_observation/v0_1/controlled_pilot_observation_plan_v0_1.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "fap.enneagram.result_page.controlled_pilot_observation.v0.1",
+  "status": "observation_plan_only",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "activation_happened": false,
+  "production_rollback_happened": false,
+  "runtime_switch_happened": false,
+  "bulk_content_generation_happened": false,
+  "cms_write_happened": false,
+  "frontend_change_happened": false,
+  "requires_completed_manual_production_gate": true,
+  "requires_post_activation_smoke_pass": true,
+  "release_contract": {
+    "release_id": "enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4",
+    "candidate_manifest_sha256": "a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0",
+    "runtime_registry_sha256": "ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f",
+    "rollback_window": "60 minutes after activation"
+  },
+  "observation_windows": [
+    {
+      "window_id": "D1",
+      "offset_days_after_activation": 1,
+      "required_review": true
+    },
+    {
+      "window_id": "D7",
+      "offset_days_after_activation": 7,
+      "required_review": true
+    },
+    {
+      "window_id": "D14",
+      "offset_days_after_activation": 14,
+      "required_review": true
+    },
+    {
+      "window_id": "D28",
+      "offset_days_after_activation": 28,
+      "required_review": true
+    }
+  ],
+  "metric_contract": {
+    "allowed_metrics": [
+      "share_clicks",
+      "share_card_views",
+      "retest_starts",
+      "retest_completions",
+      "big_five_cross_test_clicks",
+      "mbti_cross_test_clicks",
+      "pdf_generation_errors",
+      "share_generation_errors",
+      "claim_gate_hits",
+      "metadata_leakage_gate_hits",
+      "fc144_boundary_gate_hits"
+    ],
+    "forbidden_metric_fields": [
+      "attempt_id",
+      "raw_score",
+      "raw_scores",
+      "score_vector",
+      "raw_score_vector",
+      "private_report_payload",
+      "private_report_url",
+      "internal_hash",
+      "release_hash",
+      "source_trace",
+      "selector_metadata",
+      "interpretation_context_id"
+    ],
+    "aggregation_minimum": "aggregate_only",
+    "public_surface_data_policy": "public_safe_summary_only"
+  },
+  "pilot_holds": {
+    "no_paid_distribution": true,
+    "no_social_campaign_expansion": true,
+    "no_seo_expansion": true,
+    "no_sitemap_inclusion_change": true,
+    "no_indexnow_submission": true,
+    "no_cms_copy_change": true,
+    "no_runtime_rollout_percentage_change": true
+  },
+  "stop_triggers": [
+    "private_payload_leak_detected",
+    "attempt_id_or_raw_score_leak_detected",
+    "forbidden_claim_detected",
+    "fc144_boundary_violation_detected",
+    "pdf_or_share_private_boundary_violation_detected",
+    "post_activation_smoke_failure",
+    "rollback_target_snapshot_missing"
+  ],
+  "review_outputs": [
+    "d1_observation_report",
+    "d7_observation_report",
+    "d14_observation_report",
+    "d28_observation_report",
+    "release_readiness_summary_after_pilot"
+  ],
+  "negative_guarantees": {
+    "production_activation_happened_by_this_plan": false,
+    "production_rollback_happened_by_this_plan": false,
+    "runtime_switch_happened_by_this_plan": false,
+    "bulk_content_generation_happened_by_this_plan": false,
+    "cms_write_happened_by_this_plan": false,
+    "frontend_change_happened_by_this_plan": false,
+    "seo_or_search_submission_happened_by_this_plan": false
+  }
+}

--- a/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageControlledPilotObservationPlanTest.php
+++ b/backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageControlledPilotObservationPlanTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Enneagram\Assets;
+
+use Tests\TestCase;
+
+final class EnneagramResultPageControlledPilotObservationPlanTest extends TestCase
+{
+    public function test_controlled_pilot_plan_locks_release_windows_metrics_and_negative_guarantees(): void
+    {
+        $root = base_path('content_assets/enneagram/result_page/controlled_pilot_observation/v0_1');
+        $plan = $this->readJson($root.'/controlled_pilot_observation_plan_v0_1.json');
+
+        $this->assertSame('fap.enneagram.result_page.controlled_pilot_observation.v0.1', $plan['schema_version'] ?? null);
+        $this->assertSame('observation_plan_only', $plan['status'] ?? null);
+        $this->assertSame('not_runtime', $plan['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($plan['production_use_allowed'] ?? true));
+        $this->assertTrue((bool) ($plan['requires_completed_manual_production_gate'] ?? false));
+        $this->assertTrue((bool) ($plan['requires_post_activation_smoke_pass'] ?? false));
+
+        $this->assertSame(
+            'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4',
+            data_get($plan, 'release_contract.release_id')
+        );
+        $this->assertSame(
+            'a9fd3eb474ea2ca0130d06ad2b1640305d9160ee1a74e559ad4f60bfc4db56c0',
+            data_get($plan, 'release_contract.candidate_manifest_sha256')
+        );
+        $this->assertSame(
+            'ac5bdaab3c761b0d01a56f92679aa58341110d64de0f47a1fa0062b64f76f97f',
+            data_get($plan, 'release_contract.runtime_registry_sha256')
+        );
+        $this->assertSame('60 minutes after activation', data_get($plan, 'release_contract.rollback_window'));
+
+        $windows = array_map(
+            static fn (array $window): string => (string) ($window['window_id'] ?? ''),
+            (array) ($plan['observation_windows'] ?? [])
+        );
+        $this->assertSame(['D1', 'D7', 'D14', 'D28'], $windows);
+
+        foreach ((array) ($plan['observation_windows'] ?? []) as $window) {
+            $this->assertTrue((bool) ($window['required_review'] ?? false));
+        }
+
+        $allowedMetrics = (array) data_get($plan, 'metric_contract.allowed_metrics', []);
+        foreach ([
+            'share_clicks',
+            'retest_starts',
+            'retest_completions',
+            'big_five_cross_test_clicks',
+            'mbti_cross_test_clicks',
+            'pdf_generation_errors',
+            'share_generation_errors',
+            'claim_gate_hits',
+        ] as $metric) {
+            $this->assertContains($metric, $allowedMetrics);
+        }
+
+        $this->assertSame('aggregate_only', data_get($plan, 'metric_contract.aggregation_minimum'));
+        $this->assertSame('public_safe_summary_only', data_get($plan, 'metric_contract.public_surface_data_policy'));
+
+        foreach ((array) data_get($plan, 'metric_contract.forbidden_metric_fields', []) as $field) {
+            $this->assertContains($field, [
+                'attempt_id',
+                'raw_score',
+                'raw_scores',
+                'score_vector',
+                'raw_score_vector',
+                'private_report_payload',
+                'private_report_url',
+                'internal_hash',
+                'release_hash',
+                'source_trace',
+                'selector_metadata',
+                'interpretation_context_id',
+            ]);
+        }
+
+        foreach ((array) ($plan['pilot_holds'] ?? []) as $enabled) {
+            $this->assertTrue((bool) $enabled);
+        }
+
+        foreach ([
+            'private_payload_leak_detected',
+            'attempt_id_or_raw_score_leak_detected',
+            'forbidden_claim_detected',
+            'fc144_boundary_violation_detected',
+            'pdf_or_share_private_boundary_violation_detected',
+            'post_activation_smoke_failure',
+            'rollback_target_snapshot_missing',
+        ] as $trigger) {
+            $this->assertContains($trigger, (array) ($plan['stop_triggers'] ?? []));
+        }
+
+        foreach ((array) ($plan['negative_guarantees'] ?? []) as $guarantee) {
+            $this->assertFalse((bool) $guarantee);
+        }
+
+        $encoded = mb_strtolower(json_encode($plan, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
+        foreach ([
+            'you are this type',
+            'fixed type',
+            'diagnosis',
+            'treatment',
+            'hiring',
+            'salary prediction',
+            'performance prediction',
+            'fc144 is more accurate',
+            'fc144 replaces',
+            '你就是这个类型',
+            '诊断',
+            '治疗',
+            '招聘',
+            '薪资预测',
+            '成功预测',
+        ] as $blockedCopy) {
+            $this->assertStringNotContainsString($blockedCopy, $encoded);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path.' must decode to an array');
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a repo-owned Enneagram controlled pilot observation plan for D1, D7, D14, and D28 post-activation review.
- Locked the plan to the approved a9fd release id, candidate manifest hash, runtime registry hash, and rollback window.
- Added unit coverage for the observation windows, aggregate-only metric contract, pilot holds, stop triggers, and negative guarantees.

## Why
The Enneagram result page should not expand operationally immediately after activation. This adds the small follow-up control packet for observing share clicks, retests, Big Five/MBTI cross-test clicks, PDF/share errors, and claim gate hits before any broader rollout.

## Validation
- `composer install --no-interaction --no-progress`
- `php -l backend/tests/Unit/Services/Enneagram/Assets/EnneagramResultPageControlledPilotObservationPlanTest.php`
- `php -r '$paths=["backend/content_assets/enneagram/result_page/controlled_pilot_observation/v0_1/controlled_pilot_observation_plan_v0_1.json"]; foreach($paths as $p){$j=json_decode(file_get_contents($p),true); if(!is_array($j)){fwrite(STDERR,"bad json $p\n"); exit(1);} echo "$p ok\n";}'`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageControlledPilotObservationPlanTest.php --no-ansi`
- `php artisan test tests/Unit/Services/Enneagram/Assets/EnneagramResultPageControlledPilotObservationPlanTest.php tests/Unit/Services/Enneagram/Assets/EnneagramResultPageProductionManualGateRunbookTest.php tests/Unit/Services/Enneagram/Assets/EnneagramResultPageReportSidecarIssueHarnessTest.php tests/Unit/Services/Enneagram/Assets/EnneagramResultPageRenderedQaSmokeHarnessTest.php --no-ansi`
- `git diff --cached --check`

Note: the PHPUnit runs exited 0 with existing warning-style output from the related harness tests.

## Intentionally deferred
- No production activation.
- No production rollback.
- No runtime switch.
- No production writes.
- No CMS writes.
- No SEO/search submission.
- No frontend changes.
- No bulk content generation.
