### PR TITLE
MBTI64-CMS-PROJECTION-DRAFT-FRESH-5-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsProjectionDraft.php
@@ -18,6 +18,8 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
 
     private const FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-FRESH-3-WRITE-01';
 
+    private const FRESH_QUERY_BACKED_5_OPERATOR_APPROVAL = 'MBTI64-CMS-PROJECTION-DRAFT-FRESH-5-WRITE-01';
+
     private const AGENT_BATCH_OPERATOR_APPROVAL = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
 
     private const WRITE_SAFETY_FLAGS = [
@@ -36,6 +38,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         {--write : Create CMS projection draft revision rows}
         {--visible-query-backed-3 : Restrict planning/write to the approved 3 query-backed visible MBTI64 URLs}
         {--fresh-query-backed-3 : Restrict planning/write to the fresh 3 query-backed MBTI64 URLs}
+        {--fresh-query-backed-5 : Restrict planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--agent-batch-size= : Restrict planning/write to an artifact-order batch; only 5 or 10 are allowed}
         {--agent-batch-offset= : Zero-based artifact-order offset for --agent-batch-size; defaults to 0}
         {--json : Emit the full JSON summary}
@@ -131,6 +134,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
         $expectedApproval = match (true) {
             (bool) $this->option('visible-query-backed-3') => self::VISIBLE_QUERY_BACKED_3_OPERATOR_APPROVAL,
             (bool) $this->option('fresh-query-backed-3') => self::FRESH_QUERY_BACKED_3_OPERATOR_APPROVAL,
+            (bool) $this->option('fresh-query-backed-5') => self::FRESH_QUERY_BACKED_5_OPERATOR_APPROVAL,
             $this->agentBatchRequested() => self::AGENT_BATCH_OPERATOR_APPROVAL,
             default => self::OPERATOR_APPROVAL,
         };
@@ -163,6 +167,7 @@ final class PersonalityMbti64CmsProjectionDraft extends Command
             'write' => (bool) $this->option('write'),
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
             'fresh_query_backed_3' => (bool) $this->option('fresh-query-backed-3'),
+            'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
             'agent_batch_size' => trim((string) $this->option('agent-batch-size')),
             'agent_batch_offset' => trim((string) $this->option('agent-batch-offset')),
             'draft_only' => (bool) $this->option('draft-only'),

--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -30,6 +30,14 @@ final class Mbti64CmsProjectionDraftWriter
         'https://fermatmind.com/zh/personality/esfj-a',
     ];
 
