### PR TITLE
PR-L: SEO Agent article title length repair canary

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticleCmsPublishCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticleCmsPublishCanaryCommand.php
@@ -30,6 +30,13 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
 
     private const TASK = 'SEO-AGENT-ARTICLE-CMS-PUBLISH-CANARY-01';
 
+    private const SEO_META_LIMITS = [
+        'seo_title' => 60,
+        'seo_description' => 160,
+        'og_title' => 90,
+        'og_description' => 200,
+    ];
+
     private const FORBIDDEN_STRINGS = [
         'raw_url',
         'raw_query',
@@ -118,6 +125,7 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
                 'package_sha256' => $packageSha,
                 'write_evidence_sha256' => $writeSha,
                 'required_confirmation_phrase' => $requiredPhrase,
+                'field_length_preflight' => (array) ($plan['field_length_preflight'] ?? []),
             ]);
             $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
 
@@ -348,6 +356,15 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
             if ((string) data_get($draftRevision->payload_json, 'seo_agent.subject_ref') !== $target) {
                 $issues[] = 'draft_revision_subject_ref_mismatch';
             }
+            $fieldLengthPreflight = $this->fieldLengthPreflight($draftRevision);
+            if (($fieldLengthPreflight['status'] ?? null) !== 'pass') {
+                $issues[] = 'seo_meta_field_length_exceeded';
+            }
+        } else {
+            $fieldLengthPreflight = [
+                'status' => 'not_checked',
+                'violations' => [],
+            ];
         }
         if ($article instanceof Article) {
             if ((string) $article->status !== 'published' || ! (bool) $article->is_public) {
@@ -383,6 +400,7 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
             'proposal' => $proposal,
             'write_ref' => $writeRef,
             'gate_verdict' => $gateVerdict,
+            'field_length_preflight' => $fieldLengthPreflight,
             'article' => $article,
             'draft_revision' => $draftRevision,
         ];
@@ -556,6 +574,64 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
     }
 
     /**
+     * @return array{status:string,violations:list<array<string, mixed>>}
+     */
+    private function fieldLengthPreflight(ArticleRevision $draftRevision): array
+    {
+        $proposal = is_array($draftRevision->payload_json)
+            ? (array) data_get($draftRevision->payload_json, 'proposal', [])
+            : [];
+        $checks = [
+            [
+                'source_field' => 'proposal.proposed_seo_title',
+                'target_column' => 'article_seo_meta.seo_title',
+                'value' => $proposal['proposed_seo_title'] ?? null,
+                'max_length' => self::SEO_META_LIMITS['seo_title'],
+            ],
+            [
+                'source_field' => 'proposal.proposed_seo_title',
+                'target_column' => 'article_seo_meta.og_title',
+                'value' => $proposal['proposed_seo_title'] ?? null,
+                'max_length' => self::SEO_META_LIMITS['og_title'],
+            ],
+            [
+                'source_field' => 'proposal.proposed_seo_description',
+                'target_column' => 'article_seo_meta.seo_description',
+                'value' => $proposal['proposed_seo_description'] ?? null,
+                'max_length' => self::SEO_META_LIMITS['seo_description'],
+            ],
+            [
+                'source_field' => 'proposal.proposed_seo_description',
+                'target_column' => 'article_seo_meta.og_description',
+                'value' => $proposal['proposed_seo_description'] ?? null,
+                'max_length' => self::SEO_META_LIMITS['og_description'],
+            ],
+        ];
+
+        $violations = [];
+        foreach ($checks as $check) {
+            $value = $check['value'];
+            if ($value === null || trim((string) $value) === '') {
+                continue;
+            }
+            $length = mb_strlen((string) $value);
+            if ($length > (int) $check['max_length']) {
+                $violations[] = [
+                    'source_field' => (string) $check['source_field'],
+                    'target_column' => (string) $check['target_column'],
+                    'length' => $length,
+                    'max_length' => (int) $check['max_length'],
+                ];
+            }
+        }
+
+        return [
+            'status' => $violations === [] ? 'pass' : 'fail',
+            'violations' => $violations,
+        ];
+    }
+
+    /**
      * @param  array<string, mixed>  $package
      * @return array<string, mixed>|null
      */
