### PR TITLE
Fix AI Impact preview projection wording

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -110,7 +110,11 @@ final class CareerAiImpactAssetPreviewService
 
         $safePayload['sources'] = $this->readerSafeSources(is_array($payload['sources'] ?? null) ? $payload['sources'] : []);
 
-        return $safePayload;
+        return $this->applyPreviewProjectionRepair(
+            $safePayload,
+            (string) ($safePayload['slug'] ?? $payload['slug'] ?? ''),
+            (string) ($safePayload['locale'] ?? $payload['locale'] ?? ''),
+        );
     }
 
     /**
@@ -207,6 +211,7 @@ final class CareerAiImpactAssetPreviewService
             '岗位会消失',
             '职业会消失',
             '职业消失',
+            '失业',
             '失业风险',
             '降薪风险',
             '降薪',
@@ -222,15 +227,159 @@ final class CareerAiImpactAssetPreviewService
             '个人职业结果预测',
             '个人职业结果预测',
             '个人职业结果预测',
+            '个人职业结果预测',
         ], $text);
 
         $sanitized = str_replace('预测预测', '预测', $sanitized);
 
-        return preg_replace(
+        $sanitized = preg_replace(
             '/个人(?:职业|收入)结果预测(?:[、，,或和及以及\s]+个人(?:职业|收入)结果预测)+/u',
             '个人职业结果预测',
             $sanitized
         ) ?? $sanitized;
+
+        return str_replace([
+            '不把它当作个人职业结果预测',
+            '不把该分数当作个人职业结果预测',
+            '不将它当作个人职业结果预测',
+            '不将该分数当作个人职业结果预测',
+        ], '不是个人职业结果预测', $sanitized);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function applyPreviewProjectionRepair(array $payload, string $slug, string $locale): array
+    {
+        $replacements = $this->previewProjectionReplacements($slug, $locale);
+
+        if ($replacements === []) {
+            return $payload;
+        }
+
+        return $this->replaceStringsRecursively($payload, $replacements);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function previewProjectionReplacements(string $slug, string $locale): array
+    {
+        $normalizedSlug = $this->normalizeSlug($slug);
+        $normalizedLocale = $this->normalizeLocale($locale);
+
+        $commonZh = [
+            '运行安全、放行条件、天气改航、间隔限制、维护记录和旅客/机组安全' => '现场安全、记录完整性、异常处置、交付边界和最终责任',
+            '运行限制说明、异常处置日志、天气/NOTAM 核对和放行复盘' => '工作说明、异常记录、复核清单和交付复盘',
+            '调度系统、检查单、维护记录、航班/车辆运行日志' => '工作记录、检查单、复核步骤和交付日志',
+        ];
+
+        $commonEn = [
+            'operational safety, release conditions, weather diversion, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
+            'operational safety, release conditions, weather diversions, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
+            'an operating-limit note, abnormal-event log, weather or NOTAM check, and release review' => 'a work note, exception log, review checklist, and delivery review',
+            'dispatch systems, checklists, maintenance records, and flight or vehicle operation logs' => 'work records, checklists, review steps, and delivery logs',
+        ];
+
+        if ($normalizedSlug === 'writers-and-authors') {
+            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+                'species observations' => 'interview notes',
+                'habitat data' => 'background material',
+                'species misidentification, ecological uncertainty' => 'factual misreadings, voice inconsistency',
+                'field summaries, figure captions, grant or article sections' => 'chapter drafts, summaries, proposal sections, or article sections',
+                'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'voice, evidence quality, copyright boundaries, editorial choices, reader interpretation, and final accountability',
+                'a work note, exception log, review checklist, and delivery review' => 'a pitch note, interview log, citation check, and revision review',
+                'work records, checklists, review steps, and delivery logs' => 'outlines, version logs, citation sheets, editor feedback, and delivery notes',
+            ] : [
+                '物种观察' => '采访记录',
+                '栖息地数据' => '背景材料',
+                '物种误识、生态不确定性' => '事实误读、叙事不一致',
+                '野外摘要、图注、基金或文章段落' => '章节草稿、摘要、提案或文章段落',
+                '现场安全、记录完整性、异常处置、交付边界和最终责任' => '表达声音、证据质量、版权边界、编辑取舍、读者理解和最终责任',
+                '工作说明、异常记录、复核清单和交付复盘' => '选题说明、采访记录、引用核对和修订复盘',
+                '工作记录、检查单、复核步骤和交付日志' => '写作提纲、版本记录、引用清单、编辑反馈和交付记录',
+            ]);
+        }
+
+        if ($normalizedSlug === 'zoologists-and-wildlife-biologists') {
+            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+                'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'field safety, species identification, sample records, habitat boundaries, permit ethics, public explanation, and final accountability',
+                'a work note, exception log, review checklist, and delivery review' => 'a field note, sample log, permit check, and observation review',
+                'work records, checklists, review steps, and delivery logs' => 'field survey sheets, sample records, GIS or habitat notes, and review checklists',
+            ] : [
+                '现场安全、记录完整性、异常处置、交付边界和最终责任' => '野外安全、物种识别、样本记录、栖息地边界、许可伦理、公众解释和最终责任',
+                '工作说明、异常记录、复核清单和交付复盘' => '野外记录、样本日志、许可核对和观察复盘',
+                '工作记录、检查单、复核步骤和交付日志' => '野外调查表、样本记录、GIS或栖息地记录和复核清单',
+            ]);
+        }
+
+        if ($normalizedSlug === 'elementary-school-teachers-except-special-education') {
+            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+                'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'student differences, classroom feedback, learning pace, family communication, assessment boundaries, and child-safety responsibility',
+                'a work note, exception log, review checklist, and delivery review' => 'a lesson plan, student-work sample, feedback record, and intervention review',
+                'work records, checklists, review steps, and delivery logs' => 'classroom notes, rubrics, progress trackers, and family-communication records',
+            ] : [
+                '现场安全、记录完整性、异常处置、交付边界和最终责任' => '学生差异、课堂反馈、教学节奏、家校沟通、评价边界和未成年人责任',
+                '工作说明、异常记录、复核清单和交付复盘' => '课程计划、学生作业样本、反馈记录和干预复盘',
+                '工作记录、检查单、复核步骤和交付日志' => '课堂记录、评价量规、学习进展表和家校沟通记录',
+            ]);
+        }
+
+        if ($normalizedSlug === 'heavy-and-tractor-trailer-truck-drivers') {
+            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+                'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'road safety, vehicle inspection, hours-of-service compliance, weather and route risk, load responsibility, and delivery communication',
+                'a work note, exception log, review checklist, and delivery review' => 'a vehicle checklist, route-risk note, maintenance handoff, and safety review',
+                'work records, checklists, review steps, and delivery logs' => 'route logs, inspection reports, maintenance handoff records, and delivery notes',
+            ] : [
+                '现场安全、记录完整性、异常处置、交付边界和最终责任' => '道路安全、车辆检查、工时合规、天气路况、装载责任和交付沟通',
+                '工作说明、异常记录、复核清单和交付复盘' => '车辆检查单、路线风险记录、维修或交接日志和安全复盘',
+                '工作记录、检查单、复核步骤和交付日志' => '路线日志、车辆检查记录、维修交接记录和交付说明',
+            ]);
+        }
+
+        if ($normalizedSlug === 'wind-turbine-technicians') {
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
+                'command chain' => 'site safety chain',
+                'weapons' => 'equipment',
+                'mission risk' => 'maintenance risk',
+            ] : [
+                '指挥链' => '现场安全链条',
+                '武器' => '设备',
+                '作战' => '检修',
+                '任务风险' => '维护风险',
+            ]);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     * @param  array<string, string>  $replacements
+     * @return array<mixed>
+     */
+    private function replaceStringsRecursively(array $value, array $replacements): array
+    {
+        $repaired = [];
+
+        foreach ($value as $key => $nestedValue) {
+            if (is_string($nestedValue)) {
+                $repaired[$key] = str_replace(array_keys($replacements), array_values($replacements), $nestedValue);
+
+                continue;
+            }
+
+            if (is_array($nestedValue)) {
+                $repaired[$key] = $this->replaceStringsRecursively($nestedValue, $replacements);
+
+                continue;
+            }
+
+            $repaired[$key] = $nestedValue;
+        }
+
+        return $repaired;
     }
 
     public function normalizeSlug(string $slug): string

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -735,7 +735,7 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $occupation = $this->seedOccupation('accountants-and-auditors');
         $row = $this->assetRow('accountants-and-auditors', 'zh-CN');
         $row['summary'] = '该分数不是岗位会消失或降薪预测。';
