### PR TITLE
PR-M: Add article post-publish propagation dry-run

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php
@@ -1,0 +1,506 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\SeoIntel\UrlTruthHandoffArtifact;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SeoAgentArticlePostPublishPropagationDryRunCommand extends Command
+{
+    private const SCHEMA_VERSION = 'seo-agent-article-post-publish-propagation-dry-run.v1';
+
+    private const PUBLISH_SCHEMA_VERSION = 'seo-agent-article-cms-publish-canary.v1';
+
+    private const SEO_TITLE_MAX_LENGTH = 60;
+
+    private const ARTICLE_PAGE_TYPE = 'article';
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_md',
+        'content_html',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-agent:article-post-publish-propagation-dry-run
+        {--publish-evidence= : Path to seo-agent-article-cms-publish-canary.v1 JSON evidence}
+        {--target= : Exact article subject ref, e.g. article:41:en}
+        {--revision-id= : Exact SEO Agent ArticleRevision id that was published}
+        {--limit=1 : Bounded target count; must equal 1}
+        {--artifact-dir= : Directory for sanitized propagation dry-run evidence}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only SEO Agent article post-publish propagation dry-run; plans URL Truth/search readiness without writes or submissions.';
+
+    public function handle(UrlTruthHandoffArtifact $urlTruthArtifact): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary('artifact_dir_unwritable'));
+        }
+
+        $input = $this->loadInput();
+        if (($input['issue'] ?? null) !== null) {
+            $summary = $this->failureSummary((string) $input['issue'], (array) ($input['extra'] ?? []));
+            $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $target = trim((string) $this->option('target'));
+        $revisionId = filter_var($this->option('revision-id'), FILTER_VALIDATE_INT);
+        $limit = filter_var($this->option('limit'), FILTER_VALIDATE_INT);
+        $publishEvidence = (array) $input['publish_evidence'];
+        $publishEvidenceSha = (string) $input['publish_evidence_sha256'];
+
+        $issues = [];
+        if ($limit !== 1) {
+            $issues[] = 'limit_must_equal_one';
+        }
+        if ($target === '' || str_contains($target, "\0") || ! is_int($revisionId) || $revisionId <= 0) {
+            $issues[] = 'target_or_revision_invalid';
+        }
+        $evidenceIssue = $this->validatePublishEvidence($publishEvidence, $target, is_int($revisionId) ? $revisionId : 0);
+        if ($evidenceIssue !== null) {
+            $issues[] = $evidenceIssue;
+        }
+
+        $articleId = $this->articleIdFromTarget($target);
+        $article = $articleId > 0
+            ? Article::query()
+                ->withoutGlobalScopes()
+                ->with([
+                    'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                    'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                ])
+                ->find($articleId)
+            : null;
+        $draftRevision = is_int($revisionId) && $revisionId > 0
+            ? ArticleRevision::query()->withoutGlobalScopes()->find($revisionId)
+            : null;
+
+        if (! $article instanceof Article) {
+            $issues[] = 'article_not_found';
+        }
+        if (! $draftRevision instanceof ArticleRevision) {
+            $issues[] = 'source_article_revision_not_found';
+        } elseif ($article instanceof Article && (int) $draftRevision->article_id !== (int) $article->id) {
+            $issues[] = 'source_article_revision_article_mismatch';
+        }
+
+        $runtime = $article instanceof Article
+            ? $this->runtimeReadiness($article, $target, is_int($revisionId) ? $revisionId : 0)
+            : null;
+        foreach ((array) ($runtime['blocking_issues'] ?? []) as $issue) {
+            $issues[] = (string) $issue;
+        }
+
+        if ($issues !== []) {
+            $summary = $this->failureSummary('post_publish_propagation_not_ready', [
+                'issues' => array_values(array_unique($issues)),
+                'target' => $target,
+                'revision_id' => $revisionId,
+                'publish_evidence_sha256' => $publishEvidenceSha,
+                'runtime' => $runtime,
+            ]);
+            $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        /** @var Article $article */
+        $canonicalPath = $this->canonicalPathForArticle($article);
+        $canonicalUrl = $this->canonicalUrl($canonicalPath);
+        $urlTruthSupported = $urlTruthArtifact->supportsPageEntityType(self::ARTICLE_PAGE_TYPE);
+        $searchBridgeSupported = false;
+        $adapterGaps = [];
+        if (! $urlTruthSupported) {
+            $adapterGaps[] = 'url_truth_article_page_type_not_supported';
+        }
+        if (! $searchBridgeSupported) {
+            $adapterGaps[] = 'post_publish_search_bridge_article_evidence_not_supported';
+        }
+
+        $summary = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => true,
+            'status' => $adapterGaps === [] ? 'planned' : 'ready_with_adapter_gap',
+            'dry_run' => true,
+            'execute' => false,
+            'target' => $target,
+            'revision_id' => $revisionId,
+            'publish_evidence_sha256' => $publishEvidenceSha,
+            'canonical' => [
+                'safe_path' => $canonicalPath,
+                'canonical_url_hash' => hash('sha256', $canonicalUrl),
+                'canonical_url_host' => parse_url($canonicalUrl, PHP_URL_HOST),
+            ],
+            'runtime' => $runtime,
+            'sitemap_llms' => [
+                'already_sitemap_eligible' => (bool) $article->sitemap_eligible,
+                'already_llms_eligible' => (bool) $article->llms_eligible,
+                'discoverability_release_required' => ! ((bool) $article->sitemap_eligible && (bool) $article->llms_eligible),
+                'discoverability_write_attempted' => false,
+                'sitemap_llms_mutation_attempted' => false,
+            ],
+            'url_truth_readiness' => [
+                'page_type' => self::ARTICLE_PAGE_TYPE,
+                'subject_ref' => $target,
+                'entity_ref' => 'article:'.(int) $article->id.':'.(string) $article->locale,
+                'source_authority' => 'backend_cms_article',
+                'public' => (bool) $article->is_public,
+                'indexable' => (bool) $article->is_indexable,
+                'url_truth_page_type_supported' => $urlTruthSupported,
+                'url_truth_adapter_required' => ! $urlTruthSupported,
+                'url_truth_write_attempted' => false,
+            ],
+            'search_channel_readiness' => [
+                'channels' => ['indexnow'],
+                'google_sitemap_planning_only' => true,
+                'article_publish_evidence_bridge_supported' => $searchBridgeSupported,
+                'search_channel_adapter_required' => ! $searchBridgeSupported,
+                'queue_enqueue_attempted' => false,
+                'live_submit_attempted' => false,
+                'external_api_calls_attempted' => false,
+            ],
+            'adapter_gaps' => $adapterGaps,
+            'next_gates' => [
+                'url_truth_write_requires_separate_approval' => true,
+                'search_channel_enqueue_requires_separate_approval' => true,
+                'indexnow_live_submit_requires_separate_approval' => true,
+            ],
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ];
+        $summary['artifact'] = $this->writeArtifact($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadInput(): array
+    {
+        $path = $this->readablePath((string) $this->option('publish-evidence'));
+        if ($path === null) {
+            return ['issue' => 'publish_evidence_unreadable'];
+        }
+
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return [
+                'issue' => 'forbidden_input_field_present',
+                'extra' => ['forbidden_matches' => $forbidden],
+            ];
+        }
+
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            return ['issue' => 'publish_evidence_json_invalid'];
+        }
+
+        return [
+            'publish_evidence' => $payload,
+            'publish_evidence_sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    private function validatePublishEvidence(array $evidence, string $target, int $revisionId): ?string
+    {
+        if (($evidence['schema_version'] ?? null) !== self::PUBLISH_SCHEMA_VERSION) {
+            return 'publish_evidence_schema_invalid';
+        }
+        if (($evidence['status'] ?? null) !== 'success' || (bool) ($evidence['execute'] ?? false) !== true) {
+            return 'publish_evidence_not_success_execute';
+        }
+        if ((int) ($evidence['published_count'] ?? 0) !== 1 || (bool) ($evidence['writes_committed'] ?? false) !== true) {
+            return 'publish_evidence_missing_one_committed_publish';
+        }
+        if (($evidence['target'] ?? null) !== $target || (int) ($evidence['revision_id'] ?? 0) !== $revisionId) {
+            return 'publish_evidence_target_revision_mismatch';
+        }
+        if ((bool) data_get($evidence, 'boundaries.url_truth_write') !== false
+            || (bool) data_get($evidence, 'boundaries.indexnow_submit') !== false
+            || (bool) data_get($evidence, 'boundaries.search_channel_enqueue') !== false
+            || (bool) data_get($evidence, 'boundaries.search_channel_submit') !== false
+            || (bool) data_get($evidence, 'boundaries.indexing_request') !== false) {
+            return 'publish_evidence_boundary_invalid';
+        }
+
+        $publishedRefFound = false;
+        foreach ((array) ($evidence['affected_refs'] ?? []) as $ref) {
+            if (! is_array($ref) || ($ref['status'] ?? null) !== 'published') {
+                continue;
+            }
+            $publishedRefFound = true;
+            if (($ref['target_model'] ?? null) !== 'article'
+                || ($ref['subject_ref'] ?? null) !== $target
+                || (int) ($ref['revision_id'] ?? 0) !== $revisionId
+                || (int) ($ref['article_translation_revision_id'] ?? 0) <= 0) {
+                return 'publish_evidence_affected_ref_invalid';
+            }
+        }
+
+        return $publishedRefFound ? null : 'publish_evidence_published_ref_missing';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function runtimeReadiness(Article $article, string $target, int $revisionId): array
+    {
+        $publishedRevision = $article->publishedRevision;
+        $seoMeta = $article->seoMeta;
+        $canonicalPath = $this->canonicalPathForArticle($article);
+        $blocking = [];
+        $seoTitle = $this->firstNonEmpty(
+            $publishedRevision instanceof ArticleTranslationRevision ? $publishedRevision->seo_title : null,
+            $seoMeta instanceof ArticleSeoMeta ? $seoMeta->seo_title : null,
+        );
+        $seoTitleLength = mb_strlen($seoTitle);
+
+        if ((string) $article->status !== 'published') {
+            $blocking[] = 'article_not_published';
+        }
+        if (! (bool) $article->is_public) {
+            $blocking[] = 'article_not_public';
+        }
+        if (! (bool) $article->is_indexable) {
+            $blocking[] = 'article_not_indexable';
+        }
+        if (! $publishedRevision instanceof ArticleTranslationRevision) {
+            $blocking[] = 'published_revision_missing';
+        } elseif ((int) $publishedRevision->article_id !== (int) $article->id
+            || (string) $publishedRevision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            $blocking[] = 'published_revision_invalid';
+        }
+        if (! $seoMeta instanceof ArticleSeoMeta) {
+            $blocking[] = 'seo_meta_missing';
+        } else {
+            $actualCanonicalPath = $this->pathFromCanonical((string) $seoMeta->canonical_url);
+            if ($actualCanonicalPath !== '' && $actualCanonicalPath !== $canonicalPath) {
+                $blocking[] = 'canonical_path_mismatch';
+            }
+            if (! (bool) $seoMeta->is_indexable || (string) $seoMeta->robots !== 'index,follow') {
+                $blocking[] = 'seo_meta_not_index_follow';
+            }
+        }
+        if ($seoTitle === '' || $seoTitleLength > self::SEO_TITLE_MAX_LENGTH) {
+            $blocking[] = 'seo_title_length_invalid';
+        }
+
+        return [
+            'article_id' => (int) $article->id,
+            'target' => $target,
+            'source_article_revision_id' => $revisionId,
+            'status' => (string) $article->status,
+            'locale' => (string) $article->locale,
+            'safe_path' => $canonicalPath,
+            'public' => (bool) $article->is_public,
+            'indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_status' => $publishedRevision instanceof ArticleTranslationRevision
+                ? (string) $publishedRevision->revision_status
+                : null,
+            'published_revision_article_id' => $publishedRevision instanceof ArticleTranslationRevision
+                ? (int) $publishedRevision->article_id
+                : null,
+            'seo_title_length' => $seoTitleLength,
+            'seo_title_max_length' => self::SEO_TITLE_MAX_LENGTH,
+            'seo_description_length' => mb_strlen($this->firstNonEmpty(
+                $publishedRevision instanceof ArticleTranslationRevision ? $publishedRevision->seo_description : null,
+                $seoMeta instanceof ArticleSeoMeta ? $seoMeta->seo_description : null,
+            )),
+            'blocking_issues' => array_values(array_unique($blocking)),
+        ];
+    }
+
+    private function articleIdFromTarget(string $target): int
+    {
+        $parts = explode(':', $target);
+        if (count($parts) < 3 || $parts[0] !== 'article') {
+            return 0;
+        }
+
+        return ctype_digit($parts[1]) ? (int) $parts[1] : 0;
+    }
+
+    private function canonicalPathForArticle(Article $article): string
+    {
+        $segment = str_starts_with(strtolower(trim((string) $article->locale)), 'zh') ? 'zh' : 'en';
+
+        return '/'.$segment.'/articles/'.rawurlencode((string) $article->slug);
+    }
+
+    private function canonicalUrl(string $canonicalPath): string
+    {
+        $base = rtrim((string) config('app.url', 'https://fermatmind.com'), '/');
+        if ($base === '') {
+            $base = 'https://fermatmind.com';
+        }
+
+        return $base.$canonicalPath;
+    }
+
+    private function pathFromCanonical(string $canonical): string
+    {
+        $canonical = trim($canonical);
+        if ($canonical === '') {
+            return '';
+        }
+        if (str_starts_with($canonical, '/')) {
+            return $canonical;
+        }
+
+        $path = parse_url($canonical, PHP_URL_PATH);
+
+        return is_string($path) ? $path : '';
+    }
+
+    private function firstNonEmpty(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) && is_readable($path) ? $path : null;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            $dir = storage_path('app/seo-agent/article-post-publish-propagation-dry-run');
+        }
+        $dir = str_starts_with($dir, '/') ? $dir : base_path($dir);
+        File::ensureDirectoryExists($dir, 0775, true);
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return array_values(array_unique($matches));
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function negativeGuarantees(): array
+    {
+        return [
+            'database_write' => false,
+            'cms_write' => false,
+            'cms_publish' => false,
+            'url_truth_write' => false,
+            'sitemap_llms_mutation' => false,
+            'search_channel_enqueue' => false,
+            'search_channel_submit' => false,
+            'indexnow_submit' => false,
+            'indexing_request' => false,
+            'scheduler_activation' => false,
+            'queue_worker_start' => false,
+            'external_model_api_call' => false,
+            'external_search_api_call' => false,
+            'live_gsc_api_call' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array{path: string, size_bytes: int, sha256: string}
+     */
+    private function writeArtifact(string $artifactDir, array $summary): array
+    {
+        $path = rtrim($artifactDir, '/').'/seo-agent-article-post-publish-propagation-dry-run-'.Carbon::now('UTC')->format('Ymd\THis\Z').'.json';
+        File::put($path, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return [
+            'path' => $path,
+            'size_bytes' => filesize($path) ?: 0,
+            'sha256' => hash_file('sha256', $path) ?: '',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue, array $extra = []): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => true,
+            'execute' => false,
+            'issue' => $issue,
+            'issues' => array_values(array_unique((array) ($extra['issues'] ?? [$issue]))),
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'negative_guarantees' => $this->negativeGuarantees(),
+        ] + $extra;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } else {
+            foreach (['status', 'dry_run', 'target', 'revision_id'] as $key) {
+                if (array_key_exists($key, $summary)) {
+                    $this->line($key.'='.(string) $summary[$key]);
+                }
+            }
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -189,6 +189,7 @@ use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SeoAgentArticleCmsPublishCanaryCommand;
 use App\Console\Commands\SeoAgentArticleDraftClaimRiskQaCommand;
 use App\Console\Commands\SeoAgentArticleDraftPreviewRuntimeQaCommand;
+use App\Console\Commands\SeoAgentArticlePostPublishPropagationDryRunCommand;
 use App\Console\Commands\SeoAgentAutoRollbackGuardCommand;
 use App\Console\Commands\SeoAgentCmsDraftPackageDryRunCommand;
 use App\Console\Commands\SeoAgentCmsDraftPayloadRepairCanaryCommand;
@@ -427,6 +428,7 @@ class Kernel extends ConsoleKernel
         SeoAgentCmsFaqGapScanCommand::class,
         SeoAgentAutoRollbackGuardCommand::class,
         SeoAgentArticleCmsPublishCanaryCommand::class,
+        SeoAgentArticlePostPublishPropagationDryRunCommand::class,
         SeoAgentArticleDraftClaimRiskQaCommand::class,
         SeoAgentArticleDraftPreviewRuntimeQaCommand::class,
         SeoAgentCmsTdkGapScanCommand::class,

--- a/backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json
+++ b/backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json
@@ -1,0 +1,58 @@
+{
+  "version": "seo-agent-article-post-publish-propagation-dry-run.v1",
+  "task": "SEO-AGENT-ARTICLE-POST-PUBLISH-PROPAGATION-DRY-RUN-01",
+  "repo": "fap-api",
+  "command": "php artisan seo-agent:article-post-publish-propagation-dry-run",
+  "input_schema": "seo-agent-article-cms-publish-canary.v1",
+  "output_schema": "seo-agent-article-post-publish-propagation-dry-run.v1",
+  "default_mode": "dry_run_only",
+  "supported_targets_v1": [
+    "article"
+  ],
+  "required_inputs": [
+    "--publish-evidence=<seo-agent-article-cms-publish-canary evidence>",
+    "--target=article:<id>:<locale>",
+    "--revision-id=<article_revision_id>",
+    "--limit=1"
+  ],
+  "dry_run_checks": [
+    "publish evidence success and one committed publish",
+    "target and revision lock match",
+    "article is published, public, and indexable",
+    "published revision pointer is valid",
+    "SEO title length is at most 60 characters",
+    "sitemap and llms eligibility is observed without mutation",
+    "URL Truth article support is reported without write",
+    "Search Channel and IndexNow article bridge support is reported without enqueue or submission"
+  ],
+  "status_values": [
+    "planned",
+    "ready_with_adapter_gap",
+    "blocked"
+  ],
+  "adapter_gap_behavior": {
+    "url_truth_article_page_type_not_supported": "reported as readiness gap only when the installed URL Truth artifact service does not support article page type; no DB write is attempted",
+    "post_publish_search_bridge_article_evidence_not_supported": "reported as readiness gap; no queue enqueue or live submission is attempted"
+  },
+  "negative_guarantees": {
+    "database_write": false,
+    "cms_write": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "sitemap_llms_mutation": false,
+    "search_channel_enqueue": false,
+    "search_channel_submit": false,
+    "indexnow_submit": false,
+    "indexing_request": false,
+    "scheduler_activation": false,
+    "queue_worker_start": false,
+    "external_model_api_call": false,
+    "external_search_api_call": false,
+    "live_gsc_api_call": false
+  },
+  "post_dry_run_gates": [
+    "URL Truth write requires a separate exact approval",
+    "Search Channel enqueue requires a separate exact approval",
+    "IndexNow live submit requires a separate exact approval"
+  ]
+}

--- a/backend/tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\Article;
+use App\Models\ArticleRevision;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoAgentArticlePostPublishPropagationDryRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_outputs_article_propagation_readiness_without_writes(): void
+    {
+        $fixture = $this->fixture();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:article-post-publish-propagation-dry-run', [
+            '--publish-evidence' => $fixture['publish_evidence_path'],
+            '--target' => $fixture['target'],
+            '--revision-id' => $fixture['article_revision_id'],
+            '--limit' => 1,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('ready_with_adapter_gap', $summary['status'] ?? null);
+        $this->assertSame('/en/articles/article-candidate', data_get($summary, 'canonical.safe_path'));
+        $this->assertSame($fixture['target'], data_get($summary, 'runtime.target'));
+        $this->assertSame($fixture['published_revision_id'], data_get($summary, 'runtime.published_revision_id'));
+        $this->assertSame(35, data_get($summary, 'runtime.seo_title_length'));
+        $this->assertTrue((bool) data_get($summary, 'sitemap_llms.already_sitemap_eligible'));
+        $this->assertTrue((bool) data_get($summary, 'sitemap_llms.already_llms_eligible'));
+        $this->assertTrue((bool) data_get($summary, 'url_truth_readiness.url_truth_page_type_supported'));
+        $this->assertFalse((bool) data_get($summary, 'url_truth_readiness.url_truth_adapter_required', true));
+        $this->assertTrue((bool) data_get($summary, 'search_channel_readiness.search_channel_adapter_required'));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.database_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.url_truth_write', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'negative_guarantees.indexnow_submit', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
+        $this->assertSame($summary['status'] ?? null, $artifact['status'] ?? null);
+        $this->assertSame($fixture['publish_evidence_sha256'], $artifact['publish_evidence_sha256'] ?? null);
+    }
+
+    #[Test]
+    public function dry_run_blocks_wrong_target_or_revision_lock(): void
+    {
+        $fixture = $this->fixture();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:article-post-publish-propagation-dry-run', [
+            '--publish-evidence' => $fixture['publish_evidence_path'],
+            '--target' => 'article:999:en',
+            '--revision-id' => $fixture['article_revision_id'],
+            '--limit' => 1,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('publish_evidence_target_revision_mismatch', $summary['issues'] ?? []);
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function dry_run_blocks_invalid_publish_evidence_schema(): void
+    {
+        $fixture = $this->fixture(['publish_schema_version' => 'wrong.v1']);
+
+        $exitCode = Artisan::call('seo-agent:article-post-publish-propagation-dry-run', [
+            '--publish-evidence' => $fixture['publish_evidence_path'],
+            '--target' => $fixture['target'],
+            '--revision-id' => $fixture['article_revision_id'],
+            '--limit' => 1,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('publish_evidence_schema_invalid', $summary['issues'] ?? []);
+    }
+
+    #[Test]
+    public function dry_run_blocks_article_that_is_not_public_indexable_and_published(): void
+    {
+        $fixture = $this->fixture([
+            'article_status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-agent:article-post-publish-propagation-dry-run', [
+            '--publish-evidence' => $fixture['publish_evidence_path'],
+            '--target' => $fixture['target'],
+            '--revision-id' => $fixture['article_revision_id'],
+            '--limit' => 1,
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('article_not_published', $summary['issues'] ?? []);
+        $this->assertContains('article_not_public', $summary['issues'] ?? []);
+        $this->assertContains('article_not_indexable', $summary['issues'] ?? []);
+        $this->assertSame($countsBefore, $this->rowCounts());
+    }
+
+    #[Test]
+    public function generated_contract_documents_article_propagation_boundaries(): void
+    {
+        $contract = $this->readJson(base_path('docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json'));
+
+        $this->assertSame('seo-agent-article-post-publish-propagation-dry-run.v1', $contract['version'] ?? null);
+        $this->assertSame('php artisan seo-agent:article-post-publish-propagation-dry-run', $contract['command'] ?? null);
+        $this->assertContains('article', $contract['supported_targets_v1'] ?? []);
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.url_truth_write', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($contract, 'negative_guarantees.indexnow_submit', true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function fixture(array $overrides = []): array
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'article-candidate',
+            'locale' => 'en',
+            'translation_group_id' => (string) Str::uuid(),
+            'source_locale' => 'en',
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => (string) ($overrides['article_status'] ?? 'published'),
+            'is_public' => (bool) ($overrides['is_public'] ?? true),
+            'is_indexable' => (bool) ($overrides['is_indexable'] ?? true),
+            'sitemap_eligible' => (bool) ($overrides['sitemap_eligible'] ?? true),
+            'llms_eligible' => (bool) ($overrides['llms_eligible'] ?? true),
+            'published_at' => now()->subDay(),
+        ]);
+        $publishedRevision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 3,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'seo_title' => 'Improved Article Title | FermatMind',
+            'seo_description' => 'Improved description for search readers.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $publishedRevision->id,
+            'published_revision_id' => (int) $publishedRevision->id,
+        ])->save();
+        ArticleSeoMeta::query()->create([
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Improved Article Title | FermatMind',
+            'seo_description' => 'Improved description for search readers.',
+            'canonical_url' => '/en/articles/article-candidate',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+        $articleRevision = ArticleRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'revision_no' => 3,
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'payload_json' => [
+                'seo_agent' => [
+                    'task' => 'SEO-AGENT-CONTROLLED-CMS-DRAFT-WRITER-01',
+                    'subject_ref' => 'article:'.$article->id.':en',
+                ],
+            ],
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $target = 'article:'.$article->id.':en';
+        $publishEvidencePath = $this->writeJson('seo-agent-article-cms-publish-canary-', [
+            'schema_version' => (string) ($overrides['publish_schema_version'] ?? 'seo-agent-article-cms-publish-canary.v1'),
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'target' => $target,
+            'revision_id' => (int) $articleRevision->id,
+            'writes_committed' => true,
+            'published_count' => 1,
+            'affected_refs' => [
+                [
+                    'status' => 'published',
+                    'target_model' => 'article',
+                    'subject_ref' => $target,
+                    'revision_id' => (int) $articleRevision->id,
+                    'article_translation_revision_id' => (int) $publishedRevision->id,
+                ],
+            ],
+            'rollback_evidence' => [
+                'available' => true,
+            ],
+            'boundaries' => [
+                'cms_publish' => true,
+                'url_truth_write' => false,
+                'sitemap_submission' => false,
+                'indexnow_submit' => false,
+                'search_channel_enqueue' => false,
+                'search_channel_submit' => false,
+                'indexing_request' => false,
+                'scheduler_activation' => false,
+                'queue_worker_start' => false,
+            ],
+        ]);
+
+        return [
+            'article_id' => (int) $article->id,
+            'target' => $target,
+            'article_revision_id' => (int) $articleRevision->id,
+            'published_revision_id' => (int) $publishedRevision->id,
+            'publish_evidence_path' => $publishEvidencePath,
+            'publish_evidence_sha256' => hash_file('sha256', $publishEvidencePath) ?: '',
+        ];
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-agent-article-post-publish-propagation-dry-run-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function writeJson(string $prefix, array $payload): string
+    {
+        $path = storage_path('framework/testing/'.$prefix.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'articles' => Article::query()->withoutGlobalScopes()->count(),
+            'article_revisions' => ArticleRevision::query()->withoutGlobalScopes()->count(),
+            'article_translation_revisions' => ArticleTranslationRevision::query()->withoutGlobalScopes()->count(),
+            'article_seo_meta' => ArticleSeoMeta::query()->withoutGlobalScopes()->count(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4601,6 +4601,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoAgentArticlePostPublishPropagationDryRunFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoAgentCmsPublishAutoCanaryFile($file)) {
                 continue;
             }
@@ -6173,6 +6177,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoAgentArticleCmsPublishCanaryCommand.php',
+        ], true);
+    }
+
+    private function isSeoAgentArticlePostPublishPropagationDryRunFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php',
         ], true);
     }
 
@@ -8490,7 +8501,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/\b(SeoAgentArticleCmsPublishCanaryCommand|SeoAgentAutoRollbackGuardCommand|SeoAgentGscCohortHandoffCommand|SeoAgentGscDraftPublishGateReadinessCommand)\b/u', $line) !== 1) {
+            if (preg_match('/\b(SeoAgentArticleCmsPublishCanaryCommand|SeoAgentArticlePostPublishPropagationDryRunCommand|SeoAgentAutoRollbackGuardCommand|SeoAgentGscCohortHandoffCommand|SeoAgentGscDraftPublishGateReadinessCommand)\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Adds backend-only read-only `seo-agent:article-post-publish-propagation-dry-run` for SEO Agent article publish canaries.
- Consumes `seo-agent-article-cms-publish-canary.v1` evidence and emits a sanitized propagation dry-run artifact.
- Reports runtime SEO, sitemap/llms eligibility, URL Truth readiness, and Search Channel / IndexNow adapter gaps without writes or submissions.

## Why
`seo-agent:post-publish-search-submit` currently supports ContentPage evidence only. Article publish canaries need their own dry-run closeout evidence before any separate URL Truth, queue, or IndexNow gates.

## Validation
- `cd backend && php artisan list | grep 'seo-agent:article-post-publish-propagation-dry-run'`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticlePostPublishPropagationDryRunTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleCmsPublishCanaryTest`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php app/Console/Kernel.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json >/dev/null`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No production dry-run was executed in this PR.
- No URL Truth write.
- No sitemap/llms mutation.
- No Search Channel enqueue.
- No IndexNow or other live search/indexing submission.
- Remaining GSC cohort candidates stay paused until article:41 post-publish propagation dry-run evidence is collected after deploy.