@@ -649,6 +725,7 @@ final class SeoAgentArticleCmsPublishCanaryCommand extends Command
             'publish_gate_evidence_sha256' => (string) ($plan['publish_gate_evidence_sha256'] ?? ''),
             'creates_article_translation_revision' => true,
             'promotes_existing_article_working_revision' => true,
+            'field_length_preflight' => (array) ($plan['field_length_preflight'] ?? []),
         ];
     }
 

--- a/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
@@ -29,6 +29,8 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         'proposal.proposal_quality',
     ];
 
+    private const SEO_TITLE_MAX_LENGTH = 60;
+
     private const FORBIDDEN_STRINGS = [
         'raw_url',
         'raw_query',
@@ -48,6 +50,7 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         {--write-evidence= : Path to the old seo-agent-controlled-cms-draft-write.v1 JSON artifact}
         {--target= : Exact article subject_ref, e.g. article:41:en}
         {--artifact-dir= : Directory for repair and compatible write evidence artifacts}
+        {--override-proposed-seo-title= : Optional controlled replacement for proposal.proposed_seo_title, max 60 chars}
         {--confirm-package-sha256= : Required package sha256 for execute mode}
         {--confirm-repair= : Exact confirmation phrase for execute mode}
         {--execute : Actually append one repaired ArticleRevision draft}
@@ -101,16 +104,33 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
 
         $packageSha = hash_file('sha256', $packagePath) ?: '';
         $confirmedSha = trim((string) $this->option('confirm-package-sha256'));
-        if ($confirmedSha !== '' && $confirmedSha !== $packageSha) {
-            return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
-                'package_sha256' => $packageSha,
-            ]));
-        }
 
+        $artifactDir = $this->artifactDir();
         $proposal = $this->proposalForTarget($package, $target);
         if ($proposal === null) {
             return $this->finish($this->failureSummary('target_not_found_in_package', [
                 'package_sha256' => $packageSha,
+            ]));
+        }
+        $overrideTitle = $this->proposedSeoTitleOverride();
+        if (is_array($overrideTitle)) {
+            return $this->finish($this->failureSummary((string) ($overrideTitle['issue'] ?? 'override_proposed_seo_title_invalid'), [
+                'package_sha256' => $packageSha,
+            ]));
+        }
+        $effectivePackage = $package;
+        $effectiveProposal = $proposal;
+        $effectivePackageSha = $packageSha;
+        $effectivePackageArtifact = null;
+        if (is_string($overrideTitle)) {
+            $effectiveProposal['proposed_seo_title'] = $overrideTitle;
+            $effectivePackage = $this->packageWithProposal($package, $target, $effectiveProposal);
+            $effectivePackageArtifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-package-repaired-', $effectivePackage);
+            $effectivePackageSha = (string) ($effectivePackageArtifact['sha256'] ?? '');
+        }
+        if ($confirmedSha !== '' && $confirmedSha !== $effectivePackageSha) {
+            return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
+                'package_sha256' => $effectivePackageSha,
             ]));
         }
 
@@ -142,55 +162,59 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             ]));
         }
 
-        $targetFields = $this->targetFields($proposal);
+        $targetFields = $this->targetFields($effectiveProposal);
         if (! $this->revisionCoreMatches($oldRevision, $packageSha, $target, $targetFields)) {
             return $this->finish($this->failureSummary('old_revision_identity_mismatch', [
                 'target' => $target,
             ]));
         }
 
