### PR TITLE
feat(seo-agent): support FAQ payload repair canary

### DIFF
--- a/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
+++ b/backend/app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php
@@ -31,6 +31,12 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
 
     private const SEO_TITLE_MAX_LENGTH = 60;
 
+    private const FAQ_MAX_ITEMS = 6;
+
+    private const FAQ_QUESTION_MAX_LENGTH = 140;
+
+    private const FAQ_ANSWER_MAX_LENGTH = 500;
+
     private const FORBIDDEN_STRINGS = [
         'raw_url',
         'raw_query',
@@ -51,6 +57,7 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         {--target= : Exact article subject_ref, e.g. article:41:en}
         {--artifact-dir= : Directory for repair and compatible write evidence artifacts}
         {--override-proposed-seo-title= : Optional controlled replacement for proposal.proposed_seo_title, max 60 chars}
+        {--override-proposed-faq-json= : Optional path to a JSON array replacing proposal.proposed_faq_items}
         {--confirm-package-sha256= : Required package sha256 for execute mode}
         {--confirm-repair= : Exact confirmation phrase for execute mode}
         {--execute : Actually append one repaired ArticleRevision draft}
@@ -118,12 +125,23 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
                 'package_sha256' => $packageSha,
             ]));
         }
+        $overrideFaqItems = $this->proposedFaqOverride();
+        if (is_array($overrideFaqItems) && array_key_exists('issue', $overrideFaqItems)) {
+            return $this->finish($this->failureSummary((string) ($overrideFaqItems['issue'] ?? 'override_proposed_faq_json_invalid'), [
+                'package_sha256' => $packageSha,
+            ]));
+        }
         $effectivePackage = $package;
         $effectiveProposal = $proposal;
         $effectivePackageSha = $packageSha;
         $effectivePackageArtifact = null;
         if (is_string($overrideTitle)) {
             $effectiveProposal['proposed_seo_title'] = $overrideTitle;
+        }
+        if (is_array($overrideFaqItems)) {
+            $effectiveProposal['proposed_faq_items'] = $overrideFaqItems;
+        }
+        if (is_string($overrideTitle) || is_array($overrideFaqItems)) {
             $effectivePackage = $this->packageWithProposal($package, $target, $effectiveProposal);
             $effectivePackageArtifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-package-repaired-', $effectivePackage);
             $effectivePackageSha = (string) ($effectivePackageArtifact['sha256'] ?? '');
@@ -179,6 +197,9 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         if (is_string($overrideTitle)) {
             $allowed[] = 'proposal.proposed_seo_title';
         }
+        if (is_array($overrideFaqItems)) {
+            $allowed[] = 'proposal.proposed_faq_items';
+        }
         sort($allowed);
 
         if ($mismatches === []) {
@@ -212,7 +233,7 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
                 'execute' => false,
                 'would_append_revision' => true,
                 'required_confirmation_phrase' => $confirmationPhrase,
-                'field_overrides' => $this->fieldOverridesEvidence($overrideTitle),
+                'field_overrides' => $this->fieldOverridesEvidence($overrideTitle, is_array($overrideFaqItems) ? $overrideFaqItems : null),
             ]);
             $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
 
@@ -254,7 +275,7 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
             'would_append_revision' => false,
             'rows_created' => 1,
             'compatible_write_evidence' => $compatibleArtifact,
-            'field_overrides' => $this->fieldOverridesEvidence($overrideTitle),
+            'field_overrides' => $this->fieldOverridesEvidence($overrideTitle, is_array($overrideFaqItems) ? $overrideFaqItems : null),
         ]);
         $artifact = $this->writeArtifact($artifactDir, 'seo-agent-cms-draft-payload-repair-canary-', $evidence);
 
@@ -298,6 +319,62 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
         }
 
         return $title;
