### PR TITLE
PR-O: Support article publish evidence in search bridge

### DIFF
--- a/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
+++ b/backend/app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\ContentPage;
 use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueuePlanner;
 use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueWriteService;
@@ -14,6 +16,8 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
     private const SCHEMA_VERSION = 'seo-agent-post-publish-search-submit.v1';
 
     private const PUBLISH_SCHEMA_VERSION = 'seo-agent-cms-publish-canary.v1';
+
+    private const ARTICLE_PUBLISH_SCHEMA_VERSION = 'seo-agent-article-cms-publish-canary.v1';
 
     private const FORBIDDEN_STRINGS = [
         'raw_url',
@@ -32,7 +36,7 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
     ];
 
     protected $signature = 'seo-agent:post-publish-search-submit
-        {--publish-evidence= : Path to seo-agent-cms-publish-canary.v1 JSON evidence}
+        {--publish-evidence= : Path to SEO Agent content_page or article publish evidence JSON}
         {--channels=indexnow,google_sitemap : Comma-separated Search Channel queue channels}
         {--limit=1 : First post-publish bridge requires exactly 1 published URL}
         {--base-url= : Public site base URL used to resolve safe paths; defaults to app.url}
@@ -77,12 +81,12 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
             return $this->finish($this->failureSummary('published_ref_missing'));
         }
 
