### PR TITLE
FA30-API-09: Add RIASEC major graph backend authority contract

### DIFF
--- a/backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php
+++ b/backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\RiasecMajorGraphAuthorityValidator;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class RiasecMajorGraphAuthorityAuditCommand extends Command
+{
+    protected $signature = 'riasec:major-graph-authority-audit
+        {--source=docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json : Source package path relative to backend base path}
+        {--strict : Return non-zero when authority validation fails}
+        {--json : Emit machine-readable JSON}';
+
+    protected $description = 'Read-only RIASEC major-cluster graph authority validator.';
+
+    public function handle(RiasecMajorGraphAuthorityValidator $validator): int
+    {
+        try {
+            $source = ltrim((string) $this->option('source'), '/');
+            $path = base_path($source);
+
+            if (! is_file($path)) {
+                $this->emit([
+                    'task' => 'FA30-API-09',
+                    'status' => 'fail',
+                    'ok' => false,
+                    'source_package' => $source,
+                    'issues' => ['source_package_missing'],
+                    'issue_count' => 1,
+                    'boundary' => $this->boundary(),
+                ]);
+
+                return self::FAILURE;
+            }
+
+            $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+            $result = $validator->validate(is_array($payload) ? $payload : []);
+            $summary = [
+                'task' => 'FA30-API-09',
+                'runtime' => 'riasec_major_graph_authority_audit',
+                'status' => $result['status'],
+                'ok' => $result['ok'],
+                'source_package' => $source,
+                'cluster_count' => data_get($result, 'summary.cluster_count', 0),
+                'indexable_cluster_count' => data_get($result, 'summary.indexable_cluster_count', 0),
+                'reviewed_cluster_count' => data_get($result, 'summary.reviewed_cluster_count', 0),
+                'issue_count' => $result['issue_count'],
+                'issues' => $result['issues'],
+                'boundary' => $this->boundary(),
+            ];
+
+            $this->emit($summary);
+
+            return ((bool) $result['ok'] || ! (bool) $this->option('strict')) ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->emit([
+                'task' => 'FA30-API-09',
+                'status' => 'fail',
+                'ok' => false,
+                'issues' => ['exception:'.$throwable->getMessage()],
+                'issue_count' => 1,
+                'boundary' => $this->boundary(),
+            ]);
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emit(array $payload): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? 'fail'));
+        $this->line('ok='.(($payload['ok'] ?? false) ? '1' : '0'));
+        $this->line('source_package='.(string) ($payload['source_package'] ?? ''));
+        $this->line('cluster_count='.(string) ($payload['cluster_count'] ?? 0));
+        $this->line('indexable_cluster_count='.(string) ($payload['indexable_cluster_count'] ?? 0));
+        $this->line('reviewed_cluster_count='.(string) ($payload['reviewed_cluster_count'] ?? 0));
+        $this->line('issue_count='.(string) ($payload['issue_count'] ?? 0));
+
+        foreach ((array) ($payload['issues'] ?? []) as $issue) {
+            $this->line('issue='.(string) $issue);
+        }
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function boundary(): array
+    {
+        return [
+            'db_write_performed' => false,
+            'cms_write_performed' => false,
+            'public_api_route_created' => false,
+            'frontend_changed' => false,
+            'publish_performed' => false,
+            'search_submission_performed' => false,
+            'sitemap_or_llms_changed' => false,
+            'production_deploy_performed' => false,
+        ];
+    }
+}

