### PR TITLE
Run full state machine before career content production import

### DIFF
--- a/.github/workflows/career-content-production-import.yml
+++ b/.github/workflows/career-content-production-import.yml
@@ -368,10 +368,61 @@ jobs:
           printf '%s  %s\n' "$AI_IMPACT_APPROVAL_MANIFEST_SHA256" "$AI_IMPACT_PROD_APPROVAL_MANIFEST" | sha256sum -c -
           printf '%s  %s\n' "$AI_IMPACT_EDITORIAL_REVIEW_SHA256" "$AI_IMPACT_PROD_EDITORIAL_REVIEW" | sha256sum -c -
 
+          page_assembly_staging_report="$PRODUCTION_IMPORT_DIR/page_assembly_staging_preview_report.json"
           page_assembly_approved_report="$PRODUCTION_IMPORT_DIR/page_assembly_approved_transition_report.json"
           page_assembly_report="$PRODUCTION_IMPORT_DIR/page_assembly_production_import_report.json"
+          ai_impact_staging_report="$PRODUCTION_IMPORT_DIR/ai_impact_staging_preview_report.json"
           ai_impact_approved_report="$PRODUCTION_IMPORT_DIR/ai_impact_approved_transition_report.json"
           ai_impact_report="$PRODUCTION_IMPORT_DIR/ai_impact_production_import_report.json"
+
+          validate_staging_report() {
+            local report_file="$1"
+            local channel="$2"
+            local expected_sha="$3"
+
+            php -r '
+              $report = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+              $channel = $argv[2];
+              $expectedSha = $argv[3];
+              $errors = [];
+
+              $checks = [
+                "decision" => "pass",
+                "mode" => "write",
+                "status" => "staging_preview",
+                "source_file_sha256" => $expectedSha,
+              ];
+
+              foreach ($checks as $key => $expected) {
+                if (($report[$key] ?? null) !== $expected) {
+                  $actual = json_encode($report[$key] ?? null);
+                  $errors[] = "{$channel}: {$key} expected {$expected}, got {$actual}";
+                }
+              }
+
+              if (($report["staging_write_performed"] ?? null) !== true) {
+                $errors[] = "{$channel}: staging_write_performed is not true";
+              }
+              if ((int) ($report["written_count"] ?? -1) !== 2092) {
+                $errors[] = "{$channel}: written_count is not 2092";
+              }
+              $expectedWrittenCount = (int) ($report["expected_written_count"] ?? $report["expected_preview_rows"] ?? -1);
+              if ($expectedWrittenCount !== 2092) {
+                $errors[] = "{$channel}: expected row count is not 2092";
+              }
+              if (($report["production_import_performed"] ?? null) === true) {
+                $errors[] = "{$channel}: staging write unexpectedly performed production import";
+              }
+              if (($report["errors"] ?? []) !== []) {
+                $errors[] = "{$channel}: staging report contains errors";
+              }
+
+              if ($errors !== []) {
+                fwrite(STDERR, implode(PHP_EOL, $errors).PHP_EOL);
+                exit(1);
+              }
+            ' "$report_file" "$channel" "$expected_sha"
+          }
 
           validate_approved_report() {
             local report_file="$1"
@@ -474,6 +525,17 @@ jobs:
             --expected-sha256="$PAGE_ASSEMBLY_EXPECTED_SHA256" \
             --all-slugs-from-file \
             --force \
+            --status=staging_preview \
+            --confirm-full-staging-preview \
+            --output="$page_assembly_staging_report" \
+            --json
+          validate_staging_report "$page_assembly_staging_report" "page_assembly" "$PAGE_ASSEMBLY_EXPECTED_SHA256"
+
+          php -d memory_limit=1024M artisan career:page-assembly-assets-import-preview \
+            --file="$PAGE_ASSEMBLY_PROD_ASSET_FILE" \
+            --expected-sha256="$PAGE_ASSEMBLY_EXPECTED_SHA256" \
+            --all-slugs-from-file \
+            --force \
             --status=approved \
             --confirm-approved-transition \
             --approval-manifest="$PAGE_ASSEMBLY_PROD_APPROVAL_MANIFEST" \
@@ -498,6 +560,17 @@ jobs:
             --output="$page_assembly_report" \
             --json
           validate_import_report "$page_assembly_report" "page_assembly" "$PAGE_ASSEMBLY_EXPECTED_SHA256"
+
+          php -d memory_limit=1024M artisan career:ai-impact-assets-import-preview \
+            --file="$AI_IMPACT_PROD_ASSET_FILE" \
+            --expected-sha256="$AI_IMPACT_EXPECTED_SHA256" \
+            --all-slugs-from-file \
+            --force \
+            --status=staging_preview \
+            --confirm-full-staging-preview \
+            --output="$ai_impact_staging_report" \
+            --json
+          validate_staging_report "$ai_impact_staging_report" "ai_impact" "$AI_IMPACT_EXPECTED_SHA256"
 
           php -d memory_limit=1024M artisan career:ai-impact-assets-import-preview \
             --file="$AI_IMPACT_PROD_ASSET_FILE" \
@@ -538,8 +611,10 @@ jobs:
             exit "$rc"
           fi
 
+          ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/page_assembly_staging_preview_report.json'" > artifacts/reports/page_assembly_staging_preview_report.json
           ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/page_assembly_approved_transition_report.json'" > artifacts/reports/page_assembly_approved_transition_report.json
           ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/page_assembly_production_import_report.json'" > artifacts/reports/page_assembly_production_import_report.json
+          ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/ai_impact_staging_preview_report.json'" > artifacts/reports/ai_impact_staging_preview_report.json
           ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/ai_impact_approved_transition_report.json'" > artifacts/reports/ai_impact_approved_transition_report.json
           ssh_retry "$PRODUCTION_PORT" "$production_target" "cat '$PRODUCTION_IMPORT_DIR/ai_impact_production_import_report.json'" > artifacts/reports/ai_impact_production_import_report.json
 
@@ -548,6 +623,7 @@ jobs:
             echo
             echo "- page_assembly_sha256: \`$PAGE_ASSEMBLY_EXPECTED_SHA256\`"
             echo "- ai_impact_sha256: \`$AI_IMPACT_EXPECTED_SHA256\`"
+            echo "- production_staging_preview_write_performed: \`true\`"
             echo "- production_approved_transition_performed: \`true\`"
             echo "- production_import_performed: \`true\`"
             echo "- page_assembly_rows_touched: \`2092\`"


### PR DESCRIPTION
## Summary
- Updates the manual career content production import workflow to run the full production DB state machine before importing.
- Adds production-side `staging_preview` writes before the existing approved transition and production import steps for both page assembly and AI Impact.
- Uploads staging, approved, and production import reports for both channels.

## Why
Previous authorized workflow runs stopped safely with `production_rows_touched=0` because production DB did not contain the expected local `staging_preview`/`approved` source rows. The importer state machine is DB-local, so the production workflow must establish `staging_preview -> approved -> production_imported` in the production environment while still requiring the exact user-approved SHAs.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/career-content-production-import.yml"); puts "yaml_ok"'`\n- `git diff --check`\n\n## Deferred\n- Does not run production import from this PR.\n- Does not change business code, content assets, runtime pages, SEO, CMS, sitemap, llms, canonical, noindex, or JSON-LD.\n- Production import still requires the manual workflow inputs with exact approved SHAs and production environment approval.