### PR TITLE
Fix career content staging preview projection leaks

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -269,21 +269,84 @@ final class CareerAiImpactAssetPreviewService
         $normalizedSlug = $this->normalizeSlug($slug);
         $normalizedLocale = $this->normalizeLocale($locale);
 
-        $commonZh = [
+        $aviationZh = [
             '运行安全、放行条件、天气改航、间隔限制、维护记录和旅客/机组安全' => '现场安全、记录完整性、异常处置、交付边界和最终责任',
             '运行限制说明、异常处置日志、天气/NOTAM 核对和放行复盘' => '工作说明、异常记录、复核清单和交付复盘',
             '调度系统、检查单、维护记录、航班/车辆运行日志' => '工作记录、检查单、复核步骤和交付日志',
         ];
 
-        $commonEn = [
+        $aviationEn = [
             'operational safety, release conditions, weather diversion, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
             'operational safety, release conditions, weather diversions, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
             'an operating-limit note, abnormal-event log, weather or NOTAM check, and release review' => 'a work note, exception log, review checklist, and delivery review',
             'dispatch systems, checklists, maintenance records, and flight or vehicle operation logs' => 'work records, checklists, review steps, and delivery logs',
         ];
 
+        $wildlifeZh = [
+            '物种观察' => '现场观察',
+            '栖息地数据' => '现场资料',
+            '物种误识、生态不确定性' => '识别误差、现场不确定性',
+        ];
+
+        $wildlifeEn = [
+            'species observations' => 'field observations',
+            'habitat data' => 'field records',
+            'species misidentification, ecological uncertainty' => 'identification errors and field uncertainty',
+        ];
+
+        $clinicalZh = [
+            '临床升级、用药核对、转诊判断、患者沟通和病情变化记录' => '业务升级、关键核对、协作判断、对象沟通和状态变化记录',
+            '临床升级' => '业务升级',
+            '用药核对' => '关键核对',
+            '转诊判断' => '协作判断',
+            '患者沟通' => '对象沟通',
+            '患者安全' => '对象安全',
+            '急诊分诊' => '优先级分流',
+        ];
+
+        $clinicalEn = [
+            'clinical escalation, medication checks, referral judgment, patient communication, and change-in-condition records' => 'workflow escalation, critical checks, handoff judgment, stakeholder communication, and change records',
+            'clinical escalation' => 'workflow escalation',
+            'patient referral' => 'service referral',
+            'clinical referral' => 'service referral',
+            'medical referral' => 'service referral',
+            'medication' => 'critical check',
+            'patient safety' => 'user safety',
+            'emergency triage' => 'priority triage',
+        ];
+
+        $militaryZh = [
+            '态势判断、指挥链、人员安全、任务规则和升级交接' => '现场判断、责任链条、人员安全、规则约束和升级交接',
+            '指挥链' => '责任链条',
+            '态势判断' => '现场判断',
+            '武器' => '设备',
+            '交战规则' => '操作规则',
+        ];
+
+        $militaryEn = [
+            'situational judgment, chain of command, personnel safety, mission rules, and escalation handoff' => 'context judgment, accountability chain, people safety, operating rules, and escalation handoff',
+            'chain of command' => 'accountability chain',
+            'situational judgment' => 'context judgment',
+            'weapons' => 'equipment',
+            'rules of engagement' => 'operating rules',
+        ];
+
+        $replacements = [];
+        if (! $this->isAviationContextSlug($normalizedSlug)) {
+            $replacements = array_merge($replacements, $normalizedLocale === 'en' ? $aviationEn : $aviationZh);
+        }
+        if (! $this->isWildlifeContextSlug($normalizedSlug)) {
+            $replacements = array_merge($replacements, $normalizedLocale === 'en' ? $wildlifeEn : $wildlifeZh);
+        }
+        if (! $this->isMedicalContextSlug($normalizedSlug)) {
+            $replacements = array_merge($replacements, $normalizedLocale === 'en' ? $clinicalEn : $clinicalZh);
+        }
+        if (! $this->isMilitaryContextSlug($normalizedSlug)) {
+            $replacements = array_merge($replacements, $normalizedLocale === 'en' ? $militaryEn : $militaryZh);
+        }
+
         if ($normalizedSlug === 'writers-and-authors') {
-            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
                 'species observations' => 'interview notes',
                 'habitat data' => 'background material',
                 'species misidentification, ecological uncertainty' => 'factual misreadings, voice inconsistency',
@@ -303,7 +366,7 @@ final class CareerAiImpactAssetPreviewService
         }
 
         if ($normalizedSlug === 'zoologists-and-wildlife-biologists') {
-            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
                 'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'field safety, species identification, sample records, habitat boundaries, permit ethics, public explanation, and final accountability',
                 'a work note, exception log, review checklist, and delivery review' => 'a field note, sample log, permit check, and observation review',
                 'work records, checklists, review steps, and delivery logs' => 'field survey sheets, sample records, GIS or habitat notes, and review checklists',
@@ -315,7 +378,7 @@ final class CareerAiImpactAssetPreviewService
         }
 
         if ($normalizedSlug === 'elementary-school-teachers-except-special-education') {
-            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
                 'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'student differences, classroom feedback, learning pace, family communication, assessment boundaries, and child-safety responsibility',
                 'a work note, exception log, review checklist, and delivery review' => 'a lesson plan, student-work sample, feedback record, and intervention review',
                 'work records, checklists, review steps, and delivery logs' => 'classroom notes, rubrics, progress trackers, and family-communication records',
@@ -327,7 +390,7 @@ final class CareerAiImpactAssetPreviewService
         }
 
         if ($normalizedSlug === 'heavy-and-tractor-trailer-truck-drivers') {
-            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
                 'operational context, exception handling, record quality, delivery boundaries, and final accountability' => 'road safety, vehicle inspection, hours-of-service compliance, weather and route risk, load responsibility, and delivery communication',
                 'a work note, exception log, review checklist, and delivery review' => 'a vehicle checklist, route-risk note, maintenance handoff, and safety review',
                 'work records, checklists, review steps, and delivery logs' => 'route logs, inspection reports, maintenance handoff records, and delivery notes',
@@ -339,7 +402,7 @@ final class CareerAiImpactAssetPreviewService
         }
 
         if ($normalizedSlug === 'wind-turbine-technicians') {
-            return array_merge($normalizedLocale === 'en' ? $commonEn : $commonZh, $normalizedLocale === 'en' ? [
+            return array_merge($replacements, $normalizedLocale === 'en' ? [
                 'command chain' => 'site safety chain',
                 'weapons' => 'equipment',
                 'mission risk' => 'maintenance risk',
@@ -351,7 +414,27 @@ final class CareerAiImpactAssetPreviewService
             ]);
         }
 
-        return [];
+        return $replacements;
+    }
+
+    private function isAviationContextSlug(string $slug): bool
+    {
+        return (bool) preg_match('/aviation|air-traffic|aircraft|avionics|flight|pilot|air-crew|transportation-security/', $slug);
+    }
+
+    private function isWildlifeContextSlug(string $slug): bool
+    {
+        return (bool) preg_match('/zoologists|wildlife|animal|veterinar|forest|conservation|environmental/', $slug);
+    }
+
+    private function isMedicalContextSlug(string $slug): bool
+    {
+        return (bool) preg_match('/allerg|immunolog|anesthesiolog|audiolog|cardiovascular|dental|dentist|dietetic|dietitian|diagnostic|dosimetrist|emergency|genetic-counselor|health|medical|clinical|nurse|pharmac|phlebotom|physician|surgeon|psychiatr|psycholog|radiolog|respiratory|sonographer|therapist|therapy|veterinar|athletic-trainer|orthotist|prosthetist|optometrist|ophthalmolog|podiatrist|urologist|midwi|orderlies|paramedic|emt/', $slug);
+    }
+
+    private function isMilitaryContextSlug(string $slug): bool
+    {
+        return (bool) preg_match('/military|weapons|command|air-crew-members|armored|artillery|infantry|tactical|special-forces/', $slug);
     }
 
     /**

--- a/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php
+++ b/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php
@@ -87,7 +87,9 @@ final class CareerPageAssemblyPreviewService
             'reader_boundary',
         ] as $readerKey) {
             if (array_key_exists($readerKey, $payload)) {
-                $safePayload[$readerKey] = $this->sanitizeReaderValue($payload[$readerKey]);
+                $safePayload[$readerKey] = $readerKey === 'occupation' && is_array($payload[$readerKey])
+                    ? $this->readerSafeOccupation($payload[$readerKey], (string) ($payload['locale'] ?? ''))
+                    : $this->sanitizeReaderValue($payload[$readerKey]);
             }
         }
 
@@ -116,6 +118,24 @@ final class CareerPageAssemblyPreviewService
             'zh', 'zh-cn', 'zh_cn' => 'zh-CN',
             default => null,
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $occupation
+     * @return array<string, mixed>
+     */
+    private function readerSafeOccupation(array $occupation, string $locale): array
+    {
+        $safeOccupation = $this->sanitizeReaderValue($occupation);
+        if (! is_array($safeOccupation)) {
+            return [];
+        }
+
+        if ($this->normalizeLocale($locale) === 'en') {
+            unset($safeOccupation['title_zh']);
+        }
+
+        return $safeOccupation;
     }
 
     private function sanitizeReaderValue(mixed $value): mixed

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -772,6 +772,8 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         Config::set('career_ai_impact_assets.preview_slugs', [
             'writers-and-authors',
             'heavy-and-tractor-trailer-truck-drivers',
+            'architects',
+            'biochemists-and-biophysicists',
         ]);
 
         $writerOccupation = $this->seedOccupation('writers-and-authors');
@@ -821,6 +823,56 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             'asset_row_hash' => $truckZh['audit_fields']['row_hash'],
         ]);
 
+        $architectOccupation = $this->seedOccupation('architects');
+        foreach (['zh-CN', 'en'] as $locale) {
+            $architectRow = $this->assetRow('architects', $locale);
+            if ($locale === 'zh-CN') {
+                $architectRow['items']['human_accountability_anchors'][0]['body'] = '正式采用仍要看态势判断、指挥链、人员安全、任务规则和升级交接。';
+            } else {
+                $architectRow['items']['human_accountability_anchors'][0]['body'] = 'Final use still depends on situational judgment, chain of command, personnel safety, mission rules, and escalation handoff.';
+            }
+
+            CareerJobAiImpactAsset::query()->create([
+                'occupation_id' => $architectOccupation->id,
+                'career_job_slug' => 'architects',
+                'locale' => $locale,
+                'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $architectRow,
+                'sources_json' => $architectRow['sources'],
+                'evidence_used_json' => $architectRow['evidence_used'],
+                'derived_from_synthesis_json' => $architectRow['derived_from_synthesis'],
+                'audit_fields_json' => $architectRow['audit_fields'],
+                'asset_row_hash' => $architectRow['audit_fields']['row_hash'],
+            ]);
+        }
+
+        $biochemistOccupation = $this->seedOccupation('biochemists-and-biophysicists');
+        foreach (['zh-CN', 'en'] as $locale) {
+            $biochemistRow = $this->assetRow('biochemists-and-biophysicists', $locale);
+            if ($locale === 'zh-CN') {
+                $biochemistRow['items']['human_accountability_anchors'][0]['body'] = '正式采用仍要看临床升级、用药核对、转诊判断、患者沟通和病情变化记录。';
+            } else {
+                $biochemistRow['items']['human_accountability_anchors'][0]['body'] = 'Final use still depends on clinical escalation, medication checks, referral judgment, patient communication, and change-in-condition records.';
+            }
+
+            CareerJobAiImpactAsset::query()->create([
+                'occupation_id' => $biochemistOccupation->id,
+                'career_job_slug' => 'biochemists-and-biophysicists',
+                'locale' => $locale,
+                'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $biochemistRow,
+                'sources_json' => $biochemistRow['sources'],
+                'evidence_used_json' => $biochemistRow['evidence_used'],
+                'derived_from_synthesis_json' => $biochemistRow['derived_from_synthesis'],
+                'audit_fields_json' => $biochemistRow['audit_fields'],
+                'asset_row_hash' => $biochemistRow['audit_fields']['row_hash'],
+            ]);
+        }
+
         $writerZhAsset = $this->getJson('/api/v0.5/career/jobs/writers-and-authors/ai-impact-asset?locale=zh-CN')
             ->assertOk()
             ->json('ai_impact_asset_v1');
@@ -830,10 +882,26 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $truckZhAsset = $this->getJson('/api/v0.5/career/jobs/heavy-and-tractor-trailer-truck-drivers/ai-impact-asset?locale=zh-CN')
             ->assertOk()
             ->json('ai_impact_asset_v1');
+        $architectZhAsset = $this->getJson('/api/v0.5/career/jobs/architects/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+        $architectEnAsset = $this->getJson('/api/v0.5/career/jobs/architects/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+        $biochemistZhAsset = $this->getJson('/api/v0.5/career/jobs/biochemists-and-biophysicists/ai-impact-asset?locale=zh-CN')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+        $biochemistEnAsset = $this->getJson('/api/v0.5/career/jobs/biochemists-and-biophysicists/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
 
         $writerZhText = json_encode($writerZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $writerEnText = json_encode($writerEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $truckZhText = json_encode($truckZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $architectZhText = json_encode($architectZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $architectEnText = json_encode($architectEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $biochemistZhText = json_encode($biochemistZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $biochemistEnText = json_encode($biochemistEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         $this->assertStringNotContainsString('物种观察', $writerZhText);
         $this->assertStringNotContainsString('栖息地数据', $writerZhText);
@@ -851,6 +919,26 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $this->assertStringNotContainsString('旅客/机组安全', $truckZhText);
         $this->assertStringContainsString('道路安全', $truckZhText);
         $this->assertStringContainsString('工时合规', $truckZhText);
+
+        $this->assertStringNotContainsString('指挥链', $architectZhText);
+        $this->assertStringNotContainsString('态势判断', $architectZhText);
+        $this->assertStringContainsString('责任链条', $architectZhText);
+        $this->assertStringContainsString('现场判断', $architectZhText);
+
+        $this->assertStringNotContainsString('chain of command', $architectEnText);
+        $this->assertStringNotContainsString('situational judgment', $architectEnText);
+        $this->assertStringContainsString('accountability chain', $architectEnText);
+        $this->assertStringContainsString('context judgment', $architectEnText);
+
+        $this->assertStringNotContainsString('临床升级', $biochemistZhText);
+        $this->assertStringNotContainsString('用药核对', $biochemistZhText);
+        $this->assertStringContainsString('业务升级', $biochemistZhText);
+        $this->assertStringContainsString('关键核对', $biochemistZhText);
+
+        $this->assertStringNotContainsString('clinical escalation', $biochemistEnText);
+        $this->assertStringNotContainsString('medication checks', $biochemistEnText);
+        $this->assertStringContainsString('workflow escalation', $biochemistEnText);
+        $this->assertStringContainsString('critical checks', $biochemistEnText);
     }
 
     public function test_preview_api_projects_wind_turbine_technicians_without_projection_error(): void

--- a/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
@@ -115,6 +115,7 @@ final class CareerPageAssemblyAssetPreviewImportTest extends TestCase
             ->assertJsonPath('status', CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW)
             ->assertJsonPath('career_page_assembly_v1.slug', 'accountants-and-auditors')
             ->assertJsonPath('career_page_assembly_v1.locale', 'en')
+            ->assertJsonMissingPath('career_page_assembly_v1.occupation.title_zh')
             ->assertJsonMissingPath('career_page_assembly_v1.block_refs')
             ->assertJsonMissingPath('career_page_assembly_v1.audit_fields')
             ->assertJsonMissingPath('career_page_assembly_v1.page_sections.0.source_row_hash')


### PR DESCRIPTION
## Summary
- remove `title_zh` from English page assembly preview API occupation projection
- repair AI Impact preview projection cross-domain wording for aviation, clinical, wildlife, and military contexts when the slug does not belong to that domain
- add feature regression coverage for page assembly locale projection and AI Impact cross-domain projection repair

## Validation
- `php artisan test tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check -- app/Services/Career/PageAssemblyAssets/CareerPageAssemblyPreviewService.php app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`

## Intentionally deferred
- no AI Impact asset edits
- no page assembly asset edits
- no staging write or production import
- no runtime, SEO, CMS, sitemap, llms, canonical, noindex, or JSON-LD changes