### PR TITLE
fix(seo-intel): requeue articles after newer publish

### DIFF
--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php
@@ -9,19 +9,25 @@ use Illuminate\Support\Facades\Schema;
 
 final class SearchChannelQueueIdempotency
 {
-    public function key(string $canonicalUrl, string $locale, string $channel): string
+    public function key(string $canonicalUrl, string $locale, string $channel, ?string $sourceVersion = null): string
     {
-        return hash('sha256', implode('|', [
+        $parts = [
             strtolower(trim($canonicalUrl)),
             strtolower(trim($locale)),
             strtolower(trim($channel)),
-        ]));
+        ];
+
+        if ($sourceVersion !== null && trim($sourceVersion) !== '') {
+            $parts[] = 'source-version:'.trim($sourceVersion);
+        }
+
+        return hash('sha256', implode('|', $parts));
     }
 
     /**
      * @return array{id:int, approval_state:string, execution_state:string}|null
      */
-    public function existingQueueItem(string $canonicalUrl, string $locale, string $channel): ?array
+    public function existingQueueItem(string $canonicalUrl, string $locale, string $channel, mixed $sourceLastmod = null, ?string $sourceContentHash = null): ?array
     {
         $connectionName = (string) config('seo_intel.connection', 'seo_intel');
 
@@ -30,23 +36,70 @@ final class SearchChannelQueueIdempotency
                 return null;
             }
 
-            $row = DB::connection($connectionName)
+            $rows = DB::connection($connectionName)
                 ->table('seo_search_channel_queue_items')
-                ->where('idempotency_key', $this->key($canonicalUrl, $locale, $channel))
-                ->select(['id', 'approval_state', 'execution_state'])
-                ->first();
+                ->where('url_hash', hash('sha256', $canonicalUrl))
+                ->where('locale', $locale)
+                ->where('channel', $channel)
+                ->orderByDesc('id')
+                ->get(['id', 'approval_state', 'execution_state', 'lastmod', 'content_hash', 'updated_at']);
 
-            if ($row === null) {
-                return null;
+            $sourceTimestamp = $this->timestamp($sourceLastmod);
+            $normalizedSourceContentHash = $this->normalizedContentHash($sourceContentHash);
+
+            foreach ($rows as $row) {
+                if ($this->submittedItemIsOlderThanSource($row, $sourceTimestamp, $normalizedSourceContentHash)) {
+                    continue;
+                }
+
+                return [
+                    'id' => (int) $row->id,
+                    'approval_state' => (string) $row->approval_state,
+                    'execution_state' => (string) $row->execution_state,
+                ];
             }
 
-            return [
-                'id' => (int) $row->id,
-                'approval_state' => (string) $row->approval_state,
-                'execution_state' => (string) $row->execution_state,
-            ];
+            return null;
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    private function submittedItemIsOlderThanSource(object $row, ?int $sourceTimestamp, ?string $sourceContentHash): bool
+    {
+        if ((string) $row->execution_state !== 'submitted') {
+            return false;
+        }
+
+        $itemContentHash = $this->normalizedContentHash($row->content_hash ?? null);
+        if ($sourceContentHash !== null && $itemContentHash !== null && ! hash_equals($itemContentHash, $sourceContentHash)) {
+            return true;
+        }
+
+        if ($sourceTimestamp === null) {
+            return false;
+        }
+
+        $itemTimestamp = $this->timestamp($row->lastmod ?? null) ?? $this->timestamp($row->updated_at ?? null);
+
+        return $itemTimestamp === null || $sourceTimestamp > $itemTimestamp;
+    }
+
+    private function timestamp(mixed $value): ?int
+    {
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        $timestamp = strtotime((string) $value);
+
+        return $timestamp === false ? null : $timestamp;
+    }
+
+    private function normalizedContentHash(mixed $value): ?string
+    {
+        $hash = strtolower(trim((string) $value));
+
+        return $hash === '' ? null : $hash;
     }
 }

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php
@@ -95,6 +95,8 @@ final class SearchChannelQueuePlanner
                     canonicalUrl: (string) ($row['canonical_url'] ?? ''),
                     locale: (string) ($row['locale'] ?? ''),
                     channel: $selectedChannel,
+                    sourceLastmod: $row['lastmod_at'] ?? null,
+                    sourceContentHash: $this->contentHash($row),
                 );
 
                 if ($duplicate !== null) {
@@ -172,9 +174,9 @@ final class SearchChannelQueuePlanner
             'private_flow' => (bool) ($row['is_private_flow'] ?? false),
             'reason_codes' => $result->reasonCodes,
             'lastmod' => $row['lastmod_at'] ?? null,
-            'content_hash' => is_string($metadata['content_hash'] ?? null) ? $metadata['content_hash'] : null,
+            'content_hash' => $this->contentHash($row),
             'url_hash' => $urlHash,
-            'idempotency_key' => $this->idempotency->key($canonicalUrl, $locale, $channel),
+            'idempotency_key' => $this->idempotency->key($canonicalUrl, $locale, $channel, $this->sourceVersion($row)),
         ];
     }
 
