### PR TITLE
MBTI64-GSC-API-READONLY-INTEGRATION-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityMbti64GscQueryReadonlyExport.php
+++ b/backend/app/Console/Commands/PersonalityMbti64GscQueryReadonlyExport.php
@@ -1,0 +1,468 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\GscReadonlyLiveAdapter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class PersonalityMbti64GscQueryReadonlyExport extends Command
+{
+    private const TASK = 'MBTI64-GSC-API-READONLY-INTEGRATION-01';
+
+    private const FORBIDDEN_PATTERNS = [
+        '/results',
+        '/orders',
+        '/share',
+        '/pay',
+        '/payment',
+        '/history',
+        '/private',
+        '/account',
+        'token=',
+        'session=',
+        'result_id=',
+        'report_id=',
+        'order_no=',
+    ];
+
+    protected $signature = 'personality:mbti64-gsc-query-readonly-export
+        {--targets= : JSON or CSV target packet containing MBTI64 canonical URLs or paths}
+        {--start-date= : Required for --execute-live-read, YYYY-MM-DD}
+        {--end-date= : Required for --execute-live-read, YYYY-MM-DD}
+        {--limit-per-url=25 : Per-URL GSC row limit, bounded 1..250}
+        {--dry-run : Required; confirms no writes/imports/queue/submission}
+        {--execute-live-read : Explicitly call the read-only GSC Search Analytics API}
+        {--json : Emit JSON summary}
+        {--output= : Optional JSON artifact path}
+        {--csv-output= : Optional CSV artifact path for fap-web importer}';
+
+    protected $description = 'Export MBTI64 public personality GSC query rows through the read-only GSC adapter.';
+
+    public function handle(GscReadonlyLiveAdapter $adapter): int
+    {
+        try {
+            $summary = $this->buildSummary($adapter);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary($exception->getMessage());
+        }
+
+        $this->writeJsonOutput($summary);
+        $this->writeCsvOutput($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(GscReadonlyLiveAdapter $adapter): array
+    {
+        if (! (bool) $this->option('dry-run')) {
+            throw new RuntimeException('--dry-run is required.');
+        }
+
+        $executeLiveRead = (bool) $this->option('execute-live-read');
+        $targets = $this->loadTargets();
+        $startDate = $this->dateOption('start-date', $executeLiveRead);
+        $endDate = $this->dateOption('end-date', $executeLiveRead);
+        if ($startDate !== null && $endDate !== null && $startDate > $endDate) {
+            throw new RuntimeException('start date must be before or equal to end date.');
+        }
+
+        $limit = $this->limitOption();
+        $preflight = $adapter->preflight([
+            'allow_external_api_calls' => $executeLiveRead,
+        ]);
+
+        $results = [];
+        $rows = [];
+        $issues = [];
+        if ($executeLiveRead) {
+            foreach ($targets as $target) {
+                $request = [
+                    'startDate' => $startDate,
+                    'endDate' => $endDate,
+                    'dimensions' => ['query', 'page'],
+                    'rowLimit' => $limit,
+                    'dimensionFilterGroups' => [[
+                        'filters' => [[
+                            'dimension' => 'page',
+                            'operator' => 'equals',
+                            'expression' => $target['canonical_url'],
+                        ]],
+                    ]],
+                ];
+                $result = $adapter->fetchSearchAnalyticsRows($request, [
+                    'allow_external_api_calls' => true,
+                    'execute_live_read' => true,
+                ]);
+
+                $targetRows = array_values(array_filter(
+                    (array) ($result['rows'] ?? []),
+                    fn (mixed $row): bool => is_array($row) && ($row['page'] ?? null) === $target['canonical_url']
+                ));
+
+                foreach ($targetRows as $row) {
+                    $rows[] = [
+                        'target_url' => $target['canonical_url'],
+                        'path' => $target['path'],
+                        'query' => (string) ($row['query'] ?? ''),
+                        'query_hash' => hash('sha256', (string) ($row['query'] ?? '')),
+                        'clicks' => (int) ($row['clicks'] ?? 0),
+                        'impressions' => (int) ($row['impressions'] ?? 0),
+                        'ctr' => $row['ctr'] ?? null,
+                        'position' => $row['position'] ?? null,
+                        'date_range' => [
+                            'start_date' => $startDate,
+                            'end_date' => $endDate,
+                        ],
+                        'source' => 'gsc_searchanalytics_readonly_api',
+                    ];
+                }
+
+                $resultIssues = array_values(array_map('strval', (array) ($result['issues'] ?? [])));
+                $issues = [...$issues, ...$resultIssues];
+                $results[] = [
+                    'target_url' => $target['canonical_url'],
+                    'status' => (string) ($result['status'] ?? 'unknown'),
+                    'rows_seen' => count($targetRows),
+                    'external_calls_attempted' => (bool) ($result['external_calls_attempted'] ?? false),
+                    'writes_attempted' => (bool) ($result['writes_attempted'] ?? false),
+                    'issues' => $resultIssues,
+                ];
+            }
+        } else {
+            foreach ($targets as $target) {
+                $results[] = [
+                    'target_url' => $target['canonical_url'],
+                    'status' => 'preflight_only',
+                    'rows_seen' => 0,
+                    'external_calls_attempted' => false,
+                    'writes_attempted' => false,
+                    'issues' => [],
+                ];
+            }
+        }
+
+        $writesAttempted = false;
+        $externalCallsAttempted = in_array(true, array_map(
+            static fn (array $result): bool => (bool) ($result['external_calls_attempted'] ?? false),
+            $results
+        ), true);
+
+        return [
+            'ok' => ! $writesAttempted && ($executeLiveRead ? $issues === [] : true),
+            'task' => self::TASK,
+            'schema_version' => 'mbti64-gsc-query-readonly-export.v1',
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'mode' => $executeLiveRead ? 'live_read' : 'preflight_only',
+            'dry_run' => true,
+            'no_write' => true,
+            'execute_live_read' => $executeLiveRead,
+            'target_count' => count($targets),
+            'targets' => $targets,
+            'date_range' => [
+                'start_date' => $startDate,
+                'end_date' => $endDate,
+            ],
+            'limit_per_url' => $limit,
+            'preflight' => $preflight,
+            'per_url_results' => $results,
+            'query_rows' => $rows,
+            'query_row_count' => count($rows),
+            'issues' => array_values(array_unique($issues)),
+            'safety_boundary' => [
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'cms_mutation_attempted' => false,
+                'enqueue_attempted' => false,
+                'search_submission_attempted' => false,
+                'indexing_request_attempted' => false,
+                'sitemap_llms_mutation_attempted' => false,
+                'external_calls_attempted' => $externalCallsAttempted,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array{canonical_url:string,path:string}>
+     */
+    private function loadTargets(): array
+    {
+        $path = trim((string) $this->option('targets'));
+        if ($path === '') {
+            throw new RuntimeException('--targets is required.');
+        }
+
+        $resolved = str_starts_with($path, '/') ? $path : base_path($path);
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('targets file not found: '.$resolved);
+        }
+
+        $raw = (string) File::get($resolved);
+        $values = str_ends_with(strtolower($resolved), '.csv')
+            ? $this->targetsFromCsv($raw)
+            : $this->targetsFromJson($raw);
+
+        $targets = [];
+        foreach ($values as $value) {
+            $target = $this->normalizeTarget($value);
+            if ($target === null) {
+                continue;
+            }
+            $this->assertPublicPersonalityTarget($target['canonical_url']);
+            $targets[$target['canonical_url']] = $target;
+        }
+
+        if ($targets === []) {
+            throw new RuntimeException('targets file did not contain any usable MBTI64 public personality URL.');
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetsFromJson(string $raw): array
+    {
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('targets JSON must be an object or array.');
+        }
+
+        $candidates = [];
+        $this->collectTargetValues($decoded, $candidates);
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<mixed>  $node
+     * @param  list<string>  $values
+     */
+    private function collectTargetValues(array $node, array &$values): void
+    {
+        foreach (['target_url', 'canonical_url', 'url', 'page', 'path'] as $key) {
+            if (isset($node[$key]) && is_string($node[$key])) {
+                $values[] = $node[$key];
+            }
+        }
+
+        foreach ($node as $value) {
+            if (is_string($value) && (str_starts_with($value, '/') || str_starts_with($value, 'https://'))) {
+                $values[] = $value;
+            } elseif (is_array($value)) {
+                $this->collectTargetValues($value, $values);
+            }
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetsFromCsv(string $raw): array
+    {
+        $lines = array_values(array_filter(preg_split('/\r\n|\n|\r/', $raw) ?: []));
+        if ($lines === []) {
+            return [];
+        }
+
+        $header = str_getcsv((string) array_shift($lines));
+        $values = [];
+        foreach ($lines as $line) {
+            $row = str_getcsv((string) $line);
+            $assoc = array_combine($header, $row);
+            if (! is_array($assoc)) {
+                continue;
+            }
+            foreach (['target_url', 'canonical_url', 'url', 'page', 'path'] as $key) {
+                if (isset($assoc[$key]) && trim((string) $assoc[$key]) !== '') {
+                    $values[] = trim((string) $assoc[$key]);
+                    break;
+                }
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array{canonical_url:string,path:string}|null
+     */
+    private function normalizeTarget(string $value): ?array
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        if (str_starts_with($value, '/')) {
+            $path = $value;
+            $canonical = 'https://fermatmind.com'.$path;
+        } else {
+            $parts = parse_url($value);
+            if (! is_array($parts) || ($parts['host'] ?? '') !== 'fermatmind.com') {
+                return null;
+            }
+            $path = (string) ($parts['path'] ?? '');
+            $canonical = 'https://fermatmind.com'.$path;
+        }
+
+        $path = rtrim($path, '/') ?: '/';
+
+        return [
+            'canonical_url' => 'https://fermatmind.com'.$path,
+            'path' => $path,
+        ];
+    }
+
+    private function assertPublicPersonalityTarget(string $canonicalUrl): void
+    {
+        $lower = strtolower($canonicalUrl);
+        foreach (self::FORBIDDEN_PATTERNS as $pattern) {
+            if (str_contains($lower, $pattern)) {
+                throw new RuntimeException('forbidden private route target: '.$canonicalUrl);
+            }
+        }
+
+        $path = (string) (parse_url($canonicalUrl, PHP_URL_PATH) ?: '');
+        if (preg_match('#^/(en|zh)/personality/[a-z]{4}-(a|t)(-vs-[a-z]{4}-(a|t))?$#', $path) !== 1) {
+            throw new RuntimeException('target is not an MBTI64 public personality URL: '.$canonicalUrl);
+        }
+    }
+
+    private function dateOption(string $name, bool $required): ?string
+    {
+        $value = trim((string) $this->option($name));
+        if ($value === '' && ! $required) {
+            return null;
+        }
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) !== 1) {
+            throw new RuntimeException('--'.$name.' must be YYYY-MM-DD.');
+        }
+
+        return $value;
+    }
+
+    private function limitOption(): int
+    {
+        $raw = trim((string) $this->option('limit-per-url'));
+        if (preg_match('/^\d+$/', $raw) !== 1) {
+            throw new RuntimeException('--limit-per-url must be an integer.');
+        }
+
+        $limit = (int) $raw;
+        if ($limit < 1 || $limit > 250) {
+            throw new RuntimeException('--limit-per-url must be between 1 and 250.');
+        }
+
+        return $limit;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $message): array
+    {
+        return [
+            'ok' => false,
+            'task' => self::TASK,
+            'schema_version' => 'mbti64-gsc-query-readonly-export.v1',
+            'generated_at' => Carbon::now('UTC')->toIso8601String(),
+            'error' => $message,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'no_write' => true,
+            'safety_boundary' => [
+                'writes_attempted' => false,
+                'writes_committed' => false,
+                'cms_mutation_attempted' => false,
+                'enqueue_attempted' => false,
+                'search_submission_attempted' => false,
+                'indexing_request_attempted' => false,
+                'sitemap_llms_mutation_attempted' => false,
+                'external_calls_attempted' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeJsonOutput(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $encoded = json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($encoded) || File::put($output, $encoded."\n") === false) {
+            throw new RuntimeException('failed to write output artifact.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeCsvOutput(array $summary): void
+    {
+        $output = trim((string) $this->option('csv-output'));
+        if ($output === '') {
+            return;
+        }
+
+        $handle = fopen($output, 'w');
+        if ($handle === false) {
+            throw new RuntimeException('failed to write CSV artifact.');
+        }
+
+        fputcsv($handle, ['target_url', 'path', 'query', 'query_hash', 'clicks', 'impressions', 'ctr', 'position', 'start_date', 'end_date', 'source']);
+        foreach ((array) ($summary['query_rows'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            fputcsv($handle, [
+                $row['target_url'] ?? '',
+                $row['path'] ?? '',
+                $row['query'] ?? '',
+                $row['query_hash'] ?? '',
+                $row['clicks'] ?? 0,
+                $row['impressions'] ?? 0,
+                $row['ctr'] ?? '',
+                $row['position'] ?? '',
+                data_get($row, 'date_range.start_date'),
+                data_get($row, 'date_range.end_date'),
+                $row['source'] ?? '',
+            ]);
+        }
+
+        fclose($handle);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('task='.self::TASK);
+        $this->line('mode='.(string) ($summary['mode'] ?? 'failed'));
+        $this->line('target_count='.(string) ($summary['target_count'] ?? 0));
+        $this->line('query_row_count='.(string) ($summary['query_row_count'] ?? 0));
+        $this->line('writes_attempted=0');
+        $this->line('search_submission_attempted=0');
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -175,6 +175,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
+use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
 use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
 use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
@@ -245,6 +246,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityImportDesktopCloneBaseline::class,
+        PersonalityMbti64GscQueryReadonlyExport::class,
         PersonalityMbti64CmsInternalLinkDraft::class,
         PersonalityMbti64CmsProjectionDraft::class,
         PersonalityMbti64CmsRevisionDraft::class,

--- a/backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php
+++ b/backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php
@@ -364,7 +364,7 @@ final class GscReadonlyLiveAdapter
             (int) config('seo_intel.gsc_readonly_adapter.max_limit', 250)
         ));
 
-        return [
+        $payload = [
             'startDate' => substr((string) ($request['startDate'] ?? now()->subDays(30)->toDateString()), 0, 10),
             'endDate' => substr((string) ($request['endDate'] ?? now()->subDays(3)->toDateString()), 0, 10),
             'dimensions' => array_values(array_intersect(
@@ -374,6 +374,62 @@ final class GscReadonlyLiveAdapter
             'type' => 'web',
             'rowLimit' => $limit,
         ];
+
+        $filterGroups = $this->safeDimensionFilterGroups($request['dimensionFilterGroups'] ?? null);
+        if ($filterGroups !== []) {
+            $payload['dimensionFilterGroups'] = $filterGroups;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function safeDimensionFilterGroups(mixed $groups): array
+    {
+        if (! is_array($groups)) {
+            return [];
+        }
+
+        $safeGroups = [];
+        foreach ($groups as $group) {
+            if (! is_array($group) || ! is_array($group['filters'] ?? null)) {
+                continue;
+            }
+
+            $filters = [];
+            foreach ($group['filters'] as $filter) {
+                if (! is_array($filter)) {
+                    continue;
+                }
+
+                $dimension = (string) ($filter['dimension'] ?? '');
+                $operator = (string) ($filter['operator'] ?? '');
+                $expression = trim((string) ($filter['expression'] ?? ''));
+                if (! in_array($dimension, ['page', 'query', 'country', 'device', 'searchAppearance'], true)) {
+                    continue;
+                }
+                if (! in_array($operator, ['equals', 'contains', 'notContains', 'includingRegex', 'excludingRegex'], true)) {
+                    continue;
+                }
+                if ($expression === '') {
+                    continue;
+                }
+
+                $filters[] = [
+                    'dimension' => $dimension,
+                    'operator' => $operator,
+                    'expression' => mb_substr($expression, 0, 2048, 'UTF-8'),
+                ];
+            }
+
+            if ($filters !== []) {
+                $safeGroups[] = ['filters' => $filters];
+            }
+        }
+
+        return $safeGroups;
     }
 
     /**

--- a/backend/tests/Feature/SeoIntel/PersonalityMbti64GscQueryReadonlyExportCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/PersonalityMbti64GscQueryReadonlyExportCommandTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PersonalityMbti64GscQueryReadonlyExportCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(PersonalityMbti64GscQueryReadonlyExport::class)
+        );
+    }
+
+    #[Test]
+    public function preflight_export_reads_mbti64_targets_without_external_calls_or_writes(): void
+    {
+        Http::fake();
+        $targets = $this->targetFile([
+            '/en/personality/enfj-a',
+            'https://fermatmind.com/zh/personality/intp-a',
+        ]);
+
+        $exitCode = Artisan::call('personality:mbti64-gsc-query-readonly-export', [
+            '--targets' => $targets,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('MBTI64-GSC-API-READONLY-INTEGRATION-01', $decoded['task'] ?? null);
+        $this->assertSame('preflight_only', $decoded['mode'] ?? null);
+        $this->assertSame(2, $decoded['target_count'] ?? null);
+        $this->assertSame(0, $decoded['query_row_count'] ?? null);
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.external_calls_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.writes_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.cms_mutation_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.enqueue_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.search_submission_attempted', true));
+        $this->assertSame('https://fermatmind.com/en/personality/enfj-a', data_get($decoded, 'targets.0.canonical_url'));
+        $this->assertSame('https://fermatmind.com/zh/personality/intp-a', data_get($decoded, 'targets.1.canonical_url'));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function live_read_export_uses_exact_page_filters_and_writes_importer_csv_without_mutations(): void
+    {
+        $this->enableAccessTokenConfig();
+        $targets = $this->targetFile([
+            '/en/personality/enfj-a',
+            '/zh/personality/intp-a',
+        ]);
+        $csvOutput = storage_path('framework/testing/mbti64-gsc-'.Str::uuid()->toString().'.csv');
+
+        Http::fake(function (Request $request) {
+            $target = data_get($request->data(), 'dimensionFilterGroups.0.filters.0.expression');
+
+            return Http::response([
+                'rows' => [
+                    [
+                        'keys' => [$target === 'https://fermatmind.com/en/personality/enfj-a' ? 'enfj a personality' : 'intp-a 人格', $target],
+                        'clicks' => $target === 'https://fermatmind.com/en/personality/enfj-a' ? 1 : 0,
+                        'impressions' => $target === 'https://fermatmind.com/en/personality/enfj-a' ? 12 : 7,
+                        'ctr' => $target === 'https://fermatmind.com/en/personality/enfj-a' ? 0.0833 : 0.0,
+                        'position' => $target === 'https://fermatmind.com/en/personality/enfj-a' ? 8.2 : 10.4,
+                    ],
+                ],
+            ], 200);
+        });
+
+        $exitCode = Artisan::call('personality:mbti64-gsc-query-readonly-export', [
+            '--targets' => $targets,
+            '--start-date' => '2026-06-20',
+            '--end-date' => '2026-06-23',
+            '--limit-per-url' => 10,
+            '--dry-run' => true,
+            '--execute-live-read' => true,
+            '--csv-output' => $csvOutput,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+        $csv = (string) file_get_contents($csvOutput);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('live_read', $decoded['mode'] ?? null);
+        $this->assertSame(2, $decoded['query_row_count'] ?? null);
+        $this->assertTrue((bool) data_get($decoded, 'safety_boundary.external_calls_attempted', false));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.writes_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.search_submission_attempted', true));
+        $this->assertSame('enfj a personality', data_get($decoded, 'query_rows.0.query'));
+        $this->assertNotEmpty(data_get($decoded, 'query_rows.0.query_hash'));
+        $this->assertStringContainsString('target_url,path,query,query_hash,clicks,impressions,ctr,position,start_date,end_date,source', $csv);
+        $this->assertStringContainsString('https://fermatmind.com/en/personality/enfj-a', $csv);
+
+        Http::assertSentCount(2);
+        Http::assertSent(function (Request $request): bool {
+            return data_get($request->data(), 'dimensionFilterGroups.0.filters.0.dimension') === 'page'
+                && data_get($request->data(), 'dimensionFilterGroups.0.filters.0.operator') === 'equals'
+                && in_array(data_get($request->data(), 'dimensionFilterGroups.0.filters.0.expression'), [
+                    'https://fermatmind.com/en/personality/enfj-a',
+                    'https://fermatmind.com/zh/personality/intp-a',
+                ], true)
+                && $request['rowLimit'] === 10
+                && $request['dimensions'] === ['query', 'page'];
+        });
+    }
+
+    #[Test]
+    public function live_read_fails_closed_when_gsc_preflight_is_blocked(): void
+    {
+        Http::fake();
+        $targets = $this->targetFile(['/en/personality/enfj-a']);
+
+        $exitCode = Artisan::call('personality:mbti64-gsc-query-readonly-export', [
+            '--targets' => $targets,
+            '--start-date' => '2026-06-20',
+            '--end-date' => '2026-06-23',
+            '--dry-run' => true,
+            '--execute-live-read' => true,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse((bool) ($decoded['ok'] ?? true));
+        $this->assertContains('gsc_enabled_false', $decoded['issues'] ?? []);
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.writes_attempted', true));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.external_calls_attempted', true));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function command_rejects_private_or_non_personality_targets_before_any_gsc_call(): void
+    {
+        Http::fake();
+        $targets = $this->targetFile([
+            '/en/results/lookup',
+            '/en/personality/enfj-a',
+        ]);
+
+        $exitCode = Artisan::call('personality:mbti64-gsc-query-readonly-export', [
+            '--targets' => $targets,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse((bool) ($decoded['ok'] ?? true));
+        $this->assertStringContainsString('forbidden private route target', (string) ($decoded['error'] ?? ''));
+        $this->assertFalse((bool) data_get($decoded, 'safety_boundary.writes_attempted', true));
+        Http::assertNothingSent();
+    }
+
+    private function enableAccessTokenConfig(): void
+    {
+        config([
+            'seo_intel.gsc_enabled' => true,
+            'seo_intel.gsc_live_api_enabled' => true,
+            'seo_intel.allow_external_api_calls' => true,
+            'seo_intel.gsc_property_url' => 'sc-domain:fermatmind.com',
+            'seo_intel.gsc_readonly_adapter.auth_mode' => 'access_token',
+            'seo_intel.gsc_readonly_adapter.access_token' => 'secret-gsc-token',
+            'seo_intel.gsc_readonly_adapter.default_limit' => 250,
+            'seo_intel.gsc_readonly_adapter.max_limit' => 250,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $urls
+     */
+    private function targetFile(array $urls): string
+    {
+        $path = storage_path('framework/testing/mbti64-gsc-targets-'.Str::uuid()->toString().'.json');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode(['targets' => $urls], JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -359,6 +359,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti64_gsc_readonly_export_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityMbti64GscQueryReadonlyExport.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityMbti64GscQueryReadonlyExport;',
+            '+        PersonalityMbti64GscQueryReadonlyExport::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -5400,6 +5415,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsInternalLinkDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsProjectionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6003,6 +6019,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoIntelGscFoundationFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/PersonalityMbti64GscQueryReadonlyExport.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportCanaryCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelImportDryRunCommand.php',
             'backend/app/Console/Commands/SeoIntelGscReadModelCanaryReadbackCommand.php',
@@ -9317,6 +9334,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityMbti64CmsRevisionPromote\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsMbti64GscReadonlyExportOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityMbti64GscQueryReadonlyExport\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:mbti64-gsc-query-readonly-export` for MBTI64 public personality GSC query-row export.
- Reused the existing GSC read-only adapter and added safe `dimensionFilterGroups` pass-through for exact page filters.
- Added focused feature coverage for preflight-only mode, explicit live-read mode, private-route rejection, importer CSV output, and no-write/search safety flags.
- Updated the Big Five runtime-freeze classifier contract so this MBTI64 read-only GSC command registration is not misclassified as Big Five runtime drift.

## Why
This removes the manual CSV dependency for MBTI64 query evidence while preserving the existing no-write/no-submit GSC boundary.

## Validation
- `php -l backend/app/Console/Commands/PersonalityMbti64GscQueryReadonlyExport.php`
- `php -l backend/app/Services/SeoIntel/GscReadonlyLiveAdapter.php`
- `php -l backend/tests/Feature/SeoIntel/PersonalityMbti64GscQueryReadonlyExportCommandTest.php`
- `php artisan test tests/Feature/SeoIntel/PersonalityMbti64GscQueryReadonlyExportCommandTest.php tests/Feature/SeoIntel/SeoIntelGscLiveReadonlyAdapterTest.php --display-warnings`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --display-warnings`
- `php artisan list | rg "personality:mbti64-gsc-query-readonly-export"`
- `git diff --check`
- GitHub required checks: passed after the Big Five freeze-scope fix.

## Known local check note
- `bash backend/scripts/ci_verify_mbti.sh` was run and failed in existing Big Five pack publish/rollback tests (`PacksPublishBig5Test`, `PacksRollbackBig5Test`) while this PR's focused GSC tests and the GitHub required MBTI/BigFive checks passed. The failing local assertions are outside this PR scope and concern generated Big Five compiled package directories.

## Deferred
- No production GSC read is executed by this PR.
- No CMS write, publish, sitemap/llms mutation, Search Queue enqueue, approval, submit, or Request Indexing is included.
- Agent runner and approval queue remain separate PRs.

## Repository rule impact
Backend remains the authority for live GSC API access. This PR adds a read-only export command only; it does not move content authority to frontend or add any production mutation path.
