### PR TITLE
MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -16,6 +16,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01';
 
+    private const AGENT_BATCH_OPERATOR_APPROVAL = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
     private const WRITE_SAFETY_FLAGS = [
         'draft-only',
         'no-publish',
@@ -31,6 +33,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--dry-run : Validate and plan without database writes}
         {--write : Create CMS projection draft revision rows}
         {--visible-query-backed-3 : Restrict planning/write to the approved 3 query-backed visible MBTI64 URLs}
+        {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
+        {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--draft-only : Required for --write; confirms revision draft only}
@@ -121,9 +125,11 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             }
         }
 
-        $expectedApproval = (bool) $this->option('visible-query-backed-3')
-            ? self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL
-            : self::OPERATOR_APPROVAL;
+        $expectedApproval = match (true) {
+            (bool) $this->option('visible-query-backed-3') => self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL,
+            $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
+            default => self::OPERATOR_APPROVAL,
+        };
 
         if ((string) $this->option('operator-approved') !== $expectedApproval) {
             throw new RuntimeException('--operator-approved='.$expectedApproval.' is required with --write.');
@@ -152,6 +158,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'dry_run' => (bool) $this->option('dry-run'),
             'write' => (bool) $this->option('write'),
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
+            'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
+            'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),
             'no_publish' => (bool) $this->option('no-publish'),
             'no_index' => (bool) $this->option('no-index'),
@@ -160,6 +168,12 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'no_search_release' => (bool) $this->option('no-search-release'),
             'operator_approved' => (string) $this->option('operator-approved'),
         ];
