### PR TITLE
Fix content release id length for exact candidate releases

### DIFF
--- a/backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php
+++ b/backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const RELEASE_ID_LENGTH = 128;
+
+    /**
+     * @var array<string,string>
+     */
+    private const FOREIGN_KEYS = [
+        'content_release_manifests.content_pack_release_id' => 'crm_rel_fk',
+        'content_release_exact_manifests.content_pack_release_id' => 'crem_rel_fk',
+        'content_release_snapshots.from_content_pack_release_id' => 'crs_from_rel_fk',
+        'content_release_snapshots.to_content_pack_release_id' => 'crs_to_rel_fk',
+        'content_release_snapshots.activation_before_release_id' => 'crs_ab_rel_fk',
+        'content_release_snapshots.activation_after_release_id' => 'crs_aa_rel_fk',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->dropReleaseForeignKeys();
+
+        $this->changeColumn('content_pack_releases', 'id', nullable: false);
+        $this->changeColumn('content_release_manifests', 'content_pack_release_id', nullable: true);
+        $this->changeColumn('content_release_exact_manifests', 'content_pack_release_id', nullable: true);
+        $this->changeColumn('content_pack_activations', 'release_id', nullable: true);
+
+        foreach ([
+            'from_content_pack_release_id',
+            'to_content_pack_release_id',
+            'activation_before_release_id',
+            'activation_after_release_id',
+        ] as $column) {
+            $this->changeColumn('content_release_snapshots', $column, nullable: true);
+        }
+
+        $this->restoreReleaseForeignKeys();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent truncating long release ids.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function changeColumn(string $table, string $column, bool $nullable): void
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $column)) {
+            return;
+        }
+
+        if (! in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
+        DB::statement(sprintf(
+            'ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(%d) %s',
+            str_replace('`', '``', $table),
+            str_replace('`', '``', $column),
+            self::RELEASE_ID_LENGTH,
+            $nullable ? 'NULL' : 'NOT NULL',
+        ));
+    }
+
+    private function dropReleaseForeignKeys(): void
+    {
+        foreach (self::FOREIGN_KEYS as $tableColumn => $foreignKey) {
+            [$table, $column] = explode('.', $tableColumn, 2);
+            if (! $this->foreignKeyExists($table, $foreignKey)) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $blueprint) use ($foreignKey): void {
+                $blueprint->dropForeign($foreignKey);
+            });
+        }
+    }
+
+    private function restoreReleaseForeignKeys(): void
+    {
+        foreach (self::FOREIGN_KEYS as $tableColumn => $foreignKey) {
+            [$table, $column] = explode('.', $tableColumn, 2);
+            if (! Schema::hasTable($table)
+                || ! Schema::hasColumn($table, $column)
+                || $this->foreignKeyExists($table, $foreignKey)) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $blueprint) use ($column, $foreignKey): void {
+                $blueprint->foreign($column, $foreignKey)
+                    ->references('id')
+                    ->on('content_pack_releases')
+                    ->nullOnDelete();
+            });
+        }
+    }
+
+    private function foreignKeyExists(string $table, string $foreignKey): bool
+    {
+        if (! Schema::hasTable($table)) {
+            return false;
+        }
+
+        $driver = DB::getDriverName();
+        if (! in_array($driver, ['mysql', 'mariadb'], true)) {
+            return false;
+        }
+
+        return DB::table('information_schema.TABLE_CONSTRAINTS')
+            ->whereRaw('CONSTRAINT_SCHEMA = DATABASE()')
+            ->where('TABLE_NAME', $table)
+            ->where('CONSTRAINT_NAME', $foreignKey)
+            ->where('CONSTRAINT_TYPE', 'FOREIGN KEY')
+            ->exists();
+    }
+};