-        $comparisons = $this->comparisons($proposal, is_array($oldRevision->payload_json) ? $oldRevision->payload_json : []);
+        $comparisons = $this->comparisons($effectiveProposal, is_array($oldRevision->payload_json) ? $oldRevision->payload_json : []);
         $mismatches = array_values(array_map(
             static fn (array $row): string => (string) ($row['field'] ?? ''),
             array_filter($comparisons, static fn (array $row): bool => ($row['matched'] ?? false) !== true)
         ));
         sort($mismatches);
         $allowed = self::ALLOWED_MISMATCHES;
+        if (is_string($overrideTitle)) {
+            $allowed[] = 'proposal.proposed_seo_title';
+        }
         sort($allowed);
 
         if ($mismatches === []) {
             return $this->finish($this->failureSummary('old_revision_already_clean', [
                 'target' => $target,
-                'package_sha256' => $packageSha,
+                'package_sha256' => $effectivePackageSha,
             ]));
         }
-        if ($mismatches !== $allowed) {
+        if (array_values(array_diff($mismatches, $allowed)) !== []) {
             return $this->finish($this->failureSummary('mismatch_set_not_repairable', [
                 'target' => $target,
-                'package_sha256' => $packageSha,
+                'package_sha256' => $effectivePackageSha,
                 'mismatches' => $mismatches,
                 'allowed_mismatches' => $allowed,
             ]));
         }
-        if ($this->matchingCleanRepairExists($articleId, $packageSha, $target, $proposal, (int) $oldRevision->id)) {
+        if ($this->matchingCleanRepairExists($articleId, $effectivePackageSha, $target, $effectiveProposal, (int) $oldRevision->id)) {
             return $this->finish($this->failureSummary('repaired_revision_already_exists', [
                 'target' => $target,
-                'package_sha256' => $packageSha,
+                'package_sha256' => $effectivePackageSha,
             ]));
         }
 
         $execute = (bool) $this->option('execute');
-        $confirmationPhrase = $this->requiredConfirmationPhrase($target, $packageSha);
+        $confirmationPhrase = $this->requiredConfirmationPhrase($target, $effectivePackageSha);
         if (! $execute) {
-            $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $target, $article, $oldRevision, null, $mismatches, [
+            $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $effectivePackageSha, $effectivePackageArtifact, $target, $article, $oldRevision, null, $mismatches, [
                 'ok' => true,
                 'status' => 'planned',
                 'dry_run' => true,
                 'execute' => false,
                 'would_append_revision' => true,
                 'required_confirmation_phrase' => $confirmationPhrase,
+                'field_overrides' => $this->fieldOverridesEvidence($overrideTitle),
             ]);
-            $artifact = $this->writeArtifact($this->artifactDir(), 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
+            $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
 
             return $this->finish([
                 ...$evidence,
@@ -198,9 +222,9 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             ]);
         }
 
-        if ($confirmedSha !== $packageSha) {
+        if ($confirmedSha !== $effectivePackageSha) {
             return $this->finish($this->failureSummary('package_sha256_confirmation_mismatch', [
-                'package_sha256' => $packageSha,
+                'package_sha256' => $effectivePackageSha,
                 'required_confirmation_phrase' => $confirmationPhrase,
             ]));
         }
@@ -212,18 +236,17 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         }
 
         try {
-            $newRevision = DB::transaction(fn (): ArticleRevision => $this->appendRepairRevision($article, $oldRevision, $proposal, $packageSha, $targetFields));
+            $newRevision = DB::transaction(fn (): ArticleRevision => $this->appendRepairRevision($article, $oldRevision, $effectiveProposal, $effectivePackageSha, $targetFields));
         } catch (RuntimeException $exception) {
             return $this->finish($this->failureSummary($exception->getMessage(), [
                 'target' => $target,
-                'package_sha256' => $packageSha,
+                'package_sha256' => $effectivePackageSha,
             ]));
         }
 
-        $artifactDir = $this->artifactDir();
-        $compatibleWriteEvidence = $this->compatibleWriteEvidence($packageSha, $target, (int) $newRevision->id);
+        $compatibleWriteEvidence = $this->compatibleWriteEvidence($effectivePackageSha, $target, (int) $newRevision->id);
         $compatibleArtifact = $this->writeArtifact($artifactDir, 'seo-agent-controlled-cms-draft-write-repair-', $compatibleWriteEvidence);
-        $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $target, $article, $oldRevision, $newRevision, $mismatches, [
+        $evidence = $this->repairEvidence($packagePath, $writeEvidencePath, $packageSha, $effectivePackageSha, $effectivePackageArtifact, $target, $article, $oldRevision, $newRevision, $mismatches, [
             'ok' => true,
             'status' => 'success',
             'dry_run' => false,
@@ -231,6 +254,7 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             'would_append_revision' => false,
             'rows_created' => 1,
             'compatible_write_evidence' => $compatibleArtifact,
+            'field_overrides' => $this->fieldOverridesEvidence($overrideTitle),
         ]);
         $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
 
@@ -250,6 +274,30 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         $path = str_starts_with($path, '/') ? $path : base_path($path);
 
         return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    /**
+     * @return string|array{issue:string}|null
+     */
+    private function proposedSeoTitleOverride(): string|array|null
+    {
+        $raw = $this->option('override-proposed-seo-title');
+        if ($raw === null) {
+            return null;
+        }
+
+        $title = trim((string) $raw);
+        if ($title === '' || str_contains($title, "\0")) {
+            return ['issue' => 'override_proposed_seo_title_invalid'];
+        }
+        if ($this->forbiddenStringsPresent($title) !== []) {
+            return ['issue' => 'forbidden_input_field_present'];
+        }
+        if (mb_strlen($title) > self::SEO_TITLE_MAX_LENGTH) {
+            return ['issue' => 'override_proposed_seo_title_too_long'];
+        }
+
+        return $title;
     }
 
     /**
@@ -295,6 +343,30 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @param  array<string, mixed>  $proposal
+     * @return array<string, mixed>
+     */
+    private function packageWithProposal(array $package, string $target, array $proposal): array
+    {
+        foreach (['proposal_items', 'draft_briefs'] as $key) {
+            if (! is_array($package[$key] ?? null)) {
+                continue;
+            }
+            foreach ($package[$key] as $index => $item) {
+                if (is_array($item) && (string) ($item['subject_ref'] ?? '') === $target) {
+                    $package[$key][$index] = [
+                        ...$item,
+                        ...$proposal,
+                    ];
+                }
+            }
+        }
+
+        return $package;
     }
 
     private function articleIdFromTarget(string $target): ?int
@@ -553,6 +625,8 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         string $packagePath,
         string $writeEvidencePath,
         string $packageSha,
+        string $effectivePackageSha,
+        ?array $effectivePackageArtifact,
         string $target,
         Article $article,
         ArticleRevision $oldRevision,
@@ -564,12 +638,18 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             'schema_version' => self::SCHEMA_VERSION,
             ...$state,
             'target' => $target,
-            'package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'source_package' => $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
+            'effective_package' => $effectivePackageArtifact ?? $this->artifactRef($packagePath, self::PACKAGE_SCHEMA_VERSION),
             'old_write_evidence' => $this->artifactRef($writeEvidencePath, self::WRITE_SCHEMA_VERSION),
-            'package_sha256' => $packageSha,
+            'source_package_sha256' => $packageSha,
+            'package_sha256' => $effectivePackageSha,
             'repair_policy' => [
                 'mode' => 'append_article_revision',
-                'allowed_mismatches' => self::ALLOWED_MISMATCHES,
+                'allowed_mismatches' => [
+                    ...self::ALLOWED_MISMATCHES,
+                    'proposal.proposed_seo_title',
+                ],
+                'seo_title_max_length' => self::SEO_TITLE_MAX_LENGTH,
                 'copy_body_from_previous_draft_revision' => true,
                 'mutate_old_revision' => false,
             ],
@@ -597,6 +677,24 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             ],
             'mismatches_repaired' => $mismatches,
             'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function fieldOverridesEvidence(?string $overrideTitle): ?array
+    {
+        if ($overrideTitle === null) {
+            return null;
+        }
+
+        return [
+            'proposal.proposed_seo_title' => [
+                'length' => mb_strlen($overrideTitle),
+                'max_length' => self::SEO_TITLE_MAX_LENGTH,
+                'sha256' => hash('sha256', $overrideTitle),
+            ],
         ];
     }
 

--- a/backend/docs/seo/generated/seo-agent-article-cms-publish-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-article-cms-publish-canary.v1.json
@@ -33,8 +33,16 @@
     "runtime_publish_table": "article_translation_revisions",
     "behavior": "creates one approved article_translation_revision from the SEO Agent article draft, locks it as the article working revision, then promotes it through ArticlePublishService",
     "requires_publish_gate_status": "publish_ready",
+    "preflight_blocks_runtime_seo_meta_length_overflow": true,
     "requires_write_evidence_sha256_confirmation": true,
     "requires_exact_human_confirmation": true
+  },
+  "runtime_field_length_preflight": {
+    "article_seo_meta.seo_title": 60,
+    "article_seo_meta.seo_description": 160,
+    "article_seo_meta.og_title": 90,
+    "article_seo_meta.og_description": 200,
+    "blocked_issue": "seo_meta_field_length_exceeded"
   },
   "post_publish_boundaries": {
     "url_truth_write": false,

--- a/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
@@ -14,6 +14,14 @@
     "--confirm-package-sha256=<sha256>",
     "--confirm-repair=<exact phrase>"
   ],
+  "optional_repair_inputs": {
+    "--override-proposed-seo-title": {
+      "field": "proposal.proposed_seo_title",
+      "max_length": 60,
+      "writes_repaired_package_artifact": true,
+      "confirmation_sha256_target": "effective repaired package sha256"
+    }
+  },
   "supported_targets": [
     "article"
   ],
@@ -21,8 +29,10 @@
   "compatible_write_evidence_schema": "seo-agent-controlled-cms-draft-write.v1",
   "allowed_mismatches": [
     "proposal.proposed_internal_link_actions",
-    "proposal.proposal_quality"
+    "proposal.proposal_quality",
+    "proposal.proposed_seo_title when --override-proposed-seo-title is provided"
   ],
+  "effective_package_behavior": "When a controlled field override is supplied, the command emits a repaired seo-agent-cms-draft-package-dry-run.v1 artifact and compatible write evidence references that repaired package sha256 so readback QA can compare against the repaired proposal.",
   "copies_body_from_previous_draft_revision": true,
   "mutates_old_revision": false,
   "publishes_content": false,

--- a/backend/tests/Feature/SeoIntel/SeoAgentArticleCmsPublishCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentArticleCmsPublishCanaryTest.php
@@ -50,6 +50,34 @@ final class SeoAgentArticleCmsPublishCanaryTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_blocks_seo_meta_title_that_exceeds_runtime_column_limit(): void
+    {
+        $fixture = $this->fixture([
+            'proposed_seo_title' => 'What Is RIASEC? Holland Code Test & 6 Career Types | FermatMind',
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:article-cms-publish-canary', [
+            '--package' => $fixture['package_path'],
+            '--write-evidence' => $fixture['write_evidence_path'],
+            '--publish-gate-evidence' => $fixture['gate_evidence_path'],
+            '--target' => $fixture['target'],
+            '--revision-id' => $fixture['draft_revision_id'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('seo_meta_field_length_exceeded', $summary['issues'] ?? []);
+        $this->assertSame('fail', data_get($summary, 'field_length_preflight.status'));
+        $this->assertSame('article_seo_meta.seo_title', data_get($summary, 'field_length_preflight.violations.0.target_column'));
+        $this->assertFalse((bool) ($summary['writes_committed'] ?? true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
     public function execute_publishes_one_article_revision_through_translation_revision_without_search_side_effects(): void
     {
         $fixture = $this->fixture();
@@ -256,7 +284,8 @@ final class SeoAgentArticleCmsPublishCanaryTest extends TestCase
         ]);
 
         $target = 'article:'.$article->id.':en';
-        $packagePath = $this->writePackage($target);
+        $proposedSeoTitle = (string) ($overrides['proposed_seo_title'] ?? 'Improved Article Title | FermatMind');
+        $packagePath = $this->writePackage($target, $proposedSeoTitle);
         $packageSha = hash_file('sha256', $packagePath) ?: '';
         $draftRevision = ArticleRevision::query()->create([
             'org_id' => 0,
@@ -282,7 +311,7 @@ final class SeoAgentArticleCmsPublishCanaryTest extends TestCase
                 ],
                 'proposal' => [
                     'safe_path' => '/en/articles/article-candidate',
-                    'proposed_seo_title' => 'Improved Article Title | FermatMind',
+                    'proposed_seo_title' => $proposedSeoTitle,
                     'proposed_seo_description' => 'Improved description for search readers.',
                     'proposed_faq_items' => [],
                     'proposal_quality' => [
@@ -314,7 +343,7 @@ final class SeoAgentArticleCmsPublishCanaryTest extends TestCase
         ];
     }
 
-    private function writePackage(string $target): string
+    private function writePackage(string $target, string $proposedSeoTitle): string
     {
         return $this->writeJson('seo-agent-cms-draft-package-', [
             'schema_version' => 'seo-agent-cms-draft-package-dry-run.v1',
@@ -329,7 +358,7 @@ final class SeoAgentArticleCmsPublishCanaryTest extends TestCase
                     'subject_ref' => $target,
                     'safe_path' => '/en/articles/article-candidate',
                     'target_fields' => ['seo_title', 'seo_description'],
-                    'proposed_seo_title' => 'Improved Article Title | FermatMind',
+                    'proposed_seo_title' => $proposedSeoTitle,
                     'proposed_seo_description' => 'Improved description for search readers.',
                     'claim_gate_required' => true,
                     'human_approval_required' => true,

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
@@ -112,6 +112,79 @@ final class SeoAgentCmsDraftPayloadRepairCanaryTest extends TestCase
     }
 
     #[Test]
+    public function execute_can_repair_only_proposed_seo_title_with_repaired_package_handoff(): void
+    {
+        $article = $this->article();
+        $proposal = [
+            ...$this->proposal((int) $article->id),
+            'proposed_seo_title' => 'What Is RIASEC? Holland Code Test & 6 Career Types | FermatMind',
+        ];
+        $packagePath = $this->writePackage([$proposal]);
+        $sourcePackageSha = hash_file('sha256', $packagePath) ?: '';
+        $oldRevision = $this->articleRevision($article, $proposal, $sourcePackageSha, includeOptionalProposalFields: true);
+        $writeEvidencePath = $this->writeEvidence($sourcePackageSha, $proposal['subject_ref'], (int) $oldRevision->id);
+        $shortTitle = 'RIASEC Holland Code Test: 6 Career Types';
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--override-proposed-seo-title' => $shortTitle,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $dryRun = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $dryRun['status'] ?? null);
+        $this->assertSame(['proposal.proposed_seo_title'], $dryRun['mismatches_repaired'] ?? null);
+        $this->assertSame($sourcePackageSha, $dryRun['source_package_sha256'] ?? null);
+        $this->assertNotSame($sourcePackageSha, $dryRun['package_sha256'] ?? null);
+        $this->assertSame(mb_strlen($shortTitle), $dryRun['field_overrides']['proposal.proposed_seo_title']['length'] ?? null);
+        $effectivePackagePath = (string) data_get($dryRun, 'effective_package.path');
+        $effectivePackageSha = (string) ($dryRun['package_sha256'] ?? '');
+        $this->assertFileExists($effectivePackagePath);
+
+        $phrase = $this->approvalPhrase($proposal['subject_ref'], $effectivePackageSha);
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--override-proposed-seo-title' => $shortTitle,
+            '--confirm-package-sha256' => $effectivePackageSha,
+            '--confirm-repair' => $phrase,
+            '--artifact-dir' => $artifactDir,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $newRevision = ArticleRevision::query()->findOrFail((int) data_get($summary, 'new_revision.revision_id'));
+        $this->assertSame($shortTitle, data_get($newRevision->payload_json, 'proposal.proposed_seo_title'));
+        $this->assertSame($effectivePackageSha, data_get($newRevision->payload_json, 'seo_agent.package_sha256'));
+
+        $compatibleEvidencePath = (string) data_get($summary, 'compatible_write_evidence.path');
+        $compatibleEvidence = $this->readJson($compatibleEvidencePath);
+        $this->assertSame($effectivePackageSha, $compatibleEvidence['package_sha256'] ?? null);
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $effectivePackagePath,
+            '--write-evidence' => $compatibleEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $effectivePackageSha,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $readback = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $readback['status'] ?? null);
+        $this->assertSame(0, $readback['mismatch_count'] ?? null);
+    }
+
+    #[Test]
     public function it_blocks_mismatch_sets_outside_optional_payload_fields(): void
     {
         [, $proposal, $packagePath, , , $writeEvidencePath] = $this->oldDraftMissingOptionalFields([


### PR DESCRIPTION
## What changed
- Added article publish canary preflight for runtime `article_seo_meta` field lengths before any publish write.
- Extended the draft payload repair canary with a controlled `--override-proposed-seo-title` path that emits a repaired dry-run package artifact plus compatible write evidence.
- Added focused coverage for the production-like overlong article:41 SEO title case and repaired package/readback handoff.
- Updated generated SEO command contracts.

## Why
The article:41 publish canary failed closed in production because the proposed SEO title exceeded the `article_seo_meta.seo_title` 60-character runtime column. This PR makes that failure visible during dry-run/preflight and provides a bounded repair path that appends a new draft revision without mutating the old revision or publishing.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='SeoAgentArticleCmsPublishCanaryTest|SeoAgentCmsDraftPayloadRepairCanaryTest'`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='SeoAgentCmsDraftReadbackQaTest|SeoAgentArticleDraftClaimRiskQaTest|SeoAgentArticleDraftPreviewRuntimeQaTest|SeoAgentGscDraftPublishGateReadinessTest'`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' vendor/bin/phpunit tests/Feature/SeoIntel/SeoAgentArticleCmsPublishCanaryTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftReadbackQaTest.php tests/Feature/SeoIntel/SeoAgentArticleDraftClaimRiskQaTest.php tests/Feature/SeoIntel/SeoAgentArticleDraftPreviewRuntimeQaTest.php tests/Feature/SeoIntel/SeoAgentGscDraftPublishGateReadinessTest.php`
- `cd backend && php artisan list | rg 'seo-agent:(article-cms-publish-canary|cms-draft-payload-repair-canary)'`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticleCmsPublishCanaryCommand.php app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php tests/Feature/SeoIntel/SeoAgentArticleCmsPublishCanaryTest.php tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-article-cms-publish-canary.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production repair execute.
- No CMS publish execute.
- No URL Truth write, sitemap submission, IndexNow, search enqueue/submit, indexing request, scheduler activation, queue worker start, external model call, or live GSC call.

## Repository rule impact
Backend CMS remains the authority for article SEO and publication state. This PR only tightens controlled backend commands and does not add frontend/CMS fallback content.
