### PR TITLE
MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -16,6 +16,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-VISIBLE-3-WRITE-01';
 
+    private const FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-WRITE-01';
+
     private const AGENT_BATCH_OPERATOR_APPROVAL = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
 
     private const WRITE_SAFETY_FLAGS = [
@@ -33,6 +35,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--dry-run : Validate and plan without database writes}
         {--write : Create CMS projection draft revision rows}
         {--visible-query-backed-3 : Restrict planning/write to the approved 3 query-backed visible MBTI64 URLs}
+        {--fresh-query-backed-3 : Restrict planning/write to the fresh 3 query-backed MBTI64 URLs}
         {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
         {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
@@ -127,6 +130,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
         $expectedApproval = match (true) {
             (bool) $this->option('visible-query-backed-3') => self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL,
+            (bool) $this->option('fresh-query-backed-3') => self::FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL,
             $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
             default => self::OPERATOR_APPROVAL,
         };
@@ -158,6 +162,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'dry_run' => (bool) $this->option('dry-run'),
             'write' => (bool) $this->option('write'),
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
+            'fresh_query_backed_3' => (bool) $this->option('fresh-query-backed-3'),
             'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
             'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -24,6 +24,12 @@ final class Mbti64CmsProjectionDraftWriter
         'https://fermatmind.com/zh/personality/esfp-a',
     ];
 
+    private const FRESH_QUERY_BACKED_3_URLS = [
+        'https://fermatmind.com/zh/personality/istp-a',
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfj-a',
+    ];
+
     private const AGENT_BATCH_ALLOWED_SIZES = [5, 10];
 
     private const FORBIDDEN_ROUTE_PATTERNS = [
@@ -293,19 +299,20 @@ final class Mbti64CmsProjectionDraftWriter
     {
         $recommendations = $this->recommendations($package);
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
+        $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $agentBatchRequested = $this->agentBatchRequested($options);
 
-        if ($visibleQueryBacked3 && $agentBatchRequested) {
+        if (($visibleQueryBacked3 ? 1 : 0) + ($freshQueryBacked3 ? 1 : 0) + ($agentBatchRequested ? 1 : 0) > 1) {
             $errors[] = [
                 'field' => 'options',
                 'code' => 'exclusive_subset_modes_required',
-                'message' => '--visible-query-backed-3 cannot be combined with --agent-batch-size or --agent-batch-offset.',
+                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, or agent batch options.',
             ];
 
             return [];
         }
 
-        if (! $visibleQueryBacked3 && ! $agentBatchRequested) {
+        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $agentBatchRequested) {
             return $recommendations;
         }
 
@@ -318,21 +325,25 @@ final class Mbti64CmsProjectionDraftWriter
             return array_values(array_slice($recommendations, $batchOptions['offset'], $batchOptions['size']));
         }
 
-        $allowed = array_fill_keys(self::VISIBLE_QUERY_BACKED_3_URLS, true);
+        $expectedUrls = $freshQueryBacked3 ? self::FRESH_QUERY_BACKED_3_URLS : self::VISIBLE_QUERY_BACKED_3_URLS;
+        $subsetCode = $freshQueryBacked3
+            ? 'fresh_query_backed_subset_required_urls_missing'
+            : 'visible_query_backed_subset_required_urls_missing';
+        $subsetLabel = $freshQueryBacked3 ? 'fresh query-backed' : 'visible query-backed';
+        $allowed = array_fill_keys($expectedUrls, true);
         $subset = array_values(array_filter(
             $recommendations,
             static fn (array $item): bool => isset($allowed[(string) ($item['target_url'] ?? '')])
         ));
         $subsetUrls = array_map(static fn (array $item): string => (string) ($item['target_url'] ?? ''), $subset);
         sort($subsetUrls);
-        $expectedUrls = self::VISIBLE_QUERY_BACKED_3_URLS;
         sort($expectedUrls);
 
         if ($subsetUrls !== $expectedUrls) {
             $errors[] = [
                 'field' => 'recommendations',
-                'code' => 'visible_query_backed_subset_required_urls_missing',
-                'message' => 'The visible query-backed subset must resolve exactly the 3 approved URLs.',
+                'code' => $subsetCode,
+                'message' => 'The '.$subsetLabel.' subset must resolve exactly the 3 approved URLs.',
             ];
         }
 
@@ -681,6 +692,7 @@ final class Mbti64CmsProjectionDraftWriter
     private function subsetSummary(array $options, array $preparedRows = []): array
     {
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
+        $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
         $agentBatchRequested = $this->agentBatchRequested($options);
         $selectedUrls = array_values(array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
@@ -699,6 +711,17 @@ final class Mbti64CmsProjectionDraftWriter
                     ? trim((string) ($options['agent_batch_offset'] ?? ''))
                     : '0',
                 'arbitrary_url_subset_allowed' => false,
+                'selected_urls' => $selectedUrls,
+            ];
+        }
+
+        if ($freshQueryBacked3) {
+            return [
+                'mode' => 'fresh_query_backed_3',
+                'enabled' => true,
+                'dry_run_only' => false,
+                'write_allowed_with_strict_approval' => true,
+                'allowed_urls' => self::FRESH_QUERY_BACKED_3_URLS,
                 'selected_urls' => $selectedUrls,
             ];
         }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -38,6 +38,12 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         'https://fermatmind.com/zh/personality/esfp-a',
     ];
 
+    private const FRESH_QUERY_BACKED_3_URLS = [
+        'https://fermatmind.com/zh/personality/istp-a',
+        'https://fermatmind.com/zh/personality/intp-a',
+        'https://fermatmind.com/zh/personality/esfj-a',
+    ];
+
     public function test_dry_run_plans_eighty_eight_projection_drafts_without_writes(): void
     {
         $this->seedAllTargets();
@@ -223,6 +229,142 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertFalse($payload['ok']);
         $this->assertContains('visible_query_backed_subset_required_urls_missing', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_three_dry_run_plans_only_fresh_approved_urls_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--fresh-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['would_create_revision_count']);
+        $this->assertSame('fresh_query_backed_3', $payload['subset']['mode']);
+        $this->assertTrue($payload['subset']['enabled']);
+        $this->assertFalse($payload['subset']['dry_run_only']);
+        $this->assertTrue($payload['subset']['write_allowed_with_strict_approval']);
+
+        $plannedUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($plannedUrls);
+        $expectedUrls = self::FRESH_QUERY_BACKED_3_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $plannedUrls);
+        $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_three_write_requires_fresh_three_approval_token(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--fresh-query-backed-3'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-WRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_three_write_creates_only_fresh_approved_variant_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $profileBefore = $this->profileLiveState($targets['zh-CN|ISTP']);
+        $variantBefore = $this->variantLiveState($targets['zh-CN|ISTP-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--fresh-query-backed-3'] = true;
+        $options['--operator-approved'] = 'MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(3, $payload['row_count']);
+        $this->assertSame(3, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(3, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('fresh_query_backed_3', $payload['subset']['mode']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(3, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['zh-CN|ISTP']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['zh-CN|ISTP-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $createdUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($createdUrls);
+        $expectedUrls = self::FRESH_QUERY_BACKED_3_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $createdUrls);
+
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json);
+        }
+    }
+
+    public function test_fresh_query_backed_three_rejects_other_subset_mode_combinations_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--fresh-query-backed-3' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('exclusive_subset_modes_required', array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             $payload['errors'] ?? []
         ));


### PR DESCRIPTION
## What changed
- Added a fixed `--fresh-query-backed-3` subset mode to `personality:mbti64-cms-projection-draft`.
- Locked the subset to the three fresh query-backed URLs:
  - `https://fermatmind.com/zh/personality/istp-a`
  - `https://fermatmind.com/zh/personality/intp-a`
  - `https://fermatmind.com/zh/personality/esfj-a`
- Added a stricter write approval token: `MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-WRITE-01`.
- Extended focused feature tests for dry-run, approval gating, write scope, and subset mode exclusivity.

## Why
Fresh GSC query evidence selected a new 3-page MBTI64 candidate set. The existing visible-3 contract targets a different fixed subset, so production dry-run/write needs a separate fixed contract instead of reusing the old flag or allowing arbitrary URL selection.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
  - Passed: 25 tests, 458 assertions
  - Note: local temp worktree emitted `.env` missing warnings only; assertions passed.
- `bash backend/scripts/ci_verify_mbti.sh`
  - Passed.
- `git diff --check`
  - Passed.
- Scope validation
  - Passed: changed files are limited to command, writer service, and focused command test.

## Intentionally deferred
- No production write.
- No CMS live content change.
- No publish, index, sitemap, llms, or search release.
- No frontend changes.
- Next step after merge/deploy: production dry-run with `--fresh-query-backed-3`.