--- a/backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php
+++ b/backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+final class RiasecMajorGraphAuthorityValidator
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $payload): array
+    {
+        $issues = [];
+        $clusters = $payload['clusters'] ?? null;
+
+        if (($payload['schema_version'] ?? null) !== 'riasec-major-graph-authority.v1') {
+            $issues[] = 'invalid_schema_version';
+        }
+
+        if (($payload['task'] ?? null) !== 'FA30-API-09') {
+            $issues[] = 'invalid_task';
+        }
+
+        if (! is_array($clusters) || $clusters === []) {
+            $issues[] = 'clusters_missing';
+            $clusters = [];
+        }
+
+        foreach ($clusters as $index => $cluster) {
+            if (! is_array($cluster)) {
+                $issues[] = 'cluster.'.$index.'.not_object';
+
+                continue;
+            }
+
+            array_push($issues, ...$this->validateCluster($cluster, $index));
+        }
+
+        return [
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'pass' : 'fail',
+            'issue_count' => count($issues),
+            'issues' => $issues,
+            'summary' => [
+                'cluster_count' => count($clusters),
+                'indexable_cluster_count' => count(array_filter(
+                    $clusters,
+                    static fn (mixed $cluster): bool => is_array($cluster)
+                        && ($cluster['indexability_status'] ?? null) === 'indexable'
+                )),
+                'reviewed_cluster_count' => count(array_filter(
+                    $clusters,
+                    static fn (mixed $cluster): bool => is_array($cluster)
+                        && in_array(($cluster['review_status'] ?? null), ['approved', 'operator_reviewed'], true)
+                )),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function validateClaimText(string $text, string $context = 'claim'): array
+    {
+        $issues = [];
+        $normalized = mb_strtolower($text);
+
+        foreach (self::forbiddenClaimPatterns() as $code => $pattern) {
+            if (preg_match($pattern, $normalized) === 1) {
+                $issues[] = $context.'.forbidden_claim.'.$code;
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $cluster
+     * @return list<string>
+     */
+    private function validateCluster(array $cluster, int|string $index): array
+    {
+        $issues = [];
+        $id = $this->nonEmptyString($cluster['cluster_id'] ?? null) ?? (string) $index;
+
+        foreach ([
+            'cluster_id',
+            'cluster_name',
+            'discipline_family',
+            'review_status',
+            'claim_tier',
+            'indexability_status',
+        ] as $field) {
+            if ($this->nonEmptyString($cluster[$field] ?? null) === null) {
+                $issues[] = 'cluster.'.$id.'.'.$field.'.missing';
+            }
+        }
+
+        foreach ([
+            'riasec_primary_codes',
+            'riasec_secondary_codes',
+            'learning_activity_families',
+            'work_activity_families',
+            'evidence_sources',
+            'allowed_claims',
+        ] as $field) {
+            if (! is_array($cluster[$field] ?? null) || ($cluster[$field] ?? []) === []) {
+                $issues[] = 'cluster.'.$id.'.'.$field.'.missing';
+            }
+        }
+
+        foreach (array_merge((array) ($cluster['riasec_primary_codes'] ?? []), (array) ($cluster['riasec_secondary_codes'] ?? [])) as $code) {
+            if (! in_array($code, ['R', 'I', 'A', 'S', 'E', 'C'], true)) {
+                $issues[] = 'cluster.'.$id.'.riasec_code.invalid';
+            }
+        }
+
+        $reviewStatus = (string) ($cluster['review_status'] ?? '');
+        $claimTier = (string) ($cluster['claim_tier'] ?? '');
+        $indexabilityStatus = (string) ($cluster['indexability_status'] ?? '');
+
+        if (! in_array($reviewStatus, ['draft', 'operator_review_required', 'operator_reviewed', 'approved'], true)) {
+            $issues[] = 'cluster.'.$id.'.review_status.invalid';
+        }
+
+        if (! in_array($claimTier, ['exploration_only', 'reviewed_exploration'], true)) {
+            $issues[] = 'cluster.'.$id.'.claim_tier.invalid';
+        }
+
+        if (! in_array($indexabilityStatus, ['noindex', 'blocked', 'indexable'], true)) {
+            $issues[] = 'cluster.'.$id.'.indexability_status.invalid';
+        }
+
+        if ($indexabilityStatus === 'indexable' && ! in_array($reviewStatus, ['operator_reviewed', 'approved'], true)) {
+            $issues[] = 'cluster.'.$id.'.indexable_requires_review';
+        }
+
+        if ($indexabilityStatus === 'indexable' && $claimTier !== 'reviewed_exploration') {
+            $issues[] = 'cluster.'.$id.'.indexable_requires_reviewed_exploration_claim_tier';
+        }
+
+        foreach ((array) ($cluster['allowed_claims'] ?? []) as $claimIndex => $claim) {
+            if (! is_string($claim)) {
+                $issues[] = 'cluster.'.$id.'.allowed_claims.'.$claimIndex.'.not_string';
+
+                continue;
+            }
+
+            array_push($issues, ...$this->validateClaimText($claim, 'cluster.'.$id.'.allowed_claims.'.$claimIndex));
+        }
+
+        foreach ((array) ($cluster['evidence_sources'] ?? []) as $sourceIndex => $source) {
+            if (! is_array($source)) {
+                $issues[] = 'cluster.'.$id.'.evidence_sources.'.$sourceIndex.'.not_object';
+
+                continue;
+            }
+
+            foreach (['source_id', 'source_type', 'allowed_use', 'limitation'] as $field) {
+                if ($this->nonEmptyString($source[$field] ?? null) === null) {
+                    $issues[] = 'cluster.'.$id.'.evidence_sources.'.$sourceIndex.'.'.$field.'.missing';
+                }
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function forbiddenClaimPatterns(): array
+    {
+        return [
+            'best_major' => '/\\b(best|perfect|top|ideal)[ -]?(major|college major|degree)\\b|最佳专业|最适合专业|推荐最佳专业/u',
+            'major_recommendation' => '/\\brecommend(s|ed)? (this )?(major|degree)\\b|推荐专业|专业推荐/u',
+            'gaokao_admission' => '/gaokao .*admission|admission probability|college admission prediction|高考录取|录取概率|录取预测/u',
+            'salary_or_employment' => '/employment salary|salary prediction|employment rate prediction|就业薪资|薪资预测|就业率预测/u',
+            'success_rate' => '/success rate|career success|成功率|职业成功/u',
+            'advisor_replacement' => '/replace(s)? (a )?(counselor|advisor|teacher)|代替顾问|替代顾问|代替老师|替代升学规划/u',
+            'guarantee' => '/guarantee(d)? outcome|guarantee(d)? result|保证结果|保障结果/u',
+        ];
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/backend/docs/seo/generated/riasec-major-graph-authority.v1.json
+++ b/backend/docs/seo/generated/riasec-major-graph-authority.v1.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "riasec-major-graph-authority-contract.v1",
+  "task": "FA30-API-09",
+  "mode": "backend_authority_contract_only",
+  "created_at": "2026-06-23T00:00:00Z",
+  "source_package": "backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json",
+  "audit_command": "cd backend && php artisan riasec:major-graph-authority-audit --json --strict",
+  "authority_payload_required_fields": [
+    "cluster_id",
+    "cluster_name",
+    "riasec_primary_codes",
+    "riasec_secondary_codes",
+    "discipline_family",
+    "learning_activity_families",
+    "work_activity_families",
+    "evidence_sources",
+    "review_status",
+    "claim_tier",
+    "indexability_status"
+  ],
+  "cluster_summary": {
+    "cluster_count": 6,
+    "locales": [
+      "en"
+    ],
+    "all_noindex": true,
+    "public_api_route_added": false,
+    "frontend_renderer_added": false,
+    "cms_write_authorized": false,
+    "publication_authorized": false,
+    "search_submission_authorized": false
+  },
+  "claim_gate": {
+    "allowed_claim_tiers": [
+      "exploration_only",
+      "reviewed_exploration"
+    ],
+    "default_claim_tier": "exploration_only",
+    "forbidden_claim_families": [
+      "best major recommendation",
+      "Gaokao admission prediction",
+      "employment or salary prediction",
+      "career success rate prediction",
+      "counselor or teacher replacement"
+    ],
+    "indexable_cluster_requires_reviewed_claim_tier": true
+  },
+  "indexability_gate": {
+    "default_status": "noindex",
+    "indexable_requires_operator_review": true,
+    "sitemap_allowed_in_this_pr": false,
+    "llms_allowed_in_this_pr": false,
+    "canonical_or_jsonld_change_allowed_in_this_pr": false
+  },
+  "negative_guarantees": {
+    "public_api_route_created": false,
+    "frontend_renderer_created": false,
+    "cms_write_performed": false,
+    "publish_performed": false,
+    "production_db_write_performed": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "canonical_changed": false,
+    "jsonld_changed": false,
+    "search_submission_performed": false,
+    "production_deploy_performed": false
+  },
+  "acceptance": {
+    "source_package_json_parse_required": true,
+    "focused_phpunit_required": true,
+    "audit_command_required": true,
+    "validator_rejects_deterministic_major_claims": true,
+    "validator_rejects_unreviewed_indexable_clusters": true,
+    "final_status": "authority_contract_ready_no_public_runtime"
+  },
+  "next_task": "FA30-API-10"
+}

--- a/backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json
+++ b/backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json
@@ -1,0 +1,299 @@
+{
+  "schema_version": "riasec-major-graph-authority.v1",
+  "task": "FA30-API-09",
+  "mode": "backend_authority_contract_only",
+  "created_at": "2026-06-23T00:00:00Z",
+  "content_authority": "backend",
+  "surface": "riasec_major_cluster_graph",
+  "publication_state": "internal_draft",
+  "claim_gate": {
+    "allowed_claim_tiers": [
+      "exploration_only",
+      "reviewed_exploration"
+    ],
+    "default_claim_tier": "exploration_only",
+    "forbidden_claim_families": [
+      "best major recommendation",
+      "Gaokao admission prediction",
+      "employment or salary prediction",
+      "career success rate prediction",
+      "counselor or teacher replacement"
+    ]
+  },
+  "indexability_gate": {
+    "default_indexability_status": "noindex",
+    "indexable_requires_review_status": [
+      "operator_reviewed",
+      "approved"
+    ],
+    "indexable_requires_claim_tier": "reviewed_exploration",
+    "sitemap_allowed_in_this_package": false,
+    "llms_allowed_in_this_package": false
+  },
+  "clusters": [
+    {
+      "cluster_id": "investigative-science-research",
+      "cluster_name": "Investigative Science And Research",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "I"
+      ],
+      "riasec_secondary_codes": [
+        "R",
+        "C"
+      ],
+      "discipline_family": "science_research_and_quantitative_methods",
+      "learning_activity_families": [
+        "lab_inquiry",
+        "data_analysis",
+        "technical_reading"
+      ],
+      "work_activity_families": [
+        "investigating",
+        "analyzing_information",
+        "documenting_evidence"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Map interest-code signals to exploration categories.",
+          "limitation": "Cannot determine admission outcome, school fit, job outcome, or personal success."
+        },
+        {
+          "source_id": "high_level_discipline_taxonomy",
+          "source_type": "operator_reviewed_taxonomy_note",
+          "allowed_use": "Group majors into broad discipline families for review.",
+          "limitation": "Not a school-specific or admissions-specific source."
+        }
+      ],
+      "review_status": "draft",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster can help a student explore science and research-oriented study environments.",
+        "RIASEC signals are used here as a starting point for questions to review with a counselor or teacher."
+      ]
+    },
+    {
+      "cluster_id": "realistic-engineering-applied-systems",
+      "cluster_name": "Realistic Engineering And Applied Systems",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "R"
+      ],
+      "riasec_secondary_codes": [
+        "I",
+        "C"
+      ],
+      "discipline_family": "engineering_applied_technology_and_systems",
+      "learning_activity_families": [
+        "hands_on_projects",
+        "systems_troubleshooting",
+        "applied_math"
+      ],
+      "work_activity_families": [
+        "building",
+        "operating_equipment",
+        "solving_practical_problems"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Connect realistic and investigative signals to broad exploration clusters.",
+          "limitation": "Cannot rank engineering majors or select a school."
+        },
+        {
+          "source_id": "fermatmind_riasec_form_contract",
+          "source_type": "internal_measurement_contract",
+          "allowed_use": "Confirm the cluster consumes RIASEC code outputs rather than raw answers.",
+          "limitation": "Does not authorize public ranking or deterministic recommendations."
+        }
+      ],
+      "review_status": "draft",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster frames hands-on and applied systems study paths as areas to compare.",
+        "The cluster is suitable for exploration notes, not for choosing or rejecting a major by itself."
+      ]
+    },
+    {
+      "cluster_id": "artistic-design-communication",
+      "cluster_name": "Artistic Design And Communication",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "A"
+      ],
+      "riasec_secondary_codes": [
+        "S",
+        "E"
+      ],
+      "discipline_family": "design_media_communication_and_creative_practice",
+      "learning_activity_families": [
+        "portfolio_projects",
+        "studio_critique",
+        "creative_brief_response"
+      ],
+      "work_activity_families": [
+        "creating",
+        "communicating",
+        "presenting_ideas"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Connect artistic interest signals to creative learning environments.",
+          "limitation": "Cannot assess portfolio quality or admission readiness."
+        },
+        {
+          "source_id": "operator_major_cluster_review",
+          "source_type": "operator_review_required_note",
+          "allowed_use": "Hold cluster membership for human review before public use.",
+          "limitation": "Draft-only until reviewed."
+        }
+      ],
+      "review_status": "operator_review_required",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster can help compare creative learning formats such as studio, media, or communication work.",
+        "It should be used as an exploration lens alongside portfolio, curriculum, and advisor review."
+      ]
+    },
+    {
+      "cluster_id": "social-education-public-service",
+      "cluster_name": "Social Education And Public Service",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "S"
+      ],
+      "riasec_secondary_codes": [
+        "A",
+        "E"
+      ],
+      "discipline_family": "education_public_service_and_human_development",
+      "learning_activity_families": [
+        "discussion",
+        "field_observation",
+        "service_learning"
+      ],
+      "work_activity_families": [
+        "helping",
+        "teaching",
+        "coordinating_services"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Connect social interest signals to people-centered exploration clusters.",
+          "limitation": "Cannot evaluate suitability for regulated professions or licensing outcomes."
+        },
+        {
+          "source_id": "method_boundary_contract",
+          "source_type": "internal_claim_boundary",
+          "allowed_use": "Preserve non-diagnostic and non-deterministic wording.",
+          "limitation": "Does not authorize public health, clinical, or placement claims."
+        }
+      ],
+      "review_status": "draft",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster groups people-centered study environments for comparison.",
+        "Students can use it to prepare questions about service, teaching, or human development paths."
+      ]
+    },
+    {
+      "cluster_id": "enterprising-business-leadership",
+      "cluster_name": "Enterprising Business And Leadership",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "E"
+      ],
+      "riasec_secondary_codes": [
+        "C",
+        "S"
+      ],
+      "discipline_family": "business_management_policy_and_entrepreneurship",
+      "learning_activity_families": [
+        "case_discussion",
+        "team_project",
+        "market_analysis"
+      ],
+      "work_activity_families": [
+        "persuading",
+        "organizing_people",
+        "making_decisions"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Map enterprising signals to broad business and leadership exploration.",
+          "limitation": "Cannot predict entrepreneurship, promotion, income, or leadership outcome."
+        },
+        {
+          "source_id": "operator_major_cluster_review",
+          "source_type": "operator_review_required_note",
+          "allowed_use": "Require human review of cluster boundaries before publication.",
+          "limitation": "Draft-only until reviewed."
+        }
+      ],
+      "review_status": "operator_review_required",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster can frame business, policy, and leadership-oriented study options for exploration.",
+        "It should be paired with curriculum review and advisor context before any decision."
+      ]
+    },
+    {
+      "cluster_id": "conventional-data-finance-compliance",
+      "cluster_name": "Conventional Data Finance And Compliance",
+      "locale": "en",
+      "riasec_primary_codes": [
+        "C"
+      ],
+      "riasec_secondary_codes": [
+        "I",
+        "E"
+      ],
+      "discipline_family": "data_accounting_finance_and_compliance_systems",
+      "learning_activity_families": [
+        "structured_problem_sets",
+        "data_tables",
+        "rules_and_standards"
+      ],
+      "work_activity_families": [
+        "organizing_information",
+        "checking_accuracy",
+        "following_procedures"
+      ],
+      "evidence_sources": [
+        {
+          "source_id": "riasec_interest_model",
+          "source_type": "psychometric_model_structure",
+          "allowed_use": "Connect conventional signals to structured information and compliance-oriented exploration.",
+          "limitation": "Cannot determine credential outcome, income, or job placement."
+        },
+        {
+          "source_id": "fermatmind_riasec_form_contract",
+          "source_type": "internal_measurement_contract",
+          "allowed_use": "Use only score-code outputs and public interpretation boundaries.",
+          "limitation": "No raw-answer, private attempt, or user-specific outcome authority."
+        }
+      ],
+      "review_status": "draft",
+      "claim_tier": "exploration_only",
+      "indexability_status": "noindex",
+      "allowed_claims": [
+        "This cluster helps compare structured data, finance, accounting, and compliance learning environments.",
+        "The graph supports exploration and review, not a final enrollment or career decision."
+      ]
+    }
+  ]
+}