+    }
+
+    /**
+     * @return list<array{question:string, answer:string}>|array{issue:string}|null
+     */
+    private function proposedFaqOverride(): ?array
+    {
+        $rawPath = $this->option('override-proposed-faq-json');
+        if ($rawPath === null) {
+            return null;
+        }
+
+        $path = $this->readablePath((string) $rawPath);
+        if ($path === null) {
+            return ['issue' => 'override_proposed_faq_json_unreadable'];
+        }
+
+        $raw = (string) file_get_contents($path);
+        if ($this->forbiddenStringsPresent($raw) !== []) {
+            return ['issue' => 'forbidden_input_field_present'];
+        }
+
+        $items = json_decode($raw, true);
+        if (! is_array($items) || ! array_is_list($items)) {
+            return ['issue' => 'override_proposed_faq_json_invalid'];
+        }
+        if ($items === [] || count($items) > self::FAQ_MAX_ITEMS) {
+            return ['issue' => 'override_proposed_faq_item_count_invalid'];
+        }
+
+        $normalized = [];
+        foreach ($items as $item) {
+            if (! is_array($item)) {
+                return ['issue' => 'override_proposed_faq_item_invalid'];
+            }
+            $question = trim((string) ($item['question'] ?? ''));
+            $answer = trim((string) ($item['answer'] ?? ''));
+            if ($question === '' || $answer === '' || str_contains($question, "\0") || str_contains($answer, "\0")) {
+                return ['issue' => 'override_proposed_faq_item_invalid'];
+            }
+            if ($this->forbiddenStringsPresent($question.$answer) !== []) {
+                return ['issue' => 'forbidden_input_field_present'];
+            }
+            if (mb_strlen($question) > self::FAQ_QUESTION_MAX_LENGTH) {
+                return ['issue' => 'override_proposed_faq_question_too_long'];
+            }
+            if (mb_strlen($answer) > self::FAQ_ANSWER_MAX_LENGTH) {
+                return ['issue' => 'override_proposed_faq_answer_too_long'];
+            }
+            $normalized[] = [
+                'question' => $question,
+                'answer' => $answer,
+            ];
+        }
+
+        return $normalized;
     }
 
     /**
@@ -648,8 +725,12 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
                 'allowed_mismatches' => [
                     ...self::ALLOWED_MISMATCHES,
                     'proposal.proposed_seo_title',
+                    'proposal.proposed_faq_items',
                 ],
                 'seo_title_max_length' => self::SEO_TITLE_MAX_LENGTH,
+                'faq_max_items' => self::FAQ_MAX_ITEMS,
+                'faq_question_max_length' => self::FAQ_QUESTION_MAX_LENGTH,
+                'faq_answer_max_length' => self::FAQ_ANSWER_MAX_LENGTH,
                 'copy_body_from_previous_draft_revision' => true,
                 'mutate_old_revision' => false,
             ],
@@ -683,19 +764,33 @@ final class SeoAgentCmsDraftPayloadRepairCanaryCommand extends Command
     /**
      * @return array<string, mixed>|null
      */
