### PR TITLE
Fix content release action length for inactive imports

### DIFF
--- a/backend/database/migrations/2026_06_23_000200_expand_content_release_action_column.php
+++ b/backend/database/migrations/2026_06_23_000200_expand_content_release_action_column.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const ACTION_LENGTH = 128;
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('content_pack_releases') || ! Schema::hasColumn('content_pack_releases', 'action')) {
+            return;
+        }
+
+        if (! in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
+        DB::statement(sprintf(
+            'ALTER TABLE `content_pack_releases` MODIFY COLUMN `action` VARCHAR(%d) NOT NULL',
+            self::ACTION_LENGTH,
+        ));
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent truncating release action identifiers.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php
+++ b/backend/tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php
@@ -18,11 +18,14 @@ final class ContentReleaseIdLengthSchemaTest extends TestCase
     public function test_content_release_tables_accept_exact_enneagram_candidate_release_id(): void
     {
         $releaseId = 'enneagram_1r_a_to_1r_h_phase8b_candidate_20260427_a9fd3eb4';
+        $action = 'enneagram_registry_import_inactive_candidate';
         $this->assertSame(58, strlen($releaseId));
+        $this->assertGreaterThan(32, strlen($action));
+        $this->assertLessThanOrEqual(128, strlen($action));
 
         DB::table('content_pack_releases')->insert([
             'id' => $releaseId,
-            'action' => 'enneagram_registry_import_inactive_candidate',
+            'action' => $action,
             'region' => 'GLOBAL',
             'locale' => 'global',
             'dir_alias' => 'v2',
@@ -85,7 +88,10 @@ final class ContentReleaseIdLengthSchemaTest extends TestCase
             'created_by' => 'test',
         ]);
 
-        $this->assertDatabaseHas('content_pack_releases', ['id' => $releaseId]);
+        $this->assertDatabaseHas('content_pack_releases', [
+            'id' => $releaseId,
+            'action' => $action,
+        ]);
         $this->assertDatabaseHas('content_release_manifests', ['content_pack_release_id' => $releaseId]);
         $this->assertDatabaseHas('content_release_exact_manifests', ['content_pack_release_id' => $releaseId]);
         $this->assertDatabaseHas('content_pack_activations', ['release_id' => $releaseId]);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -817,6 +817,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php',
+            'backend/database/migrations/2026_06_23_000200_expand_content_release_action_column.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -6464,6 +6465,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php',
             'backend/database/migrations/2026_02_27_110000_ensure_norms_table_lookup_index.php',
             'backend/database/migrations/2026_06_23_000100_expand_content_release_id_columns.php',
+            'backend/database/migrations/2026_06_23_000200_expand_content_release_action_column.php',
         ], true);
     }
 


### PR DESCRIPTION
## Summary
- Expand `content_pack_releases.action` from `varchar(32)` to `varchar(128)` with a forward-only migration.
- Extend the content release schema regression test to prove the Enneagram inactive import action identifier is longer than 32 and can be written with the exact a9fd release id.
- Add the new schema-only migration to the narrow BigFive runtime freeze allowlist used by CI.

## Why
The server-side Enneagram inactive import now passes release id length validation, but production import failed on `content_pack_releases.action` because `enneagram_registry_import_inactive_candidate` exceeds the previous 32-character column limit.

## Validation
- `php -l database/migrations/2026_06_23_000200_expand_content_release_action_column.php`
- `php -l tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php`
- `php -l tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --no-ansi`
- `php artisan test tests/Feature/Storage/ContentReleaseIdLengthSchemaTest.php --no-ansi`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter "runtime_paths_have_no_uncommitted_diff|content_release_id_length_schema_fix" --no-ansi`
- `php artisan test tests/Feature/Console/EnneagramInactiveCandidateReleaseCommandTest.php tests/Feature/Storage/ContentReleaseManifestCatalogServiceTest.php tests/Feature/Storage/ContentReleaseSnapshotCatalogServiceTest.php tests/Feature/Storage/ExactReleaseFileSetCatalogServiceTest.php --no-ansi`
- `git diff --check`

## Deferred
- No candidate import in this PR.
- No pending gate refresh in this PR.
- No activation.
- No runtime switch.
- No production writes from this PR.