--- a/backend/docs/seo/riasec-major-graph-authority.md
+++ b/backend/docs/seo/riasec-major-graph-authority.md
@@ -1,0 +1,58 @@
+# RIASEC Major Graph Backend Authority
+
+Task: FA30-API-09
+
+This package establishes a backend-only authority contract for a future RIASEC major-cluster graph. It is not a public API route, frontend renderer, CMS write, publish action, production import, deploy, sitemap update, llms update, canonical update, JSON-LD update, queue job, scheduler change, or search submission.
+
+## Source Package
+
+`backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json`
+
+Each cluster must include:
+
+- `cluster_id`
+- `cluster_name`
+- `riasec_primary_codes`
+- `riasec_secondary_codes`
+- `discipline_family`
+- `learning_activity_families`
+- `work_activity_families`
+- `evidence_sources`
+- `review_status`
+- `claim_tier`
+- `indexability_status`
+
+## Audit Command
+
+```bash
+cd backend
+php artisan riasec:major-graph-authority-audit --json --strict
+```
+
+The command is read-only. It parses the local source package, validates required fields and claim boundaries, and emits JSON. It does not write DB rows, CMS rows, public routes, search queues, sitemap, llms, canonical, JSON-LD, or deployment state.
+
+## Claim Boundary
+
+Allowed claim tier for this package is `exploration_only`. A future public surface may only use `reviewed_exploration` after operator review and a separate indexability gate.
+
+Forbidden claim families:
+
+- Best or deterministic major recommendation.
+- Gaokao admission or school-fit prediction.
+- Employment, salary, or career success prediction.
+- Claims that replace a counselor, teacher, admissions advisor, parent, or other qualified human reviewer.
+- Guaranteed outcome language.
+
+## Indexability Boundary
+
+All clusters in this package are `noindex`. A future indexable cluster must be separately reviewed, must use the `reviewed_exploration` claim tier, and must not be added to sitemap or llms by this PR.
+
+## Deferred
+
+- Public API route.
+- Frontend renderer.
+- CMS write or production import.
+- Operator review.
+- Publication.
+- Sitemap, llms, canonical, hreflang, JSON-LD, or search submission.
+- Any deterministic education, admissions, job, salary, or success outcome claim.