-        $row['items']['reader_boundary']['body'] = '该分数不是岗位会消失、降薪或个人职业结果预测预测。';
+        $row['items']['reader_boundary']['body'] = 'FermatMind 用它描述任务可被辅助的程度，不把它当作失业、个人职业结果预测。';
 
         CareerJobAiImpactAsset::query()->create([
             'occupation_id' => $occupation->id,
@@ -762,7 +762,95 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertStringNotContainsString('职业会消失', $encodedAsset);
         $this->assertStringNotContainsString('降薪', $encodedAsset);
         $this->assertStringNotContainsString('预测预测', $encodedAsset);
+        $this->assertStringNotContainsString('失业', $encodedAsset);
         $this->assertStringContainsString('不是个人职业结果预测', $asset['items']['reader_boundary']['body']);
+    }
+
+    public function test_preview_api_repairs_known_cross_domain_context_in_reader_projection(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', true);
+        Config::set('career_ai_impact_assets.preview_slugs', [
+            'writers-and-authors',
+            'heavy-and-tractor-trailer-truck-drivers',
+        ]);
+
+        $writerOccupation = $this->seedOccupation('writers-and-authors');
+        $writerZh = $this->assetRow('writers-and-authors', 'zh-CN');
+        $writerZh['items']['most_ai_exposed_workflows'][0]['body'] = '整理研究笔记、物种观察、采访材料、草稿段落、引用、栖息地数据和期刊或出版规则。';
+        $writerZh['items']['most_ai_exposed_workflows'][1] = [
+            'label' => '复核线索',
+            'body' => '正式采用仍要看运行安全、放行条件、天气改航、间隔限制、维护记录和旅客/机组安全。',
+        ];
+        $writerZh['items']['how_to_prepare'][0]['body'] = '把材料做成运行限制说明、异常处置日志、天气/NOTAM 核对和放行复盘。';
+        $writerEn = $this->assetRow('writers-and-authors', 'en');
+        $writerEn['items']['most_ai_exposed_workflows'][0]['body'] = 'organize research notes, species observations, interview material, draft sections, citations, habitat data, and journal or publisher rules.';
+        $writerEn['items']['human_accountability_anchors'][0]['body'] = 'The hard part is operational safety, release conditions, weather diversion, separation limits, maintenance records, and crew or passenger safety.';
+
+        foreach ([$writerZh, $writerEn] as $row) {
+            CareerJobAiImpactAsset::query()->create([
+                'occupation_id' => $writerOccupation->id,
+                'career_job_slug' => 'writers-and-authors',
+                'locale' => $row['locale'],
+                'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $row,
+                'sources_json' => $row['sources'],
+                'evidence_used_json' => $row['evidence_used'],
+                'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+                'audit_fields_json' => $row['audit_fields'],
+                'asset_row_hash' => $row['audit_fields']['row_hash'],
+            ]);
+        }
+
+        $truckOccupation = $this->seedOccupation('heavy-and-tractor-trailer-truck-drivers');
+        $truckZh = $this->assetRow('heavy-and-tractor-trailer-truck-drivers', 'zh-CN');
+        $truckZh['items']['human_accountability_anchors'][0]['body'] = '正式采用仍要看运行安全、放行条件、天气改航、间隔限制、维护记录和旅客/机组安全。';
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $truckOccupation->id,
+            'career_job_slug' => 'heavy-and-tractor-trailer-truck-drivers',
+            'locale' => 'zh-CN',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $truckZh,
+            'sources_json' => $truckZh['sources'],
+            'evidence_used_json' => $truckZh['evidence_used'],
+            'derived_from_synthesis_json' => $truckZh['derived_from_synthesis'],
+            'audit_fields_json' => $truckZh['audit_fields'],
+            'asset_row_hash' => $truckZh['audit_fields']['row_hash'],
+        ]);
+
+        $writerZhAsset = $this->getJson('/api/v0.5/career/jobs/writers-and-authors/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+        $writerEnAsset = $this->getJson('/api/v0.5/career/jobs/writers-and-authors/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+        $truckZhAsset = $this->getJson('/api/v0.5/career/jobs/heavy-and-tractor-trailer-truck-drivers/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+
+        $writerZhText = json_encode($writerZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $writerEnText = json_encode($writerEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $truckZhText = json_encode($truckZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $this->assertStringNotContainsString('物种观察', $writerZhText);
+        $this->assertStringNotContainsString('栖息地数据', $writerZhText);
+        $this->assertStringNotContainsString('天气改航', $writerZhText);
+        $this->assertStringContainsString('采访记录', $writerZhText);
+        $this->assertStringContainsString('编辑取舍', $writerZhText);
+
+        $this->assertStringNotContainsString('species observations', $writerEnText);
+        $this->assertStringNotContainsString('habitat data', $writerEnText);
+        $this->assertStringNotContainsString('weather diversion', $writerEnText);
+        $this->assertStringContainsString('interview notes', $writerEnText);
+        $this->assertStringContainsString('editorial choices', $writerEnText);
+
+        $this->assertStringNotContainsString('天气改航', $truckZhText);
+        $this->assertStringNotContainsString('旅客/机组安全', $truckZhText);
+        $this->assertStringContainsString('道路安全', $truckZhText);
+        $this->assertStringContainsString('工时合规', $truckZhText);
     }
 
     public function test_ai_impact_preview_asset_can_provide_restricted_detail_shell_when_bundle_is_missing(): void


### PR DESCRIPTION
## Summary
- Normalize zh-CN AI Impact boundary wording in the reader-safe API projection so unsafe outcome phrasing such as unemployment or wage-loss wording collapses to `不是个人职业结果预测`.
- Add a narrow preview projection repair for known 50-slug QA cross-domain context leaks, limited to the affected slugs and reader-facing payload strings.
- Add regression coverage for boundary wording and cross-domain projection cleanup.

## Why
The latest 50-slug staging page/editorial QA showed pages and APIs are reachable, but the AI Impact preview projection still had:
- zh-CN boundary wording containing outcome terms such as `失业`.
- 10 rows where preview text crossed occupational contexts, such as writers showing aviation/wildlife operational wording.

## Validation
- `php -l backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php`
- `php -l backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check`
- `cd backend && php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `cd backend && php artisan route:list --path=career/jobs`

## Intentionally deferred
- No route changes.
- No SEO/runtime changes.
- No CMS/staging/production import.
- No AI Impact asset JSONL edits.
- No production deployment verification in this PR.

## Repository rule impact
This remains backend/API projection logic only. It does not change content authority, import state, SEO generation, sitemap, llms, canonical, noindex, or JSON-LD behavior.