+    private const FRESH_QUERY_BACKED_5_URLS = [
+        'https://fermatmind.com/en/personality/enfp-a',
+        'https://fermatmind.com/zh/personality/istp-a',
+        'https://fermatmind.com/en/personality/esfj-a',
+        'https://fermatmind.com/zh/personality/esfj-a',
+        'https://fermatmind.com/en/personality/intp-a',
+    ];
+
     private const AGENT_BATCH_ALLOWED_SIZES = [5, 10];
 
     private const FORBIDDEN_ROUTE_PATTERNS = [
@@ -300,19 +308,23 @@ final class Mbti64CmsProjectionDraftWriter
         $recommendations = $this->recommendations($package);
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
+        $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $agentBatchRequested = $this->agentBatchRequested($options);
 
-        if (($visibleQueryBacked3 ? 1 : 0) + ($freshQueryBacked3 ? 1 : 0) + ($agentBatchRequested ? 1 : 0) > 1) {
+        if (($visibleQueryBacked3 ? 1 : 0)
+            + ($freshQueryBacked3 ? 1 : 0)
+            + ($freshQueryBacked5 ? 1 : 0)
+            + ($agentBatchRequested ? 1 : 0) > 1) {
             $errors[] = [
                 'field' => 'options',
                 'code' => 'exclusive_subset_modes_required',
-                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, or agent batch options.',
+                'message' => 'Only one subset mode can be used: --visible-query-backed-3, --fresh-query-backed-3, --fresh-query-backed-5, or agent batch options.',
             ];
 
             return [];
         }
 
-        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $agentBatchRequested) {
+        if (! $visibleQueryBacked3 && ! $freshQueryBacked3 && ! $freshQueryBacked5 && ! $agentBatchRequested) {
             return $recommendations;
         }
 
@@ -325,11 +337,23 @@ final class Mbti64CmsProjectionDraftWriter
             return array_values(array_slice($recommendations, $batchOptions['offset'], $batchOptions['size']));
         }
 
-        $expectedUrls = $freshQueryBacked3 ? self::FRESH_QUERY_BACKED_3_URLS : self::VISIBLE_QUERY_BACKED_3_URLS;
-        $subsetCode = $freshQueryBacked3
-            ? 'fresh_query_backed_subset_required_urls_missing'
-            : 'visible_query_backed_subset_required_urls_missing';
-        $subsetLabel = $freshQueryBacked3 ? 'fresh query-backed' : 'visible query-backed';
+        [$expectedUrls, $subsetCode, $subsetLabel] = match (true) {
+            $freshQueryBacked5 => [
+                self::FRESH_QUERY_BACKED_5_URLS,
+                'fresh_query_backed_5_subset_required_urls_missing',
+                'fresh query-backed 5',
+            ],
+            $freshQueryBacked3 => [
+                self::FRESH_QUERY_BACKED_3_URLS,
+                'fresh_query_backed_subset_required_urls_missing',
+                'fresh query-backed 3',
+            ],
+            default => [
+                self::VISIBLE_QUERY_BACKED_3_URLS,
+                'visible_query_backed_subset_required_urls_missing',
+                'visible query-backed 3',
+            ],
+        };
         $allowed = array_fill_keys($expectedUrls, true);
         $subset = array_values(array_filter(
             $recommendations,
@@ -343,7 +367,7 @@ final class Mbti64CmsProjectionDraftWriter
             $errors[] = [
                 'field' => 'recommendations',
                 'code' => $subsetCode,
-                'message' => 'The '.$subsetLabel.' subset must resolve exactly the 3 approved URLs.',
+                'message' => 'The '.$subsetLabel.' subset must resolve exactly the '.count($expectedUrls).' approved URLs.',
             ];
         }
 
@@ -693,6 +717,7 @@ final class Mbti64CmsProjectionDraftWriter
     {
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
         $freshQueryBacked3 = (bool) ($options['fresh_query_backed_3'] ?? false);
+        $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
         $agentBatchRequested = $this->agentBatchRequested($options);
         $selectedUrls = array_values(array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
@@ -722,6 +747,17 @@ final class Mbti64CmsProjectionDraftWriter
                 'dry_run_only' => false,
                 'write_allowed_with_strict_approval' => true,
                 'allowed_urls' => self::FRESH_QUERY_BACKED_3_URLS,
+                'selected_urls' => $selectedUrls,
+            ];
+        }
+
+        if ($freshQueryBacked5) {
+            return [
+                'mode' => 'fresh_query_backed_5',
+                'enabled' => true,
+                'dry_run_only' => false,
+                'write_allowed_with_strict_approval' => true,
+                'allowed_urls' => self::FRESH_QUERY_BACKED_5_URLS,
                 'selected_urls' => $selectedUrls,
             ];
         }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -44,6 +44,14 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         'https://fermatmind.com/zh/personality/esfj-a',
     ];
 
+    private const FRESH_QUERY_BACKED_5_URLS = [
+        'https://fermatmind.com/en/personality/enfp-a',
+        'https://fermatmind.com/zh/personality/istp-a',
+        'https://fermatmind.com/en/personality/esfj-a',
+        'https://fermatmind.com/zh/personality/esfj-a',
+        'https://fermatmind.com/en/personality/intp-a',
+    ];
+
     public function test_dry_run_plans_eighty_eight_projection_drafts_without_writes(): void
     {
         $this->seedAllTargets();
@@ -365,6 +373,149 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(1, $exitCode);
         $this->assertFalse($payload['ok']);
         $this->assertContains('exclusive_subset_modes_required', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_five_dry_run_plans_only_fresh_approved_urls_without_writes(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--fresh-query-backed-5' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(5, $payload['would_create_revision_count']);
+        $this->assertSame('fresh_query_backed_5', $payload['subset']['mode']);
+        $this->assertTrue($payload['subset']['enabled']);
+        $this->assertFalse($payload['subset']['dry_run_only']);
+        $this->assertTrue($payload['subset']['write_allowed_with_strict_approval']);
+
+        $plannedUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($plannedUrls);
+        $expectedUrls = self::FRESH_QUERY_BACKED_5_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $plannedUrls);
+        $this->assertSame($expectedUrls, array_values($this->sortedStrings((array) $payload['subset']['allowed_urls'])));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_five_write_requires_fresh_five_approval_token(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--fresh-query-backed-5'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=MBTI64-CMS-PROJECTION-DRAFT-FRESH-5-WRITE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_fresh_query_backed_five_write_creates_only_fresh_approved_variant_draft_revisions(): void
+    {
+        $targets = $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $profileBefore = $this->profileLiveState($targets['en|ENFP']);
+        $variantBefore = $this->variantLiveState($targets['en|ENFP-A']);
+        $surfaceCountsBefore = $this->liveSurfaceCounts();
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--fresh-query-backed-5'] = true;
+        $options['--operator-approved'] = 'MBTI64-CMS-PROJECTION-DRAFT-FRESH-5-WRITE-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(5, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertSame('fresh_query_backed_5', $payload['subset']['mode']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(5, PersonalityProfileVariantRevision::query()->count());
+        $this->assertSame($profileBefore, $this->profileLiveState($targets['en|ENFP']));
+        $this->assertSame($variantBefore, $this->variantLiveState($targets['en|ENFP-A']));
+        $this->assertSame($surfaceCountsBefore, $this->liveSurfaceCounts());
+
+        $createdUrls = array_map(
+            static fn (array $row): string => (string) ($row['url'] ?? ''),
+            $payload['rows'] ?? []
+        );
+        sort($createdUrls);
+        $expectedUrls = self::FRESH_QUERY_BACKED_5_URLS;
+        sort($expectedUrls);
+        $this->assertSame($expectedUrls, $createdUrls);
+
+        foreach (PersonalityProfileVariantRevision::query()->get() as $revision) {
+            $this->assertProjectionSnapshot($revision->snapshot_json);
+        }
+    }
+
+    public function test_fresh_query_backed_five_fails_closed_when_allowlisted_url_is_missing(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        foreach ($package['recommendations'] as &$recommendation) {
+            if (($recommendation['target_url'] ?? null) === 'https://fermatmind.com/en/personality/enfp-a') {
+                $recommendation['target_url'] = 'https://fermatmind.com/en/personality/entp-a';
+                break;
+            }
+        }
+        unset($recommendation);
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $this->validQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--fresh-query-backed-5' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('fresh_query_backed_5_subset_required_urls_missing', array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             $payload['errors'] ?? []
         ));


### PR DESCRIPTION
## Summary
- Add a fixed `--fresh-query-backed-5` subset to `personality:mbti64-cms-projection-draft`.
- Lock the subset to exactly five GSC query-backed MBTI64 variant URLs.
- Add a dedicated write approval token: `MBTI64-CMS-PROJECTION-DRAFT-FRESH-5-WRITE-01`.
- Extend focused command tests for dry-run, write guard, write behavior, and fail-closed missing allowlist coverage.

## Why
Production dry-run for the fresh 5 could not safely use contiguous batch mode because the target rows are non-contiguous in the 88-page package. This patch adds the same fixed-subset fail-closed contract pattern used by visible-3/fresh-3.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only projection draft command, writer, and focused command test changed.

## Deferred
- No production write.
- No CMS mutation.
- No publish/index/search.
- No sitemap/llms mutation.
- No frontend changes.

## Repository rule impact
CMS/backend remains the authority for MBTI64 public profile projection drafts. This PR only narrows a backend command subset contract and does not introduce frontend fallback content or a new content authority.