-    private function fieldOverridesEvidence(?string $overrideTitle): ?array
+    private function fieldOverridesEvidence(?string $overrideTitle, ?array $overrideFaqItems): ?array
     {
-        if ($overrideTitle === null) {
+        if ($overrideTitle === null && $overrideFaqItems === null) {
             return null;
         }
 
-        return [
-            'proposal.proposed_seo_title' => [
+        $evidence = [];
+        if ($overrideTitle !== null) {
+            $evidence['proposal.proposed_seo_title'] = [
                 'length' => mb_strlen($overrideTitle),
                 'max_length' => self::SEO_TITLE_MAX_LENGTH,
                 'sha256' => hash('sha256', $overrideTitle),
-            ],
-        ];
+            ];
+        }
+        if ($overrideFaqItems !== null) {
+            $evidence['proposal.proposed_faq_items'] = [
+                'count' => count($overrideFaqItems),
+                'max_items' => self::FAQ_MAX_ITEMS,
+                'sha256' => hash('sha256', json_encode($overrideFaqItems, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+                'question_hashes' => array_map(
+                    static fn (array $item): string => hash('sha256', (string) ($item['question'] ?? '')),
+                    $overrideFaqItems
+                ),
+            ];
+        }
+
+        return $evidence;
     }
 
     private function requiredConfirmationPhrase(string $target, string $packageSha): string

--- a/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
+++ b/backend/docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json
@@ -20,6 +20,15 @@
       "max_length": 60,
       "writes_repaired_package_artifact": true,
       "confirmation_sha256_target": "effective repaired package sha256"
+    },
+    "--override-proposed-faq-json": {
+      "field": "proposal.proposed_faq_items",
+      "input": "path to JSON array of {question, answer} objects",
+      "max_items": 6,
+      "max_question_length": 140,
+      "max_answer_length": 500,
+      "writes_repaired_package_artifact": true,
+      "confirmation_sha256_target": "effective repaired package sha256"
     }
   },
   "supported_targets": [
@@ -30,7 +39,8 @@
   "allowed_mismatches": [
     "proposal.proposed_internal_link_actions",
     "proposal.proposal_quality",
-    "proposal.proposed_seo_title when --override-proposed-seo-title is provided"
+    "proposal.proposed_seo_title when --override-proposed-seo-title is provided",
+    "proposal.proposed_faq_items when --override-proposed-faq-json is provided"
   ],
   "effective_package_behavior": "When a controlled field override is supplied, the command emits a repaired seo-agent-cms-draft-package-dry-run.v1 artifact and compatible write evidence references that repaired package sha256 so readback QA can compare against the repaired proposal.",
   "copies_body_from_previous_draft_revision": true,

--- a/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php
@@ -185,6 +185,92 @@ final class SeoAgentCmsDraftPayloadRepairCanaryTest extends TestCase
     }
 
     #[Test]
+    public function execute_can_repair_only_proposed_faq_items_with_repaired_package_handoff(): void
+    {
+        $article = $this->article();
+        $proposal = [
+            ...$this->proposal((int) $article->id),
+            'proposed_faq_items' => [
+                [
+                    'question' => '这篇文章需要补充哪些常见问题？',
+                    'answer' => '仅作为字段级草稿建议；答案需基于现有正文、claim gate 和人工审核后再写入。',
+                ],
+            ],
+        ];
+        $packagePath = $this->writePackage([$proposal]);
+        $sourcePackageSha = hash_file('sha256', $packagePath) ?: '';
+        $oldRevision = $this->articleRevision($article, $proposal, $sourcePackageSha, includeOptionalProposalFields: true);
+        $writeEvidencePath = $this->writeEvidence($sourcePackageSha, $proposal['subject_ref'], (int) $oldRevision->id);
+        $faqItems = [
+            [
+                'question' => '大五人格测试可以诊断心理问题吗？',
+                'answer' => '不能。大五人格测试只能作为自我观察和教育参考，不能替代心理诊断、临床评估或专业建议。',
+            ],
+            [
+                'question' => '大五人格结果能预测职业成功吗？',
+                'answer' => '不能。它可以帮助你观察长期行为倾向和工作习惯，但职业结果还取决于技能、经验、环境和真实反馈。',
+            ],
+        ];
+        $faqPath = $this->writeJson('seo-agent-faq-override-', $faqItems);
+        $artifactDir = $this->artifactDir();
+
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--override-proposed-faq-json' => $faqPath,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $dryRun = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('planned', $dryRun['status'] ?? null);
+        $this->assertSame(['proposal.proposed_faq_items'], $dryRun['mismatches_repaired'] ?? null);
+        $this->assertSame($sourcePackageSha, $dryRun['source_package_sha256'] ?? null);
+        $this->assertNotSame($sourcePackageSha, $dryRun['package_sha256'] ?? null);
+        $this->assertSame(2, $dryRun['field_overrides']['proposal.proposed_faq_items']['count'] ?? null);
+        $effectivePackagePath = (string) data_get($dryRun, 'effective_package.path');
+        $effectivePackageSha = (string) ($dryRun['package_sha256'] ?? '');
+        $this->assertFileExists($effectivePackagePath);
+
+        $phrase = $this->approvalPhrase($proposal['subject_ref'], $effectivePackageSha);
+        $exitCode = Artisan::call('seo-agent:cms-draft-payload-repair-canary', [
+            '--package' => $packagePath,
+            '--write-evidence' => $writeEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--override-proposed-faq-json' => $faqPath,
+            '--confirm-package-sha256' => $effectivePackageSha,
+            '--confirm-repair' => $phrase,
+            '--artifact-dir' => $artifactDir,
+            '--execute' => true,
+            '--json' => true,
+        ]);
+        $summary = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $summary['status'] ?? null);
+        $newRevision = ArticleRevision::query()->findOrFail((int) data_get($summary, 'new_revision.revision_id'));
+        $this->assertSame($faqItems, data_get($newRevision->payload_json, 'proposal.proposed_faq_items'));
+        $this->assertSame($effectivePackageSha, data_get($newRevision->payload_json, 'seo_agent.package_sha256'));
+        $this->assertSame($sourcePackageSha, $summary['source_package_sha256'] ?? null);
+
+        $compatibleEvidencePath = (string) data_get($summary, 'compatible_write_evidence.path');
+        $exitCode = Artisan::call('seo-agent:cms-draft-readback-qa', [
+            '--package' => $effectivePackagePath,
+            '--write-evidence' => $compatibleEvidencePath,
+            '--target' => $proposal['subject_ref'],
+            '--package-sha256' => $effectivePackageSha,
+            '--artifact-dir' => $artifactDir,
+            '--json' => true,
+        ]);
+        $readback = json_decode(trim(Artisan::output()), true);
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('success', $readback['status'] ?? null);
+        $this->assertSame(0, $readback['mismatch_count'] ?? null);
+    }
+
+    #[Test]
     public function it_blocks_mismatch_sets_outside_optional_payload_fields(): void
     {
         [, $proposal, $packagePath, , , $writeEvidencePath] = $this->oldDraftMissingOptionalFields([


### PR DESCRIPTION
## Summary
- add `--override-proposed-faq-json` to `seo-agent:cms-draft-payload-repair-canary`
- validate FAQ override JSON as bounded `{question, answer}` items and emit repaired package evidence
- allow readback-compatible appended draft revisions for FAQ-only payload repair
- update generated command contract and focused tests

## Why
`article:3:zh-CN` and `article:40:zh-CN` currently have SEO Agent draft payloads whose FAQ proposal items are internal placeholder review text. Production publish canary does not write FAQ publicly, but the placeholder payload blocks clean evidence and future automation. This change adds the narrow repair capability needed before production repair dry-run/execute.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsDraftPayloadRepairCanaryTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentCmsDraftReadbackQaTest`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoAgentCmsDraftPayloadRepairCanaryCommand.php tests/Feature/SeoIntel/SeoAgentCmsDraftPayloadRepairCanaryTest.php`
- `cd backend && python3 -m json.tool docs/seo/generated/seo-agent-cms-draft-payload-repair-canary.v1.json >/dev/null`
- `cd backend && git diff --check`

## Deferred
- no production deploy in this PR
- no production repair execute
- no CMS publish
- no URL Truth, sitemap, Search Channel, IndexNow, indexing, scheduler, queue worker, GSC, or model API action
- local untracked handoff doc `backend/docs/seo/seo-agent-gsc-draft-canary-handoff-2026-06-23.md` is intentionally not included in this PR