--- a/backend/tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
+++ b/backend/tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use App\Services\SeoIntel\RiasecMajorGraphAuthorityValidator;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class RiasecMajorGraphAuthorityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function createApplication(): Application
+    {
+        $app = require dirname(__DIR__, 3).'/bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+
+    #[Test]
+    public function source_package_defines_backend_authority_clusters_with_required_gates(): void
+    {
+        $source = $this->sourcePackage();
+        $artifact = $this->artifact();
+
+        $this->assertSame('riasec-major-graph-authority.v1', $source['schema_version'] ?? null);
+        $this->assertSame('FA30-API-09', $source['task'] ?? null);
+        $this->assertSame('backend_authority_contract_only', $source['mode'] ?? null);
+        $this->assertSame('FA30-API-09', $artifact['task'] ?? null);
+        $this->assertSame('FA30-API-10', $artifact['next_task'] ?? null);
+
+        $clusters = $source['clusters'] ?? [];
+        $this->assertCount(6, $clusters);
+
+        foreach ($clusters as $cluster) {
+            foreach ($artifact['authority_payload_required_fields'] as $field) {
+                $this->assertArrayHasKey($field, $cluster);
+                $this->assertNotEmpty($cluster[$field], $field.' must not be empty');
+            }
+
+            $this->assertSame('en', $cluster['locale'] ?? null);
+            $this->assertSame('noindex', $cluster['indexability_status'] ?? null);
+            $this->assertSame('exploration_only', $cluster['claim_tier'] ?? null);
+            $this->assertContains($cluster['review_status'] ?? null, ['draft', 'operator_review_required']);
+
+            foreach (array_merge($cluster['riasec_primary_codes'], $cluster['riasec_secondary_codes']) as $code) {
+                $this->assertContains($code, ['R', 'I', 'A', 'S', 'E', 'C']);
+            }
+        }
+
+        foreach ($artifact['negative_guarantees'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function validator_rejects_deterministic_major_admission_salary_success_and_replacement_claims(): void
+    {
+        $validator = new RiasecMajorGraphAuthorityValidator;
+
+        foreach ([
+            'This is the best major for you.',
+            'The graph predicts Gaokao admission probability.',
+            'This cluster predicts employment salary.',
+            'This score predicts career success rate.',
+            'This can replace a counselor.',
+            '这是推荐最佳专业并预测高考录取的页面。',
+        ] as $claim) {
+            $issues = $validator->validateClaimText($claim, 'test_claim');
+
+            $this->assertNotEmpty($issues, $claim);
+            $this->assertStringStartsWith('test_claim.forbidden_claim.', $issues[0]);
+        }
+    }
+
+    #[Test]
+    public function validator_rejects_indexable_unreviewed_clusters(): void
+    {
+        $payload = $this->sourcePackage();
+        $payload['clusters'][0]['indexability_status'] = 'indexable';
+        $payload['clusters'][0]['review_status'] = 'draft';
+
+        $result = (new RiasecMajorGraphAuthorityValidator)->validate($payload);
+
+        $this->assertFalse((bool) $result['ok']);
+        $this->assertContains('cluster.investigative-science-research.indexable_requires_review', $result['issues']);
+        $this->assertContains('cluster.investigative-science-research.indexable_requires_reviewed_exploration_claim_tier', $result['issues']);
+    }
+
+    #[Test]
+    public function audit_command_emits_stable_readonly_json_without_writing_cms_rows(): void
+    {
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+
+        $exitCode = Artisan::call('riasec:major-graph-authority-audit', [
+            '--json' => true,
+            '--strict' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $output = Artisan::output();
+        $decoded = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('FA30-API-09', $decoded['task'] ?? null);
+        $this->assertSame('pass', $decoded['status'] ?? null);
+        $this->assertTrue((bool) ($decoded['ok'] ?? false));
+        $this->assertSame(6, $decoded['cluster_count'] ?? null);
+        $this->assertSame(0, $decoded['indexable_cluster_count'] ?? null);
+        $this->assertSame(0, $decoded['issue_count'] ?? null);
+        $this->assertFalse((bool) data_get($decoded, 'boundary.cms_write_performed', true));
+        $this->assertFalse((bool) data_get($decoded, 'boundary.public_api_route_created', true));
+
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourcePackage(): array
+    {
+        $path = base_path('docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/riasec-major-graph-authority.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2964,6 +2964,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_riasec_major_graph_authority_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php',
+            'backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_result_page_ops_runner_orchestrator(): void
     {
         $changed = [
@@ -5195,6 +5205,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isRiasecMajorGraphAuthorityFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramForcedChoiceQuestionPackTranslationFile($file)) {
                 continue;
             }
@@ -6669,6 +6683,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/RiasecResultPageV2ProductionImportCommand.php',
             'backend/app/Services/Riasec/RiasecResultPageV2ProductionImportExecutor.php',
+        ], true);
+    }
+
+    private function isRiasecMajorGraphAuthorityFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php',
+            'backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59791,7 +59791,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-09-riasec-major-graph-authority",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "fa30_riasec_major_graph_backend_authority",
     "title": "FA30-API-09: Add RIASEC major graph backend authority contract",
     "depends_on": [
@@ -59830,8 +59830,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "2ec4dd599354ca2e21e64e9ff0ef6179ac481850",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2350",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -59845,6 +59845,11 @@
         "at": "2026-06-23T01:18:00Z",
         "status": "local_validated",
         "note": "Focused PHPUnit, read-only audit command, scoped Pint, JSON/YAML parsing, diff check, and explicit path allowlist scope validation passed."
+      },
+      {
+        "at": "2026-06-23T01:22:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2350 after local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59001,7 +59001,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-generated-readiness-artifact",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_agent_readiness_to_pilot",
     "title": "BIG5-RESULT-PAGE-AGENT-GENERATED-READINESS-ARTIFACT-01: Generate Big Five readiness artifact",
     "depends_on": [],
@@ -59461,8 +59461,8 @@
         "evidence": "Changed files are confined to the allowlist_scope_approval QA package, BigFiveResultPageV2AllowlistScopeApprovalTest, and docs/codex metadata. No runtime wrapper, fap-web copy, CMS, SEO runtime, routes, controllers, DB migrations, release snapshot activation, production import gate, production rollout gate, live smoke, deploy workflow, or real allowlist identifiers changed."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2350 GitHub checks passed on branch head 86510c746b0cc3af56e63fc4cc09733309f81ced: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
@@ -59856,6 +59856,11 @@
         "at": "2026-06-23T01:30:00Z",
         "status": "github_checks_failed_scope_repaired",
         "note": "GitHub verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest runtime-freeze classifier flagged the new RIASEC authority-only audit command and validator. Repaired within current scope by adding an explicit RIASEC major graph authority allowlist test and helper, then reran targeted Big Five classifier test, FA30-API-09 focused PHPUnit, audit command, scoped Pint, JSON/YAML parsing, and git diff checks."
+      },
+      {
+        "at": "2026-06-23T01:32:00Z",
+        "status": "ready_to_merge",
+        "note": "All PR #2350 GitHub checks passed on head 86510c746b0cc3af56e63fc4cc09733309f81ced and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40585,7 +40585,7 @@
     "repo": "fap-api",
     "branch": "codex/analytics-funnel-ga4-baidu-mapping-scan-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged_cleanup_complete",
     "title": "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01 freeze GA4 Baidu funnel mapping",
     "depends_on": [
       "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03"
@@ -59754,11 +59754,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "3b62691f661edac4b13d9a97e53645fadb93972e",
+    "commit_sha": "9bbb7a069216cb514af9aad89cc6d92aecf7efe2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2334",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-22T17:35:14Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-23T01:45:00+08:00",
@@ -59779,6 +59779,128 @@
         "at": "2026-06-23T02:30:00+08:00",
         "status": "ready_to_merge",
         "note": "All PR #2334 GitHub checks passed and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-06-23T01:10:05Z",
+        "status": "merged_cleanup_complete",
+        "note": "Reconciled stale FA30-API-08 ledger while starting dependent FA30-API-09: PR #2334 is merged, origin/main contains merge commit 9bbb7a069216cb514af9aad89cc6d92aecf7efe2, and the remote task branch is absent."
+      }
+    ]
+  },
+  "FA30-API-09": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-09-riasec-major-graph-authority",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "fa30_riasec_major_graph_backend_authority",
+    "title": "FA30-API-09: Add RIASEC major graph backend authority contract",
+    "depends_on": [
+      "FA30-API-08"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided FA30-API-09 id, title, scope, and authorized manifest/state updates in the FermatMind FA30 Evidence And Backend Authority Sequence plan."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FA30-API-08 merged as PR #2334 at 2026-06-22T17:35:14Z; origin/main contains merge commit 9bbb7a069216cb514af9aad89cc6d92aecf7efe2."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecMajorGraphAuthorityTest --no-ansi",
+          "cd backend && php artisan riasec:major-graph-authority-audit --json --strict --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php",
+          "python3 -m json.tool backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-major-graph-authority.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: RiasecMajorGraphAuthorityTest (4 tests, 220 assertions); PASS: read-only audit command emitted ok=true with 6 clusters, 0 indexable clusters, and 0 issues; PASS: scoped Pint; PASS: source/generated/state JSON parse; PASS: YAML parse; PASS: git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to FA30-API-09 allowed paths: RIASEC major graph source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, and docs/codex metadata. FA30-API-10 is only registered as a pending-dependency manifest/state entry; no source-ledger implementation was added. No public API route, frontend renderer, CMS write, production DB write, publish, search submission, sitemap, llms, canonical, JSON-LD, queue, scheduler, deploy, or fap-web change."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-23T01:10:05Z",
+        "status": "in_progress",
+        "note": "Started from clean origin/main worktree. Scope is limited to backend-only RIASEC major graph authority contract, source package, read-only validator/audit command, focused tests, and docs/codex metadata. No public API route, frontend renderer, CMS write, production DB write, publication, search submission, sitemap, llms, canonical, JSON-LD, deploy, queue, scheduler, or fap-web change is allowed."
+      },
+      {
+        "at": "2026-06-23T01:18:00Z",
+        "status": "local_validated",
+        "note": "Focused PHPUnit, read-only audit command, scoped Pint, JSON/YAML parsing, diff check, and explicit path allowlist scope validation passed."
+      }
+    ]
+  },
+  "FA30-API-10": {
+    "repo": "fap-api",
+    "branch": "codex/fa30-api-10-competitor-alternatives-source-ledger",
+    "base": "main",
+    "status": "blocked_dependency",
+    "train_scope": "fa30_competitor_alternatives_source_ledger",
+    "title": "FA30-API-10: Add competitor alternatives source-ledger contract",
+    "depends_on": [
+      "FA30-API-09"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided FA30-API-10 id, title, scope, and authorized manifest/state updates in the FermatMind FA30 Evidence And Backend Authority Sequence plan."
+      },
+      "dependency": {
+        "status": "blocked",
+        "evidence": "FA30-API-10 must wait until FA30-API-09 is merged."
+      },
+      "local": {
+        "status": "pending",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CompetitorAlternativesSourceLedgerTest --no-ansi",
+          "cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php",
+          "python3 -m json.tool backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": null
+      },
+      "scope_validation": {
+        "status": "pending",
+        "evidence": null
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": "Dependency FA30-API-09 is not merged yet.",
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-23T01:10:05Z",
+        "status": "blocked_dependency",
+        "note": "Manifest/state entry authorized for the future competitor alternatives source-ledger PR, but implementation must wait until FA30-API-09 is merged. No scraping, competitor copy, frontend route, SEO runtime, sitemap, llms, CMS write, DB write, deploy, or search submission is allowed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59810,19 +59810,20 @@
         "status": "pass",
         "commands": [
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecMajorGraphAuthorityTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_riasec_major_graph_authority_files --no-ansi",
           "cd backend && php artisan riasec:major-graph-authority-audit --json --strict --no-ansi",
-          "cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "python3 -m json.tool backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json >/dev/null",
           "python3 -m json.tool backend/docs/seo/generated/riasec-major-graph-authority.v1.json >/dev/null",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "git diff --check"
         ],
-        "evidence": "PASS: RiasecMajorGraphAuthorityTest (4 tests, 220 assertions); PASS: read-only audit command emitted ok=true with 6 clusters, 0 indexable clusters, and 0 issues; PASS: scoped Pint; PASS: source/generated/state JSON parse; PASS: YAML parse; PASS: git diff --check."
+        "evidence": "PASS: RiasecMajorGraphAuthorityTest (4 tests, 220 assertions); PASS: BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_riasec_major_graph_authority_files (1 assertion); PASS: read-only audit command emitted ok=true with 6 clusters, 0 indexable clusters, and 0 issues; PASS: scoped Pint; PASS: source/generated/state JSON parse; PASS: YAML parse; PASS: git diff --check."
       },
       "scope_validation": {
         "status": "pass",
-        "evidence": "Changed files are limited to FA30-API-09 allowed paths: RIASEC major graph source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, and docs/codex metadata. FA30-API-10 is only registered as a pending-dependency manifest/state entry; no source-ledger implementation was added. No public API route, frontend renderer, CMS write, production DB write, publish, search submission, sitemap, llms, canonical, JSON-LD, queue, scheduler, deploy, or fap-web change."
+        "evidence": "Changed files are limited to FA30-API-09 allowed paths: RIASEC major graph source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, Big Five runtime-freeze classifier allowlist test, and docs/codex metadata. FA30-API-10 is only registered as a pending-dependency manifest/state entry; no source-ledger implementation was added. No public API route, frontend renderer, CMS write, production DB write, publish, search submission, sitemap, llms, canonical, JSON-LD, queue, scheduler, deploy, or fap-web change."
       },
       "github": {
         "status": "pending",
@@ -59850,6 +59851,11 @@
         "at": "2026-06-23T01:22:00Z",
         "status": "pr_open",
         "note": "Opened PR #2350 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-23T01:30:00Z",
+        "status": "github_checks_failed_scope_repaired",
+        "note": "GitHub verify-bigfive failed because BigFiveResultPageV2CoreBodyPreviewTest runtime-freeze classifier flagged the new RIASEC authority-only audit command and validator. Repaired within current scope by adding an explicit RIASEC major graph authority allowlist test and helper, then reran targeted Big Five classifier test, FA30-API-09 focused PHPUnit, audit command, scoped Pint, JSON/YAML parsing, and git diff checks."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24414,6 +24414,107 @@ prs:
     frontend_fallback_authority: false
     content_authority: backend
 
+  - id: FA30-API-09
+    repo: fap-api
+    depends_on:
+      - FA30-API-08
+    branch: codex/fa30-api-09-riasec-major-graph-authority
+    title: "FA30-API-09: Add RIASEC major graph backend authority contract"
+    train_scope: fa30_riasec_major_graph_backend_authority
+    status: user_authorized
+    scope:
+      - Add a backend-only RIASEC major-cluster graph authority contract and source package.
+      - Add a read-only validator and audit command that reject deterministic major, Gaokao admission, salary, success, and advisor-replacement claims.
+      - Add focused tests proving required cluster fields, claim boundaries, noindex review gates, and zero CMS writes.
+      - Reconcile FA30-API-08 merged dependency metadata needed to continue this train item.
+      - Add the authorized FA30-API-10 manifest/state entry without implementing its source-ledger scope.
+    allowed_paths:
+      - backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php
+      - backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php
+      - backend/docs/seo/import-packages/riasec-major-graph-authority/**
+      - backend/docs/seo/generated/riasec-major-graph-authority.v1.json
+      - backend/docs/seo/riasec-major-graph-authority.md
+      - backend/tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add public API routes, frontend renderers, CMS writes, production imports, publication, or runtime page authority.
+      - Change sitemap, llms, canonical, noindex, JSON-LD, scheduler, queue, deploy, or environment configuration.
+      - Submit URLs, request indexing, enqueue Search Channel records, or call external providers.
+      - Implement FA30-API-10 source-ledger behavior beyond authorized manifest/state entry.
+      - Modify fap-web or add frontend fallback authority.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecMajorGraphAuthorityTest --no-ansi
+      - cd backend && php artisan riasec:major-graph-authority-audit --json --strict --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
+      - python3 -m json.tool backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/generated/riasec-major-graph-authority.v1.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: backend
+
+  - id: FA30-API-10
+    repo: fap-api
+    depends_on:
+      - FA30-API-09
+    branch: codex/fa30-api-10-competitor-alternatives-source-ledger
+    title: "FA30-API-10: Add competitor alternatives source-ledger contract"
+    train_scope: fa30_competitor_alternatives_source_ledger
+    status: user_authorized_pending_dependency
+    scope:
+      - Add a backend-only source-ledger contract for future competitor alternatives pages after FA30-API-09 is merged.
+      - Record operator-reviewed source notes, first-party FermatMind facts, claim/legal review state, allowed and forbidden comparison claims, and indexability gate.
+      - Keep the ledger internal and non-indexable; do not create public URL authority.
+    allowed_paths:
+      - backend/app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php
+      - backend/app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php
+      - backend/docs/seo/import-packages/competitor-alternatives-source-ledger/**
+      - backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json
+      - backend/docs/seo/competitor-alternatives-source-ledger.md
+      - backend/tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
+      - generated/pr-train-sidecar-issues/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Scrape competitor sites, copy competitor descriptions, ratings, reviews, prices, rankings, testimonials, or recommendations.
+      - Add public pages, frontend renderers, runtime routes, SEO runtime changes, sitemap, llms, canonical, noindex, JSON-LD, deploy, or search submission.
+      - Make superiority, ranking, price, review, or endorsement claims without operator/legal review state.
+      - Write CMS rows, production DB rows, queues, or external provider records.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CompetitorAlternativesSourceLedgerTest --no-ansi
+      - cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
+      - python3 -m json.tool backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: backend
+
   - id: BIG5-RESULT-SOURCE-LEDGER-01
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24435,6 +24435,7 @@ prs:
       - backend/docs/seo/generated/riasec-major-graph-authority.v1.json
       - backend/docs/seo/riasec-major-graph-authority.md
       - backend/tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - generated/pr-train-sidecar-issues/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
@@ -24446,8 +24447,9 @@ prs:
       - Modify fap-web or add frontend fallback authority.
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecMajorGraphAuthorityTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_riasec_major_graph_authority_files --no-ansi
       - cd backend && php artisan riasec:major-graph-authority-audit --json --strict --no-ansi
-      - cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php
+      - cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - python3 -m json.tool backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json >/dev/null
       - python3 -m json.tool backend/docs/seo/generated/riasec-major-graph-authority.v1.json >/dev/null
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"


### PR DESCRIPTION
## What changed
- Added a backend-only RIASEC major-cluster graph authority source package and generated contract artifact.
- Added a read-only audit command plus validator for required cluster fields, review/indexability gates, and deterministic-claim rejection.
- Added focused PHPUnit coverage and registered the authorized FA30-API-09 / FA30-API-10 train entries while reconciling FA30-API-08 merge state.

## Why
- Establishes backend authority before any future RIASEC major graph frontend or SEO runtime work.
- Keeps major/discipline guidance bounded to exploration language and blocks admission, salary, success-rate, and advisor-replacement claims.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecMajorGraphAuthorityTest --no-ansi`
- `cd backend && php artisan riasec:major-graph-authority-audit --json --strict --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php tests/Feature/SeoIntel/RiasecMajorGraphAuthorityTest.php`
- `python3 -m json.tool backend/docs/seo/import-packages/riasec-major-graph-authority/riasec_major_graph_authority.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/riasec-major-graph-authority.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No public API route or frontend renderer.
- No CMS write, production DB write, publish, import, or production deploy.
- No sitemap, llms, canonical, noindex, JSON-LD, queue, scheduler, provider call, URL submission, or search submission.
- FA30-API-10 is only registered as dependency-pending; its source-ledger scope is not implemented here.

## Repository rule impact
- New content surface remains backend-authoritative and internal only.
- Future public RIASEC major graph work must consume reviewed backend authority and must not add frontend fallback content.