### PR TITLE
Add page assembly production import gate

### DIFF
--- a/backend/app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php
@@ -18,17 +18,18 @@ final class CareerImportPageAssemblyAssetsPreview extends Command
         {--all-slugs-from-file : Dry-run every slug found in the source JSONL instead of the configured preview allowlist}
         {--confirm-full-staging-preview : Explicitly confirm that --force may write every slug found in the source JSONL to staging_preview}
         {--confirm-approved-transition : Explicitly confirm that --force may mark validated rows as approved}
+        {--confirm-production-import : Explicitly confirm that production import preflight or --force may import validated, approved page assembly rows into production_imported}
         {--approval-manifest= : Approval manifest JSON produced by the editorial review package}
         {--approval-manifest-sha256= : Optional expected SHA-256 for the approval manifest}
         {--editorial-review-report= : Editorial review JSON report that authorizes the approved transition}
         {--editorial-review-sha256= : Optional expected SHA-256 for the editorial review report}
-        {--dry-run : Validate only; do not write staging rows}
-        {--force : Write rows only when --status=staging_preview or perform explicit approved transition}
-        {--status=staging_preview : Target import status; staging_preview and approved are supported through their explicit gates}
+        {--dry-run : Validate only; do not write staging or production rows}
+        {--force : Write rows only when --status=staging_preview, perform explicit approved transition, or perform explicit production import}
+        {--status=staging_preview : Target import status; staging_preview, approved, and production_imported are supported through their explicit gates}
         {--json : Emit machine-readable JSON report}
         {--output= : Optional report output path}';
 
