### PR TITLE
PR-N: Use public canonical host for article propagation

### DIFF
--- a/backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php
+++ b/backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php
@@ -23,6 +23,13 @@ final class SeoAgentArticlePostPublishPropagationDryRunCommand extends Command
 
     private const ARTICLE_PAGE_TYPE = 'article';
 
+    private const PUBLIC_CANONICAL_BASE_URL = 'https://fermatmind.com';
+
+    private const PUBLIC_CANONICAL_HOSTS = [
+        'fermatmind.com',
+        'www.fermatmind.com',
+    ];
+
     private const FORBIDDEN_STRINGS = [
         'raw_url',
         'raw_query',
@@ -354,9 +361,10 @@ final class SeoAgentArticlePostPublishPropagationDryRunCommand extends Command
 
     private function canonicalUrl(string $canonicalPath): string
     {
-        $base = rtrim((string) config('app.url', 'https://fermatmind.com'), '/');
-        if ($base === '') {
-            $base = 'https://fermatmind.com';
+        $base = rtrim((string) config('seo_intel.public_canonical_host', self::PUBLIC_CANONICAL_BASE_URL), '/');
+        $host = strtolower((string) parse_url($base, PHP_URL_HOST));
+        if ($base === '' || ! in_array($host, self::PUBLIC_CANONICAL_HOSTS, true)) {
+            $base = self::PUBLIC_CANONICAL_BASE_URL;
         }
 
         return $base.$canonicalPath;

--- a/backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json
+++ b/backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json
@@ -21,10 +21,20 @@
     "article is published, public, and indexable",
     "published revision pointer is valid",
     "SEO title length is at most 60 characters",
+    "canonical URL planning uses seo_intel.public_canonical_host and never app.url/ops host as public canonical authority",
     "sitemap and llms eligibility is observed without mutation",
     "URL Truth article support is reported without write",
     "Search Channel and IndexNow article bridge support is reported without enqueue or submission"
   ],
+  "canonical_host_policy": {
+    "config_key": "seo_intel.public_canonical_host",
+    "default": "https://fermatmind.com",
+    "allowed_hosts": [
+      "fermatmind.com",
+      "www.fermatmind.com"
+    ],
+    "app_url_usage": "not used for public canonical URL planning"
+  },
   "status_values": [
     "planned",
     "ready_with_adapter_gap",

--- a/backend/tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php
@@ -22,6 +22,11 @@ final class SeoAgentArticlePostPublishPropagationDryRunTest extends TestCase
     #[Test]
     public function dry_run_outputs_article_propagation_readiness_without_writes(): void
     {
+        config([
+            'app.url' => 'https://ops.fermatmind.com',
+            'seo_intel.public_canonical_host' => 'https://fermatmind.com',
+        ]);
+
         $fixture = $this->fixture();
         $countsBefore = $this->rowCounts();
 
@@ -39,6 +44,11 @@ final class SeoAgentArticlePostPublishPropagationDryRunTest extends TestCase
         $this->assertTrue((bool) ($summary['ok'] ?? false));
         $this->assertSame('ready_with_adapter_gap', $summary['status'] ?? null);
         $this->assertSame('/en/articles/article-candidate', data_get($summary, 'canonical.safe_path'));
+        $this->assertSame('fermatmind.com', data_get($summary, 'canonical.canonical_url_host'));
+        $this->assertSame(
+            hash('sha256', 'https://fermatmind.com/en/articles/article-candidate'),
+            data_get($summary, 'canonical.canonical_url_hash')
+        );
         $this->assertSame($fixture['target'], data_get($summary, 'runtime.target'));
         $this->assertSame($fixture['published_revision_id'], data_get($summary, 'runtime.published_revision_id'));
         $this->assertSame(35, data_get($summary, 'runtime.seo_title_length'));
@@ -55,6 +65,7 @@ final class SeoAgentArticlePostPublishPropagationDryRunTest extends TestCase
 
         $artifact = $this->readJson((string) data_get($summary, 'artifact.path'));
         $this->assertSame($summary['status'] ?? null, $artifact['status'] ?? null);
+        $this->assertSame('fermatmind.com', data_get($artifact, 'canonical.canonical_url_host'));
         $this->assertSame($fixture['publish_evidence_sha256'], $artifact['publish_evidence_sha256'] ?? null);
     }
 


### PR DESCRIPTION
## Summary
- Update `seo-agent:article-post-publish-propagation-dry-run` so article canonical URL planning uses `seo_intel.public_canonical_host` instead of `app.url`.
- Fail closed to `https://fermatmind.com` when the configured canonical host is empty or not a public FermatMind site host.
- Add regression coverage for production-style `app.url=https://ops.fermatmind.com` while still emitting `canonical_url_host=fermatmind.com`.

## Why
PR-M production evidence showed the safe path was correct, but canonical URL planning inherited the ops host from `app.url`. URL Truth / IndexNow planning must use the public canonical site host before any future propagation gate.

## Validation
- `cd backend && php -l app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticlePostPublishPropagationDryRunTest`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php`
- `python3 -m json.tool backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json >/dev/null`
- `cd backend && php artisan list | grep 'seo-agent:article-post-publish-propagation-dry-run'`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticleCmsPublishCanaryTest`
- `git diff --check -- backend/app/Console/Commands/SeoAgentArticlePostPublishPropagationDryRunCommand.php backend/tests/Feature/SeoIntel/SeoAgentArticlePostPublishPropagationDryRunTest.php backend/docs/seo/generated/seo-agent-article-post-publish-propagation-dry-run.v1.json`

## Intentionally Deferred
- No production deploy in this PR.
- No production dry-run execution in this PR.
- No URL Truth write, sitemap/llms mutation, Search Channel enqueue, IndexNow submit, scheduler activation, queue worker start, external model API, or live GSC/search API call.

## Repository Rule Impact
Backend SEO propagation evidence only; no content authority, publishing SOP, public API contract, or frontend content ownership changes.
