### PR TITLE
RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01

### DIFF
--- a/backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_authorized_blocked_v0_1.json
+++ b/backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_authorized_blocked_v0_1.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "fap.riasec.result_page_v2.production_import_execution.v0.1",
+  "task_id": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01",
+  "created_date": "2026-06-23",
+  "received_at_utc": "2026-06-22T18:18:08Z",
+  "record_type": "production_import_execution_attempt",
+  "decision": "NO-GO_BLOCKED_MISSING_CONTROLLED_IMPORT_COMMAND",
+  "authorization_status": "explicit_second_import_execution_authorization_received",
+  "execution_status": "not_executed",
+  "scope": {
+    "tenant_ids": [
+      "single_owner_global"
+    ],
+    "form_codes": [
+      "riasec_60",
+      "riasec_140"
+    ],
+    "locales": [
+      "zh-CN"
+    ],
+    "allowlist": [
+      "owner_manual_import_only"
+    ]
+  },
+  "authorization_received": {
+    "operator_statement": "我授权执行 RIASEC Result Page V2 production import execution。",
+    "approved_snapshot_id": "riasec_result_page_v2_prod_approved_2026_06_22_01",
+    "approved_snapshot_sha256": "999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741",
+    "approval_evidence_id": "riasec_result_page_v2_production_import_approval_2026_06_22_01",
+    "dry_run_artifact_sha256": "038f8118a992caf58112ff06e225272bfdaeda603e4d5f26ad3ac30aab89b55d",
+    "rollback_kill_switch_confirmed": "yes",
+    "kill_switch_ref": "riasec_result_page_v2.production_emergency_disabled",
+    "post_deploy_smoke_procedure_id": "riasec_result_page_v2_post_deploy_smoke_v0_1",
+    "rollout_separation_confirmation": "确认本授权只允许 production import execution，不允许 rollout。"
+  },
+  "inputs_verified": {
+    "production_approved_snapshot": {
+      "snapshot_id": "riasec_result_page_v2_prod_approved_2026_06_22_01",
+      "path": "backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json",
+      "expected_sha256": "999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741",
+      "actual_sha256": "999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741",
+      "sha256_match": true,
+      "ready_for_production_import": true,
+      "ready_for_production_rollout": false,
+      "production_import_performed": false
+    },
+    "production_import_approval_evidence": {
+      "approval_evidence_id": "riasec_result_page_v2_production_import_approval_2026_06_22_01",
+      "path": "backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json",
+      "actual_sha256": "1fecb849e2ee47d2234631ad10614e327463928be2a390a0836552acdff23095",
+      "decision": "GO"
+    },
+    "authorized_snapshot_import_gate_dry_run": {
+      "path": "backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json",
+      "expected_sha256": "038f8118a992caf58112ff06e225272bfdaeda603e4d5f26ad3ac30aab89b55d",
+      "actual_sha256": "038f8118a992caf58112ff06e225272bfdaeda603e4d5f26ad3ac30aab89b55d",
+      "sha256_match": true,
+      "dry_run_status": "pass_read_only",
+      "decision": "GO_FOR_IMPORT_EXECUTION_AUTHORIZATION_ONLY"
+    },
+    "prior_execution_authorization_record": {
+      "path": "backend/content_assets/riasec/result_page_v2/qa/production_import_execution_authorization/v0_1/riasec_result_page_v2_production_import_execution_authorization_v0_1.json",
+      "task_id": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-AUTHORIZATION-01"
+    }
+  },
+  "execution_path_scan": {
+    "riasec_console_commands_found": [
+      "riasec:result-page-v2-agent",
+      "riasec:result-page-ops-runner"
+    ],
+    "controlled_production_import_command_found": false,
+    "staging_only_harness_found": true,
+    "missing_required_command_capabilities": [
+      "exact_snapshot_hash_guard",
+      "exact_approval_evidence_guard",
+      "exact_dry_run_artifact_hash_guard",
+      "tenant_form_locale_allowlist_scope_guard",
+      "rollback_kill_switch_evidence_record",
+      "cms_production_write_execution",
+      "post_import_readback_evidence"
+    ]
+  },
+  "preconditions": {
+    "production_approved_snapshot_exists": true,
+    "import_gate_dry_run_passed_for_exact_approved_snapshot": true,
+    "complete_human_import_approval_evidence_exists": true,
+    "explicit_second_execution_authorization_present": true,
+    "rollout_separation_preserved": true,
+    "controlled_import_command_exists": false
+  },
+  "non_execution_record": {
+    "production_import_command_run": false,
+    "cms_write_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_opened": false,
+    "production_rollout_performed": false
+  },
+  "negative_guarantees": {
+    "production_import_performed": false,
+    "cms_write_performed": false,
+    "runtime_change_performed": false,
+    "environment_change_performed": false,
+    "production_rollout_opened": false,
+    "production_rollout_performed": false,
+    "production_gate_enabled": false,
+    "approved_snapshot_modified": false,
+    "source_rc_snapshot_modified": false,
+    "staging_only_assets_marked_production_ready": false,
+    "frontend_fallback_introduced": false,
+    "codex_approved_production_rollout": false
+  },
+  "go_no_go": {
+    "production_import_execution_completed": false,
+    "execute_production_import_now": false,
+    "cms_production_write_allowed_now": false,
+    "runtime_production_enablement_allowed_now": false,
+    "production_rollout_allowed_now": false,
+    "import_approval_counts_as_rollout_approval": false,
+    "required_next_pr": "RIASEC-RESULT-V2-PRODUCTION-IMPORT-COMMAND-IMPLEMENTATION-01"
+  }
+}