-    protected $description = 'Dry-run or staging-preview import of PASS v1 career page assembly asset rows.';
+    protected $description = 'Validate or write PASS v1 career page assembly asset rows through staging, approval, or explicit production gates.';
 
     public function __construct(
         private readonly CareerPageAssemblyImportService $importService,
@@ -61,10 +62,11 @@ final class CareerImportPageAssemblyAssetsPreview extends Command
             if (! in_array($status, [
                 CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW,
                 CareerJobPageAssemblyAsset::STATUS_APPROVED,
+                CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
             ], true)) {
                 return $this->finish([
                     'decision' => 'fail',
-                    'errors' => ['Only --status=staging_preview or --status=approved is supported.'],
+                    'errors' => ['Only --status=staging_preview, --status=approved, or --status=production_imported is supported.'],
                 ], false);
             }
 
@@ -91,6 +93,19 @@ final class CareerImportPageAssemblyAssetsPreview extends Command
                     trim((string) $this->option('editorial-review-report')),
                     trim((string) $this->option('editorial-review-sha256')) ?: null,
                     (bool) $this->option('confirm-approved-transition'),
+                );
+            } elseif ($status === CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED && ($force || $dryRun)) {
+                $report = $this->importService->importApprovedAssetsToProduction(
+                    $file,
+                    $this->requestedSlugs(),
+                    trim((string) $this->option('expected-sha256')) ?: null,
+                    (bool) $this->option('all-slugs-from-file'),
+                    trim((string) $this->option('approval-manifest')),
+                    trim((string) $this->option('approval-manifest-sha256')) ?: null,
+                    trim((string) $this->option('editorial-review-report')),
+                    trim((string) $this->option('editorial-review-sha256')) ?: null,
+                    (bool) $this->option('confirm-production-import'),
+                    $force,
                 );
             } else {
                 $report = $force

--- a/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
+++ b/backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php
@@ -434,6 +434,261 @@ final class CareerPageAssemblyImportService
      * @param  list<string>|null  $requestedSlugs
      * @return array<string, mixed>
      */
+    public function importApprovedAssetsToProduction(
+        string $file,
+        ?array $requestedSlugs = null,
+        ?string $expectedSha256 = null,
+        bool $allSlugsFromFile = false,
+        string $approvalManifestFile = '',
+        ?string $expectedApprovalManifestSha256 = null,
+        string $editorialReviewReportFile = '',
+        ?string $expectedEditorialReviewSha256 = null,
+        bool $confirmed = false,
+        bool $write = true,
+    ): array {
+        $baseReport = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile, ! $allSlugsFromFile);
+        if (! $confirmed) {
+            return array_merge($baseReport, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'errors' => ['--confirm-production-import is required to import page assembly assets into production.'],
+            ]);
+        }
+
+        if ($this->normalizeSha256($expectedSha256) === null) {
+            return array_merge($baseReport, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'errors' => ['--expected-sha256 with the approved asset artifact SHA is required for production import.'],
+            ]);
+        }
+
+        $validation = $this->validateFile(
+            $file,
+            $requestedSlugs,
+            $expectedSha256,
+            $allSlugsFromFile,
+            false,
+        );
+        if (($validation['decision'] ?? null) !== 'pass') {
+            return array_merge($validation, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'write_skipped_reason' => 'validation_failed',
+            ]);
+        }
+
+        $errors = [];
+        $sourceFileSha256 = is_string($validation['source_file_sha256'] ?? null)
+            ? (string) $validation['source_file_sha256']
+            : null;
+        $targetSlugs = array_values(array_map('strval', (array) ($validation['target_slugs'] ?? [])));
+        $expectedRows = (int) ($validation['expected_preview_rows'] ?? (count($targetSlugs) * 2));
+        $targetSlugCount = count($targetSlugs);
+
+        $approvalArtifact = $this->readJsonArtifact($approvalManifestFile, $expectedApprovalManifestSha256, 'approval manifest', $errors);
+        $editorialArtifact = $this->readJsonArtifact($editorialReviewReportFile, $expectedEditorialReviewSha256, 'editorial review report', $errors);
+        $approvalManifest = is_array($approvalArtifact['payload'] ?? null) ? $approvalArtifact['payload'] : [];
+        $editorialReview = is_array($editorialArtifact['payload'] ?? null) ? $editorialArtifact['payload'] : [];
+
+        $this->validateApprovalManifest($approvalManifest, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+        $this->validateEditorialReviewReport($editorialReview, $sourceFileSha256, $expectedRows, $targetSlugCount, $errors);
+
+        $assetVersion = CareerJobPageAssemblyAsset::ASSET_VERSION_V1;
+        $targetKeys = [];
+        foreach ($targetSlugs as $slug) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $targetKeys[$slug.'|'.$locale] = ['slug' => $slug, 'locale' => $locale];
+            }
+        }
+
+        $existingRows = CareerJobPageAssemblyAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->get();
+
+        $existingByKey = [];
+        foreach ($existingRows as $asset) {
+            $existingByKey[$asset->career_job_slug.'|'.$asset->locale] = $asset;
+        }
+
+        $rollbackRows = [];
+        $previousStatusCounts = [];
+        foreach ($targetKeys as $key => $target) {
+            $asset = $existingByKey[$key] ?? null;
+            if (! $asset instanceof CareerJobPageAssemblyAsset) {
+                $previousStatusCounts['missing'] = (int) ($previousStatusCounts['missing'] ?? 0) + 1;
+                $errors[] = "{$target['slug']}/{$target['locale']}: production import requires existing approved source rows, found missing.";
+                $rollbackRows[] = [
+                    'slug' => $target['slug'],
+                    'locale' => $target['locale'],
+                    'previous_status' => 'missing',
+                    'new_status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                ];
+
+                continue;
+            }
+
+            $previousStatus = (string) $asset->status;
+            $previousStatusCounts[$previousStatus] = (int) ($previousStatusCounts[$previousStatus] ?? 0) + 1;
+            if (! in_array($previousStatus, [
+                CareerJobPageAssemblyAsset::STATUS_APPROVED,
+                CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            ], true)) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: production import requires approved source rows, found {$previousStatus}.";
+            }
+
+            if (is_string($asset->source_artifact_sha256) && $sourceFileSha256 !== null && $asset->source_artifact_sha256 !== $sourceFileSha256) {
+                $errors[] = "{$target['slug']}/{$target['locale']}: existing source artifact SHA does not match the approved production artifact SHA.";
+            }
+
+            $rollbackRows[] = [
+                'slug' => $target['slug'],
+                'locale' => $target['locale'],
+                'previous_status' => $previousStatus,
+                'new_status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($validation, [
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'fail',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => false,
+                'production_import_performed' => false,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                ],
+                'errors' => $errors,
+            ]);
+        }
+
+        if (! $write) {
+            return array_merge($validation, [
+                'mode' => 'production_import_dry_run',
+                'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'pass',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => true,
+                'production_import_performed' => false,
+                'staging_write_performed' => false,
+                'approval_manifest_file' => $approvalManifestFile,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_report_file' => $editorialReviewReportFile,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'expected_written_count' => $expectedRows,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                    'rollback_sql_intent' => 'No rows were changed during dry-run. If executed, rollback restores each row to previous_status by career_job_slug, locale, asset_version, and import_run_id.',
+                ],
+                'errors' => [],
+            ]);
+        }
+
+        $targetRows = $this->targetRowsFromFile($file, array_keys($targetKeys));
+        $importRunId = (string) Str::uuid();
+        $writtenRows = [];
+
+        DB::transaction(function () use ($targetRows, $sourceFileSha256, $importRunId, &$writtenRows): void {
+            foreach ($targetRows as $key => $row) {
+                $slug = $this->previewService->normalizeSlug((string) ($row['slug'] ?? ''));
+                $locale = $this->previewService->normalizeLocale((string) ($row['locale'] ?? ''));
+                $occupation = Occupation::query()->where('canonical_slug', $slug)->firstOrFail();
+                $asset = CareerJobPageAssemblyAsset::query()->updateOrCreate(
+                    [
+                        'career_job_slug' => $slug,
+                        'locale' => $locale,
+                        'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                        'preview_allowlisted' => false,
+                        'asset_payload_json' => $row,
+                        'block_refs_json' => is_array($row['block_refs'] ?? null) ? $row['block_refs'] : null,
+                        'audit_fields_json' => is_array($row['audit_fields'] ?? null) ? $row['audit_fields'] : null,
+                        'asset_row_hash' => (string) data_get($row, 'audit_fields.row_hash'),
+                        'source_artifact_sha256' => $sourceFileSha256,
+                        'import_run_id' => $importRunId,
+                    ],
+                );
+                $writtenRows[] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'row_id' => $asset->id,
+                    'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                    'operation' => $asset->wasRecentlyCreated ? 'created' : 'updated',
+                    'key' => $key,
+                ];
+            }
+        });
+
+        $productionImportedCount = CareerJobPageAssemblyAsset::query()
+            ->where('asset_version', $assetVersion)
+            ->whereIn('career_job_slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->where('status', CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED)
+            ->count();
+        $decision = count($writtenRows) === $expectedRows && $productionImportedCount === $expectedRows ? 'pass' : 'fail';
+
+        return array_merge($validation, [
+            'mode' => 'production_import',
+            'status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            'decision' => $decision,
+            'approved_transition_performed' => false,
+            'production_import_allowed' => true,
+            'production_import_performed' => true,
+            'staging_write_performed' => false,
+            'import_run_id' => $importRunId,
+            'approval_manifest_file' => $approvalManifestFile,
+            'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+            'editorial_review_report_file' => $editorialReviewReportFile,
+            'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+            'written_count' => count($writtenRows),
+            'created_count' => count(array_filter($writtenRows, static fn (array $row): bool => ($row['operation'] ?? null) === 'created')),
+            'updated_count' => count(array_filter($writtenRows, static fn (array $row): bool => ($row['operation'] ?? null) === 'updated')),
+            'expected_written_count' => $expectedRows,
+            'production_imported_count' => $productionImportedCount,
+            'production_rows_touched' => count($writtenRows),
+            'written_rows' => $writtenRows,
+            'rollback_report' => [
+                'available' => true,
+                'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                'previous_status_counts' => $previousStatusCounts,
+                'rows' => $rollbackRows,
+                'rollback_sql_intent' => 'Restore each row to previous_status by career_job_slug, locale, asset_version, and import_run_id if rollback is required.',
+            ],
+            'errors' => $decision === 'pass' ? [] : ['Production import row count invariant failed.'],
+        ]);
+    }
+
+    /**
+     * @param  list<string>|null  $requestedSlugs
+     * @return array<string, mixed>
+     */
     private function baseReport(string $file, ?array $requestedSlugs, bool $allSlugsFromFile, bool $enforcePreviewAllowlist): array
     {
         return [
@@ -442,7 +697,15 @@ final class CareerPageAssemblyImportService
             'requested_slugs' => $requestedSlugs,
             'all_slugs_from_file' => $allSlugsFromFile,
             'preview_allowlist_enforced' => $enforcePreviewAllowlist,
-            'status_policy' => 'dry_run_staging_preview_or_approved_transition',
+            'status_policy' => 'dry_run_staging_preview_approved_transition_or_explicit_production_import',
+            'production_import_allowed' => false,
+            'production_import_gate' => [
+                'current_command_supports_production_import' => true,
+                'requires_expected_sha256' => true,
+                'requires_confirm_production_import' => true,
+                'requires_approved_source_rows' => true,
+                'requires_approval_manifest_and_editorial_report' => true,
+            ],
         ];
     }
 
