### PR TITLE
IQ-OWNER-30-BACKEND-SCORING-02: Add private scoring for owner-original IQ 30 bank

### DIFF
--- a/backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+++ b/backend/scripts/iq/iq_owner_original30_image_bank_lib.php
@@ -30,6 +30,8 @@ function iqOwner30FileMap(): array
         'manifest' => $dir.'/manifest.json',
         'items' => $dir.'/items.json',
         'asset_inventory' => $dir.'/asset_inventory.json',
+        'answer_key' => $dir.'/answer_key.json',
+        'scoring_spec' => $dir.'/scoring_spec.json',
     ];
 }
 
@@ -229,7 +231,7 @@ function iqOwner30BuildPayloadsFromSource(string $sourceDir, bool $copyAssets): 
                 'stem' => 'sha256:'.$stemMetadata['sha256'],
                 'options' => $optionHashes,
             ],
-            'answer_key_status' => 'deferred_to_IQ_OWNER_30_BACKEND_SCORING_02',
+            'answer_key_status' => 'private_backend_answer_key_available',
             'provenance' => iqOwner30Provenance(),
         ];
         $inventoryAssets[] = iqOwner30InventoryEntry($questionNumber, 'stem', null, $stemRelative, $stemMetadata);
@@ -284,8 +286,8 @@ function iqOwner30ManifestPayload(): array
         'files' => [
             'items' => 'items.json',
             'asset_inventory' => 'asset_inventory.json',
-            'answer_key' => 'deferred_to_IQ_OWNER_30_BACKEND_SCORING_02',
-            'scoring_spec' => 'deferred_to_IQ_OWNER_30_BACKEND_SCORING_02',
+            'answer_key' => 'answer_key.json',
+            'scoring_spec' => 'scoring_spec.json',
         ],
         'asset_root' => 'assets/iq_owner_original_30',
         'ownership_policy' => iqOwner30Provenance(),
@@ -421,8 +423,8 @@ function iqOwner30VerifyCommittedArtifacts(): void
             throw new RuntimeException('Missing or duplicate item id: '.$itemId);
         }
         $seenIds[$itemId] = true;
