### PR TITLE
MBTI64-CMS-PROJECTION-PROMOTE-FRESH-5-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
+++ b/backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php
@@ -27,6 +27,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
         {--dry-run : Plan promotion without database writes}
         {--write : Promote latest matching revision snapshots to live CMS content fields}
         {--visible-query-backed-3 : Restrict agent projection promotion planning/write to the approved 3 query-backed visible MBTI64 URLs}
+        {--fresh-query-backed-5 : Restrict agent projection promotion planning/write to the fresh 5 query-backed MBTI64 URLs}
         {--json : Emit the full JSON summary}
         {--output= : Optional path to write the JSON summary}
         {--promote-live-content : Required for --write; confirms live CMS content promotion intent}
@@ -137,6 +138,7 @@ final class PersonalityMbti64CmsRevisionPromote extends Command
             'no_search_release' => (bool) $this->option('no-search-release'),
             'operator_approved' => (string) $this->option('operator-approved'),
             'visible_query_backed_3' => (bool) $this->option('visible-query-backed-3'),
+            'fresh_query_backed_5' => (bool) $this->option('fresh-query-backed-5'),
         ];
     }
 

--- a/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
+++ b/backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php
@@ -32,6 +32,14 @@ final class Mbti64CmsRevisionPromotionService
         'https://fermatmind.com/zh/personality/esfp-a',
     ];
 
+    private const FRESH_QUERY_BACKED_5_URLS = [
+        'https://fermatmind.com/en/personality/enfp-a',
+        'https://fermatmind.com/zh/personality/istp-a',
+        'https://fermatmind.com/en/personality/esfj-a',
+        'https://fermatmind.com/zh/personality/esfj-a',
+        'https://fermatmind.com/en/personality/intp-a',
+    ];
+
     public function __construct(private readonly Mbti64BackendImportContractPlanner $planner)
     {
     }
@@ -185,8 +193,23 @@ final class Mbti64CmsRevisionPromotionService
             array_keys($rawRecommendations)
         );
         $visibleQueryBacked3 = (bool) ($options['visible_query_backed_3'] ?? false);
-        $contractRecommendations = $visibleQueryBacked3
-            ? $this->visibleQueryBacked3Recommendations($recommendations)
+        $freshQueryBacked5 = (bool) ($options['fresh_query_backed_5'] ?? false);
+        $subsetModeCount = ($visibleQueryBacked3 ? 1 : 0) + ($freshQueryBacked5 ? 1 : 0);
+        if ($subsetModeCount > 1) {
+            $errors[] = [
+                'field' => 'options',
+                'code' => 'multiple_agent_projection_subset_modes',
+                'message' => 'Only one agent projection subset mode can be used.',
+            ];
+        }
+
+        $subsetUrls = match (true) {
+            $visibleQueryBacked3 => self::VISIBLE_QUERY_BACKED_3_URLS,
+            $freshQueryBacked5 => self::FRESH_QUERY_BACKED_5_URLS,
+            default => [],
+        };
+        $contractRecommendations = $subsetUrls !== []
+            ? $this->recommendationsForFixedUrls($recommendations, $subsetUrls)
             : $recommendations;
 
         if ((string) ($package['artifact'] ?? '') !== self::AGENT_PROJECTION_ARTIFACT) {
@@ -209,6 +232,13 @@ final class Mbti64CmsRevisionPromotionService
                 'field' => 'recommendations',
                 'code' => 'visible_query_backed_3_subset_incomplete',
                 'message' => 'Expected exactly the 3 approved query-backed visible MBTI64 recommendations.',
+            ];
+        }
+        if ($freshQueryBacked5 && count($contractRecommendations) !== 5) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'fresh_query_backed_5_subset_incomplete',
+                'message' => 'Expected exactly the 5 fresh query-backed MBTI64 recommendations.',
             ];
         }
 
@@ -247,9 +277,13 @@ final class Mbti64CmsRevisionPromotionService
             'artifact' => 'MBTI64-CMS-PROJECTION-PROMOTE-88-CONTRACT-PATCH-01',
             'source_kind' => 'mbti64_agent_projection_draft_v1',
             'subset' => [
-                'mode' => $visibleQueryBacked3 ? 'visible_query_backed_3' : 'full_agent_projection_88',
-                'enabled' => $visibleQueryBacked3,
-                'allowed_urls' => $visibleQueryBacked3 ? self::VISIBLE_QUERY_BACKED_3_URLS : [],
+                'mode' => match (true) {
+                    $visibleQueryBacked3 => 'visible_query_backed_3',
+                    $freshQueryBacked5 => 'fresh_query_backed_5',
+                    default => 'full_agent_projection_88',
+                },
+                'enabled' => $subsetUrls !== [],
+                'allowed_urls' => $subsetUrls,
             ],
             'row_count' => count($rows),
             'variant_row_count' => count(array_filter($rows, static fn (array $row): bool => ($row['page_type'] ?? null) === 'variant')),
@@ -327,18 +361,18 @@ final class Mbti64CmsRevisionPromotionService
      * @param  list<array<string,mixed>>  $recommendations
      * @return list<array<string,mixed>>
      */