--- a/backend/tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ContentReleaseManifestCatalogService;
+use App\Services\Storage\ContentReleaseSnapshotCatalogService;
+use App\Services\Storage\ExactReleaseFileSetCatalogService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class ContentReleaseIdLengthSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_content_release_tables_accept_exact_enneagram_candidate_release_id(): void
+    {
+        $releaseId = 'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4';
+        $this->assertSame(58, strlen($releaseId));
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'enneagram_registry_import_inactive_candidate',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v2',
+            'to_pack_id' => 'ENNEAGRAM',
+            'status' => 'success',
+            'message' => 'schema regression exact release id fixture',
+            'created_by' => 'test',
+            'manifest_hash' => 'sha256:'.str_repeat('a', 64),
+            'compiled_hash' => 'sha256:'.str_repeat('b', 64),
+            'content_hash' => 'sha256:'.str_repeat('a', 64),
+            'pack_version' => 'v2',
+            'storage_path' => 'private/content_releases/ENNEAGRAM/v2/'.$releaseId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        app(ContentReleaseManifestCatalogService::class)->upsertManifest([
+            'content_pack_release_id' => $releaseId,
+            'manifest_hash' => str_repeat('c', 64),
+            'schema_version' => 'enneagram.inactive_candidate_release_manifest.v1',
+            'storage_disk' => 'local',
+            'storage_path' => 'private/content_releases/ENNEAGRAM/v2/'.$releaseId,
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('a', 64),
+            'payload_json' => ['release_id' => $releaseId],
+        ]);
+
+        app(ExactReleaseFileSetCatalogService::class)->upsertExactManifest([
+            'content_pack_release_id' => $releaseId,
+            'source_identity_hash' => str_repeat('d', 64),
+            'manifest_hash' => str_repeat('e', 64),
+            'source_kind' => 'inactive_candidate',
+            'source_disk' => 'local',
+            'source_storage_path' => 'private/content_releases/ENNEAGRAM/v2/'.$releaseId.'/candidate',
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'compiled_hash' => str_repeat('b', 64),
+            'content_hash' => str_repeat('a', 64),
+        ]);
+
+        DB::table('content_pack_activations')->insert([
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'release_id' => $releaseId,
+            'activated_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        app(ContentReleaseSnapshotCatalogService::class)->recordSnapshot([
+            'pack_id' => 'ENNEAGRAM',
+            'pack_version' => 'v2',
+            'from_content_pack_release_id' => $releaseId,
+            'to_content_pack_release_id' => $releaseId,
+            'activation_before_release_id' => $releaseId,
+            'activation_after_release_id' => $releaseId,
+            'reason' => 'schema_regression',
+            'created_by' => 'test',
+        ]);
+
+        $this->assertDatabaseHas('content_pack_releases', ['id' => $releaseId]);
+        $this->assertDatabaseHas('content_release_manifests', ['content_pack_release_id' => $releaseId]);
+        $this->assertDatabaseHas('content_release_exact_manifests', ['content_pack_release_id' => $releaseId]);
+        $this->assertDatabaseHas('content_pack_activations', ['release_id' => $releaseId]);
+        $this->assertDatabaseHas('content_release_snapshots', [
+            'from_content_pack_release_id' => $releaseId,
+            'to_content_pack_release_id' => $releaseId,
+            'activation_before_release_id' => $releaseId,
+            'activation_after_release_id' => $releaseId,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -813,6 +813,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_content_release_id_length_schema_fix(): void
+    {
+        $changed = [
+            'backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_public_recency_ordering_only(): void
     {
         $changed = [
@@ -6429,6 +6438,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php',
             'backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php',
             'backend/database/migrations/2026_02_27_110000_ensure_norms_table_lookup_index.php',
+            'backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php',
         ], true);
     }
 


### PR DESCRIPTION
## Summary
- Adds a forward-only migration expanding content release id columns to `string(128)` so exact candidate release ids can be stored.
- Covers `content_pack_releases.id`, manifest release references, activation release id, exact manifest references, and release snapshot release references.
- Adds a focused regression test using the exact Enneagram a9fd release id shape.
- Adds a narrow Big Five runtime-freeze allowlist test for this schema-only release-id migration.

## Why
The Enneagram server-side inactive import failed closed because the exact release id `enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4` is 58 characters, while production content release id columns are still `char(36)`.

## Validation
- `php -l database/migrations/2026_06_23_000100_expand_content_release_id_columns.php`
- `php -l tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_paths_have_no_uncommitted_diff|content_release_id_length_schema_fix" --no-ansi`
- `php artisan test tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php --no-ansi`
- `php artisan test tests/Feature/Console/EnneagramInactiveCandidateReleaseCommandTest.php tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php --no-ansi`
- `git diff --check`

## Intentionally deferred
- No inactive import in this PR.
- No pending gate refresh in this PR.
- No production activation.
- No runtime switch.
- No candidate content changes.
- No frontend changes.
- No manual deploy triggered by this PR.

## Repository rule impact
Backend storage schema only. Content authority and runtime ownership are unchanged.
