### PR TITLE
Fix remaining career AI Impact projection context leaks

### DIFF
--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php
@@ -278,6 +278,9 @@ final class CareerAiImpactAssetPreviewService
         $aviationEn = [
             'operational safety, release conditions, weather diversion, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
             'operational safety, release conditions, weather diversions, separation limits, maintenance records, and crew or passenger safety' => 'operational context, exception handling, record quality, delivery boundaries, and final accountability',
+            'passenger or crew safety' => 'user and field safety',
+            'passenger/crew safety' => 'user and field safety',
+            'crew safety' => 'field safety',
             'an operating-limit note, abnormal-event log, weather or NOTAM check, and release review' => 'a work note, exception log, review checklist, and delivery review',
             'dispatch systems, checklists, maintenance records, and flight or vehicle operation logs' => 'work records, checklists, review steps, and delivery logs',
         ];
@@ -296,6 +299,14 @@ final class CareerAiImpactAssetPreviewService
 
         $clinicalZh = [
             '临床升级、用药核对、转诊判断、患者沟通和病情变化记录' => '业务升级、关键核对、协作判断、对象沟通和状态变化记录',
+            '去标识病例复盘、交接记录、关键核对表和转诊说明' => '脱敏项目复盘、交接记录、关键核对表和协作说明',
+            '病历/EHR 摘要、医嘱核对、生命体征趋势和随访清单' => '项目记录摘要、关键要求核对、状态趋势和后续清单',
+            '病例复盘' => '项目复盘',
+            '转诊说明' => '协作说明',
+            '病历/EHR' => '项目记录',
+            '医嘱核对' => '关键要求核对',
+            '生命体征' => '状态指标',
+            '随访清单' => '后续清单',
             '临床升级' => '业务升级',
             '用药核对' => '关键核对',
             '转诊判断' => '协作判断',

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -853,6 +853,7 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             $biochemistRow = $this->assetRow('biochemists-and-biophysicists', $locale);
             if ($locale === 'zh-CN') {
                 $biochemistRow['items']['human_accountability_anchors'][0]['body'] = '正式采用仍要看临床升级、用药核对、转诊判断、患者沟通和病情变化记录。';
+                $biochemistRow['items']['how_to_prepare'][0]['body'] = '把实验记录做成去标识病例复盘、交接记录、关键核对表和转诊说明；再围绕统计输出建立病历/EHR 摘要、医嘱核对、生命体征趋势和随访清单。';
             } else {
                 $biochemistRow['items']['human_accountability_anchors'][0]['body'] = 'Final use still depends on clinical escalation, medication checks, referral judgment, patient communication, and change-in-condition records.';
             }
@@ -895,6 +896,28 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertOk()
             ->json('ai_impact_asset_v1');
 
+        $equipmentOccupation = $this->seedOccupation('electrical-and-electronics-installers-and-repairers-transportation-equipment');
+        $equipmentEn = $this->assetRow('electrical-and-electronics-installers-and-repairers-transportation-equipment', 'en');
+        $equipmentEn['items']['human_accountability_anchors'][0]['body'] = 'When document lockout steps, passenger or crew safety, release tests, and responsible technician sign-off creates disagreement, the worker must own the final handoff.';
+        CareerJobAiImpactAsset::query()->create([
+            'occupation_id' => $equipmentOccupation->id,
+            'career_job_slug' => 'electrical-and-electronics-installers-and-repairers-transportation-equipment',
+            'locale' => 'en',
+            'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+            'status' => CareerJobAiImpactAsset::STATUS_STAGING_PREVIEW,
+            'preview_allowlisted' => true,
+            'asset_payload_json' => $equipmentEn,
+            'sources_json' => $equipmentEn['sources'],
+            'evidence_used_json' => $equipmentEn['evidence_used'],
+            'derived_from_synthesis_json' => $equipmentEn['derived_from_synthesis'],
+            'audit_fields_json' => $equipmentEn['audit_fields'],
+            'asset_row_hash' => $equipmentEn['audit_fields']['row_hash'],
+        ]);
+
+        $equipmentEnAsset = $this->getJson('/api/v0.5/career/jobs/electrical-and-electronics-installers-and-repairers-transportation-equipment/ai-impact-asset?locale=en')
+            ->assertOk()
+            ->json('ai_impact_asset_v1');
+
         $writerZhText = json_encode($writerZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $writerEnText = json_encode($writerEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $truckZhText = json_encode($truckZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
@@ -902,6 +925,7 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
         $architectEnText = json_encode($architectEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $biochemistZhText = json_encode($biochemistZhAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         $biochemistEnText = json_encode($biochemistEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        $equipmentEnText = json_encode($equipmentEnAsset, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
         $this->assertStringNotContainsString('物种观察', $writerZhText);
         $this->assertStringNotContainsString('栖息地数据', $writerZhText);
@@ -932,13 +956,24 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
 
         $this->assertStringNotContainsString('临床升级', $biochemistZhText);
         $this->assertStringNotContainsString('用药核对', $biochemistZhText);
+        $this->assertStringNotContainsString('转诊说明', $biochemistZhText);
+        $this->assertStringNotContainsString('病历/EHR', $biochemistZhText);
+        $this->assertStringNotContainsString('医嘱核对', $biochemistZhText);
+        $this->assertStringNotContainsString('生命体征', $biochemistZhText);
+        $this->assertStringNotContainsString('随访清单', $biochemistZhText);
         $this->assertStringContainsString('业务升级', $biochemistZhText);
         $this->assertStringContainsString('关键核对', $biochemistZhText);
+        $this->assertStringContainsString('协作说明', $biochemistZhText);
+        $this->assertStringContainsString('项目记录摘要', $biochemistZhText);
 
         $this->assertStringNotContainsString('clinical escalation', $biochemistEnText);
         $this->assertStringNotContainsString('medication checks', $biochemistEnText);
         $this->assertStringContainsString('workflow escalation', $biochemistEnText);
         $this->assertStringContainsString('critical checks', $biochemistEnText);
+
+        $this->assertStringNotContainsString('passenger or crew safety', $equipmentEnText);
+        $this->assertStringNotContainsString('crew safety', $equipmentEnText);
+        $this->assertStringContainsString('user and field safety', $equipmentEnText);
     }
 
     public function test_preview_api_projects_wind_turbine_technicians_without_projection_error(): void


### PR DESCRIPTION
## Summary
- add projection-only replacements for remaining non-medical clinical wording in zh-CN AI Impact preview payloads
- add projection-only replacements for remaining non-aviation passenger/crew safety wording in en AI Impact preview payloads
- extend regression coverage for the 40-row staging editorial QA residue

## Validation
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`
- `git diff --check -- app/Services/Career/AiImpactAssets/CareerAiImpactAssetPreviewService.php tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php`

## Intentionally deferred
- no AI Impact asset edits
- no page assembly asset edits
- no staging write or production import
- no runtime, SEO, CMS, sitemap, llms, canonical, noindex, or JSON-LD changes