@@ -695,8 +958,10 @@ final class CareerPageAssemblyImportService
             'dry_run_writes_database' => false,
             'staging_preview_write_supported_in_this_pr' => true,
             'approved_transition_supported_in_this_pr' => true,
-            'production_import_supported_in_this_pr' => false,
+            'production_import_supported_in_this_pr' => true,
             'production_import_requires_approved_status' => true,
+            'production_import_requires_exact_artifact_sha' => true,
+            'production_import_requires_explicit_confirmation' => true,
             'rollback_boundary' => 'Rows written by staging_preview or marked approved are scoped by import_run_id and target key.',
         ];
     }

--- a/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php
@@ -292,6 +292,178 @@ final class CareerPageAssemblyAssetPreviewImportTest extends TestCase
             ->assertJsonMissingPath('career_page_assembly_v1.search_projection');
     }
 
+    public function test_force_production_import_requires_explicit_confirmation(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/page-assembly-production-missing-confirmation.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('--confirm-production-import is required', implode(' ', $decoded['errors']));
+    }
+
+    public function test_production_import_requires_exact_asset_sha(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $report = storage_path('framework/testing/page-assembly-production-missing-source-sha.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--force' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertStringContainsString('--expected-sha256 with the approved asset artifact SHA is required', implode(' ', $decoded['errors']));
+    }
+
+    public function test_production_import_dry_run_validates_approved_rows_without_writing(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $assetSha = hash_file('sha256', $file);
+        $this->seedPageAssemblyRows($file, CareerJobPageAssemblyAsset::STATUS_APPROVED);
+        [$approvalManifest, $approvalManifestSha, $editorialReport, $editorialReportSha] = $this->writeProductionApprovalArtifacts($assetSha);
+        $report = storage_path('framework/testing/page-assembly-production-dry-run.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--dry-run' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalManifestSha,
+            '--editorial-review-report' => $editorialReport,
+            '--editorial-review-sha256' => $editorialReportSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(2, CareerJobPageAssemblyAsset::query()->where('status', CareerJobPageAssemblyAsset::STATUS_APPROVED)->count());
+        $this->assertSame(0, CareerJobPageAssemblyAsset::query()->where('status', CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED)->count());
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('production_import_dry_run', $decoded['mode']);
+        $this->assertTrue((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertSame(0, $decoded['production_rows_touched']);
+        $this->assertSame(2, $decoded['expected_written_count']);
+        $this->assertSame($approvalManifestSha, $decoded['approval_manifest_sha256']);
+        $this->assertSame($editorialReportSha, $decoded['editorial_review_sha256']);
+        $this->assertTrue((bool) $decoded['rollback_report']['available']);
+    }
+
+    public function test_force_production_import_blocks_non_approved_source_rows(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $assetSha = hash_file('sha256', $file);
+        $this->seedPageAssemblyRows($file, CareerJobPageAssemblyAsset::STATUS_STAGING_PREVIEW);
+        [$approvalManifest, $approvalManifestSha, $editorialReport, $editorialReportSha] = $this->writeProductionApprovalArtifacts($assetSha);
+        $report = storage_path('framework/testing/page-assembly-production-staging-blocked.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalManifestSha,
+            '--editorial-review-report' => $editorialReport,
+            '--editorial-review-sha256' => $editorialReportSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(0, CareerJobPageAssemblyAsset::query()->where('status', CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED)->count());
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('fail', $decoded['decision']);
+        $this->assertFalse((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertStringContainsString('production import requires approved source rows, found staging_preview', implode(' ', $decoded['errors']));
+    }
+
+    public function test_force_production_import_marks_approved_rows_production_imported_with_rollback_report(): void
+    {
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+        $file = $this->writeJsonl([
+            $this->assemblyRow('accountants-and-auditors', 'zh-CN'),
+            $this->assemblyRow('accountants-and-auditors', 'en'),
+        ]);
+        $assetSha = hash_file('sha256', $file);
+        $this->seedPageAssemblyRows($file, CareerJobPageAssemblyAsset::STATUS_APPROVED);
+        [$approvalManifest, $approvalManifestSha, $editorialReport, $editorialReportSha] = $this->writeProductionApprovalArtifacts($assetSha);
+        $report = storage_path('framework/testing/page-assembly-production-import.json');
+
+        $exitCode = Artisan::call('career:page-assembly-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--force' => true,
+            '--status' => CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalManifestSha,
+            '--editorial-review-report' => $editorialReport,
+            '--editorial-review-sha256' => $editorialReportSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(0, CareerJobPageAssemblyAsset::query()->where('status', CareerJobPageAssemblyAsset::STATUS_APPROVED)->count());
+        $this->assertSame(2, CareerJobPageAssemblyAsset::query()->where('status', CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED)->count());
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('production_import', $decoded['mode']);
+        $this->assertTrue((bool) $decoded['production_import_allowed']);
+        $this->assertTrue((bool) $decoded['production_import_performed']);
+        $this->assertFalse((bool) $decoded['staging_write_performed']);
+        $this->assertSame(2, $decoded['written_count']);
+        $this->assertSame(2, $decoded['updated_count']);
+        $this->assertSame(2, $decoded['production_imported_count']);
+        $this->assertSame(2, $decoded['production_rows_touched']);
+        $this->assertSame($approvalManifestSha, $decoded['approval_manifest_sha256']);
+        $this->assertSame($editorialReportSha, $decoded['editorial_review_sha256']);
+        $this->assertSame(2, $decoded['rollback_report']['previous_status_counts'][CareerJobPageAssemblyAsset::STATUS_APPROVED]);
+    }
+
     private function seedCareerJobBundleAuthority(string $slug): void
     {
         $this->seedRuntimeProjectionAuthority([$slug]);
@@ -415,6 +587,64 @@ final class CareerPageAssemblyAssetPreviewImportTest extends TestCase
         file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
 
         return [$path, hash_file('sha256', $path)];
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string, 3: string}
+     */
+    private function writeProductionApprovalArtifacts(string $assetSha): array
+    {
+        [$approvalManifest, $approvalManifestSha] = $this->writeJsonArtifact('page-assembly-production-approval-manifest', [
+            'final_conclusion' => 'CAREER_CONTENT_1046_EDITORIAL_REVIEW_PASS',
+            'approved_count' => 2,
+            'rejected_count' => 0,
+            'slug_count' => 1,
+            'production_import_approved' => false,
+            'production_import_allowed' => false,
+            'next_allowed_transition' => CareerJobPageAssemblyAsset::STATUS_APPROVED,
+            'required_for_approved_transition' => [
+                'asset_sha256' => $assetSha,
+                'row_count' => 2,
+                'slug_count' => 1,
+            ],
+        ]);
+        [$editorialReport, $editorialReportSha] = $this->writeJsonArtifact('page-assembly-production-editorial-review', [
+            'final_conclusion' => 'CAREER_CONTENT_1046_EDITORIAL_REVIEW_PASS',
+            'approved_rows' => 2,
+            'rejected' => 0,
+            'production_import_approved' => false,
+            'metrics' => [
+                'slug_count' => 1,
+                'expected_locale_rows' => 2,
+                'finding_count' => 0,
+            ],
+            'inputs' => [
+                'final_repaired_asset_sha256' => $assetSha,
+            ],
+        ]);
+
+        return [$approvalManifest, $approvalManifestSha, $editorialReport, $editorialReportSha];
+    }
+
+    private function seedPageAssemblyRows(string $file, string $status): void
+    {
+        $sourceSha = hash_file('sha256', $file);
+        foreach (['zh-CN', 'en'] as $locale) {
+            $row = $this->assemblyRow('accountants-and-auditors', $locale);
+            CareerJobPageAssemblyAsset::query()->create([
+                'occupation_id' => Occupation::query()->where('canonical_slug', 'accountants-and-auditors')->value('id'),
+                'career_job_slug' => 'accountants-and-auditors',
+                'locale' => $locale,
+                'asset_version' => CareerJobPageAssemblyAsset::ASSET_VERSION_V1,
+                'status' => $status,
+                'preview_allowlisted' => $status !== CareerJobPageAssemblyAsset::STATUS_PRODUCTION_IMPORTED,
+                'asset_payload_json' => $row,
+                'block_refs_json' => $row['block_refs'],
+                'audit_fields_json' => $row['audit_fields'],
+                'asset_row_hash' => (string) $row['audit_fields']['row_hash'],
+                'source_artifact_sha256' => $sourceSha,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add explicit `production_imported` dry-run/execute gate to `career:page-assembly-assets-import-preview`
- require `--confirm-production-import`, exact source artifact SHA, approval manifest SHA, editorial review report SHA, and existing approved source rows before production import
- emit rollback reports for dry-run and execute paths, and keep staging/runtime/SEO/search-projection flags closed

## Why
Career content 1046 production readiness needs page assembly parity with the AI Impact import gate before production import can be approved by exact SHA.

## Validation
- `php -l backend/app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php`
- `php -l backend/app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php`
- `php -l backend/tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php`
- `composer install --no-interaction --prefer-dist` (temporary worktree dependency install)
- `cp .env.example .env && php artisan test tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php`
- `php artisan career:page-assembly-assets-import-preview --help`
- `php artisan route:list --path=api/v0.5/career/jobs --except-vendor`
- `./vendor/bin/pint --test app/Console/Commands/CareerImportPageAssemblyAssetsPreview.php app/Services/Career/PageAssemblyAssets/CareerPageAssemblyImportService.php tests/Feature/Career/CareerPageAssemblyAssetPreviewImportTest.php`
- `git diff --check`

## Deferred / Out of scope
- no production import executed
- no staging write executed
- no content asset edits
- no runtime, SEO, CMS, sitemap, llms, canonical, noindex, or JSON-LD changes