-        $targetIssue = $this->validatePublishedContentPage($affected);
-        if ($targetIssue !== null) {
-            return $this->finish($this->failureSummary($targetIssue));
+        $target = $this->publishedTarget($affected, (string) ($evidence['schema_version'] ?? ''));
+        if ($target['issue'] !== null) {
+            return $this->finish($this->failureSummary((string) $target['issue']));
         }
 
-        $safePath = (string) ($affected['safe_path'] ?? '');
+        $safePath = (string) $target['safe_path'];
         $canonicalUrl = $this->canonicalUrl($safePath);
         if ($canonicalUrl === null) {
             return $this->finish($this->failureSummary('canonical_url_resolution_failed'));
@@ -107,7 +111,7 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
         $duplicates = 0;
 
         foreach ($channels as $channel) {
-            $plan = $planner->plan($channel, 'content_page', 20, $canonicalUrl);
+            $plan = $planner->plan($channel, (string) $target['page_entity_type'], 20, $canonicalUrl);
             $plans[$channel] = $this->safePlanSummary($plan);
             if ((int) ($plan['planned_queue_count'] ?? 0) > 0) {
                 $plannedItems = array_merge($plannedItems, (array) ($plan['planned_items'] ?? []));
@@ -130,6 +134,8 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
                 'publish_evidence_sha256' => $evidenceSha,
                 'canonical_url_hash' => hash('sha256', $canonicalUrl),
                 'safe_path' => $safePath,
+                'target_model' => $target['target_model'],
+                'page_entity_type' => $target['page_entity_type'],
                 'channels' => $channels,
                 'planned_queue_count' => count($plannedItems),
                 'duplicate_count' => $duplicates,
@@ -163,6 +169,8 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
             'publish_evidence_sha256' => $evidenceSha,
             'canonical_url_hash' => hash('sha256', $canonicalUrl),
             'safe_path' => $safePath,
+            'target_model' => $target['target_model'],
+            'page_entity_type' => $target['page_entity_type'],
             'channels' => $channels,
             'batch_ids' => $writeResult['batch_ids'],
             'written_items' => (int) $writeResult['written_items'],
@@ -194,7 +202,10 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
      */
     private function validatePublishEvidence(array $evidence): ?string
     {
-        if (($evidence['schema_version'] ?? null) !== self::PUBLISH_SCHEMA_VERSION) {
+        if (! in_array(($evidence['schema_version'] ?? null), [
+            self::PUBLISH_SCHEMA_VERSION,
+            self::ARTICLE_PUBLISH_SCHEMA_VERSION,
+        ], true)) {
             return 'publish_evidence_schema_invalid';
         }
         if (($evidence['status'] ?? null) !== 'success' || (bool) ($evidence['execute'] ?? false) !== true) {
@@ -232,27 +243,83 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
 
     /**
      * @param  array<string, mixed>  $affected
+     * @return array{issue: string|null, target_model?: string, page_entity_type?: string, safe_path?: string}
      */
-    private function validatePublishedContentPage(array $affected): ?string
+    private function publishedTarget(array $affected, string $schemaVersion): array
     {
-        if (($affected['target_model'] ?? null) !== 'content_page') {
-            return 'target_model_not_supported';
-        }
+        return match ((string) ($affected['target_model'] ?? '')) {
+            'content_page' => $schemaVersion === self::PUBLISH_SCHEMA_VERSION
+                ? $this->publishedContentPageTarget($affected)
+                : ['issue' => 'publish_evidence_schema_target_mismatch'],
+            'article' => $schemaVersion === self::ARTICLE_PUBLISH_SCHEMA_VERSION
+                ? $this->publishedArticleTarget($affected)
+                : ['issue' => 'publish_evidence_schema_target_mismatch'],
+            default => ['issue' => 'target_model_not_supported'],
+        };
+    }
 
+    /**
+     * @param  array<string, mixed>  $affected
+     * @return array{issue: string|null, target_model?: string, page_entity_type?: string, safe_path?: string}
+     */
+    private function publishedContentPageTarget(array $affected): array
+    {
         $pageId = $this->idFromSubjectRef((string) ($affected['subject_ref'] ?? ''), 'content_page');
         if ($pageId < 1) {
-            return 'subject_ref_invalid';
+            return ['issue' => 'subject_ref_invalid'];
         }
 
         $page = ContentPage::query()->withoutGlobalScopes()->find($pageId);
         if (! $page instanceof ContentPage) {
-            return 'content_page_not_found';
+            return ['issue' => 'content_page_not_found'];
         }
         if ((string) $page->status !== ContentPage::STATUS_PUBLISHED || ! (bool) $page->is_public || ! (bool) $page->is_indexable) {
-            return 'content_page_not_public_indexable';
+            return ['issue' => 'content_page_not_public_indexable'];
         }
 
-        return null;
+        return [
+            'issue' => null,
+            'target_model' => 'content_page',
+            'page_entity_type' => 'content_page',
+            'safe_path' => (string) ($affected['safe_path'] ?? ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $affected
+     * @return array{issue: string|null, target_model?: string, page_entity_type?: string, safe_path?: string}
+     */
+    private function publishedArticleTarget(array $affected): array
+    {
+        $articleId = $this->idFromSubjectRef((string) ($affected['subject_ref'] ?? ''), 'article');
+        if ($articleId < 1) {
+            return ['issue' => 'subject_ref_invalid'];
+        }
+
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['publishedRevision' => static fn ($query) => $query->withoutGlobalScopes()])
+            ->find($articleId);
+        if (! $article instanceof Article) {
+            return ['issue' => 'article_not_found'];
+        }
+        if ((string) $article->status !== 'published' || ! (bool) $article->is_public || ! (bool) $article->is_indexable) {
+            return ['issue' => 'article_not_public_indexable'];
+        }
+
+        $publishedRevision = $article->publishedRevision;
+        if (! $publishedRevision instanceof ArticleTranslationRevision
+            || (int) $publishedRevision->article_id !== (int) $article->id
+            || (string) $publishedRevision->revision_status !== ArticleTranslationRevision::STATUS_PUBLISHED) {
+            return ['issue' => 'article_published_revision_invalid'];
+        }
+
+        return [
+            'issue' => null,
+            'target_model' => 'article',
+            'page_entity_type' => 'article',
+            'safe_path' => $this->canonicalPathForArticle($article),
+        ];
     }
 
     private function idFromSubjectRef(string $subjectRef, string $expectedType): int
@@ -279,6 +346,13 @@ final class SeoAgentPostPublishSearchSubmitCommand extends Command
         $url = rtrim($base, '/').$safePath;
 
         return filter_var($url, FILTER_VALIDATE_URL) ? $url : null;
+    }
+
+    private function canonicalPathForArticle(Article $article): string
+    {
+        $segment = str_starts_with(strtolower(trim((string) $article->locale)), 'zh') ? 'zh' : 'en';
+
+        return '/'.$segment.'/articles/'.rawurlencode((string) $article->slug);
     }
 
     /**

--- a/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
+++ b/backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json
@@ -3,7 +3,10 @@
   "task": "SEO-AGENT-POST-PUBLISH-SEARCH-SUBMIT-01",
   "repo": "fap-api",
   "command": "php artisan seo-agent:post-publish-search-submit",
-  "input_schema": "seo-agent-cms-publish-canary.v1",
+  "input_schema": [
+    "seo-agent-cms-publish-canary.v1",
+    "seo-agent-article-cms-publish-canary.v1"
+  ],
   "output_schema": "seo-agent-post-publish-search-submit.v1",
   "default_mode": "dry_run_plan",
   "execute_requires": [
@@ -12,7 +15,8 @@
     "--confirm-evidence-sha256=<publish-evidence-sha256>"
   ],
   "supported_targets_v1": [
-    "content_page"
+    "content_page",
+    "article"
   ],
   "channels_v1": [
     "indexnow",
@@ -27,6 +31,12 @@
     "writes_committed": true,
     "published_count": 1,
     "rollback_evidence_available": true
+  },
+  "article_support": {
+    "input_schema": "seo-agent-article-cms-publish-canary.v1",
+    "safe_path_source": "article slug and locale",
+    "requires_article_public_indexable_published": true,
+    "live_submit": false
   },
   "write_targets": [
     "seo_search_channel_queue_items",

--- a/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\SeoIntel;
 
+use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\ContentPage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -80,7 +82,6 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
             '--json' => true,
         ]);
         $summary = json_decode(trim(Artisan::output()), true);
-
         $this->assertSame(0, $exitCode, Artisan::output());
         $this->assertSame('success', $summary['status'] ?? null);
         $this->assertTrue((bool) ($summary['search_channel_enqueue_attempted'] ?? false));
@@ -112,6 +113,72 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_plans_article_publish_evidence_without_writing(): void
+    {
+        $article = $this->createPublishedArticle();
+        $canonicalUrl = 'https://www.fermatmind.com/en/articles/article-candidate';
+        $this->seedSeoUrl($canonicalUrl, (string) $article->id, 'article', 'en');
+        $evidencePath = $this->writeArticlePublishEvidence($article);
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--channels' => 'indexnow',
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertSame('/en/articles/article-candidate', $summary['safe_path'] ?? null);
+        $this->assertSame('article', $summary['target_model'] ?? null);
+        $this->assertSame('article', $summary['page_entity_type'] ?? null);
+        $this->assertSame(1, $summary['planned_queue_count'] ?? null);
+        $this->assertSame(1, data_get($summary, 'plans.indexnow.planned_queue_count'));
+        $this->assertFalse((bool) ($summary['search_channel_enqueue_attempted'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_enqueue', true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+    }
+
+    #[Test]
+    public function execute_enqueues_article_publish_evidence_without_live_submission(): void
+    {
+        $article = $this->createPublishedArticle();
+        $canonicalUrl = 'https://www.fermatmind.com/en/articles/article-candidate';
+        $this->seedSeoUrl($canonicalUrl, (string) $article->id, 'article', 'en');
+        $evidencePath = $this->writeArticlePublishEvidence($article);
+        $evidenceSha = hash_file('sha256', $evidencePath) ?: '';
+
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $evidencePath,
+            '--channels' => 'indexnow',
+            '--limit' => 1,
+            '--confirm-evidence-sha256' => $evidenceSha,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertSame('article', $summary['page_entity_type'] ?? null);
+        $this->assertTrue((bool) ($summary['search_channel_enqueue_attempted'] ?? false));
+        $this->assertTrue((bool) ($summary['search_channel_enqueue_committed'] ?? false));
+        $this->assertFalse((bool) ($summary['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($summary['google_indexing_live_api_called'] ?? true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.search_channel_submit', true));
+        $this->assertFalse((bool) data_get($summary, 'boundaries.indexing_request', true));
+        $this->assertSame(1, $summary['written_items'] ?? null);
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->first();
+        $this->assertNotNull($item);
+        $this->assertSame('indexnow', $item->channel);
+        $this->assertSame('article', $item->page_entity_type);
+        $this->assertSame((string) $article->id, $item->entity_id);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_indexnow_submissions')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_domestic_submission_logs')->count());
+    }
+
+    #[Test]
     public function execute_fails_closed_for_bad_sha_or_unpublished_evidence(): void
     {
         $page = $this->createPublishedPage();
@@ -139,6 +206,19 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         $summary = json_decode(trim(Artisan::output()), true);
         $this->assertSame(1, $exitCode);
         $this->assertContains('publish_evidence_missing_one_committed_publish', $summary['issues'] ?? []);
+
+        $article = $this->createPublishedArticle();
+        $mismatchedSchemaPath = $this->writeArticlePublishEvidence($article, [
+            'schema_version' => 'seo-agent-cms-publish-canary.v1',
+        ]);
+        $exitCode = Artisan::call('seo-agent:post-publish-search-submit', [
+            '--publish-evidence' => $mismatchedSchemaPath,
+            '--limit' => 1,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(1, $exitCode);
+        $this->assertContains('publish_evidence_schema_target_mismatch', $summary['issues'] ?? []);
     }
 
     #[Test]
@@ -150,6 +230,7 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         $this->assertSame('php artisan seo-agent:post-publish-search-submit', $artifact['command'] ?? null);
         $this->assertSame(1, $artifact['max_published_urls_per_execution'] ?? null);
         $this->assertContains('content_page', $artifact['supported_targets_v1'] ?? []);
+        $this->assertContains('article', $artifact['supported_targets_v1'] ?? []);
         $this->assertFalse((bool) data_get($artifact, 'live_submission.search_channel_submit', true));
         $this->assertFalse((bool) data_get($artifact, 'live_submission.google_indexing_live_api_call', true));
     }
@@ -184,6 +265,49 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         ]);
     }
 
+    private function createPublishedArticle(): Article
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'article-candidate',
+            'locale' => 'en',
+            'translation_group_id' => (string) Str::uuid(),
+            'source_locale' => 'en',
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'content_html' => '<p>Existing article HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subDay(),
+        ]);
+        $publishedRevision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 7,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => 'Article Candidate',
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing article markdown.',
+            'seo_title' => 'Article Candidate | FermatMind',
+            'seo_description' => 'Search-safe article candidate description.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $publishedRevision->id,
+            'published_revision_id' => (int) $publishedRevision->id,
+        ])->save();
+
+        return $article->refresh();
+    }
+
     private function writePublishEvidence(ContentPage $page, array $overrides = []): string
     {
         return $this->writeJson('seo-agent-cms-publish-canary-', array_replace_recursive([
@@ -212,19 +336,59 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
         ], $overrides));
     }
 
-    private function seedSeoUrl(string $canonicalUrl, string $entityId): void
+    private function writeArticlePublishEvidence(Article $article, array $overrides = []): string
     {
+        return $this->writeJson('seo-agent-article-cms-publish-canary-', array_replace_recursive([
+            'schema_version' => 'seo-agent-article-cms-publish-canary.v1',
+            'ok' => true,
+            'status' => 'success',
+            'dry_run' => false,
+            'execute' => true,
+            'target' => 'article:'.(int) $article->id.':en',
+            'revision_id' => 71,
+            'writes_committed' => true,
+            'published_count' => 1,
+            'affected_refs' => [[
+                'status' => 'published',
+                'target_model' => 'article',
+                'subject_ref' => 'article:'.(int) $article->id.':en',
+                'revision_id' => 71,
+                'article_translation_revision_id' => (int) $article->published_revision_id,
+            ]],
+            'rollback_evidence' => [
+                'available' => true,
+            ],
+            'boundaries' => [
+                'cms_publish' => true,
+                'url_truth_write' => false,
+                'sitemap_submission' => false,
+                'indexnow_submit' => false,
+                'search_channel_enqueue' => false,
+                'search_channel_submit' => false,
+                'indexing_request' => false,
+                'scheduler_activation' => false,
+                'queue_worker_start' => false,
+            ],
+        ], $overrides));
+    }
+
+    private function seedSeoUrl(
+        string $canonicalUrl,
+        string $entityId,
+        string $pageEntityType = 'content_page',
+        string $locale = 'zh-CN'
+    ): void {
         DB::connection('seo_intel')->table('seo_urls')->insert([
             'canonical_url_hash' => hash('sha256', $canonicalUrl),
             'canonical_url' => $canonicalUrl,
-            'locale' => 'zh-CN',
-            'page_entity_type' => 'content_page',
+            'locale' => $locale,
+            'page_entity_type' => $pageEntityType,
             'entity_id_or_slug' => $entityId,
-            'cluster' => 'content_page',
+            'cluster' => $pageEntityType,
             'source_authority' => 'backend_cms',
             'indexability_state' => 'indexable',
             'lastmod_at' => now()->subMinute(),
-            'lastmod_source' => 'content_pages.updated_at',
+            'lastmod_source' => $pageEntityType === 'article' ? 'articles.updated_at' : 'content_pages.updated_at',
             'is_private_flow' => false,
             'first_seen_at' => now()->subDay(),
             'last_seen_at' => now(),
@@ -232,7 +396,7 @@ final class SeoAgentPostPublishSearchSubmitTest extends TestCase
                 'claim_safe' => true,
                 'claim_boundary_state' => 'approved',
                 'publication_state' => 'published',
-                'source_table' => 'content_pages',
+                'source_table' => $pageEntityType === 'article' ? 'articles' : 'content_pages',
             ], JSON_THROW_ON_ERROR),
             'created_at' => now(),
             'updated_at' => now(),


### PR DESCRIPTION
## Summary
- extend seo-agent:post-publish-search-submit to accept seo-agent-article-cms-publish-canary.v1 evidence
- validate article targets are published, public, indexable, and backed by a published translation revision
- plan/enqueue Search Channel rows with page_entity_type=article while preserving no live submission boundaries
- update generated SEO contract docs and focused tests

## Validation
- cd backend && php artisan list | grep 'seo-agent:post-publish-search-submit'
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentPostPublishSearchSubmitTest
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentArticlePostPublishPropagationDryRunTest
- cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentPostPublishSearchSubmitCommand.php tests/Feature/SeoIntel/SeoAgentPostPublishSearchSubmitTest.php
- python3 -m json.tool backend/docs/seo/generated/seo-agent-post-publish-search-submit.v1.json >/dev/null
- git diff --check
- git diff --cached --check

## Intentionally Deferred
- no production enqueue
- no live IndexNow submit
- no Google Indexing API call
- no CMS write or publish
- no sitemap/llms mutation
- no scheduler or queue worker action

## Repository Rule Impact
This keeps backend CMS/SEO Agent as the authority layer and only adds a bounded backend bridge for article publish evidence. No frontend content or public editorial fallback is introduced.