@@ -204,6 +206,32 @@ final class SearchChannelQueuePlanner
         }
 
         return str_contains($source, '.') ? explode('.', $source, 2)[0] : $source;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function sourceVersion(array $row): ?string
+    {
+        $contentHash = $this->contentHash($row);
+        if ($contentHash !== null) {
+            return 'content:'.$contentHash;
+        }
+
+        $lastmod = trim((string) ($row['lastmod_at'] ?? ''));
+
+        return $lastmod === '' ? null : 'lastmod:'.$lastmod;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function contentHash(array $row): ?string
+    {
+        $metadata = $this->metadata($row);
+        $hash = strtolower(trim((string) ($metadata['content_hash'] ?? '')));
+
+        return $hash === '' ? null : $hash;
     }
 
     /**

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -516,6 +516,175 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
     }
 
     #[Test]
+    public function submitted_queue_item_older_than_url_truth_lastmod_allows_article_requeue(): void
+    {
+        config(['seo_intel.search_channel_queue.write_enabled' => true]);
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/big-five-tool-guide';
+        $newLastmod = now();
+        $oldLastmod = now()->subDays(9);
+
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => '3',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_at' => $newLastmod,
+            'lastmod_source' => 'articles.updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+        $submittedId = $this->seedQueueItem($canonicalUrl, [
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id' => '3',
+            'approval_state' => 'approved',
+            'execution_state' => 'submitted',
+            'lastmod' => $oldLastmod,
+            'updated_at' => $oldLastmod,
+        ]);
+
+        $dryRun = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--page-type' => 'article',
+            '--limit' => 1,
+        ]);
+
+        $this->assertSame('success', $dryRun['status'] ?? null);
+        $this->assertSame(1, $dryRun['planned_queue_count'] ?? null);
+        $this->assertSame(0, $dryRun['blocked_count'] ?? null);
+        $this->assertFalse((bool) ($dryRun['duplicate_detected'] ?? true));
+
+        $write = $this->runQueueCommand([
+            '--enqueue' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--page-type' => 'article',
+            '--limit' => 1,
+        ]);
+
+        $this->assertSame('success', $write['status'] ?? null);
+        $this->assertSame(1, $write['written_items'] ?? null);
+        $this->assertSame(2, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame('submitted', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $submittedId)->value('execution_state'));
+
+        $newItem = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_items')
+            ->where('id', '!=', $submittedId)
+            ->first();
+
+        $this->assertNotNull($newItem);
+        $this->assertSame('pending', $newItem->approval_state);
+        $this->assertSame('dry_run_ready', $newItem->execution_state);
+        $this->assertSame($newLastmod->toDateTimeString(), $newItem->lastmod);
+    }
+
+    #[Test]
+    public function active_unsubmitted_queue_items_still_block_article_requeue_even_when_older(): void
+    {
+        foreach (['dry_run_ready', 'submitting'] as $state) {
+            $canonicalUrl = 'https://fermatmind.com/zh/articles/requeue-blocked-'.$state;
+            $this->seedSeoUrl([
+                'canonical_url' => $canonicalUrl,
+                'locale' => 'zh-CN',
+                'page_entity_type' => 'article',
+                'entity_id_or_slug' => $state,
+                'cluster' => 'article',
+                'source_authority' => 'backend_cms',
+                'lastmod_at' => now(),
+                'lastmod_source' => 'articles.updated_at',
+                'metadata_json' => [
+                    'claim_safe' => true,
+                    'claim_boundary_state' => 'approved',
+                    'publication_state' => 'published',
+                    'source_table' => 'articles',
+                ],
+            ]);
+            $this->seedQueueItem($canonicalUrl, [
+                'locale' => 'zh-CN',
+                'page_entity_type' => 'article',
+                'entity_id' => $state,
+                'execution_state' => $state,
+                'lastmod' => now()->subDays(9),
+                'updated_at' => now()->subDays(9),
+            ]);
+
+            $output = $this->runQueueCommand([
+                '--dry-run' => true,
+                '--no-write' => true,
+                '--json' => true,
+                '--canonical-url' => $canonicalUrl,
+                '--channel' => 'indexnow',
+                '--page-type' => 'article',
+                '--limit' => 1,
+            ], expectSuccess: false);
+
+            $this->assertSame('blocked', $output['status'] ?? null);
+            $this->assertSame(0, $output['planned_queue_count'] ?? null);
+            $this->assertTrue((bool) ($output['duplicate_detected'] ?? false));
+            $this->assertSame(1, data_get($output, 'reason_code_breakdown.existing_active_queue_item'));
+        }
+    }
+
+    #[Test]
+    public function submitted_queue_item_with_same_lastmod_still_dedupes(): void
+    {
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/requeue-same-lastmod';
+        $lastmod = now()->subHour();
+
+        $this->seedSeoUrl([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => 'same-lastmod',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_at' => $lastmod,
+            'lastmod_source' => 'articles.updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+        $this->seedQueueItem($canonicalUrl, [
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id' => 'same-lastmod',
+            'approval_state' => 'approved',
+            'execution_state' => 'submitted',
+            'lastmod' => $lastmod,
+            'updated_at' => $lastmod,
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--canonical-url' => $canonicalUrl,
+            '--channel' => 'indexnow',
+            '--page-type' => 'article',
+            '--limit' => 1,
+        ], expectSuccess: false);
+
+        $this->assertSame('blocked', $output['status'] ?? null);
+        $this->assertSame(0, $output['planned_queue_count'] ?? null);
+        $this->assertTrue((bool) ($output['duplicate_detected'] ?? false));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.existing_active_queue_item'));
+    }
+
+    #[Test]
     public function audit_event_is_created_only_when_write_gate_is_enabled(): void
     {
         $this->seedSeoUrl();
@@ -616,7 +785,7 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
             'cluster' => $overrides['cluster'] ?? 'research',
             'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
             'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
-            'lastmod_at' => now()->subHour(),
+            'lastmod_at' => $overrides['lastmod_at'] ?? now()->subHour(),
             'lastmod_source' => $overrides['lastmod_source'] ?? 'research_reports.updated_at',
             'is_private_flow' => (bool) ($overrides['is_private_flow'] ?? false),
             'first_seen_at' => now()->subDay(),
@@ -704,5 +873,42 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
                 $schema->id();
             });
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(string $canonicalUrl, array $overrides = []): int
+    {
+        return (int) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insertGetId([
+            'batch_id' => null,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'research_report',
+            'entity_type' => $overrides['entity_type'] ?? ($overrides['page_entity_type'] ?? 'research_report'),
+            'entity_id' => $overrides['entity_id'] ?? 'safe-research-report',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'source_table' => $overrides['source_table'] ?? 'articles',
+            'channel' => $overrides['channel'] ?? 'indexnow',
+            'eligibility_state' => $overrides['eligibility_state'] ?? 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'pending',
+            'execution_state' => $overrides['execution_state'] ?? 'dry_run_ready',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'claim_boundary_state' => $overrides['claim_boundary_state'] ?? 'claim_safe',
+            'private_flow' => (bool) ($overrides['private_flow'] ?? false),
+            'reason_codes' => json_encode($overrides['reason_codes'] ?? [], JSON_THROW_ON_ERROR),
+            'lastmod' => $overrides['lastmod'] ?? now()->subHour(),
+            'content_hash' => $overrides['content_hash'] ?? null,
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => $overrides['idempotency_key'] ?? hash('sha256', implode('|', [
+                strtolower(trim($canonicalUrl)),
+                strtolower(trim((string) ($overrides['locale'] ?? 'en'))),
+                strtolower(trim((string) ($overrides['channel'] ?? 'indexnow'))),
+            ])),
+            'approved_by' => $overrides['approved_by'] ?? null,
+            'approved_at' => $overrides['approved_at'] ?? null,
+            'created_at' => $overrides['created_at'] ?? now()->subDay(),
+            'updated_at' => $overrides['updated_at'] ?? now()->subHour(),
+        ]);
     }
 }


### PR DESCRIPTION
## What changed
- Allows Search Channel planning to requeue an article URL when URL Truth has a newer lastmod/content version than an already-submitted queue item.
- Keeps dry_run_ready/submitting queue items as active duplicates so in-flight work is not duplicated.
- Uses source-versioned idempotency keys for new queue rows so historical submitted evidence is preserved instead of overwritten.

## Why
article:3 was republished on 2026-06-23, but its existing IndexNow queue item was submitted on 2026-06-14 with an older lastmod. The bridge correctly found URL Truth but deduped against stale submitted evidence. This PR lets newer published article revisions get a fresh bounded queue item while preserving all approval/live-submit gates.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoIntelSearchChannelQueueRuntimeTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoAgentPostPublishSearchSubmitTest`
- `cd backend && vendor/bin/pint --test app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php`
- `git diff --check -- backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueuePlanner.php backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueIdempotency.php backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php`

## Intentionally deferred
- No production deploy in this PR.
- No Search Channel enqueue, approve, live IndexNow submit, Google Indexing API, sitemap/llms mutation, CMS publish, scheduler, or queue worker action.
- Existing unrelated local EQ compiled files and generated sidecar files were not staged.

## Repository rule impact
Backend SEO/Search Channel queue policy changed only for source-version-aware queue idempotency. Runtime content authority and live submission gates remain backend-controlled and unchanged.