-        if (($item['answer_key_status'] ?? '') !== 'deferred_to_IQ_OWNER_30_BACKEND_SCORING_02') {
-            throw new RuntimeException($itemId.' must defer answer key to PR2');
+        if (($item['answer_key_status'] ?? '') !== 'private_backend_answer_key_available') {
+            throw new RuntimeException($itemId.' must declare private backend answer key availability');
         }
         iqOwner30VerifyAssetNode((array) ($item['stem'] ?? []), $questionNumber, 'stem');
         $options = $item['options'] ?? [];
@@ -440,6 +442,113 @@ function iqOwner30VerifyCommittedArtifacts(): void
 
     foreach ($assets as $asset) {
         iqOwner30VerifyInventoryAsset((array) $asset);
+    }
+}
+
+function iqOwner30VerifyPrivateScoringArtifacts(): void
+{
+    iqOwner30VerifyCommittedArtifacts();
+
+    $files = iqOwner30FileMap();
+    $manifest = iqOwner30ReadJson($files['manifest']);
+    $itemsPayload = iqOwner30ReadJson($files['items']);
+    $answerKey = iqOwner30ReadJson($files['answer_key']);
+    $scoring = iqOwner30ReadJson($files['scoring_spec']);
+
+    if (($manifest['files']['answer_key'] ?? null) !== 'answer_key.json') {
+        throw new RuntimeException('Manifest must point to the private answer_key.json');
+    }
+    if (($manifest['files']['scoring_spec'] ?? null) !== 'scoring_spec.json') {
+        throw new RuntimeException('Manifest must point to scoring_spec.json');
+    }
+    if (($manifest['public_payload_policy']['may_emit_answer_key'] ?? true) !== false) {
+        throw new RuntimeException('Manifest must keep answer key out of public payloads');
+    }
+    if (($manifest['public_payload_policy']['may_emit_solution_rule'] ?? true) !== false) {
+        throw new RuntimeException('Manifest must keep solution rules out of public payloads');
+    }
+    if (($answerKey['public_payload'] ?? true) !== false) {
+        throw new RuntimeException('Answer key must not be public payload');
+    }
+    if (($answerKey['storage_policy'] ?? '') !== 'backend_only_never_emit_to_public_api') {
+        throw new RuntimeException('Answer key storage policy must be backend-only');
+    }
+    if (($scoring['runtime_binding']['enabled'] ?? true) !== false) {
+        throw new RuntimeException('Scoring spec must remain runtime-unbound in PR2');
+    }
+    if (($scoring['norm_policy']['iq_claims_enabled'] ?? true) !== false) {
+        throw new RuntimeException('IQ claims must remain disabled before norm authority');
+    }
+
+    $items = $itemsPayload['items'] ?? [];
+    $answers = $answerKey['answers'] ?? [];
+    if (! is_array($items) || count($items) !== 30 || ! is_array($answers) || count($answers) !== 30) {
+        throw new RuntimeException('Expected 30 items and 30 private answers');
+    }
+
+    $dimensionCounts = [];
+    foreach ($items as $index => $item) {
+        $itemId = (string) ($item['item_id'] ?? '');
+        $questionId = (string) ($item['question_id'] ?? '');
+        if ($itemId === '' || ! isset($answers[$itemId])) {
+            throw new RuntimeException('Missing private answer for '.$itemId);
+        }
+
+        iqOwner30AssertNoPublicAnswerLeak((array) $item, $itemId);
+
+        $answer = (array) $answers[$itemId];
+        if (($answer['question_id'] ?? null) !== $questionId) {
+            throw new RuntimeException('Question id mismatch for '.$itemId);
+        }
+        $correct = (string) ($answer['correct_answer'] ?? '');
+        if (! in_array($correct, iqOwner30OptionCodes(), true)) {
+            throw new RuntimeException('Invalid correct answer for '.$itemId);
+        }
+        $dimension = (string) ($answer['dimension'] ?? '');
+        if ($dimension === '') {
+            throw new RuntimeException('Missing scoring dimension for '.$itemId);
+        }
+        $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+        $difficulty = $answer['difficulty_level'] ?? null;
+        if (! is_int($difficulty) || $difficulty < 1 || $difficulty > 5) {
+            throw new RuntimeException('Invalid difficulty level for '.$itemId);
+        }
+
+        $expectedItemId = sprintf('IQ_OWNER_ORIGINAL_30_%02d', $index + 1);
+        if ($itemId !== $expectedItemId) {
+            throw new RuntimeException('Unexpected item id order: '.$itemId);
+        }
+    }
+
+    ksort($dimensionCounts);
+    $scoringCounts = (array) ($scoring['dimension_counts'] ?? []);
+    ksort($scoringCounts);
+    if ($scoringCounts !== $dimensionCounts) {
+        throw new RuntimeException('Scoring dimension counts do not match answer key');
+    }
+    if (($scoring['raw_score']['max'] ?? null) !== 30 || ($scoring['raw_score']['correct_item_value'] ?? null) !== 1) {
+        throw new RuntimeException('Raw score spec must score 30 one-point items');
+    }
+}
+
+function iqOwner30AssertNoPublicAnswerLeak(array $node, string $context): void
+{
+    $forbidden = [
+        'answer_key',
+        'answerKey',
+        'correct_answer',
+        'correctAnswer',
+        'solution_rule',
+        'solutionRule',
+    ];
+
+    foreach ($node as $key => $value) {
+        if (is_string($key) && in_array($key, $forbidden, true)) {
+            throw new RuntimeException('Public item payload leaks private field '.$key.' in '.$context);
+        }
+        if (is_array($value)) {
+            iqOwner30AssertNoPublicAnswerLeak($value, $context);
+        }
     }
 }
 

--- a/backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
+++ b/backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_owner_original30_image_bank_lib.php';
+
+try {
+    iqOwner30VerifyPrivateScoringArtifacts();
+} catch (Throwable $e) {
+    fwrite(STDERR, 'IQ_OWNER_ORIGINAL_30 private scoring verification failed: '.$e->getMessage()."\n");
+    exit(1);
+}
+
+echo "IQ_OWNER_ORIGINAL_30 private scoring verification passed.\n";

