### PR TITLE
IQ-OWNER-30-ASSET-URL-HOTFIX-01: expose owner original IQ asset URLs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php
+++ b/backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Services\Iq\IqOwnerOriginal30BankService;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class IqOwnerOriginal30AssetController extends Controller
+{
+    public function __construct(
+        private readonly IqOwnerOriginal30BankService $ownerBank,
+    ) {}
+
+    public function show(string $path): BinaryFileResponse
+    {
+        return $this->ownerBank->publicAssetResponse($path);
+    }
+}

--- a/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+++ b/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
@@ -8,6 +8,7 @@ use App\DTO\Attempts\SubmitAttemptDTO;
 use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class IqOwnerOriginal30BankService
 {
@@ -22,6 +23,10 @@ final class IqOwnerOriginal30BankService
     public const DIR_VERSION = 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO';
 
     public const DELIVERY_MODE = 'current_question';
+
+    private const PUBLIC_ASSET_SOURCE_PREFIX = 'assets/iq_owner_original_30/';
+
+    private const PUBLIC_ASSET_ROUTE_PREFIX = 'iq_owner_original_30/';
 
     /**
      * @return array<string,mixed>
@@ -162,6 +167,17 @@ final class IqOwnerOriginal30BankService
         }
     }
 
+    public function publicAssetResponse(string $path): BinaryFileResponse
+    {
+        $absolutePath = $this->publicAssetAbsolutePath($path);
+
+        return response()->file($absolutePath, [
+            'Content-Type' => $this->contentTypeForAsset($absolutePath),
+            'Cache-Control' => 'public, max-age=31536000, immutable',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
     /**
      * @return array<int,array<string,mixed>>
      */
@@ -249,15 +265,90 @@ final class IqOwnerOriginal30BankService
      */
     private function onlyPublicMediaFields(array $media): array
     {
+        $assets = is_array($media['assets'] ?? null) ? $media['assets'] : [];
+        $publicUrl = $this->publicAssetUrl(is_string($assets['image'] ?? null) ? (string) $assets['image'] : '');
+
         return [
             'type' => (string) ($media['type'] ?? 'image'),
             'media_type' => (string) ($media['media_type'] ?? 'image/webp'),
-            'assets' => is_array($media['assets'] ?? null) ? $media['assets'] : [],
+            'assets' => $assets,
+            ...($publicUrl !== null ? [
+                'src' => $publicUrl,
+                'public_url' => $publicUrl,
+            ] : []),
             'width' => (int) ($media['width'] ?? 0),
             'height' => (int) ($media['height'] ?? 0),
             'sha256' => (string) ($media['sha256'] ?? ''),
             'accessibility_label' => (string) ($media['accessibility_label'] ?? ''),
         ];
+    }
+
+    private function publicAssetUrl(string $assetPath): ?string
+    {
+        $routePath = $this->publicRoutePathForAsset($assetPath);
+        if ($routePath === null) {
+            return null;
+        }
+
+        return url('/api/v0.3/iq-owner-original-30/assets/'.$this->encodePublicPath($routePath));
+    }
+
+    private function publicRoutePathForAsset(string $assetPath): ?string
+    {
+        $normalized = $this->normalizeAssetPath($assetPath);
+        if ($normalized === null || ! str_starts_with($normalized, self::PUBLIC_ASSET_SOURCE_PREFIX)) {
+            return null;
+        }
+
+        return substr($normalized, strlen('assets/'));
+    }
+
+    private function publicAssetAbsolutePath(string $routePath): string
+    {
+        $normalized = $this->normalizeAssetPath($routePath);
+        if ($normalized === null || ! str_starts_with($normalized, self::PUBLIC_ASSET_ROUTE_PREFIX)) {
+            throw new ApiProblemException(404, 'IQ_OWNER_ASSET_NOT_FOUND', 'owner IQ asset not found.');
+        }
+
+        $assetRoot = realpath($this->assetDir());
+        $assetPath = realpath($this->assetDir().'/'.$normalized);
+
+        if ($assetRoot === false || $assetPath === false || ! str_starts_with($assetPath, $assetRoot.DIRECTORY_SEPARATOR)) {
+            throw new ApiProblemException(404, 'IQ_OWNER_ASSET_NOT_FOUND', 'owner IQ asset not found.');
+        }
+
+        if (! is_file($assetPath)) {
+            throw new ApiProblemException(404, 'IQ_OWNER_ASSET_NOT_FOUND', 'owner IQ asset not found.');
+        }
+
+        return $assetPath;
+    }
+
+    private function normalizeAssetPath(string $path): ?string
+    {
+        $normalized = str_replace('\\', '/', trim($path));
+        $normalized = ltrim($normalized, '/');
+        if ($normalized === '' || str_contains($normalized, "\0") || str_contains($normalized, '..')) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private function encodePublicPath(string $path): string
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $path)));
+    }
+
+    private function contentTypeForAsset(string $path): string
+    {
+        return match (strtolower((string) pathinfo($path, PATHINFO_EXTENSION))) {
+            'webp' => 'image/webp',
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'svg' => 'image/svg+xml',
+            default => 'application/octet-stream',
+        };
     }
 
     /**
@@ -281,5 +372,10 @@ final class IqOwnerOriginal30BankService
     private function bankDir(): string
     {
         return base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.self::DIR_VERSION.'/banks/'.self::BANK_ID);
+    }
+
+    private function assetDir(): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/'.self::DIR_VERSION.'/assets');
     }
 }

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1062,6 +1062,28 @@
                 ]
             }
         },
+        "/api/v0.3/iq-owner-original-30/assets/{path}": {
+            "get": {
+                "operationId": "api.v0_3.iq_owner_original_30.assets.show",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\IqOwnerOriginal30AssetController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ],
+                "x-laravel-name": "api.v0_3.iq_owner_original_30.assets.show"
+            }
+        },
         "/api/v0.3/me/attempts": {
             "get": {
                 "operationId": "get_api_v0_3_me_attempts",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\API\V0_3\ClaimController as ClaimV03Controller;
 use App\Http\Controllers\API\V0_3\ComplianceDsarController;
 use App\Http\Controllers\API\V0_3\EmailCaptureController;
 use App\Http\Controllers\API\V0_3\EmailPreferenceController;
+use App\Http\Controllers\API\V0_3\IqOwnerOriginal30AssetController;
 use App\Http\Controllers\API\V0_3\MbtiAttributionEventController;
 use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
@@ -231,6 +232,9 @@ Route::prefix('v0.3')->middleware([
         Route::get('/public-gateways/tests', [PublicGatewaySurfaceController::class, 'tests']);
         Route::get('/public-gateways/help', [PublicGatewaySurfaceController::class, 'help']);
         Route::get('/public-gateways/help/{slug}', [PublicGatewaySurfaceController::class, 'helpDetail']);
+        Route::get('/iq-owner-original-30/assets/{path}', [IqOwnerOriginal30AssetController::class, 'show'])
+            ->where('path', '.*')
+            ->name('api.v0_3.iq_owner_original_30.assets.show');
         Route::get('/scales/{scale_code}/questions', [ScalesController::class, 'questions']);
         Route::get('/scales/{scale_code}/technical-note', [ScalesController::class, 'technicalNote']);
         Route::get('/scales/{scale_code}', [ScalesController::class, 'show']);

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -70,7 +70,19 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         ]);
         $this->assertCount(1, $response->json('questions.items'));
         $this->assertSame('IQOWNER30-Q01', $response->json('questions.items.0.question_id'));
+        $this->assertOwnerOriginalQ1AssetsArePubliclyResolvable($response->json('questions.items.0'));
         $this->assertPayloadHasNoPrivateIqFields($response->json());
+    }
+
+    #[Test]
+    public function owner_original_asset_route_rejects_invalid_paths(): void
+    {
+        $response = $this->getJson('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/../banks/IQ_OWNER_ORIGINAL_30/answer_key.json');
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'error_code' => 'IQ_OWNER_ASSET_NOT_FOUND',
+        ]);
     }
 
     #[Test]
@@ -234,5 +246,49 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
                 $this->assertPayloadHasNoPrivateIqFields($value);
             }
         }
+    }
+
+    private function assertOwnerOriginalQ1AssetsArePubliclyResolvable(array $item): void
+    {
+        $media = [
+            'stem' => data_get($item, 'stem'),
+        ];
+
+        foreach (['A', 'B', 'C', 'D', 'E', 'F'] as $code) {
+            $option = collect(data_get($item, 'options', []))
+                ->first(static fn (array $candidate): bool => ($candidate['code'] ?? null) === $code);
+            $this->assertIsArray($option, 'missing option '.$code);
+            $media['option_'.$code] = $option;
+        }
+
+        foreach ($media as $label => $payload) {
+            $this->assertIsArray($payload, $label.' media payload missing');
+            $src = (string) data_get($payload, 'src');
+            $publicUrl = (string) data_get($payload, 'public_url');
+            $assetPath = (string) data_get($payload, 'assets.image');
+
+            $this->assertNotSame('', $src, $label.' src missing');
+            $this->assertSame($src, $publicUrl, $label.' public_url should match src');
+            $this->assertStringStartsWith(url('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/'), $src);
+            $this->assertStringStartsWith('assets/iq_owner_original_30/q01/', $assetPath);
+            $this->assertStringNotContainsString(base_path(), $src);
+            $this->assertStringNotContainsString('/private/', $src);
+            $this->assertStringNotContainsString('../', $src);
+
+            $assetResponse = $this->get($this->pathFromPublicUrl($src));
+            $assetResponse->assertStatus(200);
+            $assetResponse->assertHeader('X-Content-Type-Options', 'nosniff');
+            $this->assertStringStartsWith('image/webp', (string) $assetResponse->headers->get('content-type'));
+            $this->assertGreaterThan(0, $assetResponse->baseResponse->getFile()->getSize());
+        }
+    }
+
+    private function pathFromPublicUrl(string $url): string
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+        $this->assertIsString($path);
+        $this->assertStringStartsWith('/api/v0.3/iq-owner-original-30/assets/', $path);
+
+        return $path;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2819,6 +2819,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_owner_original30_asset_url_hotfix(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php',
+            'backend/app/Services/Iq/IqOwnerOriginal30BankService.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_3\\IqOwnerOriginal30AssetController;',
+            "+        Route::get('/iq-owner-original-30/assets/{path}', [IqOwnerOriginal30AssetController::class, 'show'])",
+            "+            ->where('path', '.*')",
+            "+            ->name('api.v0_3.iq_owner_original_30.assets.show');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_attempt_submission_reliability_hardening(): void
     {
         $changed = [
@@ -6616,6 +6638,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php',
+            'backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php',
             'backend/app/Http/Middleware/FmTokenAuth.php',
             'backend/app/Http/Middleware/ResolveOrgContext.php',
             'backend/app/Services/Attempts/AttemptStartService.php',
@@ -9360,7 +9383,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/AttemptQuestionDeliveryController|\\/attempts\\/\\{attempt_id\\}\\/questions|FmTokenAuth|uuid:attempt_id|public_realm|api\\.v0_3\\.attempts\\.questions/u', $line) !== 1) {
+            if (preg_match('/AttemptQuestionDeliveryController|IqOwnerOriginal30AssetController|\\/attempts\\/\\{attempt_id\\}\\/questions|\\/iq-owner-original-30\\/assets\\/\\{path\\}|FmTokenAuth|uuid:attempt_id|public_realm|where\\(|api\\.v0_3\\.attempts\\.questions|api\\.v0_3\\.iq_owner_original_30\\.assets\\.show/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added a V0.3 public asset route for IQ_OWNER_ORIGINAL_30 image files.
- Added a backend asset URL resolver so delivery payload stem/options include browser-loadable `src` and `public_url` fields while preserving internal `assets.image`.
- Extended owner-original IQ session delivery tests to verify no answer leakage, q01 stem and A-F option URLs exist, URLs do not expose local filesystem paths, and each public URL resolves to a WebP response.

## Why
The deployed owner-original IQ take page receives question payloads, but the image fields were still internal content-package paths. Browsers need a stable public URL from the API to render the stem and option assets.

## Validation
- `php -l backend/routes/api.php && php -l backend/app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php && php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php && php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `php artisan route:list --path=api/v0.3/iq-owner-original-30`
- `php artisan migrate --pretend --no-interaction --force`
- `vendor/bin/pint --test app/Http/Controllers/API/V0_3/IqOwnerOriginal30AssetController.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php routes/api.php`
- `php artisan test --filter=IqOwnerOriginal30`
- `git diff --check`

## Intentionally deferred
- No frontend changes.
- No CMS writes or production imports.
- No staging or production deploy.
- No hard-blocking of legacy full-bank payload reads.
- Did not run `backend/scripts/ci_verify_mbti.sh`; it is a broad cross-scale gate and this hotfix is scoped to IQ_OWNER_ORIGINAL_30 asset delivery with focused feature coverage.