### PR TITLE
Sanitize career detail source refs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -30,17 +30,43 @@ final class CareerJobDetailController extends Controller
         if ($payload === null) {
             $cnProxySurface = $this->cnProxySurfaceBuilder->buildBySlug($slug, $publicLocale);
             if ($cnProxySurface !== null) {
-                return response()->json($cnProxySurface);
+                return response()->json($this->projectReaderSafePayload($cnProxySurface));
             }
 
             $aiImpactPreviewShell = $this->aiImpactPreviewDetailShellBuilder->build($slug, $publicLocale);
             if ($aiImpactPreviewShell !== null) {
-                return response()->json($aiImpactPreviewShell);
+                return response()->json($this->projectReaderSafePayload($aiImpactPreviewShell));
             }
 
             return $this->notFoundResponse('career job detail bundle unavailable.');
         }
 
-        return response()->json($payload);
+        return response()->json($this->projectReaderSafePayload($payload));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function projectReaderSafePayload(array $payload): array
+    {
+        if (! is_array($payload['truth_layer']['source_refs'] ?? null)) {
+            return $payload;
+        }
+
+        $payload['truth_layer']['source_refs'] = array_values(array_map(
+            static function (mixed $sourceRef): mixed {
+                if (! is_array($sourceRef)) {
+                    return $sourceRef;
+                }
+
+                unset($sourceRef['source_id'], $sourceRef['source_trace_id']);
+
+                return $sourceRef;
+            },
+            $payload['truth_layer']['source_refs'],
+        ));
+
+        return $payload;
     }
 }

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -165,6 +165,23 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         }
     }
 
+    public function test_job_detail_projection_does_not_expose_internal_source_ids(): void
+    {
+        $occupation = $this->seedCompiledOccupation('accountants-and-auditors');
+        $this->addCrosswalks($occupation, 'accountants-and-auditors');
+        $this->createDisplayAsset($occupation);
+
+        $response = $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors?locale=en')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
+            ->assertJsonMissingPath('truth_layer.source_refs.0.source_id')
+            ->assertJsonMissingPath('truth_layer.source_refs.0.source_trace_id');
+
+        $encoded = json_encode($response->json('truth_layer.source_refs'), JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('source_id', $encoded);
+        $this->assertStringNotContainsString('source_trace_id', $encoded);
+    }
+
     public function test_it_adds_display_surface_for_selected_d5_assets(): void
     {
         foreach ([


### PR DESCRIPTION
## What changed
- Sanitizes public career job detail responses before JSON output.
- Removes internal `source_id` and `source_trace_id` from `truth_layer.source_refs`.
- Adds a feature test for the career detail projection path.

## Why
Post-import live QA found 12 career detail API rows exposing `truth_layer.source_refs[*].source_id`. The 7 historical live 404 rows were rechecked before this PR and now return 200, so this PR does not change route readiness or content assets.

## Validation
- `git diff --check`
- `php -l backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php`
- `php -l backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php`

Targeted Laravel test note: local temp worktree does not have a usable Composer autoload/vendor path, so CI should run the full feature test.

## Deferred
- No AI Impact asset changes.
- No career content import or staging/production write.
- No sitemap, llms, canonical, noindex, or JSON-LD changes.
- Frontend English locale rendering guard is handled in the separate fap-web PR.