--- a/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+++ b/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Iq\IqResultPayloadRedactor;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class IqOwnerOriginal30PrivateScoringTest extends TestCase
+{
+    private function bankDir(): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30');
+    }
+
+    private function readJson(string $file): array
+    {
+        $payload = json_decode((string) file_get_contents($this->bankDir().'/'.$file), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    #[Test]
+    public function private_answer_key_and_scoring_spec_are_present_but_runtime_unbound(): void
+    {
+        $manifest = $this->readJson('manifest.json');
+        $answerKey = $this->readJson('answer_key.json');
+        $scoring = $this->readJson('scoring_spec.json');
+
+        $this->assertSame('IQ_OWNER_ORIGINAL_30', $manifest['bank_id']);
+        $this->assertSame('answer_key.json', $manifest['files']['answer_key']);
+        $this->assertSame('scoring_spec.json', $manifest['files']['scoring_spec']);
+        $this->assertFalse($manifest['runtime_bound']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_answer_key']);
+        $this->assertFalse($answerKey['public_payload']);
+        $this->assertSame('backend_only_never_emit_to_public_api', $answerKey['storage_policy']);
+        $this->assertCount(30, $answerKey['answers']);
+        $this->assertSame(30, $scoring['raw_score']['max']);
+        $this->assertSame(1, $scoring['raw_score']['correct_item_value']);
+        $this->assertFalse($scoring['norm_policy']['iq_claims_enabled']);
+        $this->assertFalse($scoring['runtime_binding']['enabled']);
+    }
+
+    #[Test]
+    public function answer_key_covers_every_item_without_exposing_correct_answers_in_items(): void
+    {
+        $items = $this->readJson('items.json')['items'] ?? [];
+        $answers = $this->readJson('answer_key.json')['answers'] ?? [];
+        $this->assertCount(30, $items);
+        $this->assertCount(30, $answers);
+
+        foreach ($items as $index => $item) {
+            $itemId = sprintf('IQ_OWNER_ORIGINAL_30_%02d', $index + 1);
+            $this->assertSame($itemId, $item['item_id'] ?? null);
+            $this->assertSame('private_backend_answer_key_available', $item['answer_key_status'] ?? null);
+            $this->assertArrayHasKey($itemId, $answers);
+            $this->assertSame($item['question_id'] ?? null, $answers[$itemId]['question_id'] ?? null);
+            $this->assertContains($answers[$itemId]['correct_answer'] ?? null, ['A', 'B', 'C', 'D', 'E', 'F']);
+            $this->assertPayloadHasNoPrivateIqFields($item);
+        }
+    }
+
+    #[Test]
+    public function redacted_public_payload_contains_no_answer_key_or_solution_fields(): void
+    {
+        $items = $this->readJson('items.json')['items'] ?? [];
+        $this->assertNotEmpty($items);
+
+        $redacted = IqResultPayloadRedactor::redactAnswerKeys([
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => 'IQ_OWNER_ORIGINAL_30',
+            'items' => [$items[0]],
+            'answer_key' => $this->readJson('answer_key.json'),
+            'scoring_spec' => $this->readJson('scoring_spec.json'),
+        ]);
+
+        $this->assertSame('IQ_OWNER_ORIGINAL_30', $redacted['bank_id'] ?? null);
+        $this->assertPayloadHasNoPrivateIqFields($redacted);
+    }
+
+    private function assertPayloadHasNoPrivateIqFields(array $payload): void
+    {
+        $forbidden = [
+            'answer_key',
+            'answerKey',
+            'correct_answer',
+            'correctAnswer',
+            'solution_rule',
+            'solutionRule',
+            'distractor_logic',
+            'distractorLogic',
+            'generator_metadata',
+            'generatorMetadata',
+        ];
+
+        foreach ($payload as $key => $value) {
+            $this->assertNotContains($key, $forbidden);
+
+            if (is_array($value)) {
+                $this->assertPayloadHasNoPrivateIqFields($value);
+            }
+        }
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json
@@ -1,0 +1,194 @@
+{
+    "schema_version": "fm.iq.item_bank.answer_key.v1",
+    "bank_id": "IQ_OWNER_ORIGINAL_30",
+    "public_payload": false,
+    "storage_policy": "backend_only_never_emit_to_public_api",
+    "answer_source": {
+        "authority": "owner_approved_visual_analysis",
+        "approved_by": "FermatMind / Rainie",
+        "approved_at": "2026-06-23",
+        "notes": "Owner-confirmed answer key for the owner-original 30-question IQ image bank."
+    },
+    "answers": {
+        "IQ_OWNER_ORIGINAL_30_01": {
+            "question_id": "IQOWNER30-Q01",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_OWNER_ORIGINAL_30_02": {
+            "question_id": "IQOWNER30-Q02",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_OWNER_ORIGINAL_30_03": {
+            "question_id": "IQOWNER30-Q03",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_OWNER_ORIGINAL_30_04": {
+            "question_id": "IQOWNER30-Q04",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_05": {
+            "question_id": "IQOWNER30-Q05",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_06": {
+            "question_id": "IQOWNER30-Q06",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_07": {
+            "question_id": "IQOWNER30-Q07",
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_08": {
+            "question_id": "IQOWNER30-Q08",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_09": {
+            "question_id": "IQOWNER30-Q09",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_10": {
+            "question_id": "IQOWNER30-Q10",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_11": {
+            "question_id": "IQOWNER30-Q11",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_12": {
+            "question_id": "IQOWNER30-Q12",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_13": {
+            "question_id": "IQOWNER30-Q13",
+            "correct_answer": "F",
+            "dimension": "NPR",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_14": {
+            "question_id": "IQOWNER30-Q14",
+            "correct_answer": "C",
+            "dimension": "NPR",
+            "difficulty_level": 2
+        },
+        "IQ_OWNER_ORIGINAL_30_15": {
+            "question_id": "IQOWNER30-Q15",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_16": {
+            "question_id": "IQOWNER30-Q16",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 4
+        },
+        "IQ_OWNER_ORIGINAL_30_17": {
+            "question_id": "IQOWNER30-Q17",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_OWNER_ORIGINAL_30_18": {
+            "question_id": "IQOWNER30-Q18",
+            "correct_answer": "E",
+            "dimension": "NPR",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_19": {
+            "question_id": "IQOWNER30-Q19",
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_OWNER_ORIGINAL_30_20": {
+            "question_id": "IQOWNER30-Q20",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_OWNER_ORIGINAL_30_21": {
+            "question_id": "IQOWNER30-Q21",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_OWNER_ORIGINAL_30_22": {
+            "question_id": "IQOWNER30-Q22",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_OWNER_ORIGINAL_30_23": {
+            "question_id": "IQOWNER30-Q23",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_24": {
+            "question_id": "IQOWNER30-Q24",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_25": {
+            "question_id": "IQOWNER30-Q25",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_26": {
+            "question_id": "IQOWNER30-Q26",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_27": {
+            "question_id": "IQOWNER30-Q27",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_28": {
+            "question_id": "IQOWNER30-Q28",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_29": {
+            "question_id": "IQOWNER30-Q29",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        },
+        "IQ_OWNER_ORIGINAL_30_30": {
+            "question_id": "IQOWNER30-Q30",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 5
+        }
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json
@@ -115,7 +115,7 @@
                     "F": "sha256:a89b76256fb05672f50c824501fb7dd270011400a82ed90d8fb792c1b2c9b4d9"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -236,7 +236,7 @@
                     "F": "sha256:da4f65e330ffd5cb0f569bf1976b09f1a1422f9af89afb02d9324fab563c9fd2"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -357,7 +357,7 @@
                     "F": "sha256:8e0277019d8f5e1303e738d99d939cc6b298b91888c2f4f7d045d66c902edfb9"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -478,7 +478,7 @@
                     "F": "sha256:59ee278fa78c8a46b8860f8b31c80091f7321726ccdbcc999192c92857580f8b"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -599,7 +599,7 @@
                     "F": "sha256:eec65f94765614c57e4680e5097c98cf949499a751c05d5b39e1c1f254a3241d"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -720,7 +720,7 @@
                     "F": "sha256:8cccfb36d9f35d8373cc4575a7ecc404c18b6e8d89cb9ac74c698531d28668a0"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -841,7 +841,7 @@
                     "F": "sha256:2195c0d2ed0f1c1f6d48362368fc0449e31c9507e8c777572026049b1761b56c"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -962,7 +962,7 @@
                     "F": "sha256:c9a959ecab5333012d602f0b2d13f020fee3b5f9cf119d31987b732b788d25c3"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1083,7 +1083,7 @@
                     "F": "sha256:0dac435e510a40691020901cd7e0c7a92c5a1127923af8c519d5e31ddfdfd180"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1204,7 +1204,7 @@
                     "F": "sha256:149844bd9ff423168dd4d5845f1fd654c00bb577af232012505511aae5d9114a"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1325,7 +1325,7 @@
                     "F": "sha256:dc2ee6cf2d7b6c2e66eb5159979e37d987083473822f09f0b1bdfbd2c8196e96"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1446,7 +1446,7 @@
                     "F": "sha256:363e569ae689cf71834a9b73121633658f6c2b1766957bf0078a8f8be341410c"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1567,7 +1567,7 @@
                     "F": "sha256:1f3e94e292f35e01452bf01b3acfdf5959f1f3f05a46f008f51d25f7eb779eb9"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1688,7 +1688,7 @@
                     "F": "sha256:f1019e697041f2cb62a58f1a9221bcd977b18bd7203894ce6194f25a93bec02d"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1809,7 +1809,7 @@
                     "F": "sha256:014ec9853542576755c2f72baabca9b7a64b12d8a1a881163bea07400a3de7d9"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -1930,7 +1930,7 @@
                     "F": "sha256:2e4ee25714fe3c0296c7b9b90ba9283b68dd49ab4c1b6b5dc3f8de2a3e0b65f9"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2051,7 +2051,7 @@
                     "F": "sha256:f648c7db833b8939248a16234b61ba488a4a3b719bd615300da80619755e247f"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2172,7 +2172,7 @@
                     "F": "sha256:b4797ab31b36bae076e8cfd7937706182fe818057527ccb77e1ddf293d4db27f"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2293,7 +2293,7 @@
                     "F": "sha256:e81e0ab93bcb561b353343d9c1d796ee06c56c6ce9025ae904ade7e7d5b5785a"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2414,7 +2414,7 @@
                     "F": "sha256:18be4fa60f75562951f5ccf0cf8a8127085723f01fd0fb0b17fb0b2a86d8a822"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2535,7 +2535,7 @@
                     "F": "sha256:7b63c12377345349aa9000f36ebb10383f80aef8769fab06484d607fd2d159e1"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2656,7 +2656,7 @@
                     "F": "sha256:2cac77e630f72f44114363615eb79deaa465126f1835ae41ad35b5eb5211d01b"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2777,7 +2777,7 @@
                     "F": "sha256:6ffb2f4cdac776e949a974eb615df09af6fc715f9e2b746fb01eaccbaf9478d6"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -2898,7 +2898,7 @@
                     "F": "sha256:76b2c6c6a1223b0bd28f9043c4cce57d06e20893c0a33abb075eab385a944a88"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3019,7 +3019,7 @@
                     "F": "sha256:7c98c1bfb057a3a3e1f1a23b45e48e6994437d396ef234f1c571fa5ed5f55b8d"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3140,7 +3140,7 @@
                     "F": "sha256:8d14c815580c0e5caa98257e962a4e0af4c773060f2cc3631c73660915edefbc"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3261,7 +3261,7 @@
                     "F": "sha256:23b12822651247691a1eeafcbd7bbdda6c25ef65798cd3a6f25c7b33e785feaa"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3382,7 +3382,7 @@
                     "F": "sha256:2a10f9cfbe8a3e3dde53bffc58cbaeb5bc62fee6610abaf4c7f42d28a9ecd2a8"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3503,7 +3503,7 @@
                     "F": "sha256:2072eb228da6944774be085f475b2ac67bf8e3406ca21e7619ed48de68c5b11a"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",
@@ -3624,7 +3624,7 @@
                     "F": "sha256:91caa9e27052d714659e865e99a5fa20ee88806ad324e98f031ffecfeebe51db"
                 }
             },
-            "answer_key_status": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
+            "answer_key_status": "private_backend_answer_key_available",
             "provenance": {
                 "source_mode": "owner_original_local_asset_import",
                 "declared_original_owner": "FermatMind / Rainie",

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
@@ -3,7 +3,7 @@
     "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
     "bank_id": "IQ_OWNER_ORIGINAL_30",
     "name": "FermatMind IQ Owner Original 30",
-    "status": "owner_original_imported_runtime_unbound",
+    "status": "owner_original_private_scoring_ready_runtime_unbound",
     "runtime_bound": false,
     "locale": "zh-CN",
     "market": "CN_MAINLAND",
@@ -21,8 +21,8 @@
     "files": {
         "items": "items.json",
         "asset_inventory": "asset_inventory.json",
-        "answer_key": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02",
-        "scoring_spec": "deferred_to_IQ_OWNER_30_BACKEND_SCORING_02"
+        "answer_key": "answer_key.json",
+        "scoring_spec": "scoring_spec.json"
     },
     "asset_root": "assets/iq_owner_original_30",
     "ownership_policy": {

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
@@ -1,0 +1,32 @@
+{
+    "schema_version": "fm.iq.scoring_spec.v1",
+    "bank_id": "IQ_OWNER_ORIGINAL_30",
+    "status": "owner_original_private_scoring_ready_runtime_unbound",
+    "raw_score": {
+        "min": 0,
+        "max": 30,
+        "correct_item_value": 1,
+        "incorrect_item_value": 0
+    },
+    "dimension_counts": {
+        "NPR": 3,
+        "VSI": 13,
+        "VSPR": 14
+    },
+    "norm_policy": {
+        "iq_claims_enabled": false,
+        "percentile_claims_enabled": false,
+        "population_norm_table_required_before_production": true,
+        "owner_original_bank_norm_table_required_before_iq_claims": true,
+        "beta_copy_allowed_claim": "practice-style cognitive reasoning score only"
+    },
+    "public_payload_policy": {
+        "may_emit_answer_key": false,
+        "may_emit_solution_rule": false,
+        "may_emit_scoring_key": false
+    },
+    "runtime_binding": {
+        "enabled": false,
+        "deferred_to_pr": "IQ-OWNER-30-FE-FORMCODE-04"
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59284,7 +59284,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-controlled-pilot-gate",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "big5_result_page_agent_readiness_to_pilot",
     "title": "BIG5-CONTROLLED-PILOT-GATE-01: Add Big Five controlled pilot gate",
     "depends_on": [
@@ -60064,12 +60064,12 @@
         "evidence": "Changed files are limited to PR2 allowed paths: owner-original IQ private answer key, scoring spec, owner IQ verification helper/script, focused PHPUnit test, bank manifest/items answer-key status, and docs/codex metadata. Runtime question selection, public scale APIs, attempt submission, frontend rendering, CMS, SEO runtime, sitemap, llms, JSON-LD, staging deploy, and production deploy were not modified."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "All PR #2364 GitHub checks passed on head 91026e907eae9e8fa7b7e10d9e6957f9dc2d4c15: hygiene, Semgrep blocking secrets, semgrep SARIF non-blocking upload, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, and Semgrep OSS. mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "9adbb0ac9898c12117b6cb5751b002f8c5e569b4",
+    "commit_sha": "91026e907eae9e8fa7b7e10d9e6957f9dc2d4c15",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2364",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -60089,6 +60089,11 @@
         "at": "2026-06-23T10:31:20Z",
         "status": "pr_open",
         "note": "Opened PR #2364 after PR2 local validation and explicit allowed-path scope validation passed."
+      },
+      {
+        "at": "2026-06-23T10:37:39Z",
+        "status": "ready_to_merge",
+        "note": "All PR #2364 GitHub checks passed on head 91026e907eae9e8fa7b7e10d9e6957f9dc2d4c15 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60026,7 +60026,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-backend-scoring-02",
     "base": "main",
-    "status": "local_validated",
+    "status": "pr_open",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-BACKEND-SCORING-02: Add private scoring for owner-original IQ 30 bank",
     "depends_on": [
@@ -60069,8 +60069,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9adbb0ac9898c12117b6cb5751b002f8c5e569b4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2364",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -60084,6 +60084,11 @@
         "at": "2026-06-23T10:28:51Z",
         "status": "local_validated",
         "note": "Required PR2 local validation and explicit allowed-path scope validation passed. Composer vendor and backend .env were local ignored test dependencies only and are excluded from scope."
+      },
+      {
+        "at": "2026-06-23T10:31:20Z",
+        "status": "pr_open",
+        "note": "Opened PR #2364 after PR2 local validation and explicit allowed-path scope validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -59213,7 +59213,7 @@
     "repo": "fap-api",
     "branch": "codex/big5-result-page-seo-geo-control-handoff",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "big5_result_page_agent_readiness_to_pilot",
     "title": "BIG5-RESULT-PAGE-SEO-GEO-CONTROL-HANDOFF-01: Add Big Five SEO/GEO control handoff",
     "depends_on": [
@@ -59984,16 +59984,16 @@
         "evidence": "PR1 changes are limited to backend/scripts/iq owner-original bank import/verify scripts, IQ_OWNER_ORIGINAL_30 bank JSON, iq_owner_original_30 image assets, and docs/codex manifest/state metadata. Existing backend/content_packs/EQ_60/v1/compiled drift is outside scope and will not be staged."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2362 is MERGED at 2026-06-23T08:17:44Z with merge commit 8018703a39d50ecd77225efc482d95af69d26c70; origin/main contains the merge commit."
       }
     },
     "failure_reason": null,
-    "commit_sha": "8b3cc91ac88c38e13f25a1fd28b056dda75ad411",
+    "commit_sha": "9eeb91f57477072fe472b8269ac30ba83004691b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2362",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-23T08:17:44Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-23T07:58:33Z",
@@ -60014,6 +60014,76 @@
         "at": "2026-06-23T08:10:09Z",
         "status": "ready_to_merge",
         "note": "All PR #2362 GitHub checks passed on head 8b3cc91ac88c38e13f25a1fd28b056dda75ad411 and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+      },
+      {
+        "at": "2026-06-23T10:21:44Z",
+        "status": "merged",
+        "note": "Reconciled stale PR1 ledger while starting PR2: GitHub reports PR #2362 merged at 2026-06-23T08:17:44Z with merge commit 8018703a39d50ecd77225efc482d95af69d26c70; origin/main contains the merge commit; local branch codex/iq-owner-30-backend-assets-01 is absent; remote branch is absent."
+      }
+    ]
+  },
+  "IQ-OWNER-30-BACKEND-SCORING-02": {
+    "repo": "fap-api",
+    "branch": "codex/iq-owner-30-backend-scoring-02",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "iq_owner_original_30_launch",
+    "title": "IQ-OWNER-30-BACKEND-SCORING-02: Add private scoring for owner-original IQ 30 bank",
+    "depends_on": [
+      "IQ-OWNER-30-BACKEND-ASSETS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided /goal authorization for IQ_OWNER_ORIGINAL_30 PR train and confirmed the proposed owner-original answer scheme with: 就按照的方案开."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-OWNER-30-BACKEND-ASSETS-01 is merged: PR #2362 merged at 2026-06-23T08:17:44Z with merge commit 8018703a39d50ecd77225efc482d95af69d26c70, and origin/main contains that merge commit."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php",
+          "php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php",
+          "php -l backend/scripts/iq/verify_iq_owner_original30_private_scoring.php",
+          "cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest --no-ansi",
+          "cd backend && vendor/bin/pint --test tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: private scoring verifier; PHP syntax checks for iq_owner_original30_image_bank_lib.php and verify_iq_owner_original30_private_scoring.php; PHPUnit IqOwnerOriginal30PrivateScoringTest (3 tests, 3326 assertions); scoped Pint; JSON/YAML parse checks; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to PR2 allowed paths: owner-original IQ private answer key, scoring spec, owner IQ verification helper/script, focused PHPUnit test, bank manifest/items answer-key status, and docs/codex metadata. Runtime question selection, public scale APIs, attempt submission, frontend rendering, CMS, SEO runtime, sitemap, llms, JSON-LD, staging deploy, and production deploy were not modified."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-23T10:21:44Z",
+        "status": "in_progress",
+        "note": "Started PR2 from latest fap-api main on codex/iq-owner-30-backend-scoring-02. Scope is limited to backend-only private answer key, raw scoring spec, no-answer-leak verification, focused test, and docs/codex metadata. Runtime formCode switching, public session delivery, frontend rendering, staging deploy, and production deploy are deferred."
+      },
+      {
+        "at": "2026-06-23T10:28:51Z",
+        "status": "local_validated",
+        "note": "Required PR2 local validation and explicit allowed-path scope validation passed. Composer vendor and backend .env were local ignored test dependencies only and are excluded from scope."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -27721,3 +27721,52 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: IQ-OWNER-30-BACKEND-SCORING-02
+    repo: fap-api
+    depends_on:
+      - IQ-OWNER-30-BACKEND-ASSETS-01
+    branch: codex/iq-owner-30-backend-scoring-02
+    title: "IQ-OWNER-30-BACKEND-SCORING-02: Add private scoring for owner-original IQ 30 bank"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Add the backend-only private answer key for IQ_OWNER_ORIGINAL_30 using the owner-approved answer scheme.
+      - Add raw-score scoring spec with IQ and percentile claims disabled until a norm table exists.
+      - Verify public item payloads do not expose correct answers, answer keys, or solution rules.
+      - Keep the bank runtime-unbound and defer formCode switching, session delivery, frontend rendering, staging deploy, and production deploy.
+    allowed_paths:
+      - backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+      - backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
+      - backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime question selection, public scale APIs, attempt submission, frontend rendering, CMS, SEO runtime, sitemap, llms, JSON-LD, production imports, staging deploy, or production deploy.
+      - Bind IQ_OWNER_ORIGINAL_30 to a public formCode or session delivery endpoint.
+      - Emit correct answers, answer keys, solution rules, or answer-source notes in public payloads.
+    validation:
+      - php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
+      - php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+      - php -l backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
+      - cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added backend-only `answer_key.json` for the owner-original `IQ_OWNER_ORIGINAL_30` bank using the owner-approved 30-answer scheme.
- Added `scoring_spec.json` with 30-point raw scoring, dimension counts, and IQ/percentile claims disabled until norm authority exists.
- Updated the owner bank manifest/items to mark private backend scoring as available without exposing answers in public item payloads.
- Added a private scoring verifier and focused PHPUnit coverage for answer-key coverage and no-answer-leak behavior.
- Reconciled stale PR1 ledger state after verifying PR #2362 is merged and contained in `origin/main`.

## Why
This is PR2 in the IQ owner-original 30 launch train. It establishes the private backend scoring authority while keeping the bank runtime-unbound and preventing answer leakage through public item payloads.

## Validation
- `php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php`
- `php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php`
- `php -l backend/scripts/iq/verify_iq_owner_original30_private_scoring.php`
- `cd backend && php artisan test --filter=IqOwnerOriginal30PrivateScoringTest --no-ansi`
- `cd backend && vendor/bin/pint --test tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php`
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null`
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null`
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null`
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- explicit allowed-path scope validation passed

## Intentionally deferred
- Runtime formCode/bank switch
- Public session/windowed delivery
- Frontend image renderer and layout
- Staging deploy wait
- Production import/deploy
- IQ/percentile norm claims
