### PR TITLE
FA30-API-10: Add competitor alternatives source-ledger contract

### DIFF
--- a/backend/app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php
+++ b/backend/app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\CompetitorAlternativesSourceLedgerValidator;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class CompetitorAlternativesSourceLedgerAuditCommand extends Command
+{
+    protected $signature = 'competitor-alternatives:source-ledger-audit
+        {--source=docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json : Source package path relative to backend base path}
+        {--strict : Return non-zero when source-ledger validation fails}
+        {--json : Emit machine-readable JSON}';
+
+    protected $description = 'Read-only competitor alternatives source-ledger validator.';
+
+    public function handle(CompetitorAlternativesSourceLedgerValidator $validator): int
+    {
+        try {
+            $source = ltrim((string) $this->option('source'), '/');
+            $path = base_path($source);
+
+            if (! is_file($path)) {
+                $this->emit([
+                    'task' => 'FA30-API-10',
+                    'status' => 'fail',
+                    'ok' => false,
+                    'source_package' => $source,
+                    'issues' => ['source_package_missing'],
+                    'issue_count' => 1,
+                    'boundary' => $this->boundary(),
+                ]);
+
+                return self::FAILURE;
+            }
+
+            $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+            $result = $validator->validate(is_array($payload) ? $payload : []);
+            $summary = [
+                'task' => 'FA30-API-10',
+                'runtime' => 'competitor_alternatives_source_ledger_audit',
+                'status' => $result['status'],
+                'ok' => $result['ok'],
+                'source_package' => $source,
+                'entry_count' => data_get($result, 'summary.entry_count', 0),
+                'indexable_entry_count' => data_get($result, 'summary.indexable_entry_count', 0),
+                'legal_approved_count' => data_get($result, 'summary.legal_approved_count', 0),
+                'issue_count' => $result['issue_count'],
+                'issues' => $result['issues'],
+                'boundary' => $this->boundary(),
+            ];
+
+            $this->emit($summary);
+
+            return ((bool) $result['ok'] || ! (bool) $this->option('strict')) ? self::SUCCESS : self::FAILURE;
+        } catch (Throwable $throwable) {
+            $this->emit([
+                'task' => 'FA30-API-10',
+                'status' => 'fail',
+                'ok' => false,
+                'issues' => ['exception:'.$throwable->getMessage()],
+                'issue_count' => 1,
+                'boundary' => $this->boundary(),
+            ]);
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function emit(array $payload): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('status='.(string) ($payload['status'] ?? 'fail'));
+        $this->line('ok='.(($payload['ok'] ?? false) ? '1' : '0'));
+        $this->line('source_package='.(string) ($payload['source_package'] ?? ''));
+        $this->line('entry_count='.(string) ($payload['entry_count'] ?? 0));
+        $this->line('indexable_entry_count='.(string) ($payload['indexable_entry_count'] ?? 0));
+        $this->line('legal_approved_count='.(string) ($payload['legal_approved_count'] ?? 0));
+        $this->line('issue_count='.(string) ($payload['issue_count'] ?? 0));
+
+        foreach ((array) ($payload['issues'] ?? []) as $issue) {
+            $this->line('issue='.(string) $issue);
+        }
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function boundary(): array
+    {
+        return [
+            'scrape_performed' => false,
+            'external_write_performed' => false,
+            'db_write_performed' => false,
+            'cms_write_performed' => false,
+            'public_api_route_created' => false,
+            'frontend_changed' => false,
+            'seo_runtime_changed' => false,
+            'search_submission_performed' => false,
+            'production_deploy_performed' => false,
+        ];
+    }
+}

--- a/backend/app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php
+++ b/backend/app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+final class CompetitorAlternativesSourceLedgerValidator
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(array $payload): array
+    {
+        $issues = [];
+        $entries = $payload['entries'] ?? null;
+
+        if (($payload['schema_version'] ?? null) !== 'competitor-alternatives-source-ledger.v1') {
+            $issues[] = 'invalid_schema_version';
+        }
+
+        if (($payload['task'] ?? null) !== 'FA30-API-10') {
+            $issues[] = 'invalid_task';
+        }
+
+        if (! is_array($entries) || $entries === []) {
+            $issues[] = 'entries_missing';
+            $entries = [];
+        }
+
+        foreach ($entries as $index => $entry) {
+            if (! is_array($entry)) {
+                $issues[] = 'entry.'.$index.'.not_object';
+
+                continue;
+            }
+
+            array_push($issues, ...$this->validateEntry($entry, $index));
+        }
+
+        array_push($issues, ...$this->scanForbiddenKeys($entries, 'entries'));
+
+        return [
+            'ok' => $issues === [],
+            'status' => $issues === [] ? 'pass' : 'fail',
+            'issue_count' => count($issues),
+            'issues' => array_values(array_unique($issues)),
+            'summary' => [
+                'entry_count' => count($entries),
+                'indexable_entry_count' => count(array_filter(
+                    $entries,
+                    static fn (mixed $entry): bool => is_array($entry)
+                        && ($entry['indexability_status'] ?? null) === 'indexable'
+                )),
+                'legal_approved_count' => count(array_filter(
+                    $entries,
+                    static fn (mixed $entry): bool => is_array($entry)
+                        && ($entry['legal_review_status'] ?? null) === 'approved'
+                )),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function validateComparisonText(string $text, string $context = 'comparison_text'): array
+    {
+        $issues = [];
+        $normalized = mb_strtolower($text);
+
+        foreach (self::forbiddenClaimPatterns() as $code => $pattern) {
+            if (preg_match($pattern, $normalized) === 1) {
+                $issues[] = $context.'.forbidden_claim.'.$code;
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @return list<string>
+     */
+    private function validateEntry(array $entry, int|string $index): array
+    {
+        $issues = [];
+        $id = $this->nonEmptyString($entry['ledger_id'] ?? null) ?? (string) $index;
+
+        foreach ([
+            'ledger_id',
+            'comparison_surface',
+            'source_review_status',
+            'claim_review_status',
+            'legal_review_status',
+            'indexability_status',
+        ] as $field) {
+            if ($this->nonEmptyString($entry[$field] ?? null) === null) {
+                $issues[] = 'entry.'.$id.'.'.$field.'.missing';
+            }
+        }
+
+        foreach ([
+            'operator_reviewed_source_notes',
+            'fermatmind_first_party_facts',
+            'allowed_claims',
+            'forbidden_claims',
+        ] as $field) {
+            if (! is_array($entry[$field] ?? null) || ($entry[$field] ?? []) === []) {
+                $issues[] = 'entry.'.$id.'.'.$field.'.missing';
+            }
+        }
+
+        if (! in_array(($entry['source_review_status'] ?? null), ['operator_review_required', 'operator_reviewed', 'approved'], true)) {
+            $issues[] = 'entry.'.$id.'.source_review_status.invalid';
+        }
+
+        if (! in_array(($entry['claim_review_status'] ?? null), ['not_reviewed', 'operator_review_required', 'approved'], true)) {
+            $issues[] = 'entry.'.$id.'.claim_review_status.invalid';
+        }
+
+        if (! in_array(($entry['legal_review_status'] ?? null), ['not_reviewed', 'required', 'approved'], true)) {
+            $issues[] = 'entry.'.$id.'.legal_review_status.invalid';
+        }
+
+        if (! in_array(($entry['indexability_status'] ?? null), ['noindex', 'blocked', 'indexable'], true)) {
+            $issues[] = 'entry.'.$id.'.indexability_status.invalid';
+        }
+
+        if (($entry['indexability_status'] ?? null) === 'indexable') {
+            if (($entry['claim_review_status'] ?? null) !== 'approved') {
+                $issues[] = 'entry.'.$id.'.indexable_requires_claim_approval';
+            }
+
+            if (($entry['legal_review_status'] ?? null) !== 'approved') {
+                $issues[] = 'entry.'.$id.'.indexable_requires_legal_approval';
+            }
+        }
+
+        foreach (['operator_reviewed_source_notes', 'fermatmind_first_party_facts', 'allowed_claims'] as $field) {
+            foreach ((array) ($entry[$field] ?? []) as $claimIndex => $claim) {
+                if (! is_string($claim)) {
+                    $issues[] = 'entry.'.$id.'.'.$field.'.'.$claimIndex.'.not_string';
+
+                    continue;
+                }
+
+                array_push($issues, ...$this->validateComparisonText($claim, 'entry.'.$id.'.'.$field.'.'.$claimIndex));
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scanForbiddenKeys(mixed $value, string $path): array
+    {
+        $issues = [];
+
+        if (! is_array($value)) {
+            return $issues;
+        }
+
+        foreach ($value as $key => $child) {
+            $keyString = is_string($key) ? $key : (string) $key;
+            if (in_array($keyString, self::forbiddenFieldNames(), true)) {
+                $issues[] = $path.'.'.$keyString.'.forbidden_field';
+            }
+
+            array_push($issues, ...$this->scanForbiddenKeys($child, $path.'.'.$keyString));
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function forbiddenFieldNames(): array
+    {
+        return [
+            'competitor_description',
+            'copied_description',
+            'scraped_reviews',
+            'review_score',
+            'rating',
+            'ranking',
+            'rank',
+            'price',
+            'pricing',
+            'stars',
+            'testimonials',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function forbiddenClaimPatterns(): array
+    {
+        return [
+            'copied_competitor_copy' => '/copied from|verbatim competitor|competitor copy|复制竞品|照搬竞品/u',
+            'ranking_claim' => '/\\b(no\\. ?1|#1|best|top ranked|better than|superior to|outperforms)\\b|排名第一|优于竞品|更好|最佳/u',
+            'review_or_rating_claim' => '/\\brated\\b|\\breview score\\b|reviews say|user reviews|评分|评价说|用户评论/u',
+            'pricing_claim' => '/\\bprice\\b|\\bpricing\\b|cheaper than|more expensive than|收费|价格|更便宜/u',
+            'endorsement_claim' => '/endorsed by|official partner|官方合作|官方背书/u',
+        ];
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/backend/docs/seo/competitor-alternatives-source-ledger.md
+++ b/backend/docs/seo/competitor-alternatives-source-ledger.md
@@ -1,0 +1,59 @@
+# Competitor Alternatives Source Ledger
+
+Task: FA30-API-10
+
+This package establishes a backend-only source-ledger contract for future competitor alternatives pages. It is not a crawler, scraper, public page, public API route, frontend renderer, SEO runtime change, CMS write, production import, deploy, sitemap update, llms update, canonical update, JSON-LD update, queue job, scheduler change, or search submission.
+
+## Source Package
+
+`backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json`
+
+Each ledger entry must include:
+
+- `ledger_id`
+- `comparison_surface`
+- `operator_reviewed_source_notes`
+- `fermatmind_first_party_facts`
+- `allowed_claims`
+- `forbidden_claims`
+- `source_review_status`
+- `claim_review_status`
+- `legal_review_status`
+- `indexability_status`
+
+## Audit Command
+
+```bash
+cd backend
+php artisan competitor-alternatives:source-ledger-audit --json --strict
+```
+
+The command is read-only. It parses the local source package, validates source and claim boundaries, and emits JSON. It does not scrape sites, write DB rows, write CMS rows, create public routes, enqueue search jobs, change SEO runtime, or deploy.
+
+## Source Boundary
+
+Allowed:
+
+- Operator-reviewed source notes.
+- First-party FermatMind facts.
+- Claim/legal/indexability review states.
+- Explicit allowed and forbidden comparison claim boundaries.
+
+Forbidden:
+
+- Scraped competitor descriptions, reviews, ratings, prices, rankings, testimonials, recommendation text, or marketing copy.
+- Superiority, ranking, endorsement, price, or review-score claims.
+- Public URL authority before separate claim and legal review.
+
+## Indexability Boundary
+
+All entries in this package are `noindex`. A future indexable alternatives page must be separately approved through claim review and legal review, and must be introduced in a separate public runtime PR.
+
+## Deferred
+
+- Public alternatives pages.
+- Frontend renderer.
+- Public API route.
+- CMS write or production import.
+- Sitemap, llms, canonical, hreflang, JSON-LD, or search submission.
+- Any crawler, scraper, or competitor-content ingestion.

--- a/backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json
+++ b/backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "competitor-alternatives-source-ledger-contract.v1",
+  "task": "FA30-API-10",
+  "mode": "backend_source_ledger_contract_only",
+  "created_at": "2026-06-23T00:00:00Z",
+  "source_package": "backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json",
+  "audit_command": "cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict",
+  "ledger_entry_required_fields": [
+    "ledger_id",
+    "comparison_surface",
+    "operator_reviewed_source_notes",
+    "fermatmind_first_party_facts",
+    "allowed_claims",
+    "forbidden_claims",
+    "source_review_status",
+    "claim_review_status",
+    "legal_review_status",
+    "indexability_status"
+  ],
+  "ledger_summary": {
+    "entry_count": 3,
+    "all_internal_draft": true,
+    "all_noindex": true,
+    "public_url_authority_created": false,
+    "frontend_renderer_added": false,
+    "seo_runtime_changed": false,
+    "scraping_performed": false
+  },
+  "source_boundary": {
+    "scraping_allowed": false,
+    "copied_competitor_copy_allowed": false,
+    "review_rating_price_rank_fields_allowed": false,
+    "first_party_facts_required": true,
+    "operator_reviewed_source_notes_required": true
+  },
+  "claim_gate": {
+    "claim_review_required": true,
+    "legal_review_required_before_indexing": true,
+    "forbidden_claim_families": [
+      "copied competitor copy",
+      "ranking or superiority claim",
+      "review or rating claim",
+      "pricing claim",
+      "official endorsement claim"
+    ]
+  },
+  "negative_guarantees": {
+    "scrape_performed": false,
+    "external_write_performed": false,
+    "public_api_route_created": false,
+    "frontend_renderer_created": false,
+    "cms_write_performed": false,
+    "production_db_write_performed": false,
+    "seo_runtime_changed": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "canonical_changed": false,
+    "jsonld_changed": false,
+    "search_submission_performed": false,
+    "production_deploy_performed": false
+  },
+  "acceptance": {
+    "source_package_json_parse_required": true,
+    "focused_phpunit_required": true,
+    "audit_command_required": true,
+    "validator_rejects_copied_competitor_copy": true,
+    "validator_rejects_ranking_rating_pricing_fields": true,
+    "validator_rejects_missing_claim_or_legal_review_state": true,
+    "final_status": "source_ledger_contract_ready_no_public_runtime"
+  },
+  "next_task": "none_in_this_train"
+}

--- a/backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json
+++ b/backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "competitor-alternatives-source-ledger.v1",
+  "task": "FA30-API-10",
+  "mode": "backend_source_ledger_contract_only",
+  "created_at": "2026-06-23T00:00:00Z",
+  "content_authority": "backend",
+  "surface": "future_competitor_alternatives_pages",
+  "publication_state": "internal_draft",
+  "source_boundary": {
+    "scraping_allowed": false,
+    "competitor_copy_allowed": false,
+    "review_rating_price_rank_fields_allowed": false,
+    "first_party_facts_required": true,
+    "operator_source_notes_required": true
+  },
+  "claim_gate": {
+    "claim_review_required": true,
+    "legal_review_required_before_indexing": true,
+    "forbidden_claim_families": [
+      "copied competitor copy",
+      "ranking or superiority claim",
+      "review or rating claim",
+      "pricing claim",
+      "official endorsement claim"
+    ]
+  },
+  "indexability_gate": {
+    "default_indexability_status": "noindex",
+    "indexable_requires_claim_review_status": "approved",
+    "indexable_requires_legal_review_status": "approved",
+    "sitemap_allowed_in_this_package": false,
+    "llms_allowed_in_this_package": false
+  },
+  "entries": [
+    {
+      "ledger_id": "assessment-method-alternative-ledger-draft",
+      "comparison_surface": "assessment_method_alternatives",
+      "competitor_reference_type": "category_level",
+      "operator_reviewed_source_notes": [
+        "Use only operator-reviewed notes about page type and method boundary.",
+        "Do not preserve or paraphrase competitor marketing copy."
+      ],
+      "fermatmind_first_party_facts": [
+        "FermatMind can describe its own assessment method, scoring boundary, and result interpretation limits.",
+        "FermatMind can state whether a public page has its own method note, privacy boundary, and source-ledger status."
+      ],
+      "allowed_claims": [
+        "This future ledger can support source-led comparison of method boundaries.",
+        "Claims must be phrased as FermatMind first-party facts and operator-reviewed notes."
+      ],
+      "forbidden_claims": [
+        "Ranking, superiority, review, rating, price, or endorsement claims are not allowed.",
+        "Copied competitor descriptions or user comments are not allowed."
+      ],
+      "source_review_status": "operator_review_required",
+      "claim_review_status": "not_reviewed",
+      "legal_review_status": "required",
+      "indexability_status": "noindex"
+    },
+    {
+      "ledger_id": "free-assessment-alternative-ledger-draft",
+      "comparison_surface": "free_assessment_alternatives",
+      "competitor_reference_type": "category_level",
+      "operator_reviewed_source_notes": [
+        "Use public page structure observations only when an operator records them manually.",
+        "Do not collect commercial tables, recommendation text, or page descriptions from competitor sites."
+      ],
+      "fermatmind_first_party_facts": [
+        "FermatMind can describe whether its own free assessment page exposes a public landing, test start path, and result boundary.",
+        "FermatMind can describe its own no-diagnosis and no-employment-prediction boundaries."
+      ],
+      "allowed_claims": [
+        "This ledger can support future pages that compare assessment scope and evidence boundaries.",
+        "The comparison must stay source-led and avoid claims of superiority."
+      ],
+      "forbidden_claims": [
+        "Do not claim that FermatMind is better, more accurate, cheaper, or top ranked.",
+        "Do not quote or summarize competitor reviews or ratings."
+      ],
+      "source_review_status": "operator_review_required",
+      "claim_review_status": "not_reviewed",
+      "legal_review_status": "required",
+      "indexability_status": "noindex"
+    },
+    {
+      "ledger_id": "career-interest-alternative-ledger-draft",
+      "comparison_surface": "career_interest_alternatives",
+      "competitor_reference_type": "category_level",
+      "operator_reviewed_source_notes": [
+        "Use only operator-reviewed source notes about career-interest test scope.",
+        "Do not infer competitor private scoring logic, traffic, conversion, or product performance."
+      ],
+      "fermatmind_first_party_facts": [
+        "FermatMind can describe its own RIASEC form variants, exploration boundary, and non-deterministic major/career claims.",
+        "FermatMind can state whether its own graph or ledger is draft, reviewed, or indexable."
+      ],
+      "allowed_claims": [
+        "This ledger can document reviewed differences in scope, evidence, and claim boundaries.",
+        "Future copy must identify source-review and legal-review status before publication."
+      ],
+      "forbidden_claims": [
+        "Do not predict admission, salary, employment, or career success versus another site.",
+        "Do not present competitor alternatives as a ranking table without review authority."
+      ],
+      "source_review_status": "operator_review_required",
+      "claim_review_status": "not_reviewed",
+      "legal_review_status": "required",
+      "indexability_status": "noindex"
+    }
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
+++ b/backend/tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\ContentPage;
+use App\Services\SeoIntel\CompetitorAlternativesSourceLedgerValidator;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CompetitorAlternativesSourceLedgerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function createApplication(): Application
+    {
+        $app = require dirname(__DIR__, 3).'/bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+
+    #[Test]
+    public function source_ledger_defines_internal_noindex_entries_with_required_review_gates(): void
+    {
+        $source = $this->sourcePackage();
+        $artifact = $this->artifact();
+
+        $this->assertSame('competitor-alternatives-source-ledger.v1', $source['schema_version'] ?? null);
+        $this->assertSame('FA30-API-10', $source['task'] ?? null);
+        $this->assertSame('backend_source_ledger_contract_only', $source['mode'] ?? null);
+        $this->assertSame('FA30-API-10', $artifact['task'] ?? null);
+        $this->assertSame(3, data_get($artifact, 'ledger_summary.entry_count'));
+        $this->assertFalse((bool) data_get($artifact, 'ledger_summary.public_url_authority_created', true));
+        $this->assertFalse((bool) data_get($artifact, 'ledger_summary.scraping_performed', true));
+
+        $entries = $source['entries'] ?? [];
+        $this->assertCount(3, $entries);
+
+        foreach ($entries as $entry) {
+            foreach ($artifact['ledger_entry_required_fields'] as $field) {
+                $this->assertArrayHasKey($field, $entry);
+                $this->assertNotEmpty($entry[$field], $field.' must not be empty');
+            }
+
+            $this->assertSame('noindex', $entry['indexability_status'] ?? null);
+            $this->assertSame('not_reviewed', $entry['claim_review_status'] ?? null);
+            $this->assertSame('required', $entry['legal_review_status'] ?? null);
+            $this->assertSame('operator_review_required', $entry['source_review_status'] ?? null);
+        }
+
+        foreach ($artifact['negative_guarantees'] ?? [] as $flag => $value) {
+            $this->assertFalse((bool) $value, $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function validator_rejects_copied_competitor_ranking_rating_pricing_and_endorsement_claims(): void
+    {
+        $validator = new CompetitorAlternativesSourceLedgerValidator;
+
+        foreach ([
+            'Copied from competitor copy.',
+            'FermatMind is better than the other product.',
+            'User reviews say it is rated highest.',
+            'The pricing is cheaper than the competitor.',
+            'This is an official partner endorsement.',
+            '这是复制竞品并声称排名第一的页面。',
+        ] as $claim) {
+            $issues = $validator->validateComparisonText($claim, 'test_claim');
+
+            $this->assertNotEmpty($issues, $claim);
+            $this->assertStringStartsWith('test_claim.forbidden_claim.', $issues[0]);
+        }
+    }
+
+    #[Test]
+    public function validator_rejects_forbidden_source_fields_and_missing_review_state(): void
+    {
+        $payload = $this->sourcePackage();
+        $payload['entries'][0]['rating'] = 4.9;
+        unset($payload['entries'][0]['legal_review_status']);
+        $payload['entries'][1]['indexability_status'] = 'indexable';
+
+        $result = (new CompetitorAlternativesSourceLedgerValidator)->validate($payload);
+
+        $this->assertFalse((bool) $result['ok']);
+        $this->assertContains('entries.0.rating.forbidden_field', $result['issues']);
+        $this->assertContains('entry.assessment-method-alternative-ledger-draft.legal_review_status.missing', $result['issues']);
+        $this->assertContains('entry.free-assessment-alternative-ledger-draft.indexable_requires_claim_approval', $result['issues']);
+        $this->assertContains('entry.free-assessment-alternative-ledger-draft.indexable_requires_legal_approval', $result['issues']);
+    }
+
+    #[Test]
+    public function audit_command_emits_stable_readonly_json_without_writing_cms_rows(): void
+    {
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+
+        $exitCode = Artisan::call('competitor-alternatives:source-ledger-audit', [
+            '--json' => true,
+            '--strict' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $decoded = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('FA30-API-10', $decoded['task'] ?? null);
+        $this->assertSame('pass', $decoded['status'] ?? null);
+        $this->assertTrue((bool) ($decoded['ok'] ?? false));
+        $this->assertSame(3, $decoded['entry_count'] ?? null);
+        $this->assertSame(0, $decoded['indexable_entry_count'] ?? null);
+        $this->assertSame(0, $decoded['issue_count'] ?? null);
+        $this->assertFalse((bool) data_get($decoded, 'boundary.scrape_performed', true));
+        $this->assertFalse((bool) data_get($decoded, 'boundary.cms_write_performed', true));
+        $this->assertFalse((bool) data_get($decoded, 'boundary.seo_runtime_changed', true));
+
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourcePackage(): array
+    {
+        $path = base_path('docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/competitor-alternatives-source-ledger.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2974,6 +2974,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_competitor_alternatives_source_ledger_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php',
+            'backend/app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_riasec_result_page_ops_runner_orchestrator(): void
     {
         $changed = [
@@ -5209,6 +5219,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isCompetitorAlternativesSourceLedgerFile($file)) {
+                continue;
+            }
+
             if ($this->isEnneagramForcedChoiceQuestionPackTranslationFile($file)) {
                 continue;
             }
@@ -6691,6 +6705,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/RiasecMajorGraphAuthorityAuditCommand.php',
             'backend/app/Services/SeoIntel/RiasecMajorGraphAuthorityValidator.php',
+        ], true);
+    }
+
+    private function isCompetitorAlternativesSourceLedgerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php',
+            'backend/app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59067,7 +59067,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-free-full-report-runtime-qa-readiness",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_agent_readiness_to_pilot",
     "title": "BIG5-FREE-FULL-REPORT-RUNTIME-QA-READINESS-01: Add Big Five free full-report runtime QA readiness",
     "depends_on": [
@@ -59908,8 +59908,8 @@
         "evidence": "Changed files are limited to FA30-API-10 allowed paths: competitor alternatives source-ledger source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, Big Five runtime-freeze classifier allowlist test, and docs/codex metadata. No scraping, competitor copy, public page, frontend route, SEO runtime, sitemap, llms, canonical, JSON-LD, CMS write, production DB write, queue, scheduler, external write, deploy, or search submission."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2353 GitHub checks passed on branch head f5b95c45a64f8d10c8ffb4ca03c175bf06e98835: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
@@ -59938,6 +59938,11 @@
         "at": "2026-06-23T01:49:00Z",
         "status": "pr_open",
         "note": "Opened PR #2353 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-23T01:51:00Z",
+        "status": "ready_to_merge",
+        "note": "All PR #2353 GitHub checks passed on head f5b95c45a64f8d10c8ffb4ca03c175bf06e98835 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43496,7 +43496,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-dash-collector-01-smoke-reconcile",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged_cleanup_complete",
     "train_scope": "seo_intel_collector_dry_run_smoke_evidence",
     "title": "docs(seo): record collector dry-run smoke evidence",
     "checks": {
@@ -59826,16 +59826,16 @@
         "evidence": "Changed files are limited to FA30-API-09 allowed paths: RIASEC major graph source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, Big Five runtime-freeze classifier allowlist test, and docs/codex metadata. FA30-API-10 is only registered as a pending-dependency manifest/state entry; no source-ledger implementation was added. No public API route, frontend renderer, CMS write, production DB write, publish, search submission, sitemap, llms, canonical, JSON-LD, queue, scheduler, deploy, or fap-web change."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2350 GitHub checks passed on branch head 5bb65f6dc52da45a1439c5185d9173a596265865: hygiene, Semgrep blocking secrets, supply-chain, semgrep SARIF non-blocking upload, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS. mergeStateStatus was CLEAN before squash merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "2ec4dd599354ca2e21e64e9ff0ef6179ac481850",
+    "commit_sha": "42fb4cfa2ddc29c6e36e37b5518ec4d6ebf26087",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2350",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-23T01:36:51Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-23T01:10:05Z",
@@ -59861,6 +59861,11 @@
         "at": "2026-06-23T01:32:00Z",
         "status": "ready_to_merge",
         "note": "All PR #2350 GitHub checks passed on head 86510c746b0cc3af56e63fc4cc09733309f81ced and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-06-23T01:38:00Z",
+        "status": "merged_cleanup_complete",
+        "note": "PR #2350 is merged, origin/main contains merge commit 42fb4cfa2ddc29c6e36e37b5518ec4d6ebf26087, local main is synced to origin/main, the local task branch was deleted, and the remote task branch is absent."
       }
     ]
   },
@@ -59868,7 +59873,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-10-competitor-alternatives-source-ledger",
     "base": "main",
-    "status": "blocked_dependency",
+    "status": "local_validated",
     "train_scope": "fa30_competitor_alternatives_source_ledger",
     "title": "FA30-API-10: Add competitor alternatives source-ledger contract",
     "depends_on": [
@@ -59880,33 +59885,34 @@
         "evidence": "User explicitly provided FA30-API-10 id, title, scope, and authorized manifest/state updates in the FermatMind FA30 Evidence And Backend Authority Sequence plan."
       },
       "dependency": {
-        "status": "blocked",
-        "evidence": "FA30-API-10 must wait until FA30-API-09 is merged."
+        "status": "pass",
+        "evidence": "FA30-API-09 merged as PR #2350 at 2026-06-23T01:36:51Z; origin/main contains merge commit 42fb4cfa2ddc29c6e36e37b5518ec4d6ebf26087."
       },
       "local": {
-        "status": "pending",
+        "status": "pass",
         "commands": [
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CompetitorAlternativesSourceLedgerTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_competitor_alternatives_source_ledger_files --no-ansi",
           "cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict --no-ansi",
-          "cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "python3 -m json.tool backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json >/dev/null",
           "python3 -m json.tool backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json >/dev/null",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
           "git diff --check"
         ],
-        "evidence": null
+        "evidence": "PASS: CompetitorAlternativesSourceLedgerTest (4 tests, 125 assertions); PASS: BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_competitor_alternatives_source_ledger_files (1 assertion); PASS: read-only audit command emitted ok=true with 3 ledger entries, 0 indexable entries, and 0 issues; PASS: scoped Pint; PASS: source/generated/state JSON parse; PASS: YAML parse; PASS: git diff --check."
       },
       "scope_validation": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are limited to FA30-API-10 allowed paths: competitor alternatives source-ledger source package, generated artifact, docs note, read-only audit command, validator service, focused PHPUnit test, Big Five runtime-freeze classifier allowlist test, and docs/codex metadata. No scraping, competitor copy, public page, frontend route, SEO runtime, sitemap, llms, canonical, JSON-LD, CMS write, production DB write, queue, scheduler, external write, deploy, or search submission."
       },
       "github": {
         "status": "pending",
         "evidence": null
       }
     },
-    "failure_reason": "Dependency FA30-API-09 is not merged yet.",
+    "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
@@ -59917,6 +59923,16 @@
         "at": "2026-06-23T01:10:05Z",
         "status": "blocked_dependency",
         "note": "Manifest/state entry authorized for the future competitor alternatives source-ledger PR, but implementation must wait until FA30-API-09 is merged. No scraping, competitor copy, frontend route, SEO runtime, sitemap, llms, CMS write, DB write, deploy, or search submission is allowed."
+      },
+      {
+        "at": "2026-06-23T01:38:00Z",
+        "status": "in_progress",
+        "note": "Started from clean origin/main after FA30-API-09 merge cleanup. Scope is limited to backend-only competitor alternatives source-ledger contract, source package, read-only validator/audit command, focused tests, Big Five runtime-freeze classifier allowlist test, and docs/codex metadata. No scraping, competitor copy, public page, frontend route, SEO runtime, sitemap, llms, CMS write, production DB write, deploy, external write, or search submission is allowed."
+      },
+      {
+        "at": "2026-06-23T01:46:00Z",
+        "status": "local_validated",
+        "note": "Focused PHPUnit, Big Five runtime-freeze classifier allowlist test, read-only audit command, scoped Pint, JSON/YAML parsing, diff check, and explicit path allowlist scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59873,7 +59873,7 @@
     "repo": "fap-api",
     "branch": "codex/fa30-api-10-competitor-alternatives-source-ledger",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "fa30_competitor_alternatives_source_ledger",
     "title": "FA30-API-10: Add competitor alternatives source-ledger contract",
     "depends_on": [
@@ -59913,8 +59913,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "4de20a66e52b6a5ce1c962210c204fc9b8b334bc",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2353",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -59933,6 +59933,11 @@
         "at": "2026-06-23T01:46:00Z",
         "status": "local_validated",
         "note": "Focused PHPUnit, Big Five runtime-freeze classifier allowlist test, read-only audit command, scoped Pint, JSON/YAML parsing, diff check, and explicit path allowlist scope validation passed."
+      },
+      {
+        "at": "2026-06-23T01:49:00Z",
+        "status": "pr_open",
+        "note": "Opened PR #2353 after local validation and scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24487,6 +24487,7 @@ prs:
       - backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json
       - backend/docs/seo/competitor-alternatives-source-ledger.md
       - backend/tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - generated/pr-train-sidecar-issues/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
@@ -24497,8 +24498,9 @@ prs:
       - Write CMS rows, production DB rows, queues, or external provider records.
     validation:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CompetitorAlternativesSourceLedgerTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_competitor_alternatives_source_ledger_files --no-ansi
       - cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict --no-ansi
-      - cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php
+      - cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - python3 -m json.tool backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json >/dev/null
       - python3 -m json.tool backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json >/dev/null
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"


### PR DESCRIPTION
## What changed
- Added a backend-only competitor alternatives source-ledger package and generated contract artifact.
- Added a read-only audit command plus validator that rejects copied competitor copy, ranking/superiority claims, review/rating/pricing fields, and missing claim/legal review state.
- Added focused PHPUnit coverage and a Big Five runtime-freeze allowlist test for these authority-only files.
- Reconciled FA30-API-09 merged cleanup state and activated FA30-API-10 dependency status.

## Why
- Establishes source-ledger authority before any future alternatives-page runtime work.
- Keeps comparison surfaces grounded in operator-reviewed notes and first-party FermatMind facts, not scraped or copied competitor content.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=CompetitorAlternativesSourceLedgerTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_competitor_alternatives_source_ledger_files --no-ansi`
- `cd backend && php artisan competitor-alternatives:source-ledger-audit --json --strict --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/CompetitorAlternativesSourceLedgerAuditCommand.php app/Services/SeoIntel/CompetitorAlternativesSourceLedgerValidator.php tests/Feature/SeoIntel/CompetitorAlternativesSourceLedgerTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/seo/import-packages/competitor-alternatives-source-ledger/competitor_alternatives_source_ledger.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/generated/competitor-alternatives-source-ledger.v1.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`

## Intentionally deferred
- No competitor scraping, copied competitor copy, ratings, reviews, prices, rankings, testimonials, or recommendations.
- No public alternatives pages, frontend renderer, runtime route, SEO runtime, sitemap, llms, canonical, noindex, JSON-LD, queue, scheduler, provider call, URL submission, or search submission.
- No CMS write, production DB write, import, publish, external write, or production deploy.

## Repository rule impact
- New alternatives source-ledger remains backend-authoritative and internal only.
- Future public alternatives pages must consume reviewed source-ledger authority and must not add frontend fallback content.