+    }
+
+    private function agentBatchRequested(): bool
+    {
+        return trim((string) $this->option('agent-batch-size')) !== ''
+            || trim((string) $this->option('agent-batch-offset')) !== '';
     }
 
     /**

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -24,6 +24,8 @@ final class Mbti64CmsProjectionDraftWriter
         'https://fermatmind.com/zh/personality/esfp-a',
     ];
 
+    private const AGENT_BATCH_ALLOWED_SIZES = [5, 10];
+
     private const FORBIDDEN_ROUTE_PATTERNS = [
         '#/results?(?:/|$)#i',
         '#/orders?(?:/|$)#i',
@@ -149,6 +151,7 @@ final class Mbti64CmsProjectionDraftWriter
                 'row_count' => count($preparedRows),
                 'variant_row_count' => $this->countRows($preparedRows, 'variant'),
                 'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
+                'subset' => $this->subsetSummary($options, $preparedRows),
                 'rows' => $preparedRows,
                 'errors' => $errors,
                 'warnings' => $warnings,
@@ -197,6 +200,7 @@ final class Mbti64CmsProjectionDraftWriter
             'skipped_existing_count' => $skippedExisting,
             'would_create_revision_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
             'writes_committed' => $write && $created > 0,
+            'subset' => $this->subsetSummary($options, $preparedRows),
             'rows' => $preparedRows,
             'errors' => [],
             'warnings' => $warnings,
@@ -288,8 +292,30 @@ final class Mbti64CmsProjectionDraftWriter
     private function recommendationsForOptions(array $package, array $options, bool $write, array &$errors): array
     {
         $recommendations = $this->recommendations($package);
-        if (! (bool) ($options['visible_query_backed_3'] ?? false)) {
+        $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
+        $agentBatchRequested = $this->agentBatchRequested($options);
+
+        if ($visibleQueryBacked3 && $agentBatchRequested) {
+            $errors[] = [
+                'field' => 'options',
+                'code' => 'exclusive_subset_modes_required',
+                'message' => '--visible-query-backed-3 cannot be combined with --agent-batch-size or --agent-batch-offset.',
+            ];
+
+            return [];
+        }
+
+        if (! $visibleQueryBacked3 && ! $agentBatchRequested) {
             return $recommendations;
+        }
+
+        if ($agentBatchRequested) {
+            $batchOptions = $this->agentBatchOptions($options, count($recommendations), $errors);
+            if ($batchOptions === null) {
+                return [];
+            }
+
+            return array_values(array_slice($recommendations, $batchOptions['offset'], $batchOptions['size']));
         }
 
         $allowed = array_fill_keys(self::VISIBLE_QUERY_BACKED_3_URLS, true);
@@ -311,6 +337,86 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         return $subset;
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function agentBatchRequested(array $options): bool
+    {
+        return trim((string) ($options['agent_batch_size'] ?? '')) !== ''
+            || trim((string) ($options['agent_batch_offset'] ?? '')) !== '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @param  list<array<string,string>>  $errors
+     * @return array{size:int,offset:int}|null
+     */
+    private function agentBatchOptions(array $options, int $recommendationCount, array &$errors): ?array
+    {
+        $rawSize = trim((string) ($options['agent_batch_size'] ?? ''));
+        $rawOffset = trim((string) ($options['agent_batch_offset'] ?? ''));
+
+        if ($rawSize === '') {
+            $errors[] = [
+                'field' => 'options.agent_batch_size',
+                'code' => 'agent_batch_size_required',
+                'message' => '--agent-batch-size is required when using agent batch mode.',
+            ];
+
+            return null;
+        }
+
+        if (! ctype_digit($rawSize)) {
+            $errors[] = [
+                'field' => 'options.agent_batch_size',
+                'code' => 'agent_batch_size_invalid',
+                'message' => '--agent-batch-size must be 5 or 10.',
+            ];
+
+            return null;
+        }
+
+        $size = (int) $rawSize;
+        if (! in_array($size, self::AGENT_BATCH_ALLOWED_SIZES, true)) {
+            $errors[] = [
+                'field' => 'options.agent_batch_size',
+                'code' => 'agent_batch_size_not_allowed',
+                'message' => '--agent-batch-size must be one of: '.implode(', ', self::AGENT_BATCH_ALLOWED_SIZES).'.',
+            ];
+
+            return null;
+        }
+
+        if ($rawOffset === '') {
+            $offset = 0;
+        } elseif (! ctype_digit($rawOffset)) {
+            $errors[] = [
+                'field' => 'options.agent_batch_offset',
+                'code' => 'agent_batch_offset_invalid',
+                'message' => '--agent-batch-offset must be a non-negative integer.',
+            ];
+
+            return null;
+        } else {
+            $offset = (int) $rawOffset;
+        }
+
+        if ($offset + $size > $recommendationCount) {
+            $errors[] = [
+                'field' => 'options.agent_batch_offset',
+                'code' => 'agent_batch_window_out_of_range',
+                'message' => 'The requested agent batch window must resolve exactly '.$size.' recommendations.',
+            ];
+
+            return null;
+        }
+
+        return [
+            'size' => $size,
+            'offset' => $offset,
+        ];
     }
 
     /**
@@ -572,16 +678,38 @@ final class Mbti64CmsProjectionDraftWriter
      * @param  array<string,mixed>  $options
      * @return array<string,mixed>
      */
-    private function subsetSummary(array $options): array
+    private function subsetSummary(array $options, array $preparedRows = []): array
     {
-        $enabled = (bool) ($options['visible_query_backed_3'] ?? false);
+        $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
+        $agentBatchRequested = $this->agentBatchRequested($options);
+        $selectedUrls = array_values(array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $preparedRows
+        ));
+
+        if ($agentBatchRequested) {
+            return [
+                'mode' => 'agent_batch_safe',
+                'enabled' => true,
+                'dry_run_only' => false,
+                'write_allowed_with_strict_approval' => true,
+                'allowed_batch_sizes' => self::AGENT_BATCH_ALLOWED_SIZES,
+                'batch_size' => trim((string) ($options['agent_batch_size'] ?? '')),
+                'batch_offset' => trim((string) ($options['agent_batch_offset'] ?? '')) !== ''
+                    ? trim((string) ($options['agent_batch_offset'] ?? ''))
+                    : '0',
+                'arbitrary_url_subset_allowed' => false,
+                'selected_urls' => $selectedUrls,
+            ];
+        }
 
         return [
-            'mode' => $enabled ? 'visible_query_backed_3' : 'full_88',
-            'enabled' => $enabled,
+            'mode' => $visibleQueryBacked3 ? 'visible_query_backed_3' : 'full_88',
+            'enabled' => $visibleQueryBacked3,
             'dry_run_only' => false,
-            'write_allowed_with_strict_approval' => $enabled,
-            'allowed_urls' => $enabled ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
+            'write_allowed_with_strict_approval' => $visibleQueryBacked3,
+            'allowed_urls' => $visibleQueryBacked3 ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
+            'selected_urls' => $selectedUrls,
         ];
     }
 

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -230,6 +230,228 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
 