--- a/backend/docs/riasec/riasec-result-page-v2-production-import-execution-authorized-2026-06-23.md
+++ b/backend/docs/riasec/riasec-result-page-v2-production-import-execution-authorized-2026-06-23.md
@@ -1,0 +1,120 @@
+# RIASEC Result Page V2 Production Import Execution - Authorized Attempt
+
+Date: 2026-06-23
+Task: `RIASEC-RESULT-V2-PRODUCTION-IMPORT-EXECUTION-01`
+Scope: production import execution evidence only. This record does not authorize or perform rollout.
+
+## Verdict
+
+`NO-GO_BLOCKED_MISSING_CONTROLLED_IMPORT_COMMAND`
+
+The operator provided the required second authorization for RIASEC Result Page V2 production import execution. The authorized snapshot, approval evidence, and import-gate dry-run hashes were verified. However, this repository currently has no controlled RIASEC production import execution command or service entrypoint comparable to the existing staging-only RIASEC harnesses.
+
+Because the execution path is missing, no production import was run. No CMS write, runtime switch, environment change, production gate opening, or rollout occurred.
+
+## Authorization Received
+
+The authorization block received in the Codex thread:
+
+```text
+我授权执行 RIASEC Result Page V2 production import execution。
+approved_snapshot_id: riasec_result_page_v2_prod_approved_2026_06_22_01
+approved_snapshot_sha256: 999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741
+approval_evidence_id: riasec_result_page_v2_production_import_approval_2026_06_22_01
+dry_run_artifact_sha256: 038f8118a992caf58112ff06e225272bfdaeda603e4d5f26ad3ac30aab89b55d
+scope:
+  tenant_ids: single_owner_global
+  form_codes: riasec_60, riasec_140
+  locales: zh-CN
+  allowlist: owner_manual_import_only
+rollback_kill_switch_confirmed: yes
+kill_switch_ref: riasec_result_page_v2.production_emergency_disabled
+post_deploy_smoke_procedure_id: riasec_result_page_v2_post_deploy_smoke_v0_1
+确认本授权只允许 production import execution，不允许 rollout。
+```
+
+Authorization interpretation:
+
+- Import execution authorization: present.
+- Rollout authorization: explicitly absent.
+- Runtime or environment authorization: absent.
+- CMS write authorization: only valid through a controlled production import command for the exact approved snapshot; no such command exists in this repository at this revision.
+
+## Inputs Verified
+
+| Input | Path | Expected SHA-256 | Verified |
+| --- | --- | --- | --- |
+| Approved snapshot | `backend/content_assets/riasec/result_page_v2/releases/production_approved/v0_1/riasec_result_page_v2_prod_approved_2026_06_22_01.json` | `999dc22a4c01b50891b342d75713a2fda1ce99b79933470f91fe1073744e0741` | yes |
+| Approval evidence | `backend/content_assets/riasec/result_page_v2/governance/production_approval_evidence/v0_1/riasec_result_page_v2_production_import_approval_2026_06_22_01.json` | `1fecb849e2ee47d2234631ad10614e327463928be2a390a0836552acdff23095` | yes |
+| Authorized import-gate dry-run | `backend/content_assets/riasec/result_page_v2/qa/production_import_gate_dry_run_authorized_snapshot/v0_1/riasec_result_page_v2_production_import_gate_dry_run_authorized_snapshot_v0_1.json` | `038f8118a992caf58112ff06e225272bfdaeda603e4d5f26ad3ac30aab89b55d` | yes |
+| Prior execution authorization record | `backend/content_assets/riasec/result_page_v2/qa/production_import_execution_authorization/v0_1/riasec_result_page_v2_production_import_execution_authorization_v0_1.json` | recorded in PR `#2339` | yes |
+
+## Execution Path Scan
+
+Current RIASEC console commands:
+
+- `riasec:result-page-v2-agent`
+- `riasec:result-page-ops-runner`
+
+Both are audit, staging, or planning surfaces. The RIASEC asset agent exposes a `stagingImportDryRun` path that records `cms_write_performed=false`, `ready_for_runtime=false`, and `ready_for_production=false`.
+
+No controlled production import command was found for:
+
+- exact approved snapshot hash enforcement;
+- approval evidence hash enforcement;
+- dry-run artifact hash enforcement;
+- tenant/form/locale/allowlist scope enforcement;
+- rollback or kill-switch evidence recording;
+- CMS production write execution;
+- post-import evidence output.
+
+## Execution Result
+
+| Check | Result |
+| --- | --- |
+| Explicit second import execution authorization present | pass |
+| Approved snapshot SHA matches authorization | pass |
+| Approval evidence exists and records import `GO` | pass |
+| Authorized import-gate dry-run SHA matches authorization | pass |
+| Rollout separation confirmed | pass |
+| Controlled RIASEC production import command exists | fail |
+| Production import executed | no |
+| CMS write performed | no |
+| Runtime switch performed | no |
+| Environment changed | no |
+| Production rollout opened | no |
+
+## Required Next Task
+
+Before import can be executed, add a separately scoped controlled importer PR, for example:
+
+`RIASEC-RESULT-V2-PRODUCTION-IMPORT-COMMAND-IMPLEMENTATION-01`
+
+That PR should implement a fail-closed command that requires:
+
+- exact `approved_snapshot_id`;
+- exact `approved_snapshot_sha256`;
+- exact `approval_evidence_id`;
+- exact approval evidence SHA-256;
+- exact authorized dry-run artifact SHA-256;
+- exact scope: `single_owner_global`, `riasec_60`, `riasec_140`, `zh-CN`, `owner_manual_import_only`;
+- rollback and kill-switch confirmation;
+- import-only mode with rollout blocked;
+- dry-run mode by default;
+- explicit `--execute` plus exact confirmation token for the production write;
+- post-import evidence artifact with readback counts and no runtime enablement.
+
+After that command exists and passes tests, the already provided authorization can be reviewed again against the new command interface. If the command requires a new exact confirmation token, request it before running the production write.
+
+## Negative Guarantees
+
+- No production import executed.
+- No CMS write performed.
+- No runtime wrapper enabled.
+- No environment variable changed.
+- No production rollout opened.
+- No approved snapshot modified.
+- No RC snapshot modified.
+- No staging-only asset marked production-ready.
+- No frontend fallback introduced.
+- Codex did not approve production activation or rollout.


### PR DESCRIPTION
## What changed
- Added an authorized RIASEC Result Page V2 production import execution attempt report.
- Added a machine-readable execution artifact recording that the second import execution authorization was received and all referenced hashes were verified.
- Recorded fail-closed status because no controlled RIASEC production import command/service entrypoint exists in this repository revision.

## Why
The operator authorized production import execution for the exact approved snapshot, but the repository only exposes RIASEC audit/staging runner commands. Production writes must not be improvised through staging harnesses or ad hoc CMS mutation paths.

## Validation
- `jq empty backend/content_assets/riasec/result_page_v2/qa/production_import_execution/v0_1/riasec_result_page_v2_production_import_execution_authorized_blocked_v0_1.json`
- `git diff --check HEAD~1..HEAD`
- Scope validation: `git diff --name-only origin/main...HEAD` contains only the two RIASEC evidence files.

## Intentionally deferred
- No production import executed.
- No CMS write performed.
- No runtime or env change.
- No production rollout opened.
- Next required scoped work is a controlled RIASEC production import command with exact hash guards, dry-run default, explicit execute token, rollback evidence, and post-import readback evidence.