### PR TITLE
PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\PersonalityAgentApprovalQueueWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityAgentApprovalQueueCommand extends Command
+{
+    private const OPERATOR_APPROVAL = 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01';
+
+    protected $signature = 'personality:agent-approval-queue
+        {--package= : Path to a personality agent recommendation package JSON artifact}
+        {--qa= : Path to a personality agent QA JSON artifact}
+        {--dry-run : Validate and plan approval queue rows without database writes}
+        {--write : Create pending human approval queue rows}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Queue QA-passed personality agent recommendations for human approval without CMS, publish, index, or search side effects.';
+
+    public function handle(PersonalityAgentApprovalQueueWriter $writer): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(PersonalityAgentApprovalQueueWriter $writer): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write && (string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+
+        $packagePath = $this->resolvePath(trim((string) $this->option('package')), 'Package');
+        $qaPath = $this->resolvePath(trim((string) $this->option('qa')), 'QA artifact');
+        $packageRaw = (string) File::get($packagePath);
+        $qaRaw = (string) File::get($qaPath);
+        $package = json_decode($packageRaw, true);
+        $qa = json_decode($qaRaw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+        if (! is_array($qa)) {
+            throw new RuntimeException('QA artifact must be a JSON object.');
+        }
+
+        $metadata = [
+            'package_path' => $packagePath,
+            'qa_path' => $qaPath,
+        ];
+
+        $summary = $write
+            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), $metadata)
+            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw), $metadata);
+
+        return array_merge($summary, [
+            'command' => 'personality:agent-approval-queue',
+        ]);
+    }
+
+    private function resolvePath(string $path, string $label): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('--'.strtolower(str_replace(' artifact', '', $label)).' is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException($label.' file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('planned_item_count='.(string) ($summary['planned_item_count'] ?? 0));
+        $this->line('created_item_count='.(string) ($summary['created_item_count'] ?? 0));
+        $this->line('skipped_existing_item_count='.(string) ($summary['skipped_existing_item_count'] ?? 0));
+        $this->line('blocked_item_count='.(string) ($summary['blocked_item_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -174,6 +174,7 @@ use App\Console\Commands\Packs2Rollback;
 use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
+use App\Console\Commands\PersonalityAgentApprovalQueueCommand;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
@@ -245,6 +246,7 @@ class Kernel extends ConsoleKernel
         FapSelfCheck::class,
         FapValidateReport::class,
         FapWeeklyReport::class,
+        PersonalityAgentApprovalQueueCommand::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64GscQueryReadonlyExport::class,
         PersonalityMbti64CmsInternalLinkDraft::class,

--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -1,0 +1,519 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use Illuminate\Support\Facades\DB;
+
+final class PersonalityAgentApprovalQueueWriter
+{
+    private const ALLOWED_FRAMEWORKS = ['mbti64', 'big_five', 'enneagram'];
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256, array $metadata = []): array
+    {
+        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false, $metadata);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256, array $metadata = []): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true, $metadata));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write, array $metadata): array
+    {
+        $qaResultsByUrl = $this->qaResultsByUrl($qa);
+        $blockedItems = [];
+        $queueItems = [];
+
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $qaResult = $qaResultsByUrl[(string) ($recommendation['target_url'] ?? '')] ?? [];
+            $prepared = $this->prepareItem($recommendation, $qaResult, $position + 1);
+            if (($prepared['blocked_reason'] ?? null) !== null) {
+                $blockedItems[] = $prepared;
+
+                continue;
+            }
+
+            $queueItems[] = $prepared;
+        }
+
+        $framework = $this->frameworkForBatch($queueItems);
+        $errors = $this->validationErrors($package, $qa, $queueItems);
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $metadata), [
+                'ok' => false,
+                'status' => 'fail',
+                'framework' => $framework,
+                'planned_item_count' => count($queueItems),
+                'blocked_item_count' => count($blockedItems),
+                'queued_item_count' => 0,
+                'created_batch_id' => null,
+                'created_item_count' => 0,
+                'skipped_existing_item_count' => 0,
+                'items' => $queueItems,
+                'blocked_items' => $blockedItems,
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $existingBatch = $this->existingBatch($framework, $sourceSha256, $qaSha256);
+        if ($existingBatch !== null) {
+            $existingItemCount = (int) DB::table('personality_agent_approval_items')
+                ->where('batch_id', (int) $existingBatch->id)
+                ->count();
+
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $metadata), [
+                'ok' => true,
+                'status' => 'pass',
+                'framework' => $framework,
+                'planned_item_count' => count($queueItems),
+                'blocked_item_count' => count($blockedItems),
+                'queued_item_count' => $write ? $existingItemCount : 0,
+                'created_batch_id' => null,
+                'existing_batch_id' => (int) $existingBatch->id,
+                'created_item_count' => 0,
+                'skipped_existing_item_count' => $existingItemCount,
+                'items' => $queueItems,
+                'blocked_items' => $blockedItems,
+                'errors' => [],
+                'warnings' => [],
+            ]);
+        }
+
+        $createdBatchId = null;
+        $createdItems = 0;
+        if ($write) {
+            $createdBatchId = $this->createBatch($package, $qa, $framework, $sourceSha256, $qaSha256, $metadata, $queueItems, $blockedItems);
+            foreach ($queueItems as $item) {
+                $this->createItem($createdBatchId, $item);
+                $createdItems++;
+            }
+        }
+
+        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $metadata), [
+            'ok' => true,
+            'status' => 'pass',
+            'framework' => $framework,
+            'planned_item_count' => count($queueItems),
+            'blocked_item_count' => count($blockedItems),
+            'queued_item_count' => $write ? $createdItems : 0,
+            'created_batch_id' => $createdBatchId,
+            'existing_batch_id' => null,
+            'created_item_count' => $createdItems,
+            'skipped_existing_item_count' => 0,
+            'writes_committed' => $write && $createdItems > 0,
+            'items' => $queueItems,
+            'blocked_items' => $blockedItems,
+            'errors' => [],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $qa
+     * @return array<string,array<string,mixed>>
+     */
+    private function qaResultsByUrl(array $qa): array
+    {
+        $sources = [
+            $qa['page_results'] ?? null,
+            $qa['results'] ?? null,
+            $qa['items'] ?? null,
+            $qa['recommendations'] ?? null,
+        ];
+        $results = [];
+
+        foreach ($sources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            foreach ($source as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $url = (string) ($item['target_url'] ?? $item['url'] ?? '');
+                if ($url !== '') {
+                    $results[$url] = $item;
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @param  array<string,mixed>  $qaResult
+     * @return array<string,mixed>
+     */
+    private function prepareItem(array $recommendation, array $qaResult, int $position): array
+    {
+        $identity = $this->identityForRecommendation($recommendation);
+        $recommendationJson = $this->jsonString($recommendation);
+        $qaDecision = (string) ($qaResult['decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
+        $blockedReason = $this->blockedReason($recommendation, $qaResult, $identity, $recommendationJson);
+
+        return [
+            'position' => $position,
+            'framework' => (string) ($recommendation['framework'] ?? ''),
+            'target_url' => (string) ($recommendation['target_url'] ?? ''),
+            'path' => (string) ($identity['path'] ?? ''),
+            'locale' => (string) ($identity['locale'] ?? $recommendation['locale'] ?? ''),
+            'page_type' => (string) ($identity['page_type'] ?? $recommendation['page_type'] ?? ''),
+            'recommendation_id' => (string) ($recommendation['recommendation_id'] ?? ''),
+            'recommendation_sha256' => hash('sha256', $recommendationJson),
+            'qa_decision' => $qaDecision,
+            'approval_state' => 'pending',
+            'blocked_reason' => $blockedReason,
+            'safety_holds' => $this->safetyHolds(),
+            'recommendation' => $recommendation,
+            'qa_result' => $qaResult,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @param  array<string,mixed>  $qaResult
+     * @param  array<string,mixed>|null  $identity
+     */
+    private function blockedReason(array $recommendation, array $qaResult, ?array $identity, string $recommendationJson): ?string
+    {
+        if ($identity === null) {
+            return 'unsupported_or_private_target_url';
+        }
+
+        $framework = (string) ($recommendation['framework'] ?? '');
+        if (! in_array($framework, self::ALLOWED_FRAMEWORKS, true)) {
+            return 'unsupported_framework';
+        }
+
+        if ($this->containsForbiddenRoutePattern((string) ($recommendation['target_url'] ?? ''))
+            || $this->containsForbiddenRoutePattern($recommendationJson)) {
+            return 'forbidden_private_route_pattern';
+        }
+
+        if ($qaResult === []) {
+            return 'qa_result_missing';
+        }
+
+        $decision = (string) ($qaResult['decision'] ?? $qaResult['status'] ?? $qaResult['qa_status'] ?? '');
+        if (! $this->qaDecisionPasses($decision)) {
+            return 'qa_not_pass';
+        }
+
+        if ((array) ($qaResult['blockers'] ?? []) !== []) {
+            return 'qa_blockers_present';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array<string,string>|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        $targetUrl = (string) ($recommendation['target_url'] ?? '');
+        $host = (string) (parse_url($targetUrl, PHP_URL_HOST) ?: '');
+        $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+        if ($host !== 'fermatmind.com') {
+            return null;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-(?<variant>a|t)$#i', $path, $matches) === 1) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'page_type' => 'personality_profile_variant',
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/(?<type>[a-z]{4})-a-vs-\k<type>-t$#i', $path, $matches) === 1) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'page_type' => 'personality_profile_comparison',
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/[a-z0-9-]+$#i', $path, $matches) === 1) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'page_type' => (string) ($recommendation['page_type'] ?? 'personality_profile'),
+            ];
+        }
+
+        return null;
+    }
+
+    private function localeFromPrefix(string $prefix): string
+    {
+        return $prefix === 'zh' ? 'zh-CN' : 'en';
+    }
+
+    private function qaDecisionPasses(string $decision): bool
+    {
+        return in_array($decision, [
+            'pass',
+            'PASS',
+            'PASS_READY_FOR_CMS_DRAFT',
+            'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
+        ], true);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $queueItems
+     * @return list<array<string,string>>
+     */
+    private function validationErrors(array $package, array $qa, array $queueItems): array
+    {
+        $errors = [];
+        if ($this->recommendations($package) === []) {
+            $errors[] = [
+                'field' => 'package.recommendations',
+                'code' => 'recommendations_missing',
+                'message' => 'The package must contain recommendation rows.',
+            ];
+        }
+        if ($this->qaResultsByUrl($qa) === []) {
+            $errors[] = [
+                'field' => 'qa.page_results',
+                'code' => 'qa_results_missing',
+                'message' => 'The QA artifact must contain per-target QA rows.',
+            ];
+        }
+        if ($queueItems === []) {
+            $errors[] = [
+                'field' => 'recommendations',
+                'code' => 'no_queueable_qa_passed_items',
+                'message' => 'No QA-passed public personality recommendations are eligible for approval queue creation.',
+            ];
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $queueItems
+     */
+    private function frameworkForBatch(array $queueItems): string
+    {
+        $frameworks = array_values(array_unique(array_map(
+            static fn (array $item): string => (string) ($item['framework'] ?? ''),
+            $queueItems
+        )));
+        sort($frameworks);
+
+        return count($frameworks) === 1 ? $frameworks[0] : 'mixed';
+    }
+
+    private function existingBatch(string $framework, string $sourceSha256, string $qaSha256): ?object
+    {
+        return DB::table('personality_agent_approval_batches')
+            ->where('framework', $framework)
+            ->where('source_package_sha256', $sourceSha256)
+            ->where('qa_sha256', $qaSha256)
+            ->first();
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $queueItems
+     * @param  list<array<string,mixed>>  $blockedItems
+     */
+    private function createBatch(
+        array $package,
+        array $qa,
+        string $framework,
+        string $sourceSha256,
+        string $qaSha256,
+        array $metadata,
+        array $queueItems,
+        array $blockedItems,
+    ): int {
+        $now = now();
+
+        return (int) DB::table('personality_agent_approval_batches')->insertGetId([
+            'framework' => $framework,
+            'source_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_artifact_path' => (string) ($metadata['package_path'] ?? ''),
+            'source_package_sha256' => $sourceSha256,
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'qa_artifact_path' => (string) ($metadata['qa_path'] ?? ''),
+            'qa_sha256' => $qaSha256,
+            'status' => 'pending_review',
+            'planned_item_count' => count($queueItems),
+            'queued_item_count' => count($queueItems),
+            'blocked_item_count' => count($blockedItems),
+            'safety_holds_json' => $this->jsonString($this->safetyHolds()),
+            'summary_json' => $this->jsonString([
+                'source_version' => (string) ($package['version'] ?? ''),
+                'source_status' => (string) ($package['status'] ?? ''),
+                'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+                'blocked_items' => array_map(
+                    static fn (array $item): array => [
+                        'target_url' => (string) ($item['target_url'] ?? ''),
+                        'blocked_reason' => (string) ($item['blocked_reason'] ?? ''),
+                    ],
+                    $blockedItems
+                ),
+            ]),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     */
+    private function createItem(int $batchId, array $item): void
+    {
+        $now = now();
+        DB::table('personality_agent_approval_items')->insert([
+            'batch_id' => $batchId,
+            'framework' => (string) ($item['framework'] ?? ''),
+            'target_url' => (string) ($item['target_url'] ?? ''),
+            'path' => (string) ($item['path'] ?? ''),
+            'locale' => (string) ($item['locale'] ?? ''),
+            'page_type' => (string) ($item['page_type'] ?? ''),
+            'recommendation_id' => (string) ($item['recommendation_id'] ?? ''),
+            'recommendation_sha256' => (string) ($item['recommendation_sha256'] ?? ''),
+            'qa_decision' => (string) ($item['qa_decision'] ?? ''),
+            'approval_state' => 'pending',
+            'approved_at' => null,
+            'rejected_at' => null,
+            'blocked_reason' => null,
+            'safety_holds_json' => $this->jsonString($this->safetyHolds()),
+            'recommendation_json' => $this->jsonString($item['recommendation'] ?? []),
+            'qa_json' => $this->jsonString($item['qa_result'] ?? []),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write, array $metadata): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01',
+            'source_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_version' => (string) ($package['version'] ?? ''),
+            'source_status' => (string) ($package['status'] ?? ''),
+            'source_package_sha256' => $sourceSha256,
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'qa_sha256' => $qaSha256,
+            'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+            'package_path' => (string) ($metadata['package_path'] ?? ''),
+            'qa_path' => (string) ($metadata['qa_path'] ?? ''),
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_attempted' => $write,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'live_content_updated' => false,
+            'approval_state_written_only' => true,
+            'safety_holds' => $this->safetyHolds(),
+        ];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function safetyHolds(): array
+    {
+        return [
+            'approval_queue_only' => true,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'live_content_updated' => false,
+        ];
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  mixed  $value
+     */
+    private function jsonString($value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php
+++ b/backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personality_agent_approval_batches', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->string('framework', 32);
+            $table->string('source_artifact', 160)->nullable();
+            $table->string('source_artifact_path', 512)->nullable();
+            $table->string('source_package_sha256', 64);
+            $table->string('qa_artifact', 160)->nullable();
+            $table->string('qa_artifact_path', 512)->nullable();
+            $table->string('qa_sha256', 64);
+            $table->string('status', 48)->default('pending_review');
+            $table->unsignedInteger('planned_item_count')->default(0);
+            $table->unsignedInteger('queued_item_count')->default(0);
+            $table->unsignedInteger('blocked_item_count')->default(0);
+            $table->json('safety_holds_json')->nullable();
+            $table->json('summary_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                ['framework', 'source_package_sha256', 'qa_sha256'],
+                'uq_personality_agent_approval_batch_source'
+            );
+            $table->index(['framework', 'status'], 'idx_personality_agent_approval_batch_status');
+        });
+
+        Schema::create('personality_agent_approval_items', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('batch_id');
+            $table->string('framework', 32);
+            $table->string('target_url', 512);
+            $table->string('path', 255);
+            $table->string('locale', 16);
+            $table->string('page_type', 64);
+            $table->string('recommendation_id', 255)->nullable();
+            $table->string('recommendation_sha256', 64);
+            $table->string('qa_decision', 64);
+            $table->string('approval_state', 32)->default('pending');
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('rejected_at')->nullable();
+            $table->string('blocked_reason', 255)->nullable();
+            $table->json('safety_holds_json')->nullable();
+            $table->json('recommendation_json');
+            $table->json('qa_json')->nullable();
+            $table->timestamps();
+
+            $table->foreign('batch_id', 'fk_personality_agent_approval_items_batch')
+                ->references('id')
+                ->on('personality_agent_approval_batches')
+                ->cascadeOnDelete();
+            $table->unique(['batch_id', 'target_url'], 'uq_personality_agent_approval_item_target');
+            $table->index(['framework', 'approval_state'], 'idx_personality_agent_approval_item_state');
+            $table->index(['target_url'], 'idx_personality_agent_approval_item_url');
+        });
+    }
+
+    public function down(): void
+    {
+        // Production safety: approval queue history is forward-only.
+        // Schema/data rollback should use a forward fix migration.
+    }
+};

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityAgentApprovalQueueCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_pending_approval_items_without_writes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(2, $payload['planned_item_count']);
+        $this->assertSame(0, $payload['blocked_item_count']);
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
+    public function test_write_creates_pending_human_approval_queue_items_only(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertFalse($payload['external_calls_attempted']);
+        $this->assertSame(2, $payload['planned_item_count']);
+        $this->assertSame(2, $payload['created_item_count']);
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->count());
+
+        $this->assertSame('pending_review', (string) DB::table('personality_agent_approval_batches')->value('status'));
+        $this->assertSame(
+            ['pending'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('approval_state')->all()
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('approved_at')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('rejected_at')->count());
+    }
+
+    public function test_second_write_is_idempotent_for_same_package_and_qa_hashes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+
+        $firstExit = Artisan::call('personality:agent-approval-queue', $options);
+        $this->assertSame(0, $firstExit);
+
+        $secondExit = Artisan::call('personality:agent-approval-queue', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_item_count']);
+        $this->assertSame(2, $payload['skipped_existing_item_count']);
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(2, DB::table('personality_agent_approval_items')->count());
+    }
+
+    public function test_write_fails_closed_without_operator_approval_token(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--operator-approved'] = 'WRONG';
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString(
+            '--operator-approved=PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01 is required',
+            (string) ($payload['errors'][0]['message'] ?? '')
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
+    public function test_failed_qa_and_private_routes_do_not_enter_approval_queue(): void
+    {
+        $package = $this->validPackage();
+        $package['recommendations'][] = $this->recommendation(
+            'mbti64-private',
+            'https://fermatmind.com/en/results/lookup',
+            'en'
+        );
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01',
+            'final_decision' => 'CONDITIONAL_REQUIRES_EDITORIAL_REPAIR',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CMS_DRAFT'),
+                $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'NO_GO_BLOCKED_BY_QA', ['claim risk']),
+                $this->qaRow('https://fermatmind.com/en/results/lookup', 'PASS_READY_FOR_CMS_DRAFT'),
+            ],
+        ]);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(1, $payload['planned_item_count']);
+        $this->assertSame(2, $payload['blocked_item_count']);
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(1, DB::table('personality_agent_approval_items')->count());
+        $this->assertSame(
+            'https://fermatmind.com/en/personality/enfj-a',
+            (string) DB::table('personality_agent_approval_items')->value('target_url')
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-01',
+            'version' => 'mbti64.agent_expansion_88_recommendations.v1',
+            'status' => 'pass_ready_for_qa_gates',
+            'recommendations' => [
+                $this->recommendation(
+                    'mbti64-agent-expansion-88:/en/personality/enfj-a',
+                    'https://fermatmind.com/en/personality/enfj-a',
+                    'en'
+                ),
+                $this->recommendation(
+                    'mbti64-agent-expansion-88:/zh/personality/intp-a',
+                    'https://fermatmind.com/zh/personality/intp-a',
+                    'zh-CN'
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validQa(): array
+    {
+        return [
+            'artifact' => 'MBTI64-PUBLIC-PROFILE-AGENT-EXPANSION-88-QA-01',
+            'final_decision' => 'PASS_READY_FOR_CMS_DRAFT',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CMS_DRAFT'),
+                $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_CMS_DRAFT'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $id, string $targetUrl, string $locale): array
+    {
+        return [
+            'recommendation_id' => $id,
+            'target_url' => $targetUrl,
+            'framework' => 'mbti64',
+            'locale' => $locale,
+            'current_surface' => [
+                'title' => 'Current title',
+                'description' => 'Current description',
+                'h1' => 'Current H1',
+            ],
+            'recommendations' => [
+                'title' => ['recommended' => 'Recommended title | FermatMind'],
+                'description' => ['recommended' => 'Recommended description.'],
+                'h1' => ['recommended' => 'Recommended H1'],
+                'quick_answer' => ['recommended' => 'Recommended quick answer.'],
+                'faq' => [],
+                'internal_links' => [],
+                'differentiation_notes' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $blockers
+     * @return array<string,mixed>
+     */
+    private function qaRow(string $targetUrl, string $decision, array $blockers = []): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'decision' => $decision,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeArtifacts(array $package, array $qa): array
+    {
+        $dir = storage_path('framework/testing/personality-agent-approval-queue');
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/package.json';
+        $qaPath = $dir.'/qa.json';
+        File::put($packagePath, (string) json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, (string) json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath, string $qaPath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--operator-approved' => 'PERSONALITY-AGENT-HUMAN-APPROVAL-QUEUE-01',
+            '--json' => true,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -374,6 +374,22 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_personality_agent_approval_queue_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
+            'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityAgentApprovalQueueCommand;',
+            '+        PersonalityAgentApprovalQueueCommand::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -4369,6 +4385,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPersonalityAgentApprovalQueueFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -5438,6 +5458,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsProjectionDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5650,6 +5671,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityMbti64CmsRevisionPromote.php',
             'backend/app/Services/Cms/Mbti64CmsRevisionPromotionService.php',
+        ], true);
+    }
+
+    private function isPersonalityAgentApprovalQueueFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php',
+            'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
+            'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
         ], true);
     }
 
@@ -9376,6 +9406,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityMbti64GscQueryReadonlyExport\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsPersonalityAgentApprovalQueueOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityAgentApprovalQueueCommand\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:agent-approval-queue` as a bounded backend command for importing QA-passed personality agent recommendations into a human approval queue.
- Added `PersonalityAgentApprovalQueueWriter` plus approval batch/item tables for pending review state only.
- Registered the command in Console Kernel.
- Added focused feature coverage for dry-run, write, idempotency, missing approval token, failed QA, and private-route exclusion.
- Updated the Big Five runtime-freeze scope classifier so this approval-queue control-plane change is not treated as Big Five runtime drift.

## Why
This creates the safety step between agent recommendations and CMS draft writers. Agent output can be queued for human review, but it cannot mutate CMS/live content, publish/index/search surfaces, queues, or external APIs.

## Validation
- `php -l backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php`
- `php -l backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php`
- `php -l backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php`
- `php -l backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --display-warnings`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter 'runtime_paths_have_no_uncommitted_diff|personality_agent_approval_queue' --display-warnings`
- `php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Warnings observed locally are from the temp worktree missing `backend/.env`; assertions passed.

## Intentionally deferred
- No CMS draft creation.
- No live content promotion.
- No publish/index/search release.
- No sitemap/llms mutation.
- No Search Queue enqueue/approve/submit.
- No active scheduler/cron activation.