+    public function test_agent_batch_safe_dry_run_plans_five_artifact_order_rows_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--agent-batch-size' => '5',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $expectedUrls = $this->expectedBatchUrls(5, 0);
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['would_create_revision_count']);
+        $this->assertSame('agent_batch_safe', $payload['subset']['mode']);
+        $this->assertSame('5', $payload['subset']['batch_size']);
+        $this->assertSame('0', $payload['subset']['batch_offset']);
+        $this->assertFalse($payload['subset']['arbitrary_url_subset_allowed']);
+        $this->assertSame([5, 10], $payload['subset']['allowed_batch_sizes']);
+        $this->assertSame($expectedUrls, $payload['subset']['selected_urls']);
+        $this->assertSame($expectedUrls, array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_dry_run_plans_ten_rows_with_offset_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--agent-batch-size' => '10',
+            '--agent-batch-offset' => '5',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $expectedUrls = $this->expectedBatchUrls(10, 5);
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(10, $payload['row_count']);
+        $this->assertSame('agent_batch_safe', $payload['subset']['mode']);
+        $this->assertSame('10', $payload['subset']['batch_size']);
+        $this->assertSame('5', $payload['subset']['batch_offset']);
+        $this->assertSame($expectedUrls, $payload['subset']['selected_urls']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_requires_batch_approval_token(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_creates_only_selected_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFJ-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('agent_batch_safe', $payload['subset']['mode']);
+        $this->assertSame($this->expectedBatchUrls(5, 0), $payload['subset']['selected_urls']);
+        $this->assertSame($payload['comparison_row_count'], PersonalityProfileRevision::query()->count());
+        $this->assertSame($payload['variant_row_count'], PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFJ']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFJ-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        foreach (PersonalityProfileRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json);
+        }
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json);
+        }
+    }
+
+    public function test_agent_batch_safe_second_write_is_idempotent_for_same_source_hash(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $firstExit = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(5, $payload['skipped_existing_count']);
+        $this->assertSame(5, PersonalityProfileRevision::query()->count() + PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_rejects_invalid_batch_size_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--agent-batch-size' => '11',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('agent_batch_size_not_allowed', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_rejects_out_of_range_offset_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--agent-batch-size' => '10',
+            '--agent-batch-offset' => '79',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('agent_batch_window_out_of_range', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_rejects_visible_three_combination_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--agent-batch-size' => '5',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('exclusive_subset_modes_required', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
     public function test_write_creates_eighty_eight_draft_revisions_without_changing_live_records(): void
     {
         $targets = $this->seedAllTargets();
@@ -629,6 +851,17 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         }
 
         return $paths;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function expectedBatchUrls(int $size, int $offset): array
+    {
+        return array_map(
+            static fn (string $path): string => 'https://fermatmind.com'.$path,
+            array_slice($this->targetPaths(), $offset, $size)
+        );
     }
 
     /**


### PR DESCRIPTION
## What changed
- Added a controlled `--agent-batch-size` / `--agent-batch-offset` mode to `personality:mbti64-cms-projection-draft`.
- Batch mode only selects artifact-order windows from the already validated 88-page MBTI64 agent recommendation package.
- Allowed batch sizes are fixed to 5 or 10; arbitrary URL subsets are not accepted.
- Write mode requires the dedicated approval token `MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01` plus the existing draft-only/no-publish/no-index/no-sitemap/no-llms/no-search-release guards.
- Added focused tests for dry-run, write, idempotency, invalid sizes, out-of-range offsets, and incompatible subset modes.

## Why
This makes the MBTI64 public profile agent pipeline operational beyond the fixed visible-3 canary while keeping CMS draft writes small, deterministic, and fail-closed.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only the projection draft command, writer service, and focused command test changed.

## Intentionally deferred
- No production dry-run or write was executed.
- No CMS live promotion, publish, index/search, sitemap/llms mutation, frontend change, URL Truth write, enqueue, approve, or submit is included.
- Selecting the first production batch and running production dry-run/write remains a separate explicitly authorized gate.
