### PR TITLE
test(seo-intel): add gsc readmodel canary readback audit

### DIFF
--- a/backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php
+++ b/backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\GscReadModelCanaryReadbackAuditor;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class SeoIntelGscReadModelCanaryReadbackCommand extends Command
+{
+    protected $signature = 'seo-intel:gsc-readmodel-canary-readback
+        {--artifact= : Path to a sanitized GSC sidecar live-read artifact}
+        {--artifact-sha256= : Required SHA256 expected for the artifact}
+        {--limit=250 : Preview/readback row limit, bounded 1..250}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Read-only audit for GSC readmodel canary idempotency/readback without writing or printing raw query/url.';
+
+    public function handle(GscReadModelCanaryReadbackAuditor $auditor): int
+    {
+        $path = $this->artifactPath();
+        if ($path === null) {
+            return $this->finish($this->failureSummary('artifact_path_required'));
+        }
+
+        $expectedSha256 = $this->expectedSha256();
+        if ($expectedSha256 === null) {
+            return $this->finish($this->failureSummary('artifact_sha256_required'));
+        }
+
+        try {
+            $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return $this->finish($this->failureSummary('artifact_json_invalid'));
+        }
+
+        if (! is_array($decoded)) {
+            return $this->finish($this->failureSummary('artifact_must_be_object'));
+        }
+
+        $summary = $auditor->audit(
+            $decoded,
+            (string) hash_file('sha256', $path),
+            $expectedSha256,
+            $this->limit(),
+        );
+
+        return $this->finish($summary);
+    }
+
+    private function artifactPath(): ?string
+    {
+        $path = trim((string) $this->option('artifact'));
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $path = str_starts_with($path, '/') ? $path : base_path($path);
+
+        return is_file($path) ? $path : null;
+    }
+
+    private function expectedSha256(): ?string
+    {
+        $sha256 = trim((string) $this->option('artifact-sha256'));
+
+        return preg_match('/^[a-f0-9]{64}$/', $sha256) === 1 ? $sha256 : null;
+    }
+
+    private function limit(): int
+    {
+        $raw = trim((string) $this->option('limit'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            return 250;
+        }
+
+        return max(1, min((int) $raw, 250));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $issue): array
+    {
+        return [
+            'schema_version' => GscReadModelCanaryReadbackAuditor::SCHEMA_VERSION,
+            'task' => GscReadModelCanaryReadbackAuditor::TASK,
+            'status' => 'blocked',
+            'ok' => false,
+            'read_only' => true,
+            'dry_run' => true,
+            'would_write' => false,
+            'target_table' => GscReadModelCanaryReadbackAuditor::TARGET_TABLE,
+            'rows_previewed' => 0,
+            'idempotency_key_count' => 0,
+            'rows_found' => 0,
+            'distinct_keys' => 0,
+            'rows_missing' => 0,
+            'would_duplicate' => false,
+            'all_rows_already_present' => false,
+            'issues' => [$issue],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function finish(array $summary): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('status='.(string) ($summary['status'] ?? 'blocked'));
+            $this->line('ok='.((bool) ($summary['ok'] ?? false) ? 'true' : 'false'));
+            $this->line('read_only=true');
+            $this->line('would_write=false');
+            $this->line('target_table=seo_gsc_daily');
+            $this->line('rows_found='.(string) ($summary['rows_found'] ?? 0));
+            $this->line('distinct_keys='.(string) ($summary['distinct_keys'] ?? 0));
+            $this->line('rows_missing='.(string) ($summary['rows_missing'] ?? 0));
+            $this->line('would_duplicate='.((bool) ($summary['would_duplicate'] ?? false) ? 'true' : 'false'));
+
+            foreach ((array) ($summary['issues'] ?? []) as $issue) {
+                $this->line('issue='.(string) $issue);
+            }
+        }
+
+        return ($summary['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php
+++ b/backend/app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel;
+
+use Illuminate\Support\Facades\DB;
+
+final class GscReadModelCanaryReadbackAuditor
+{
+    public const SCHEMA_VERSION = 'gsc-readmodel-canary-readback.v1';
+
+    public const TASK = 'GSC-READMODEL-CANARY-READBACK-01';
+
+    public const TARGET_TABLE = 'seo_gsc_daily';
+
+    public function __construct(private readonly GscReadModelArtifactDryRunImporter $dryRunImporter) {}
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     * @return array<string, mixed>
+     */
+    public function audit(array $artifact, string $artifactSha256, string $confirmedArtifactSha256, int $limit = 250): array
+    {
+        $issues = [];
+        if (! hash_equals($artifactSha256, $confirmedArtifactSha256)) {
+            $issues[] = 'artifact_sha256_mismatch';
+        }
+
+        $preview = $this->dryRunImporter->preview($artifact, $limit);
+        if (($preview['ok'] ?? false) !== true) {
+            $issues[] = 'dry_run_importer_validation_failed';
+        }
+
+        $rows = $issues === []
+            ? array_values(array_filter((array) ($preview['preview_rows'] ?? []), 'is_array'))
+            : [];
+        $keys = $this->idempotencyKeys($rows);
+        $readback = $keys === [] ? [] : $this->readbackExistingKeys($keys);
+
+        $distinctKeys = count($keys);
+        $foundKeys = count($readback);
+        $rowsMissing = max(0, $distinctKeys - $foundKeys);
+        $ok = $issues === [];
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'task' => self::TASK,
+            'status' => $ok ? 'success' : 'blocked',
+            'ok' => $ok,
+            'read_only' => true,
+            'dry_run' => true,
+            'would_write' => false,
+            'target_connection' => (string) config('seo_intel.connection', 'seo_intel'),
+            'target_table' => self::TARGET_TABLE,
+            'artifact_sha256' => $artifactSha256,
+            'artifact_sha256_confirmed' => $ok && hash_equals($artifactSha256, $confirmedArtifactSha256),
+            'rows_previewed' => count($rows),
+            'idempotency_key_count' => $distinctKeys,
+            'rows_found' => array_sum($readback),
+            'distinct_keys' => $foundKeys,
+            'rows_missing' => $rowsMissing,
+            'would_duplicate' => $foundKeys > 0,
+            'all_rows_already_present' => $distinctKeys > 0 && $rowsMissing === 0,
+            'data_origin' => $preview['data_origin'] ?? null,
+            'data_quality_gate' => $preview['data_quality_gate'] ?? null,
+            'date_window' => $preview['date_window'] ?? null,
+            'dry_run_importer_errors' => (array) ($preview['errors'] ?? []),
+            'issues' => array_values(array_unique($issues)),
+            'negative_guarantees' => [
+                'database_write' => false,
+                'seo_gsc_daily_write' => false,
+                'scheduler_activation' => false,
+                'queue_worker_activation' => false,
+                'opportunity_queue_enqueue' => false,
+                'cms_write' => false,
+                'search_channel_enqueue' => false,
+                'search_channel_submit' => false,
+                'search_provider_submission' => false,
+                'indexing_request' => false,
+                'sitemap_submission' => false,
+                'live_gsc_api_call' => false,
+                'raw_query_printed' => false,
+                'raw_url_printed' => false,
+                'credential_read_print_or_store' => false,
+                'production_env_change' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     * @return list<string>
+     */
+    private function idempotencyKeys(array $rows): array
+    {
+        $keys = [];
+        foreach ($rows as $row) {
+            $keys[] = hash('sha256', implode('|', [
+                $this->normalized($row['report_date'] ?? ''),
+                $this->normalized($row['canonical_url_hash'] ?? ''),
+                $this->normalized($row['query_hash'] ?? ''),
+                $this->normalized($row['source_engine'] ?? 'google'),
+                $this->normalized($row['device'] ?? ''),
+                $this->normalized($row['country'] ?? ''),
+                $this->normalized($row['search_type'] ?? ''),
+            ]));
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * @param  list<string>  $keys
+     * @return array<string, int>
+     */
+    private function readbackExistingKeys(array $keys): array
+    {
+        return DB::connection((string) config('seo_intel.connection', 'seo_intel'))
+            ->table(self::TARGET_TABLE)
+            ->selectRaw('idempotency_key, COUNT(*) as row_count')
+            ->whereIn('idempotency_key', $keys)
+            ->groupBy('idempotency_key')
+            ->pluck('row_count', 'idempotency_key')
+            ->map(fn (mixed $count): int => (int) $count)
+            ->all();
+    }
+
+    private function normalized(mixed $value): string
+    {
+        return trim((string) ($value ?? ''));
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelCanaryReadbackTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelGscReadModelCanaryReadbackTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelGscReadModelCanaryReadbackTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoGscDailyTable();
+    }
+
+    #[Test]
+    public function command_reports_missing_canary_rows_without_writing_or_printing_raw_values(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact(rowCount: 2));
+
+        [$exitCode, $payload, $output] = $this->runReadbackCommand($artifactPath);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['read_only'] ?? false));
+        $this->assertFalse((bool) ($payload['would_write'] ?? true));
+        $this->assertSame('seo_gsc_daily', $payload['target_table'] ?? null);
+        $this->assertSame(2, $payload['rows_previewed'] ?? null);
+        $this->assertSame(2, $payload['idempotency_key_count'] ?? null);
+        $this->assertSame(0, $payload['rows_found'] ?? null);
+        $this->assertSame(0, $payload['distinct_keys'] ?? null);
+        $this->assertSame(2, $payload['rows_missing'] ?? null);
+        $this->assertFalse((bool) ($payload['would_duplicate'] ?? true));
+        $this->assertFalse((bool) ($payload['all_rows_already_present'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        $this->assertStringNotContainsString('mbti测试', $output);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $output);
+        $this->assertArrayNotHasKey('preview_rows', $payload);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function command_reads_existing_canary_keys_and_reports_duplicate_boundary(): void
+    {
+        Http::fake();
+        $artifact = $this->validArtifact(rowCount: 2);
+        $artifactPath = $this->writeArtifact($artifact);
+        $this->insertSeoGscDailyRow($this->safeRow(0));
+        $this->insertSeoGscDailyRow($this->safeRow(1));
+
+        [$exitCode, $payload, $output] = $this->runReadbackCommand($artifactPath);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame(2, $payload['rows_found'] ?? null);
+        $this->assertSame(2, $payload['distinct_keys'] ?? null);
+        $this->assertSame(0, $payload['rows_missing'] ?? null);
+        $this->assertTrue((bool) ($payload['would_duplicate'] ?? false));
+        $this->assertTrue((bool) ($payload['all_rows_already_present'] ?? false));
+        $this->assertSame(2, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        $this->assertStringNotContainsString('mbti测试', $output);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $output);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function command_blocks_when_artifact_sha256_does_not_match(): void
+    {
+        Http::fake();
+        $artifactPath = $this->writeArtifact($this->validArtifact());
+
+        $exitCode = Artisan::call('seo-intel:gsc-readmodel-canary-readback', [
+            '--artifact' => $artifactPath,
+            '--artifact-sha256' => str_repeat('0', 64),
+            '--json' => true,
+        ]);
+        $output = trim(Artisan::output());
+        $payload = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('artifact_sha256_mismatch', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['would_write'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_gsc_daily')->count());
+        $this->assertStringNotContainsString('mbti测试', $output);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/mbti-basics', $output);
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runReadbackCommand(string $artifactPath): array
+    {
+        $exitCode = Artisan::call('seo-intel:gsc-readmodel-canary-readback', [
+            '--artifact' => $artifactPath,
+            '--artifact-sha256' => hash_file('sha256', $artifactPath),
+            '--json' => true,
+        ]);
+        $output = trim(Artisan::output());
+
+        $this->assertNotSame('', $output);
+        $payload = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $output];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validArtifact(int $rowCount = 1): array
+    {
+        return [
+            'schema_version' => 'gsc-hk-sidecar-runner-wrapper.v1',
+            'task' => 'SEO-GSC-HK-SIDECAR-RUNNER-WRAPPER-01',
+            'mode' => 'live-read',
+            'payload' => [
+                'collector' => 'gsc_foundation',
+                'status' => 'success',
+                'dry_run' => true,
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'external_calls_attempted' => true,
+                'items_seen' => $rowCount,
+                'metadata' => [
+                    'mode' => 'gsc_live_readonly_sidecar_read',
+                    'data_origin' => 'live_gsc_api',
+                    'date_window' => [
+                        'start_date' => '2026-06-17',
+                        'end_date' => '2026-06-17',
+                    ],
+                    'data_quality_gate' => [
+                        'status' => 'pass',
+                        'opportunity_queue_eligible' => true,
+                    ],
+                    'safe_row_preview' => array_map(
+                        fn (int $index): array => $this->safeRow($index),
+                        range(0, $rowCount - 1),
+                    ),
+                    'opportunity_queue_eligible' => false,
+                    'cms_write_allowed' => false,
+                    'search_channel_enqueue_allowed' => false,
+                    'indexing_request_allowed' => false,
+                    'writes_attempted' => false,
+                    'writes_committed' => false,
+                    'scheduler_enabled' => false,
+                    'queue_worker_enabled' => false,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function safeRow(int $index): array
+    {
+        return [
+            'report_date' => '2026-06-17',
+            'canonical_url_hash' => hash('sha256', 'https://fermatmind.com/zh/articles/mbti-basics-'.$index),
+            'query_hash' => hash('sha256', 'mbti测试'.$index),
+            'query_display_masked' => 'm****试',
+            'locale' => 'zh-CN',
+            'source_engine' => 'google',
+            'device' => null,
+            'country' => null,
+            'search_type' => 'web',
+            'clicks' => $index,
+            'impressions' => 60 + $index,
+            'ctr_ppm' => 0,
+            'average_position_milli' => 9000 + $index,
+            'is_brand_query' => false,
+            'query_type' => 'non_brand',
+            'data_state' => 'final',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $artifact
+     */
+    private function writeArtifact(array $artifact): string
+    {
+        $dir = storage_path('framework/testing/gsc-readmodel-readback-'.Str::uuid()->toString());
+        File::ensureDirectoryExists($dir);
+        $path = $dir.'/artifact.json';
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function insertSeoGscDailyRow(array $row): void
+    {
+        DB::connection('seo_intel')->table('seo_gsc_daily')->insert([
+            'idempotency_key' => $this->idempotencyKey($row),
+            'report_date' => (string) $row['report_date'],
+            'canonical_url_hash' => (string) $row['canonical_url_hash'],
+            'canonical_url' => null,
+            'query_hash' => (string) $row['query_hash'],
+            'query_display_masked' => $row['query_display_masked'],
+            'locale' => $row['locale'],
+            'source_engine' => 'google',
+            'device' => $row['device'],
+            'country' => $row['country'],
+            'search_type' => $row['search_type'],
+            'clicks' => (int) $row['clicks'],
+            'impressions' => (int) $row['impressions'],
+            'ctr_ppm' => $row['ctr_ppm'],
+            'average_position_milli' => $row['average_position_milli'],
+            'is_brand_query' => (bool) $row['is_brand_query'],
+            'query_type' => (string) $row['query_type'],
+            'data_state' => (string) $row['data_state'],
+            'metadata_json' => json_encode(['data_origin' => 'live_gsc_api'], JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function idempotencyKey(array $row): string
+    {
+        return hash('sha256', implode('|', [
+            trim((string) ($row['report_date'] ?? '')),
+            trim((string) ($row['canonical_url_hash'] ?? '')),
+            trim((string) ($row['query_hash'] ?? '')),
+            trim((string) ($row['source_engine'] ?? 'google')),
+            trim((string) ($row['device'] ?? '')),
+            trim((string) ($row['country'] ?? '')),
+            trim((string) ($row['search_type'] ?? '')),
+        ]));
+    }
+
+    private function createSeoGscDailyTable(): void
+    {
+        Schema::connection('seo_intel')->create('seo_gsc_daily', function (Blueprint $table): void {
+            $table->id();
+            $table->char('idempotency_key', 64)->nullable()->unique('seo_gsc_daily_idempotency_key_unique');
+            $table->date('report_date');
+            $table->char('canonical_url_hash', 64)->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->char('query_hash', 64)->nullable();
+            $table->string('query_display_masked', 255)->nullable();
+            $table->string('locale', 16)->nullable();
+            $table->string('source_engine', 64)->default('google');
+            $table->string('device', 32)->nullable();
+            $table->string('country', 16)->nullable();
+            $table->string('search_type', 32)->nullable();
+            $table->unsignedInteger('clicks')->default(0);
+            $table->unsignedInteger('impressions')->default(0);
+            $table->unsignedInteger('ctr_ppm')->nullable();
+            $table->unsignedInteger('average_position_milli')->nullable();
+            $table->boolean('is_brand_query')->default(false);
+            $table->string('query_type', 32)->default('unknown');
+            $table->string('data_state', 32)->default('final');
+            $table->timestamp('collected_at')->nullable();
+            $table->json('metadata_json')->nullable();
+            $table->timestamps();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -949,9 +949,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
+            'backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php',
+            'backend/app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',
@@ -5963,9 +5965,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
+            'backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php',
             'backend/app/Console/Commands/SeoIntelGscSidecarRunnerCommand.php',
             'backend/app/Services/SeoIntel/Collectors/GscCollector.php',
             'backend/app/Services/SeoIntel/GscReadModelControlledImportCanary.php',
+            'backend/app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php',
             'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
             'backend/app/Services/SeoIntel/GscReadModelArtifactDryRunImporter.php',
             'backend/app/Services/SeoIntel/GscDataQualityGate.php',


### PR DESCRIPTION
## Summary
- add a read-only `seo-intel:gsc-readmodel-canary-readback` command for GSC readmodel canary verification
- compute canary idempotency keys from a sanitized sidecar artifact and read back aggregate DB state only
- add focused PHPUnit coverage for missing rows, existing duplicate boundary, and artifact SHA mismatch

## Why
The existing dry-run importer is preview-only and can still report `rows_would_insert=3` after a controlled canary has inserted those rows. This command makes the post-canary readback/idempotency check explicit without writing DB rows or printing raw query/raw URL data.

## Validation
- `cd backend && php artisan test --filter=SeoIntelGscReadModelCanaryReadbackTest --no-ansi`
- `cd backend && php artisan test --filter='SeoIntelGscReadModel(ImporterDryRun|ControlledImportCanary|CanaryReadback)Test' --no-ansi`
- `cd backend && ./vendor/bin/pint app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php tests/Feature/SeoIntel/SeoIntelGscReadModelCanaryReadbackTest.php --test`
- `cd backend && php artisan list --raw | rg '^seo-intel:gsc-readmodel-canary-readback'`
- `cd backend && php artisan route:list --no-ansi >/tmp/fap-api-route-list-gsc-readback-20260623.txt`
- `cd backend && php -l app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php && php -l app/Services/SeoIntel/GscReadModelCanaryReadbackAuditor.php && php -l tests/Feature/SeoIntel/SeoIntelGscReadModelCanaryReadbackTest.php`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Deferred
- no production deploy
- no production DB import/write
- no scheduler, queue, CMS, search, indexing, sitemap, or GSC live API changes
- no PR-train manifest/state changes; this is an ad-hoc scoped PR

## Repository rule impact
Backend-authoritative SEO readmodel audit tooling only. No content ownership, publishing, sitemap/llms, public API, route, migration, or frontend authority changes.