-    private function visibleQueryBacked3Recommendations(array $recommendations): array
+    private function recommendationsForFixedUrls(array $recommendations, array $urls): array
     {
         $byUrl = [];
         foreach ($recommendations as $recommendation) {
             $url = (string) ($recommendation['target_url'] ?? '');
-            if (in_array($url, self::VISIBLE_QUERY_BACKED_3_URLS, true)) {
+            if (in_array($url, $urls, true)) {
                 $byUrl[$url] = $recommendation;
             }
         }
 
         $ordered = [];
-        foreach (self::VISIBLE_QUERY_BACKED_3_URLS as $url) {
+        foreach ($urls as $url) {
             if (isset($byUrl[$url])) {
                 $ordered[] = $byUrl[$url];
             }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php
@@ -301,6 +301,42 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileSection::query()->count());
     }
 
+    public function test_dry_run_supports_fixed_fresh_query_backed_five_subset_without_live_writes(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--fresh-query-backed-5' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertSame('fresh_query_backed_5', $payload['contract']['subset']['mode']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(5, $payload['would_promote_count']);
+        $this->assertSame([
+            'https://fermatmind.com/en/personality/enfp-a',
+            'https://fermatmind.com/zh/personality/istp-a',
+            'https://fermatmind.com/en/personality/esfj-a',
+            'https://fermatmind.com/zh/personality/esfj-a',
+            'https://fermatmind.com/en/personality/intp-a',
+        ], array_column($payload['rows'], 'url'));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
     public function test_write_promotes_eighty_eight_agent_projection_revisions_without_index_search_side_effects(): void
     {
         $targets = $this->seedProjectionTargets();
@@ -374,6 +410,42 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
             ->first());
     }
 
+    public function test_write_promotes_only_fixed_fresh_query_backed_five_subset(): void
+    {
+        $targets = $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+        $options = $this->promoteWriteOptions($packagePath);
+        $options['--fresh-query-backed-5'] = true;
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['write']);
+        $this->assertSame('fresh_query_backed_5', $payload['contract']['subset']['mode']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(5, $payload['variant_row_count']);
+        $this->assertSame(0, $payload['comparison_row_count']);
+        $this->assertSame(5, $payload['promoted_count']);
+        $this->assertSame(5, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->where('section_key', 'mbti64_comparison_a_vs_t')->count());
+
+        foreach (['en|ENFP-A', 'zh-CN|ISTP-A', 'en|ESFJ-A', 'zh-CN|ESFJ-A', 'en|INTP-A'] as $targetKey) {
+            PersonalityProfileVariantSeoMeta::query()
+                ->where('personality_profile_variant_id', (int) $targets[$targetKey]->id)
+                ->firstOrFail();
+        }
+
+        $this->assertNull(PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['en|ENTJ-A']->id)
+            ->first());
+        $this->assertNull(PersonalityProfileVariantSeoMeta::query()
+            ->where('personality_profile_variant_id', (int) $targets['zh-CN|ENFP-A']->id)
+            ->first());
+    }
+
     public function test_visible_query_backed_three_subset_is_idempotent_after_write(): void
     {
         $this->seedProjectionTargets();
@@ -439,6 +511,63 @@ final class PersonalityMbti64CmsRevisionPromoteCommandTest extends TestCase
         $this->assertSame(1, $exitCode, Artisan::output());
         $this->assertFalse($payload['ok']);
         $this->assertContains('visible_query_backed_3_subset_incomplete', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_fresh_query_backed_five_subset_fails_closed_when_fixed_url_is_missing(): void
+    {
+        $this->seedProjectionTargets();
+        $package = $this->validProjectionPackage();
+        foreach ($package['recommendations'] as &$recommendation) {
+            if (($recommendation['target_url'] ?? null) === 'https://fermatmind.com/en/personality/enfp-a') {
+                $recommendation['target_url'] = 'https://fermatmind.com/en/personality/enfp-x';
+            }
+        }
+        unset($recommendation);
+        [$packagePath] = $this->writeProjectionArtifacts($package, $this->validProjectionQa());
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--fresh-query-backed-5' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('fresh_query_backed_5_subset_incomplete', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+    }
+
+    public function test_agent_projection_subset_modes_are_mutually_exclusive(): void
+    {
+        $this->seedProjectionTargets();
+        [$packagePath, $qaPath] = $this->writeProjectionArtifacts($this->validProjectionPackage(), $this->validProjectionQa());
+        $this->createProjectionDraftRevisions($packagePath, $qaPath);
+
+        $exitCode = Artisan::call('personality:mbti64-cms-revision-promote', [
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--visible-query-backed-3' => true,
+            '--fresh-query-backed-5' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertFalse($payload['ok']);
+        $this->assertContains('multiple_agent_projection_subset_modes', array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             $payload['errors'] ?? []
         ));


### PR DESCRIPTION
## What changed
- Added `--fresh-query-backed-5` to `personality:mbti64-cms-revision-promote`.
- Added a fixed fail-closed fresh-5 allowlist for MBTI64 agent projection promotion planning/write.
- Reused the fixed-subset recommendation ordering path and made visible-3/fresh-5 modes mutually exclusive.
- Extended focused promotion command tests for fresh-5 dry-run, write, missing fixed URL fail-closed behavior, and subset mode mutual exclusion.

## Why
`MBTI64-CMS-PROJECTION-PROMOTE-FRESH-5-DRY-RUN-01` found that production promotion contract only supported `--visible-query-backed-3`. Without this patch, running promotion for the fresh query-backed 5 pages would fall back to the broader 88-page agent projection contract.

## Validation
- `php artisan test tests/Feature/Console/PersonalityMbti64CmsRevisionPromoteCommandTest.php --display-warnings` PASS; warnings only from temporary worktree missing `.env`.
- `bash backend/scripts/ci_verify_mbti.sh` PASS.
- `git diff --check` PASS.
- Scope validation: changed files limited to promotion command, promotion service, and focused promotion command test.

## Intentionally deferred
- No production deploy.
- No CMS promotion/write.
- No publish/index/search changes.
- No sitemap/llms mutation.
- No frontend changes.

## Repository rule impact
Backend CMS remains the authority. This PR only narrows a controlled backend promotion command with a fixed subset guard; it does not introduce frontend fallback content or change publishing/search policy.