### PR TITLE
Add AI Impact production import dry-run gate

### DIFF
--- a/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
+++ b/backend/app/Console/Commands/CareerImportAiImpactAssetsPreview.php
@@ -82,7 +82,7 @@ final class CareerImportAiImpactAssetsPreview extends Command
                     trim((string) $this->option('editorial-review-sha256')) ?: null,
                     (bool) $this->option('confirm-approved-transition'),
                 );
-            } elseif ($force && $status === 'production_imported') {
+            } elseif ($status === 'production_imported' && ($force || $dryRun)) {
                 $report = $this->importService->importApprovedAssetsToProduction(
                     $file,
                     $this->requestedSlugs(),
@@ -93,6 +93,7 @@ final class CareerImportAiImpactAssetsPreview extends Command
                     trim((string) $this->option('editorial-review-report')),
                     trim((string) $this->option('editorial-review-sha256')) ?: null,
                     (bool) $this->option('confirm-production-import'),
+                    $force,
                 );
             } else {
                 $report = $force

--- a/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
+++ b/backend/app/Services/Career/AiImpactAssets/CareerAiImpactAssetImportService.php
@@ -558,11 +558,12 @@ final class CareerAiImpactAssetImportService
         string $editorialReviewReportFile = '',
         ?string $expectedEditorialReviewSha256 = null,
         bool $confirmed = false,
+        bool $write = true,
     ): array {
         $baseReport = $this->baseReport($file, $requestedSlugs, $allSlugsFromFile);
         if (! $confirmed) {
             return array_merge($baseReport, [
-                'mode' => 'production_import',
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
                 'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
                 'decision' => 'fail',
                 'approved_transition_performed' => false,
@@ -574,7 +575,7 @@ final class CareerAiImpactAssetImportService
 
         if ($this->normalizeSha256($expectedSha256) === null) {
             return array_merge($baseReport, [
-                'mode' => 'production_import',
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
                 'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
                 'decision' => 'fail',
                 'approved_transition_performed' => false,
@@ -587,7 +588,7 @@ final class CareerAiImpactAssetImportService
         $validation = $this->validateFile($file, $requestedSlugs, $expectedSha256, $allSlugsFromFile, false);
         if (($validation['decision'] ?? null) !== 'pass') {
             return array_merge($validation, [
-                'mode' => 'production_import',
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
                 'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
                 'production_import_allowed' => false,
                 'production_import_performed' => false,
@@ -660,7 +661,7 @@ final class CareerAiImpactAssetImportService
 
         if ($errors !== []) {
             return array_merge($validation, [
-                'mode' => 'production_import',
+                'mode' => $write ? 'production_import' : 'production_import_dry_run',
                 'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
                 'decision' => 'fail',
                 'approved_transition_performed' => false,
@@ -676,6 +677,32 @@ final class CareerAiImpactAssetImportService
                     'rows' => $rollbackRows,
                 ],
                 'errors' => $errors,
+            ]);
+        }
+
+        if (! $write) {
+            return array_merge($validation, [
+                'mode' => 'production_import_dry_run',
+                'status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+                'decision' => 'pass',
+                'approved_transition_performed' => false,
+                'production_import_allowed' => true,
+                'production_import_performed' => false,
+                'staging_write_performed' => false,
+                'approval_manifest_file' => $approvalManifestFile,
+                'approval_manifest_sha256' => $approvalArtifact['sha256'] ?? null,
+                'editorial_review_report_file' => $editorialReviewReportFile,
+                'editorial_review_sha256' => $editorialArtifact['sha256'] ?? null,
+                'expected_written_count' => $expectedRows,
+                'production_rows_touched' => 0,
+                'rollback_report' => [
+                    'available' => true,
+                    'target_key' => ['career_job_slug', 'locale', 'asset_version'],
+                    'previous_status_counts' => $previousStatusCounts,
+                    'rows' => $rollbackRows,
+                    'rollback_sql_intent' => 'No rows were changed during dry-run. If executed, rollback restores each row to previous_status, or deletes rows whose previous_status was missing, by career_job_slug, locale, asset_version, and import_run_id.',
+                ],
+                'errors' => [],
             ]);
         }
 

--- a/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
+++ b/backend/tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php
@@ -502,6 +502,76 @@ final class CareerAiImpactAssetPreviewImportTest extends TestCase
             ->assertJsonMissingPath('ai_impact_asset_v1.search_projection');
     }
 
+    public function test_importer_production_import_dry_run_validates_approved_package_without_writing(): void
+    {
+        Config::set('career_ai_impact_assets.staging_preview_enabled', false);
+        Config::set('career_ai_impact_assets.preview_slugs', []);
+        $this->seedCareerJobBundleAuthority('accountants-and-auditors');
+
+        $zhRow = $this->assetRow('accountants-and-auditors', 'zh-CN');
+        $enRow = $this->assetRow('accountants-and-auditors', 'en');
+        $file = $this->writeJsonl([$zhRow, $enRow]);
+        $assetSha = hash_file('sha256', $file);
+        $approvalManifest = $this->writeJsonArtifact($this->approvalManifest($assetSha, 2, 1));
+        $editorialReview = $this->writeJsonArtifact($this->editorialReviewReport($assetSha, 2, 1));
+        $approvalSha = hash_file('sha256', $approvalManifest);
+        $editorialSha = hash_file('sha256', $editorialReview);
+        $occupation = Occupation::query()->where('canonical_slug', 'accountants-and-auditors')->firstOrFail();
+
+        foreach ([$zhRow, $enRow] as $row) {
+            CareerJobAiImpactAsset::query()->create([
+                'occupation_id' => $occupation->id,
+                'career_job_slug' => 'accountants-and-auditors',
+                'locale' => $row['locale'],
+                'asset_version' => CareerJobAiImpactAsset::ASSET_VERSION_V5,
+                'status' => CareerJobAiImpactAsset::STATUS_APPROVED,
+                'preview_allowlisted' => true,
+                'asset_payload_json' => $row,
+                'sources_json' => $row['sources'],
+                'evidence_used_json' => $row['evidence_used'],
+                'derived_from_synthesis_json' => $row['derived_from_synthesis'],
+                'audit_fields_json' => $row['audit_fields'],
+                'asset_row_hash' => $row['audit_fields']['row_hash'],
+                'source_artifact_sha256' => $assetSha,
+            ]);
+        }
+
+        $report = storage_path('framework/testing/ai-impact-production-import-dry-run.json');
+
+        $exitCode = Artisan::call('career:ai-impact-assets-import-preview', [
+            '--file' => $file,
+            '--slugs' => 'accountants-and-auditors',
+            '--expected-sha256' => $assetSha,
+            '--dry-run' => true,
+            '--status' => CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED,
+            '--confirm-production-import' => true,
+            '--approval-manifest' => $approvalManifest,
+            '--approval-manifest-sha256' => $approvalSha,
+            '--editorial-review-report' => $editorialReview,
+            '--editorial-review-sha256' => $editorialSha,
+            '--output' => $report,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(2, CareerJobAiImpactAsset::query()->where('status', CareerJobAiImpactAsset::STATUS_APPROVED)->count());
+        $this->assertSame(0, CareerJobAiImpactAsset::query()->where('status', CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED)->count());
+
+        $decoded = json_decode((string) file_get_contents($report), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('pass', $decoded['decision']);
+        $this->assertSame('production_import_dry_run', $decoded['mode']);
+        $this->assertSame(CareerJobAiImpactAsset::STATUS_PRODUCTION_IMPORTED, $decoded['status']);
+        $this->assertTrue((bool) $decoded['production_import_allowed']);
+        $this->assertFalse((bool) $decoded['production_import_performed']);
+        $this->assertFalse((bool) $decoded['staging_write_performed']);
+        $this->assertSame(0, $decoded['production_rows_touched']);
+        $this->assertSame($approvalSha, $decoded['approval_manifest_sha256']);
+        $this->assertSame($editorialSha, $decoded['editorial_review_sha256']);
+        $this->assertSame(2, $decoded['expected_written_count']);
+        $this->assertTrue((bool) $decoded['rollback_report']['available']);
+        $this->assertSame([CareerJobAiImpactAsset::STATUS_APPROVED => 2], $decoded['rollback_report']['previous_status_counts']);
+        $this->assertCount(2, $decoded['rollback_report']['rows']);
+    }
+
     public function test_importer_force_production_import_rejects_unapproved_existing_rows(): void
     {
         $this->seedCareerJobBundleAuthority('accountants-and-auditors');


### PR DESCRIPTION
## Summary
- Route AI Impact `--dry-run --status=production_imported` through the production import preflight gate.
- Return `mode=production_import_dry_run`, approval/editorial SHA evidence, rollback report, and zero production row touches.
- Add feature coverage proving approved rows are validated without writing production rows.

## Validation
- `php artisan test --filter=test_importer_production_import_dry_run_validates_approved_package_without_writing --no-ansi`
- `php artisan test tests/Feature/Career/CareerAiImpactAssetPreviewImportTest.php --no-ansi`
- `php artisan career:ai-impact-assets-import-preview --help`
- `git diff --check`

## Intentionally deferred
- Does not execute production import.
- Does not write staging or production rows.
- Does not rerun the AI Impact GitHub workflow until after this PR is merged and deployed.