### PR TITLE
[codex] docs: close out SEO agent GSC cohort

### DIFF
--- a/backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json
+++ b/backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json
@@ -18,6 +18,21 @@
     "chinese_claim_lint": "flag_or_block_only_no_auto_rewrite",
     "digital_pr_tracking": "manual_observation_only"
   },
+  "url_truth_effective_connection": {
+    "config_key": "seo_intel.connection",
+    "expected_production_value": "seo_intel",
+    "writer_code_path": "App\\Services\\SeoIntel\\UrlTruthInventoryRecordWriter",
+    "writer_connection": "DB::connection(config('seo_intel.connection', 'seo_intel'))",
+    "authority_tables": [
+      "seo_intel.seo_urls",
+      "seo_intel.seo_url_entities"
+    ],
+    "non_authority_default_tables": [
+      "mysql/fap_prod.seo_urls",
+      "mysql/fap_prod.seo_url_entities"
+    ],
+    "evidence_requirement": "record_effective_url_truth_connection_before_classifying_retention_drift_missing_rows_search_channel_eligibility_or_post_publish_propagation"
+  },
   "operator_surfaces": [
     "/ops/seo",
     "/ops/seo-operations",

--- a/backend/docs/seo/seo-agent-gsc-draft-canary-handoff-2026-06-23.md
+++ b/backend/docs/seo/seo-agent-gsc-draft-canary-handoff-2026-06-23.md
@@ -1,90 +1,63 @@
-# SEO Agent GSC Draft Canary Handoff - 2026-06-23
+# SEO Agent GSC Draft Canary Handoff - 2026-06-24 Closeout
 
 ## Purpose
 
-This document records the current FermatMind SEO Agent GSC cohort draft canary
-state after the June 22-23 production runs. It is a handoff for the next Codex
-or operator session.
+This document records the completed FermatMind SEO Agent GSC cohort article
+canary loop from the June 22-24 production runs. It is the operator and Codex
+handoff for future SEO Agent cohorts.
 
-It summarizes what is already closed, what remains gated, and what must not be
-combined. It does not add runtime code, mutate CMS, publish articles, write URL
-Truth, enqueue Search Channel items, submit URLs, change sitemap or `llms.txt`,
-enable scheduler, start queue workers, deploy, or call live GSC/model APIs.
+It summarizes the current capabilities, authority boundaries, production
+evidence, approval gates, and known SOP corrections. It does not add runtime
+code, mutate CMS, publish articles, write URL Truth, enqueue Search Channel
+items, submit URLs, change sitemap or `llms.txt`, enable scheduler, start queue
+workers, deploy, or call live GSC/model APIs.
 
-## Current Capability Boundary
+## Executive Status
 
-The SEO Agent is now usable as a controlled, evidence-backed semi-automated
-pipeline:
+The first real GSC cohort article canary is closed end to end.
 
-1. Ingest sanitized GSC cohort artifacts.
-2. Convert them into SEO Agent source, aggregate, Codex handoff, Codex verdict,
-   and CMS draft package dry-run artifacts.
-3. Write bounded CMS article draft revisions only after exact human approval.
-4. Run read-only readback QA, claim-risk QA, preview/runtime QA, and publish
-   gate readiness.
-5. Publish one article canary only after separate exact publish approval.
-6. Run post-publish propagation dry-run, URL Truth gate, Search Channel enqueue
-   gate, approval gate, and bounded IndexNow live submit gate separately.
+Completed:
 
-The system is not a fully automatic publisher. It must not automatically publish,
-automatically write URL Truth, automatically enqueue/search-submit, activate
-scheduler, or mutate frontend code.
+- 7 of 7 GSC article candidates were drafted, repaired where needed, QA'd,
+  published through single-article canaries, written into URL Truth, enqueued to
+  Search Channel, approved, live-submitted through IndexNow, and closed out.
+- 7 of 7 IndexNow live submissions were accepted.
+- Train-level closeout evidence was generated.
+- URL Truth retention was rechecked against the correct authority connection.
 
-## Upstream GSC Readmodel Foundation Status
+Train closeout artifact:
 
-The separate GSC readmodel foundation loop is closed for the first controlled
-artifact. This is upstream infrastructure for SEO Agent decision evidence, not
-CMS drafting or publishing work.
+- Path:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-cohort-train-closeout/20260624T-gsc-article-cohort-indexnow-closeout/seo-agent-gsc-article-cohort-train-closeout-20260624T020600Z.json`
+- Sha256:
+  `0dc3e644bda92ea329436fb5c82a1174b69556bd7ac03d6d0add7fcdf09ed249`
+- Status:
+  `success_artifact_backed_with_current_url_truth_db_probe_gap`
+- Important superseding note:
+  the URL Truth probe gap in that artifact was caused by checking the default
+  `mysql` / `fap_prod` connection instead of the URL Truth authority connection
+  `seo_intel`.
 
-Artifact:
+URL Truth authority root-cause artifact:
 
-- Sanitized GSC live-read artifact sha256:
-  `66833c07bafe5a5a0c23c6870cfed713057e0349c6800caee02ae38b92b934c0`
-
-Backend deployment:
-
-- Production backend was updated to include PR `#2357`.
-- Deployed backend SHA:
-  `2743f39309a5fe3e35d544a82763789ef20bfa5f`
-- New production command registered:
-  `seo-intel:gsc-readmodel-canary-readback`
-
-Readmodel results:
-
-- Target connection/table:
-  `seo_intel` / `seo_gsc_daily`
-- Dry-run importer consumed the sanitized artifact successfully.
-- Canary readback confirmed all previewed idempotency keys were present.
-- Controlled canary execute was rerun with exact approval and completed
-  idempotently:
-  - `rows_previewed=3`
-  - `rows_inserted=0`
-  - `rows_skipped_existing=3`
-  - `rows_missing=0`
-  - `all_rows_already_present=true`
-  - `data_quality_gate=pass`
-
-Local evidence artifacts:
-
-- `/tmp/gsc-readmodel-canary-readback-evidence-20260623.json`
-- `/tmp/gsc-readmodel-bounded-import-readiness-20260623.json`
-- `/tmp/gsc-readmodel-controlled-canary-write-evidence-20260623.json`
-
-Readmodel boundary:
-
-- The current 3-row artifact should not be reused for further write tests.
-- The readmodel lane should pause until a new, larger sanitized GSC artifact is
-  produced.
-- Future readmodel work should remain limited to GSC artifact ingestion,
-  read-only dry-run, bounded controlled import, and readback/idempotency
-  evidence.
-- It must not write CMS drafts, publish articles, enqueue Search Channel items,
-  submit URLs, mutate sitemap or `llms.txt`, enable scheduler, or change
-  frontend code.
+- Path:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/url-truth-retention-readback/20260624T-gsc-article-cohort-current-db/seo-agent-url-truth-authority-retention-root-cause-20260624T022900Z.json`
+- Sha256:
+  `1f3a741302e04841aeb4e42f443ee13a42d5e2bcc5719628139cba9d5f6dc2c2`
+- Status:
+  `success_previous_default_mysql_probe_superseded`
+- Root cause:
+  `readback_connection_mismatch`
+- Correct authority:
+  `config('seo_intel.connection') = seo_intel`
+- Current retained rows:
+  `seo_intel.seo_urls=144`, `seo_intel.seo_url_entities=144`
+- Closed cohort retained:
+  7 of 7 rows/entities.
 
 ## Source Cohort
 
-The active package is the PR-B GSC cohort draft package:
+The completed package is the PR-B GSC cohort draft package:
 
 - Package path:
   `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-cohort-handoff/20260622T-prb-d5078205-real-dryrun/seo-agent-cms-draft-package-dry-run-20260622T092803Z.json`
@@ -99,324 +72,377 @@ The active package is the PR-B GSC cohort draft package:
   6. `article:8:zh-CN`
   7. `article:51:zh-CN`
 
-## Closed Article 41 Loop
+## Current Capability Boundary
 
-`article:41:en` is the first fully executed article canary.
+The SEO Agent is a controlled, evidence-backed semi-automated pipeline.
 
-Final article state:
+Supported capabilities:
 
-- Target: `article:41:en`
-- Published revision: `71`
-- Canonical URL:
-  `https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test`
-- Search queue item: `256`
-- Channel: `indexnow`
-- IndexNow live submit result: `accepted`, HTTP `200`
+1. Ingest sanitized GSC cohort artifacts.
+2. Convert cohort artifacts into SEO Agent source, aggregate, Codex handoff,
+   Codex verdict, and CMS draft package dry-run artifacts.
+3. Write bounded CMS article draft revisions only after exact human approval.
+4. Append bounded draft payload repair revisions for approved single targets.
+5. Run read-only readback QA, claim-risk QA, preview/runtime QA, batch QA, and
+   publish gate readiness.
+6. Publish one article canary only after separate exact publish approval.
+7. Run read-only post-publish propagation planning.
+8. Export/import bounded URL Truth artifacts only after separate URL Truth write
+   approval.
+9. Bridge published article evidence into Search Channel queue planning and
+   enqueue only after separate enqueue approval.
+10. Approve queue items and live-submit IndexNow only after separate queue and
+    live-submit approvals.
+11. Produce per-article and train-level closeout evidence.
 
-Closeout artifact:
+Not supported as automatic behavior:
 
-- Path:
+- automatic CMS draft writes
+- automatic draft repairs
+- automatic CMS publish
+- automatic URL Truth import
+- automatic Search Channel enqueue
+- automatic queue approval
+- automatic IndexNow or other live search submission
+- automatic sitemap or `llms.txt` mutation
+- automatic scheduler activation
+- automatic queue worker start
+- automatic external model calls
+- live GSC API reads/writes from the SEO Agent lane
+- frontend content changes
+
+The system is not a fully automatic publisher. Every production mutation remains
+a separate exact-approval gate.
+
+## Authority Model
+
+CMS/backend remains truth for:
+
+- article content
+- article SEO title and description
+- FAQ payload chosen for public output
+- internal-link proposal payload after write approval
+- publish state
+- public/indexable flags
+- canonical path
+- claim boundary
+
+URL Truth authority is the `seo_intel` connection, not the default Laravel
+`mysql` connection:
+
+- Writer code path:
+  `App\Services\SeoIntel\UrlTruthInventoryRecordWriter`
+- Effective connection:
+  `DB::connection(config('seo_intel.connection', 'seo_intel'))`
+- Production config:
+  `config('seo_intel.connection') = seo_intel`
+- Correct readback tables:
+  `seo_intel.seo_urls`, `seo_intel.seo_url_entities`
+- Default app DB:
+  `mysql` / `fap_prod`
+- Important rule:
+  do not validate URL Truth retention by reading `fap_prod.seo_urls`; it is not
+  the URL Truth authority table.
+
+Search Channel Queue distributes approved URL Truth only. It is not allowed to
+create URL Truth or submit draft, private, noindex, non-canonical, or
+claim-unsafe URLs.
+
+GSC readmodel and GSC exported artifacts are observation inputs. They are not
+CMS truth, URL Truth, or search-submission authority.
+
+## Completed Article Inventory
+
+| Target | Canonical URL | Source ArticleRevision | Live ArticleTranslationRevision | URL Truth row/entity | Queue item | IndexNow |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| `article:41:en` | `https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test` | 71 | 67 | 34 | 256 | accepted |
+| `article:37:zh-CN` | `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` | 81 | 71 | 13 | 260 | accepted |
+| `article:34:en` | `https://fermatmind.com/en/articles/mbti-personality-test-science-vs-pseudoscience` | 80 | 70 | 17 | 259 | accepted |
+| `article:3:zh-CN` | `https://fermatmind.com/zh/articles/big-five-tool-guide` | 74 | 68 | 23 | 257 | accepted |
+| `article:40:zh-CN` | `https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained` | 75 | 69 | 18 | 258 | accepted |
+| `article:8:zh-CN` | `https://fermatmind.com/zh/articles/mbti-basics` | 84 | 72 | 40 | 261 | accepted |
+| `article:51:zh-CN` | `https://fermatmind.com/zh/articles/enneagram-personality-test-explained` | 85 | 73 | 43 | 262 | accepted |
+
+## Per-Article Closeout Evidence
+
+### `article:41:en`
+
+- Closeout:
   `/var/www/fap-api/shared/backend/storage/app/seo-agent/article41-closeout/20260623T-article41-full-closeout/seo-agent-article41-post-publish-search-closeout-20260623T045500Z.json`
-- Sha256:
+- Closeout sha256:
   `2138d2785353b1de033f4ad84def994d4de52619b5c366535af7da22b4b55ad2`
-- Status:
-  `success_with_current_url_truth_db_gap`
-
-Important caveat:
-
-- URL Truth import evidence for article 41 was successful at import time and
-  recorded one row written/read back.
-- Current production DB readback later showed `seo_urls=0` and
-  `seo_url_entities=0`.
-- Treat this as a follow-up URL Truth persistence/readback gap before relying on
-  current URL Truth rows for more article propagation.
-
-## Drafts Already Written
-
-### `article:37:zh-CN`
-
-- Draft revision: `69`
-- Write evidence:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/cms-draft-write/20260623T-gsc-next-batch-limit3/seo-agent-controlled-cms-draft-write-20260622T163133Z.json`
-- Write evidence sha256:
-  `ec4837ed026e1ad3e133b883b1c351814a70103e6da12d4f7646944c7dca4974`
-- Readback QA: success
-- Claim-risk QA: success
-- Preview/runtime QA: initial blocked artifact existed, later PR-J rerun publish
-  gate treated the draft as ready.
-- Publish gate rerun for batch 37/34:
-  `publish_ready_count=2`
-
-### `article:34:en`
-
-- Draft revision: `70`
-- Same write evidence as article 37:
-  `ec4837ed026e1ad3e133b883b1c351814a70103e6da12d4f7646944c7dca4974`
-- Readback QA: success
-- Claim-risk QA: success
-- Preview/runtime QA: initial blocked artifact existed, later PR-J rerun publish
-  gate treated the draft as ready.
-- Publish gate rerun for batch 37/34:
-  `publish_ready_count=2`
+- Publish evidence sha256:
+  `1325f446a453471d61546128033210c9aa3cefbe77dc8ba1ab68bc9aff977359`
+- URL Truth handoff sha256:
+  `c440ee9722c65d3b0ae18034f0e048391ea2791fb4aa1cfb2f56029a2dbcb4de`
+- Bounded IndexNow live evidence sha256:
+  `f53a02990d0f3426236dad6400952acabab7578027984098a6af5d8a212771f6`
 
 ### `article:3:zh-CN`
 
-- Draft revision: `72`
-- Write evidence:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/cms-draft-write/20260623T-gsc-next-batch-limit5-execute/seo-agent-controlled-cms-draft-write-20260623T070634Z.json`
-- Write evidence sha256:
-  `754967ad474898a49408827c02f831187232ef8c089f4332a2bc53bbdac93bd5`
-- Readback QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/readback/article3/seo-agent-cms-draft-readback-qa-20260623T070719Z.json`
-- Readback QA sha256:
-  `c4878d4a581634ddbb449eab8c90bbed64b86f7c801c573a99bffe9d83d050e4`
-- Claim-risk QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/claim-risk/article3/seo-agent-article-draft-claim-risk-qa-20260623T070720Z.json`
-- Claim-risk QA sha256:
-  `7a1ac7c5fe7aded90623c98a95a813dd23068549892d5152632df7bf3e147bed`
-- Preview/runtime QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/preview-runtime/article3/seo-agent-article-draft-preview-runtime-qa-20260623T070722Z.json`
-- Preview/runtime QA sha256:
-  `3e0e9e71f85f24ae8ecde183ca8d324f9026614dfc825adfb69803ffb924939c`
-
-TDK review:
-
-- Proposed SEO title:
-  `大五人格测试是什么？OCEAN 五大特质与 MBTI 区别 | FermatMind`
-- Title length: 42 characters.
-- Proposed SEO description:
-  `了解大五人格测试和 OCEAN 五大特质如何帮助你观察长期行为倾向。大五适合回答连续维度问题，但不能诊断、预测职业成功或替代真实反馈。`
-- Description length: 67 characters.
-- Claim risk: low. The description explicitly blocks diagnosis and career
-  success prediction.
-- FAQ status: not publish-ready. The current `proposed_faq_items` are internal
-  review placeholders, not user-facing FAQ content.
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260623T-article3-indexnow-closeout/seo-agent-article3-indexnow-closeout-20260623T103600Z.json`
+- Closeout sha256:
+  `36acf287e673f46e5fb4ae9a748b0585d4b5abbb879a4cdfd78336994627f95f`
+- Publish evidence sha256:
+  `9c863f4342532c8691a7c7819d124885f9bd97f54ab32b39e1aa601e139658d1`
+- URL Truth handoff sha256:
+  `c57e56aacc20b1075913aa9f7779ebaad525d3e758c84548bca493a5cc35d5a6`
+- Queue item:
+  `257`
 
 ### `article:40:zh-CN`
 
-- Draft revision: `73`
-- Write evidence:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/cms-draft-write/20260623T-gsc-next-batch-limit5-execute/seo-agent-controlled-cms-draft-write-20260623T070634Z.json`
-- Write evidence sha256:
-  `754967ad474898a49408827c02f831187232ef8c089f4332a2bc53bbdac93bd5`
-- Readback QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/readback/article40/seo-agent-cms-draft-readback-qa-20260623T070720Z.json`
-- Readback QA sha256:
-  `c0dae25032db7a7cc46986842b101a6ecd5194d167b8a13dfb6d43bb819c6ace`
-- Claim-risk QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/claim-risk/article40/seo-agent-article-draft-claim-risk-qa-20260623T070721Z.json`
-- Claim-risk QA sha256:
-  `3f23722669c1fe60609210a30bb98dbb939ba4de7aa1d0d5857f36bb4998df6e`
-- Preview/runtime QA:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/preview-runtime/article40/seo-agent-article-draft-preview-runtime-qa-20260623T070723Z.json`
-- Preview/runtime QA sha256:
-  `f1a59ca3acfef520f5e3ad900dce0bd3821a24f2ee5d06636f4ca6f28ccc1e00`
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260623T-article40-indexnow-closeout/seo-agent-article40-indexnow-closeout-20260623T115542Z.json`
+- Closeout sha256:
+  `7f0754b70ab56dca7f7959b19dca8099a2a3e7f9ce4deb379761fac924ae87e5`
+- Publish evidence sha256:
+  `ed1fbd28d7a794ccc3af09b0b4a18ab0826ecf44ae6b5c74483cf9041426b505`
+- URL Truth handoff sha256:
+  `d7d253b32e3b096bd751a3454c1d269ffe4535d660fc74d31f144ce76dc77394`
+- Queue item:
+  `258`
 
-TDK review:
+### `article:34:en`
 
-- Proposed SEO title:
-  `霍兰德职业兴趣测试准吗？RIASEC六型和职业选择 | FermatMind`
-- Title length: 38 characters.
-- Proposed SEO description:
-  `用一篇看懂 RIASEC 六型、霍兰德代码和职业兴趣测试结果：它能帮你发现适合探索的工作环境，但不能直接决定职业。`
-- Description length: 57 characters.
-- Claim risk: low to medium. The title uses the query-intent phrase `准吗`,
-  while the description keeps the boundary with `不能直接决定职业`.
-- Recommended wording improvement:
-  replace `发现适合探索的工作环境` with `发现值得探索的工作环境` to reduce
-  certainty around fit.
-- FAQ status: not publish-ready. The current `proposed_faq_items` are internal
-  review placeholders, not user-facing FAQ content.
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260623T-article34-indexnow-closeout/seo-agent-article34-indexnow-closeout-20260623T131720Z.json`
+- Closeout sha256:
+  `335658593ef048744734776d84039d0c0346f0fa8f2ed44bbef34ffcafe63e33`
+- Publish evidence sha256:
+  `da70712f5bda39839da75898c63e275f7bc4b4817365ced1ba4044f20ac7b1ba`
+- URL Truth handoff sha256:
+  `47010c51b6813f5c9489c276482d726a5205fa31f1ae67de0d64bcf503bcf59d`
+- Queue item:
+  `259`
 
-## Batch 3/40 QA Summary
+### `article:37:zh-CN`
 
-Batch write:
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260623T-article37-indexnow-closeout/seo-agent-article37-indexnow-closeout-20260623T140459Z.json`
+- Closeout sha256:
+  `267762777bd29d01b23c7ca8a72578f53d06071fa1af960d834e0c987ac4a300`
+- Publish evidence sha256:
+  `9f8a1b8c29569d97e28167a17f16deacd2e6b6742f32a6ef3aa16dc944a16b3a`
+- URL Truth handoff sha256:
+  `1aebcc5c4a20c4de4c60e3efb36efd1abff3f6c669fa624705991ebffa61995b`
+- Queue item:
+  `260`
 
-- Path:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/cms-draft-write/20260623T-gsc-next-batch-limit5-execute/seo-agent-controlled-cms-draft-write-20260623T070634Z.json`
+### `article:8:zh-CN`
+
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260624T-article8-indexnow-closeout/seo-agent-article8-indexnow-closeout-20260624T012458Z.json`
+- Closeout sha256:
+  `b6db7b52bda741fc5b8e1dd50c42e35e50eef4e8299b4789559aef7f67f0c1dd`
+- Publish evidence sha256:
+  `d6476b1b330746c52a36901e12bb8cbb5349ca90c8aac116963ef6b650577ceb`
+- URL Truth handoff sha256:
+  `77c26dffae1f7251e48265556ee94f2a0823ac441ac5721c0e275393df3297c7`
+- Queue item:
+  `261`
+
+### `article:51:zh-CN`
+
+- Closeout:
+  `/var/www/fap-api/shared/backend/storage/app/seo-agent/article-closeout/20260624T-article51-indexnow-closeout/seo-agent-article51-indexnow-closeout-20260624T015001Z.json`
+- Closeout sha256:
+  `1aaf535d95fdab97eeb0af21d8353e2e108e5d89a2f1f5616a6b7267a2c18ae4`
+- Publish evidence sha256:
+  `98eafaf6fa2106304429cff3dd0047f0094d885f685ecdd7514cab214586c910`
+- URL Truth handoff sha256:
+  `05ce15d7358725017671ec74b0fdd903a2bd252b98b0014640272d4dd11cbcb7`
+- Queue item:
+  `262`
+
+## Command Families
+
+### Cohort input and proposal chain
+
+- `seo-agent:gsc-cohort-handoff`
+- `seo-agent:codex-review-runner`
+- `seo-agent:cms-draft-package-dry-run`
+- `seo-agent:gsc-remaining-candidate-batch-plan`
+
+These commands create source, aggregate, handoff, verdict, and draft package
+artifacts. They do not write CMS or publish.
+
+### CMS draft and repair chain
+
+- `seo-agent:cms-draft-write`
+- `seo-agent:cms-draft-payload-repair-canary`
+- `seo-agent:cms-draft-readback-qa`
+- `seo-agent:article-draft-claim-risk-qa`
+- `seo-agent:article-draft-preview-runtime-qa`
+- `seo-agent:gsc-batch-draft-qa-support`
+- `seo-agent:gsc-draft-publish-gate-readiness`
+
+Draft write and repair require separate exact approvals. QA and gate readiness
+are read-only.
+
+### Publish chain
+
+- `seo-agent:article-cms-publish-canary`
+
+This command publishes one article canary only after exact approval. It must not
+write URL Truth, enqueue search, submit IndexNow, mutate sitemap, mutate
+`llms.txt`, start scheduler, or start queue workers.
+
+### Post-publish propagation chain
+
+- `seo-agent:article-post-publish-propagation-dry-run`
+- `seo-intel:url-truth-handoff`
+- `seo-agent:post-publish-search-submit`
+- `seo-intel:search-channel-approve`
+- `seo-intel:search-channel-submit-approved`
+
+URL Truth write, Search Channel enqueue, queue approval, and IndexNow live
+submission are separate gates.
+
+### Observation chain
+
+- `seo-agent:gsc-post-publish-feedback`
+- `seo-intel:gsc-readmodel-import-dry-run`
+- `seo-intel:gsc-readmodel-import-canary`
+- `seo-intel:gsc-readmodel-canary-readback`
+
+The GSC readmodel lane is upstream evidence. It must remain separate from CMS
+draft/publish/search mutation.
+
+## Required Gate Order for a New Cohort
+
+Use this order for each new cohort or article canary:
+
+1. GSC export/classification input is sanitized.
+2. `seo-agent:gsc-cohort-handoff` read-only dry-run succeeds.
+3. Draft package quality is reviewed.
+4. Exact CMS draft write approval is obtained.
+5. Draft write executes with a bounded limit.
+6. Readback QA succeeds.
+7. Claim-risk QA succeeds.
+8. Preview/runtime QA succeeds.
+9. Publish gate readiness is `publish_ready`.
+10. Exact single-article publish approval is obtained.
+11. Publish canary dry-run succeeds.
+12. Publish execute succeeds.
+13. Post-publish propagation dry-run succeeds.
+14. URL Truth export/import dry-run succeeds.
+15. Exact URL Truth import/write approval is obtained.
+16. URL Truth write executes or is idempotently confirmed.
+17. Search bridge dry-run succeeds.
+18. Exact Search Channel enqueue approval is obtained.
+19. Enqueue execute creates or idempotently confirms one queue item.
+20. Exact queue approval is obtained.
+21. Queue approval executes.
+22. Exact bounded live IndexNow approval is obtained.
+23. Live submit executes.
+24. Per-article closeout evidence is generated.
+25. Train-level closeout inventory is generated.
+
+Do not batch publish. Do not combine publish, URL Truth, Search Channel, and
+live submit in the same approval.
+
+## Claim and Content Safety Rules
+
+The article canary loop must block or require review for:
+
+- clinical or diagnostic claims
+- guaranteed outcomes
+- ranking or certainty claims
+- hiring-fit overclaims
+- career prediction overclaims
+- unsupported source claims
+- locale mismatch
+- semantic drift from the existing article
+- unsafe internal-link action
+- placeholder FAQ or placeholder TDK payload
+
+Chinese TDK and FAQ require extra review because translated or query-matching
+phrases can sound more certain than intended.
+
+FAQ repair should append a new draft revision. Do not mutate historical draft
+revisions in place.
+
+## Search and URL Truth Safety Rules
+
+URL Truth:
+
+- Must be public.
+- Must be indexable.
+- Must be non-private.
+- Must be backend-authoritative.
+- Must be read from the `seo_intel` connection.
+- Must not be inferred from frontend fallback, crawler log, search result, GSC
+  result, or local copy.
+
+Search Channel:
+
+- May enqueue only approved URL Truth.
+- Must keep draft/private/noindex/non-canonical/claim-unsafe URLs out.
+- Must keep enqueue separate from live submit.
+- May requeue after a new publish only when URL Truth lastmod/content fingerprint
+  is newer than a submitted queue item.
+
+IndexNow:
+
+- Live submit requires explicit bounded approval for the exact queue item and
+  channel.
+- No Google Indexing API, Baidu submit, sitemap submit, scheduler activation,
+  or queue worker start is implied by IndexNow approval.
+
+## Known SOP Correction
+
+The early train-level closeout artifact recorded a current URL Truth DB probe
+gap because the probe looked at `mysql` / `fap_prod`. That probe is superseded.
+
+Correct URL Truth readback SOP:
+
+1. Read `config('seo_intel.connection')`.
+2. Connect through that connection.
+3. Read `seo_urls` and `seo_url_entities` there.
+4. Record the effective connection in the evidence artifact.
+5. Only then classify retention.
+
+Evidence proving the correction:
+
+- `seo-agent-url-truth-authority-retention-root-cause-20260624T022900Z.json`
 - Sha256:
-  `754967ad474898a49408827c02f831187232ef8c089f4332a2bc53bbdac93bd5`
-- Result:
-  `rows_created=2`, `rows_skipped_existing=3`, `rows_failed=[]`
+  `1f3a741302e04841aeb4e42f443ee13a42d5e2bcc5719628139cba9d5f6dc2c2`
 
-Batch QA:
+Recommended small follow-up PR:
 
-- Path:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/batch-qa/seo-agent-gsc-batch-draft-qa-support-20260623T070718Z.json`
-- Sha256:
-  `65162490b2eac4fc0c9744e1669d4b4182456e6df8378b1e86979c63ea9eb1c8`
-- Status:
-  `review_required`
+- Add effective URL Truth connection metadata to future URL Truth readback,
+  closeout, or train inventory artifacts.
+- Update operator SOP wording so `fap_prod.seo_urls` is never used as URL Truth
+  retention truth.
 
-Publish gate:
+## GSC Readmodel Boundary
 
-- Path:
-  `/var/www/fap-api/shared/backend/storage/app/seo-agent/gsc-closeout-postdeploy/20260623T-next-batch-limit5/publish-gate/seo-agent-gsc-draft-publish-gate-readiness-20260623T070723Z.json`
-- Sha256:
-  `cb7f694b7d214dfb5b32dbb5de28a216305654c84894fe97378d7495942e8a6e`
-- Result:
-  `publish_ready_count=2`
-- Gate status:
-  `review_required`
+The GSC readmodel foundation is upstream infrastructure for SEO Agent decision
+evidence, not CMS drafting or publishing work.
 
-Reason for review hold:
+Readmodel allowed work:
 
-- `article:3` and `article:40` pass readback, claim-risk, and preview/runtime
-  QA.
-- Their FAQ payloads are still placeholder review hints and should not be
-  published as public FAQ/schema content.
-- The gate artifact emits publish approval phrases, but operator policy should
-  hold publish until FAQ is repaired or explicitly excluded from publish.
+- consume sanitized GSC artifacts
+- dry-run bounded import readiness
+- exact-approved controlled import canaries
+- readback/idempotency evidence
 
-## Remaining Unwritten Candidates
+Readmodel forbidden work:
 
-The package still has two candidates that have not received SEO Agent draft
-write canaries in this GSC cohort:
-
-- `article:8:zh-CN`
-- `article:51:zh-CN`
-
-Recommended write strategy:
-
-- Use a bounded canary that does not publish.
-- Because the writer is package-order based and existing candidates are skipped,
-  a future writer run may need a higher limit to reach candidates 6 and 7.
-- Preflight must explicitly verify expected skips and expected new rows before
-  execute approval.
-
-## Recommended Next Task Order
-
-### 0. Keep readmodel and SEO Agent CMS lanes separate
-
-Do not merge the GSC readmodel foundation lane with the SEO Agent CMS draft or
-publish lane in the same execution window.
-
-Recommended ownership:
-
-- GSC readmodel window:
-  - only generate or consume new sanitized GSC artifacts;
-  - run read-only bounded import readiness;
-  - run exact-approved controlled import canaries;
-  - run readback/idempotency evidence;
-  - stop before CMS, publish, Search Channel, IndexNow, sitemap, `llms.txt`, or
-    scheduler actions.
-- SEO Agent window:
-  - continue CMS draft write/readback/claim-risk/preview QA;
-  - repair or exclude FAQ payloads;
-  - run publish gate readiness;
-  - request separate exact approval for any publish, URL Truth, Search Channel,
-    IndexNow, or scheduler step.
-
-Current readmodel recommendation:
-
-- Do not run another write against artifact
-  `66833c07bafe5a5a0c23c6870cfed713057e0349c6800caee02ae38b92b934c0`.
-- If more readmodel evidence is needed, first produce a new sanitized GSC
-  artifact with a larger bounded preview, then run dry-run/readback before any
-  controlled write approval.
-
-### 1. Repair or exclude FAQ for `article:3` and `article:40`
-
-Do not publish these two revisions while their FAQ items are placeholder review
-text.
-
-Preferred options:
-
-1. Append repaired draft revisions with user-facing, claim-safe Chinese FAQ.
-2. Or create a scoped publish path that excludes FAQ from public write/schema if
-   the intent is TDK-only publication.
-
-After repair or exclusion:
-
-1. Run `seo-agent:cms-draft-readback-qa`.
-2. Run `seo-agent:article-draft-claim-risk-qa`.
-3. Run `seo-agent:article-draft-preview-runtime-qa`.
-4. Run `seo-agent:gsc-draft-publish-gate-readiness`.
-5. Request separate exact publish approval for one article only.
-
-### 2. Publish next single article canary
-
-Do not batch publish.
-
-Lowest-risk next publish candidate:
-
-- `article:34:en` revision `70`
-
-Rationale:
-
-- English page, lower locale/claim nuance risk.
-- Already has single-target readback success and claim-risk success.
-- Previously passed publish gate rerun as part of the 37/34 pair.
-
-Second candidate:
-
-- `article:37:zh-CN` revision `69`
-
-Rationale:
-
-- It passed readback and claim-risk, but Chinese TDK/FAQ should receive one more
-  human review before publish.
-
-Hold until FAQ repair or exclusion:
-
-- `article:3:zh-CN` revision `72`
-- `article:40:zh-CN` revision `73`
-
-### 3. Continue draft write canary for remaining candidates
-
-After the 3/40 FAQ decision, continue the remaining two candidates:
-
-- `article:8:zh-CN`
-- `article:51:zh-CN`
-
-Required steps:
-
-1. Run writer dry-run and save artifact.
-2. Confirm expected skips and expected new rows.
-3. Request exact CMS draft write approval.
-4. Execute write.
-5. Run readback QA, claim-risk QA, preview/runtime QA, and publish gate.
-6. Keep publish, URL Truth, sitemap, Search Channel enqueue, and live submit as
-   later separate gates.
-
-### 4. Investigate article URL Truth persistence/readback gap
-
-Before using URL Truth as a reliable follow-on for more article search
-propagation, investigate why the article 41 URL Truth import evidence recorded
-one row but current production `seo_urls` / `seo_url_entities` readback is empty.
-
-This should be a read-only root-cause task first. Do not re-import or rewrite
-URL Truth until the gap is understood.
-
-### 5. Observation after IndexNow
-
-For article 41, do not re-submit IndexNow.
-
-Next observation should be read-only:
-
-- GSC page/query observation after enough lag.
-- Runtime canonical and metadata smoke.
-- Search Channel duplicate-state check only if needed.
-
-## Gates That Must Stay Separate
-
-The following actions require separate exact approval phrases:
-
-- CMS draft write.
-- Draft payload repair.
-- CMS publish.
-- URL Truth import/write.
-- Sitemap or `llms.txt` release.
-- Search Channel enqueue.
-- Search Channel queue approval.
-- IndexNow or any live search submission.
-- Google Indexing API or GSC URL Inspection action.
-- Scheduler or queue worker activation.
-- Production deploy.
+- CMS draft write
+- CMS publish
+- URL Truth write
+- Search Channel enqueue
+- IndexNow or any live search submission
+- sitemap or `llms.txt` mutation
+- scheduler activation
+- frontend mutation
 
 ## Negative Guarantees for This Handoff
 
-This document creation performs no production operation and no runtime mutation:
+This document update performs no production operation and no runtime mutation:
 
 - no CMS write
 - no CMS publish
@@ -431,32 +457,21 @@ This document creation performs no production operation and no runtime mutation:
 - no live GSC API call
 - no frontend mutation
 
-## Suggested Follow-up Prompts
+## Recommended Next Steps
 
-FAQ repair / exclusion planning:
+1. Open a small docs/contract PR that makes URL Truth readback evidence state
+   the effective connection explicitly.
+2. Start the next GSC cohort only after that SOP correction is merged or at
+   least understood by the operator.
+3. Keep the same gate discipline: draft, repair, publish, URL Truth, Search
+   Channel, queue approval, and live submit remain separate exact approvals.
 
-```text
-Prepare a bounded plan for article:3:zh-CN revision 72 and article:40:zh-CN
-revision 73 FAQ cleanup. Keep it backend-only. Do not publish. Do not enqueue
-search. Decide whether to append repaired draft revisions with real claim-safe
-Chinese FAQ or to exclude FAQ from publish scope, then run read-only QA.
-```
-
-Next English publish canary:
+## Suggested Follow-up Prompt
 
 ```text
-Run production publish canary dry-run for article:34:en revision 70 using write
-evidence sha256 ec4837ed026e1ad3e133b883b1c351814a70103e6da12d4f7646944c7dca4974.
-Dry-run only. No URL Truth, sitemap, IndexNow, search, indexing, or scheduler.
-Stop for separate execute approval.
-```
-
-Remaining draft write canary:
-
-```text
-Run production dry-run/preflight for the remaining GSC cohort draft candidates
-article:8:zh-CN and article:51:zh-CN from package sha256
-889108891858699267f825351335cb8094c7733dcec169966f50bba2e0bdf416. Confirm
-expected skips and expected new draft rows. Do not execute write until separate
-exact approval.
+Implement a small backend docs/contract PR that updates URL Truth readback and
+closeout evidence wording to report effective_url_truth_connection=seo_intel.
+Do not change runtime behavior, do not write CMS, do not write URL Truth, do not
+enqueue Search Channel, and do not submit search. Validate docs JSON and
+git diff only.
 ```

--- a/backend/docs/seo/seo-ops-sop-architecture-authority-map.md
+++ b/backend/docs/seo/seo-ops-sop-architecture-authority-map.md
@@ -34,6 +34,30 @@ Chinese Claim Lint flags or blocks unsafe wording. It does not auto-rewrite, aut
 
 Digital PR tracking is manual and observation-only. Mentions, referrals, and backlinks are signals, not URL Truth.
 
+## URL Truth Effective Connection
+
+URL Truth readback must use the configured SEO Intel connection, not the default
+Laravel application connection.
+
+Production rule:
+
+- Effective config key:
+  `seo_intel.connection`
+- Expected production value:
+  `seo_intel`
+- Writer code path:
+  `App\Services\SeoIntel\UrlTruthInventoryRecordWriter`
+- Writer connection:
+  `DB::connection(config('seo_intel.connection', 'seo_intel'))`
+- Correct authority tables:
+  `seo_intel.seo_urls` and `seo_intel.seo_url_entities`
+- Non-authority default tables:
+  `mysql` / `fap_prod` tables with the same names are not URL Truth authority.
+
+Operational evidence must record the effective URL Truth connection before
+classifying retention, drift, missing rows, Search Channel eligibility, or
+post-publish propagation readiness.
+
 ## Operator Surface Map
 
 - Daily observability: `/ops/seo`.


### PR DESCRIPTION
## Summary
- Replaces the stale SEO Agent GSC draft canary handoff with the June 24 closeout state.
- Documents the completed 7/7 article cohort: revisions, URL Truth rows, queue items, IndexNow accepted status, and closeout artifact SHAs.
- Adds the URL Truth effective-connection SOP correction: URL Truth authority is `seo_intel`, not default `mysql` / `fap_prod`.
- Mirrors the connection requirement in the generated SEO Ops authority-map contract JSON.

## Why
The production GSC cohort canary train has completed end to end, but the handoff doc still described mid-train state and stale next steps. During closeout, a readback probe initially checked the wrong DB connection; this PR records the corrected root cause so future operators query `config("seo_intel.connection")` before classifying URL Truth retention.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json >/dev/null`
- `git diff --check -- backend/docs/seo/seo-agent-gsc-draft-canary-handoff-2026-06-23.md backend/docs/seo/seo-ops-sop-architecture-authority-map.md backend/docs/seo/generated/seo-ops-sop-architecture-authority-map.v1.json`
- stale-state scan for old remaining-candidate and URL Truth gap wording returned no matches

## Intentionally deferred
- No runtime command changes.
- No production operation.
- No CMS write or publish.
- No URL Truth write.
- No Search Channel enqueue or IndexNow submission.
- No scheduler, queue worker, external model, live GSC, sitemap, llms.txt, or frontend changes.

Repository rule impact: docs-only SEO operations SOP update; backend/CMS remains the authority layer, and this PR clarifies the URL Truth readback authority connection.