### PR TITLE
PR-EQ-ASSET-01 Backend EQ v1.6 content-pack import and compile lint

### DIFF
--- a/backend/app/Services/Content/Eq60ContentCompileService.php
+++ b/backend/app/Services/Content/Eq60ContentCompileService.php
@@ -731,6 +731,12 @@ final class Eq60ContentCompileService
             'cross_assessment_context',
             'seo_geo_authority',
             'sjt_bridge',
+            'result_snapshot',
+            'commercial_conversion_assets',
+            'quality_confidence',
+            'psychometric_evidence_status',
+            'agent_dialogue_playbooks',
+            'backend_integration_contract',
         ] as $key) {
             $doc = $this->loader->readJson($this->loader->rawPath('report_assets/'.$key.'.json', $version));
             if (is_array($doc)) {

--- a/backend/app/Services/Content/Eq60ContentLintService.php
+++ b/backend/app/Services/Content/Eq60ContentLintService.php
@@ -811,6 +811,12 @@ final class Eq60ContentLintService
             'cross_assessment_context',
             'seo_geo_authority',
             'sjt_bridge',
+            'result_snapshot',
+            'commercial_conversion_assets',
+            'quality_confidence',
+            'psychometric_evidence_status',
+            'agent_dialogue_playbooks',
+            'backend_integration_contract',
         ];
 
         $docs = [];
@@ -976,6 +982,86 @@ final class Eq60ContentLintService
             'button_label',
             'available',
         ], $errors);
+
+        $resultSnapshotAssets = (array) data_get($docs, 'result_snapshot.assets', []);
+        $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/result_snapshot.json', $version), (array) ($resultSnapshotAssets['eq.snapshot.high_empathy_low_recovery'] ?? []), [
+            'headline',
+            'core_judgment',
+            'evidence_point',
+            'minimal_action',
+            'share_safe_sentence',
+            'continue_path',
+        ], $errors);
+        $highEmpathySnapshot = (array) ($resultSnapshotAssets['eq.snapshot.high_empathy_low_recovery'] ?? []);
+        foreach (['zh-CN', 'en'] as $locale) {
+            if ((array) data_get($highEmpathySnapshot, $locale.'.conversion_actions', []) === []) {
+                $errors[] = $this->error($this->loader->rawPath('report_assets/result_snapshot.json', $version), 1, $locale.'.conversion_actions cannot be empty.');
+            }
+        }
+
+        $conversionAssets = (array) data_get($docs, 'commercial_conversion_assets.assets', []);
+        foreach ([
+            'eq.conversion.save_report',
+            'eq.conversion.email_revisit',
+            'eq.conversion.pdf_export',
+            'eq.conversion.share_card',
+            'eq.conversion.retest_reminder',
+            'eq.conversion.related_tests',
+            'eq.conversion.agent_entry',
+        ] as $assetId) {
+            $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/commercial_conversion_assets.json', $version), (array) ($conversionAssets[$assetId] ?? []), [
+                'title',
+                'body',
+                'cta_label',
+                'do_not_overread',
+            ], $errors);
+        }
+
+        $conversionJson = json_encode(data_get($docs, 'commercial_conversion_assets.assets', []), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        foreach (['购买', '解锁', 'paywall', 'SKU_EQ_60_FULL_299', 'EQ_60_FULL'] as $blockedTerm) {
+            if (str_contains($conversionJson, $blockedTerm)) {
+                $errors[] = $this->error($this->loader->rawPath('report_assets/commercial_conversion_assets.json', $version), 1, 'commercial conversion assets must not contain blocked term: '.$blockedTerm);
+            }
+        }
+
+        $qualityAssets = (array) data_get($docs, 'quality_confidence.assets', []);
+        foreach (['eq.quality.level.A', 'eq.quality.level.B', 'eq.quality.level.C', 'eq.quality.level.D'] as $assetId) {
+            $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/quality_confidence.json', $version), (array) ($qualityAssets[$assetId] ?? []), [
+                'label',
+                'body',
+                'user_guidance',
+                'retest_note',
+                'why_this_level',
+                'how_to_read',
+            ], $errors);
+        }
+
+        $evidenceAssets = (array) data_get($docs, 'psychometric_evidence_status.assets', []);
+        $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/psychometric_evidence_status.json', $version), (array) ($evidenceAssets['eq.evidence.content_validity'] ?? []), [
+            'status',
+            'body',
+            'user_facing_status_label',
+            'what_this_means_for_user',
+            'next_validation_step',
+        ], $errors);
+
+        $agentPlaybookAssets = (array) data_get($docs, 'agent_dialogue_playbooks.assets', []);
+        $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/agent_dialogue_playbooks.json', $version), (array) ($agentPlaybookAssets['eq.agent.playbook.understand_result'] ?? []), [
+            'title',
+            'response_policy',
+            'clarifying_question',
+            'safe_response_example',
+            'refusal_example',
+            'escalation_rule',
+        ], $errors);
+
+        $backendContractAssets = (array) data_get($docs, 'backend_integration_contract.assets', []);
+        $this->lintLocalizedAssetFields($this->loader->rawPath('report_assets/backend_integration_contract.json', $version), (array) ($backendContractAssets['eq.backend_contract.schema_mapping'] ?? []), [
+            'title',
+            'requirement',
+            'acceptance',
+            'do_not_overread',
+        ], $errors);
     }
 
     /**
@@ -1086,7 +1172,13 @@ final class Eq60ContentLintService
         }
 
         foreach (['zh-CN', 'en'] as $locale) {
-            if (trim((string) ($node[$locale] ?? '')) === '') {
+            $value = $node[$locale] ?? '';
+            if (is_array($value)) {
+                $errors[] = $this->error($file, 1, $path.'.'.$locale.' must be scalar text.');
+
+                continue;
+            }
+            if (trim((string) $value) === '') {
                 $errors[] = $this->error($file, 1, $path.'.'.$locale.' is required.');
             }
         }

--- a/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-05-31T14:50:56.929590Z",
+    "generated_at": "2026-06-24T09:44:46.656518Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -10,24 +10,28 @@
             "assets": {
                 "eq.scientific_contract.default": {
                     "zh-CN": {
-                        "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
-                        "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
-                        "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
-                        "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
-                        "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
-                        "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
-                        "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
-                        "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+                        "test_definition": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+                        "self_report_statement": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+                        "non_clinical_statement": "本报告不用于医疗、治疗或风险处置决定。如果困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
+                        "non_hiring_statement": "本结果不应用于录用、淘汰、晋升或岗位分配。它更适合个人发展、团队沟通和自我反思。",
+                        "non_ability_statement": "EQ-60 解释的是自我感知中的情绪与关系模式，不等同于认证能力评估，也不应作为高风险决策依据。未来的情境判断模块也只会补充情境选择数据，而不是把结果变成能力认证。",
+                        "norm_status_statement": "当前分数使用阶段性常模和版本化解释。百分位用于提供相对位置感，而不是精确排名。随着样本和版本更新，报告会保留当时版本以便复测对比。",
+                        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来判断解释置信度。低置信不等于结果无用，而是需要更谨慎地读。",
+                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
+                        "user_safe_summary": "适合用于自我理解、关系复盘和成长规划。",
+                        "do_not_overread": "不要把自我报告结果当作他人观察或现场行为记录。"
                     },
                     "en": {
-                        "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
-                        "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
-                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
-                        "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
-                        "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
-                        "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
-                        "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
-                        "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+                        "test_definition": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+                        "self_report_statement": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+                        "non_clinical_statement": "This report is not intended for healthcare, treatment, or safety decisions. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
+                        "non_hiring_statement": "This result should not be used for selection, promotion, rejection, or role assignment. It is better suited for development, communication, and reflection.",
+                        "non_ability_statement": "EQ-60 explains emotional and relational patterns in self-perception. It is not a certified capability evaluation and should not be used as a high-stakes decision tool. A future scenario module may add judgment data, but it would still not turn the result into a credential.",
+                        "norm_status_statement": "Scores currently use provisional norms and versioned interpretation. Percentiles provide a sense of relative standing, not an exact rank. As samples and versions improve, reports retain the version used for comparison over time.",
+                        "quality_rules_statement": "The report considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Lower confidence does not make the result useless; it means read it more cautiously.",
+                        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
+                        "user_safe_summary": "Use it for self-understanding, relational reflection, and growth planning.",
+                        "do_not_overread": "Do not treat self-report results as external observation or a live behavior record."
                     }
                 }
             }
@@ -38,140 +42,632 @@
             "global_index": {
                 "zh-CN": {
                     "label": "情绪与关系综合指数",
-                    "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+                    "definition": "综合指数把四个维度合并成一个整体视角，用来帮助你快速理解当前情绪与关系模式。",
+                    "not_a_capability_score": "它不是现场表现的能力凭证，也不应单独决定任何重要选择。",
+                    "how_to_use": "先看总览，再回到四维、质量提示和行动处方。"
                 },
                 "en": {
                     "label": "Emotional & Relational Functioning Index",
-                    "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
-                }
-            },
-            "score_notes": {
-                "zh-CN": {
-                    "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。",
-                    "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。"
-                },
-                "en": {
-                    "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range.",
-                    "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification."
+                    "definition": "The index combines the four dimensions into one overall view of your current emotional and relational pattern.",
+                    "not_a_capability_score": "It is not a credential of live performance and should not be used alone for important decisions.",
+                    "how_to_use": "Start with the overview, then read dimensions, confidence, and action prescription."
                 }
             },
             "bands": {
                 "foundational": {
-                    "zh-CN": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
-                    "en": "Foundational: the current signal suggests this area benefits from more structure, practice, and review."
+                    "zh-CN": "基础发展中",
+                    "en": "Foundational"
                 },
                 "developing": {
-                    "zh-CN": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
-                    "en": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity."
+                    "zh-CN": "发展中",
+                    "en": "Developing"
                 },
                 "stable": {
-                    "zh-CN": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。",
-                    "en": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+                    "zh-CN": "稳定可用",
+                    "en": "Stable"
                 },
                 "proficient": {
-                    "zh-CN": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
-                    "en": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs."
+                    "zh-CN": "熟练成熟",
+                    "en": "Proficient"
                 },
                 "integrated": {
-                    "zh-CN": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
-                    "en": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible."
+                    "zh-CN": "高度整合",
+                    "en": "Integrated"
                 }
             },
             "dimensions": {
                 "SA": {
                     "zh-CN": {
                         "label": "自我觉察",
-                        "definition": "识别、命名和理解自身情绪线索的倾向。",
-                        "band_explanations": {
-                            "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
-                            "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
-                            "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。",
-                            "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
-                            "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。"
-                        }
+                        "short_label": "自我觉察",
+                        "definition": "识别、命名和理解自己情绪的倾向。",
+                        "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
+                        "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
+                        "development_question": "我此刻真正的感受和需要是什么？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Self-Awareness",
-                        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
-                        "band_explanations": {
-                            "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
-                            "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
-                            "stable": "Self-awareness is stable and usually helps you understand key emotional cues.",
-                            "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
-                            "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action."
-                        }
+                        "short_label": "Self-Awareness",
+                        "definition": "The tendency to notice, name, and make sense of your own emotions.",
+                        "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
+                        "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
+                        "development_question": "What am I actually feeling and needing right now?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "ER": {
                     "zh-CN": {
                         "label": "情绪调节",
-                        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
-                        "band_explanations": {
-                            "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
-                            "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
-                            "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。",
-                            "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
-                            "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。"
-                        }
+                        "short_label": "情绪调节",
+                        "definition": "在压力、反馈、挫败或冲突中稳定和恢复自己的倾向。",
+                        "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
+                        "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
+                        "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Emotion Regulation",
-                        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
-                        "band_explanations": {
-                            "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
-                            "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
-                            "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure.",
-                            "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
-                            "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available."
-                        }
+                        "short_label": "Emotion Regulation",
+                        "definition": "The tendency to steady and recover yourself under pressure, feedback, frustration, or conflict.",
+                        "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
+                        "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
+                        "development_question": "Can I lower the heat first before choosing my response?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "EM": {
                     "zh-CN": {
                         "label": "共情理解",
-                        "definition": "理解他人情绪、立场和关系线索的倾向。",
-                        "band_explanations": {
-                            "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
-                            "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
-                            "stable": "共情理解稳定可用，多数场景能把握他人基本感受。",
-                            "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
-                            "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。"
-                        }
+                        "short_label": "共情理解",
+                        "definition": "理解他人情绪、立场和未说出口感受的倾向。",
+                        "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
+                        "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
+                        "development_question": "对方真正担心或在意的是什么？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Empathy",
-                        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
-                        "band_explanations": {
-                            "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
-                            "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
-                            "stable": "Empathy is stable and usually helps you grasp basic feelings in others.",
-                            "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
-                            "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions."
-                        }
+                        "short_label": "Empathy",
+                        "definition": "The tendency to understand others’ feelings, perspectives, and unspoken emotional cues.",
+                        "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
+                        "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
+                        "development_question": "What is the other person really concerned about?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "RM": {
                     "zh-CN": {
                         "label": "关系管理",
-                        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
-                        "band_explanations": {
-                            "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
-                            "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
-                            "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。",
-                            "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
-                            "integrated": "关系管理高度整合，重点是避免承担过多协调责任。"
-                        }
+                        "short_label": "关系管理",
+                        "definition": "通过表达、协作、边界和修复维持关系质量的倾向。",
+                        "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
+                        "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
+                        "development_question": "这句话怎样说，既真实又能让关系继续对话？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Relationship Management",
-                        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
-                        "band_explanations": {
-                            "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
-                            "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
-                            "stable": "Relationship management is stable and usually supports constructive action in collaboration.",
-                            "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
-                            "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility."
+                        "short_label": "Relationship Management",
+                        "definition": "The tendency to maintain relationship quality through expression, collaboration, boundaries, and repair.",
+                        "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
+                        "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
+                        "development_question": "How can I say this honestly while keeping the conversation open?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
+                    }
+                }
+            },
+            "dimension_bands": {
+                "SA": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
+                            "strength": "愿意回头复盘时，能够逐步看见真实感受。",
+                            "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
+                            "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
+                            "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
+                            "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。",
+                            "label": "自我觉察 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
+                            "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
+                            "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
+                            "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
+                            "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
+                            "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method.",
+                            "label": "Self-awareness · Foundational"
                         }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
+                            "strength": "你开始能把情绪从混乱体验里拆出来。",
+                            "risk": "觉察到情绪后，可能仍会被它带着走。",
+                            "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
+                            "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
+                            "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。",
+                            "label": "自我觉察 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
+                            "strength": "You are beginning to separate emotion from the overall sense of confusion.",
+                            "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
+                            "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
+                            "practice_focus": "Practice the sentence: “I feel... because I care about...”",
+                            "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming.",
+                            "label": "Self-awareness · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
+                            "strength": "你通常能说清楚自己为什么被影响。",
+                            "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
+                            "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
+                            "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
+                            "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。",
+                            "label": "自我觉察 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
+                            "strength": "You can usually explain why something affected you.",
+                            "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
+                            "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
+                            "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
+                            "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings.",
+                            "label": "Self-awareness · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
+                            "strength": "你能把复杂感受组织成比较清楚的表达。",
+                            "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
+                            "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
+                            "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
+                            "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。",
+                            "label": "自我觉察 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
+                            "strength": "You can organize complex feelings into relatively clear expression.",
+                            "risk": "You may analyze every reaction in detail and delay communication or recovery.",
+                            "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
+                            "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
+                            "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it.",
+                            "label": "Self-awareness · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
+                            "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
+                            "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
+                            "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
+                            "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
+                            "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。",
+                            "label": "自我觉察 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
+                            "strength": "You can use awareness in real time, not only in later reflection.",
+                            "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
+                            "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
+                            "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
+                            "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often.",
+                            "label": "Self-awareness · Integrated"
+                        }
+                    }
+                },
+                "ER": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
+                            "strength": "你能从明显的情绪反应中发现需要练习的场景。",
+                            "risk": "压力下容易直接回应、回避或进入长时间内耗。",
+                            "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
+                            "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
+                            "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。",
+                            "label": "情绪调节 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
+                            "strength": "Clear emotional reactions can show you exactly which situations need practice.",
+                            "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
+                            "typical_scene": "After a conflict, you may replay the conversation for a long time.",
+                            "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
+                            "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic.",
+                            "label": "Emotion regulation · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
+                            "strength": "你已经知道某些做法能帮自己缓下来。",
+                            "risk": "情绪强度一高，原本有效的方法可能想不起来。",
+                            "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
+                            "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
+                            "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。",
+                            "label": "情绪调节 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
+                            "strength": "You already know that some actions help you settle.",
+                            "risk": "When intensity rises, strategies that usually work may be hard to remember.",
+                            "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
+                            "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
+                            "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option.",
+                            "label": "Emotion regulation · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
+                            "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
+                            "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
+                            "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
+                            "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
+                            "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。",
+                            "label": "情绪调节 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
+                            "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
+                            "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
+                            "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
+                            "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
+                            "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice.",
+                            "label": "Emotion regulation · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
+                            "strength": "你能为沟通争取到更好的时机和语气。",
+                            "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
+                            "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
+                            "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
+                            "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。",
+                            "label": "情绪调节 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
+                            "strength": "You can create better timing and tone for communication.",
+                            "risk": "At times, you may appear so calm that others cannot read your real position.",
+                            "typical_scene": "When challenged, you can steady your tone before addressing the point.",
+                            "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
+                            "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information.",
+                            "label": "Emotion regulation · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
+                            "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
+                            "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
+                            "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
+                            "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
+                            "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。",
+                            "label": "情绪调节 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
+                            "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
+                            "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
+                            "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
+                            "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
+                            "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure.",
+                            "label": "Emotion regulation · Integrated"
+                        }
+                    }
+                },
+                "EM": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
+                            "strength": "你可以通过直接提问建立更清楚的信息。",
+                            "risk": "容易把沉默、语气或表情理解得过少或过多。",
+                            "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
+                            "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
+                            "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。",
+                            "label": "共情理解 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
+                            "strength": "Direct questions can give you clearer information.",
+                            "risk": "You may read too little or too much into silence, tone, or facial expression.",
+                            "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
+                            "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
+                            "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support.",
+                            "label": "Empathic understanding · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
+                            "strength": "你开始关注关系中的情绪温度。",
+                            "risk": "可能过早判断别人不高兴、失望或疏远。",
+                            "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
+                            "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
+                            "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。",
+                            "label": "共情理解 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
+                            "strength": "You are starting to track the emotional temperature in relationships.",
+                            "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
+                            "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
+                            "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
+                            "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence.",
+                            "label": "Empathic understanding · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
+                            "strength": "你能让对方感到被看见和被认真对待。",
+                            "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
+                            "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
+                            "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
+                            "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。",
+                            "label": "共情理解 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
+                            "strength": "You can help others feel seen and taken seriously.",
+                            "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
+                            "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
+                            "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
+                            "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion.",
+                            "label": "Empathic understanding · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
+                            "strength": "你能在复杂关系中捕捉未说出口的信息。",
+                            "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
+                            "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
+                            "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
+                            "do_not_overread": "熟练共情不等于你必须解决所有人的感受。",
+                            "label": "共情理解 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
+                            "strength": "You can notice unspoken information in complex relationships.",
+                            "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
+                            "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
+                            "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
+                            "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings.",
+                            "label": "Empathic understanding · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
+                            "strength": "你能在理解别人时仍保持清晰位置。",
+                            "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
+                            "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
+                            "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
+                            "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。",
+                            "label": "共情理解 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
+                            "strength": "You can understand others while keeping a clear position.",
+                            "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
+                            "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
+                            "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
+                            "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together.",
+                            "label": "Empathic understanding · Integrated"
+                        }
+                    }
+                },
+                "RM": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
+                            "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
+                            "risk": "容易在不舒服时沉默、解释过多或直接退出。",
+                            "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
+                            "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
+                            "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。",
+                            "label": "关系管理 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
+                            "strength": "With clear steps, your relationship skills can improve steadily.",
+                            "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
+                            "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
+                            "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
+                            "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar.",
+                            "label": "Relationship management · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
+                            "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
+                            "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
+                            "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
+                            "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
+                            "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。",
+                            "label": "关系管理 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
+                            "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
+                            "risk": "You may try to preserve the relationship while leaving your real position unclear.",
+                            "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
+                            "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
+                            "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame.",
+                            "label": "Relationship management · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
+                            "strength": "你能让关系在小摩擦后回到可合作状态。",
+                            "risk": "为了维持顺畅，可能回避更难但必要的话题。",
+                            "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
+                            "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
+                            "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。",
+                            "label": "关系管理 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
+                            "strength": "You can help a relationship return to cooperation after small friction.",
+                            "risk": "To keep things smooth, you may avoid harder but necessary topics.",
+                            "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
+                            "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
+                            "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship.",
+                            "label": "Relationship management · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
+                            "strength": "你能把冲突转化为更清楚的协作规则。",
+                            "risk": "别人可能默认你来收拾关系残局。",
+                            "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
+                            "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
+                            "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。",
+                            "label": "关系管理 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
+                            "strength": "You can turn conflict into clearer rules for collaboration.",
+                            "risk": "Others may assume you will clean up the relational aftermath.",
+                            "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
+                            "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
+                            "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary.",
+                            "label": "Relationship management · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
+                            "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
+                            "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
+                            "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
+                            "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
+                            "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。",
+                            "label": "关系管理 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
+                            "strength": "You can create clear and sustainable collaboration in complex relationships.",
+                            "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
+                            "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
+                            "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
+                            "do_not_overread": "Integrated does not mean you must carry all relationship maintenance.",
+                            "label": "Relationship management · Integrated"
+                        }
+                    }
+                }
+            },
+            "score_notes": {
+                "zh-CN": {
+                    "percentile": "百分位用于说明相对位置，不代表固定能力标签。",
+                    "standard_score": "标准分用于稳定展示和维度比较。",
+                    "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量和场景为准。"
+                },
+                "en": {
+                    "percentile": "Percentile explains relative position; it is not a fixed ability label.",
+                    "standard_score": "Standard score supports stable display and dimension comparison.",
+                    "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, and scenes."
+                }
+            },
+            "band_details": {
+                "foundational": {
+                    "zh-CN": {
+                        "label": "基础发展中",
+                        "meaning": "当前信号提示你需要先建立更清晰的识别、命名和复位习惯。",
+                        "strength": "从一个小而重复的动作开始，进步会更稳定。",
+                        "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
+                        "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Foundational",
+                        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits.",
+                        "strength": "Small repeatable actions can create more stable progress.",
+                        "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
+                        "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "developing": {
+                    "zh-CN": {
+                        "label": "发展中",
+                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
+                        "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
+                        "risk": "最容易卡在“知道一点，但现场用不上”。",
+                        "practice_focus": "选择一个高频场景，提前准备一句回应。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Developing",
+                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
+                        "strength": "You already catch part of the signal and can turn it into a routine.",
+                        "risk": "The common trap is knowing something but not using it in the moment.",
+                        "practice_focus": "Pick one frequent scene and prepare one response sentence.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "stable": {
+                    "zh-CN": {
+                        "label": "稳定可用",
+                        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。",
+                        "strength": "你的结果已经能支持更精细的场景训练。",
+                        "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
+                        "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Stable",
+                        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible.",
+                        "strength": "Your result can support more precise scene-based practice.",
+                        "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
+                        "practice_focus": "Identify one scene where stability drops and review it afterward.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "proficient": {
+                    "zh-CN": {
+                        "label": "熟练成熟",
+                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
+                        "strength": "你可以把个人优势转成可复制的沟通习惯。",
+                        "risk": "他人可能默认你应该一直承担稳定局面的角色。",
+                        "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Proficient",
+                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
+                        "strength": "You can turn personal strengths into repeatable communication habits.",
+                        "risk": "Others may assume you should always be the stabilizing person.",
+                        "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "integrated": {
+                    "zh-CN": {
+                        "label": "高度整合",
+                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
+                        "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
+                        "risk": "高整合也可能带来过度承担和高标准疲劳。",
+                        "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Integrated",
+                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
+                        "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
+                        "risk": "High integration may still create over-responsibility and high-standard fatigue.",
+                        "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
                     }
                 }
             }
@@ -183,281 +679,321 @@
                 "balanced_integrated": {
                     "zh-CN": {
                         "title": "均衡整合型",
-                        "one_liner": "你的情绪与关系信号比较均衡，优势在于稳定和可迁移。",
-                        "core_claim": "你通常能同时看见自己、理解他人，并在多数情境中维持可用的回应方式。",
+                        "one_liner": "你能同时照顾自己的状态、他人的感受和关系目标。",
+                        "hero_summary": "你能同时照顾自己的状态、他人的感受和关系目标。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能同时照顾自己的状态、他人的感受和关系目标。",
                         "evidence_basis": [
-                            "四维分数相对均衡",
-                            "无明显单一短板"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "稳定性和多场景适应能力。",
-                        "likely_cost": "容易低估特定高压情境对自己的消耗。",
-                        "development_lever": "选择一个真实场景做精细化复盘，而不是泛泛提升。",
-                        "do_not_overread": "这不代表你在任何情境中都不会被触发。"
+                        "primary_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                        "development_lever": "把“我来稳住”改成“我们一起定规则”。",
+                        "user_memory_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Balanced Integration",
-                        "one_liner": "Your emotional and relational signals are relatively balanced; stability is the main strength.",
-                        "core_claim": "You usually notice yourself, understand others, and maintain usable responses across many contexts.",
+                        "title": "Balanced Integrator",
+                        "one_liner": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                        "hero_summary": "You can hold your own state, other people, and the relationship goal in view at the same time. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You can hold your own state, other people, and the relationship goal in view at the same time.",
                         "evidence_basis": [
-                            "Four dimensions are relatively balanced",
-                            "No single severe gap stands out"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Stability and transfer across contexts.",
-                        "likely_cost": "You may underestimate how specific high-pressure contexts drain you.",
-                        "development_lever": "Choose one real situation for precise review rather than trying to improve everything.",
-                        "do_not_overread": "This does not mean you will never be triggered."
+                        "primary_strength": "You can keep emotion, relationship, and task in the same frame.",
+                        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                        "development_lever": "Move from “I will steady this” to “we need a shared rule.”",
+                        "user_memory_sentence": "I can steady a relationship without maintaining the whole system alone.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "high_empathy_low_recovery": {
                     "zh-CN": {
                         "title": "高共情，低恢复",
-                        "one_liner": "你容易理解他人感受，但恢复和边界是当前杠杆。",
-                        "core_claim": "你可能很快接住别人的情绪，却不一定能及时把对方状态和自己的状态分开。",
+                        "one_liner": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                        "hero_summary": "你很快读到别人的状态，但恢复系统常常追不上共情速度。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
                         "evidence_basis": [
-                            "EM 明显高于 ER",
-                            "共情信号强于恢复信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "对他人状态敏感，容易建立信任。",
-                        "likely_cost": "在冲突、求助或高情绪劳动场景中容易被卷入。",
-                        "development_lever": "共情之后建立边界和恢复动作。",
-                        "do_not_overread": "发展方向不是减少共情，而是让共情更有边界。"
+                        "primary_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                        "development_lever": "练习“理解但不接管”，让共情后面跟着边界。",
+                        "user_memory_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "High Empathy, Low Recovery",
-                        "one_liner": "You tend to understand others quickly, while recovery and boundaries are the current lever.",
-                        "core_claim": "You may absorb other people's emotions quickly without separating their state from your own soon enough.",
+                        "title": "High Empathy, Slow Recovery",
+                        "one_liner": "You read the room quickly, but recovery can lag behind empathy.",
+                        "hero_summary": "You read the room quickly, but recovery can lag behind empathy. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You read the room quickly, but recovery can lag behind empathy.",
                         "evidence_basis": [
-                            "EM is meaningfully higher than ER",
-                            "Empathy signal is stronger than recovery signal"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Sensitivity to others and trust building.",
-                        "likely_cost": "Conflict, support, and high emotional-labor settings may pull you in too deeply.",
-                        "development_lever": "Build boundaries and recovery after empathy.",
-                        "do_not_overread": "The goal is not less empathy; it is empathy with clearer boundaries."
+                        "primary_strength": "You can make people feel understood, especially when emotions run high.",
+                        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+                        "development_lever": "Practice understanding without taking over, so empathy is followed by boundary.",
+                        "user_memory_sentence": "I can understand someone without carrying the whole emotional load.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "aware_but_unregulated": {
                     "zh-CN": {
-                        "title": "高觉察，调节不足",
-                        "one_liner": "你能知道自己怎么了，但不一定能很快恢复。",
-                        "core_claim": "你可能很快觉察到被触发，却需要更稳定的暂停、命名和复位动作。",
+                        "title": "有觉察，调节不足",
+                        "one_liner": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                        "hero_summary": "你常知道自己怎么了，但把自己带回来需要更长时间。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你常知道自己怎么了，但把自己带回来需要更长时间。",
                         "evidence_basis": [
-                            "SA 高于 ER",
-                            "自我识别强于调节行动"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "能捕捉自己的情绪变化。",
-                        "likely_cost": "知道问题但仍被情绪带着走。",
-                        "development_lever": "把觉察转成具体调节步骤。",
-                        "do_not_overread": "觉察本身不是问题，问题在于缺少后续动作。"
+                        "primary_strength": "你能清楚识别触发点、感受和需要。",
+                        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                        "development_lever": "把觉察压缩成一个暂停动作，而不是继续解释。",
+                        "user_memory_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Aware but Under-Regulated",
-                        "one_liner": "You may know what is happening inside, but recovery may lag.",
-                        "core_claim": "You may notice triggers quickly and still need steadier pause, labeling, and reset actions.",
+                        "title": "Aware, Still Reactive",
+                        "one_liner": "You often know what is happening inside, but the reset button is slower than the insight.",
+                        "hero_summary": "You often know what is happening inside, but the reset button is slower than the insight. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You often know what is happening inside, but the reset button is slower than the insight.",
                         "evidence_basis": [
-                            "SA is higher than ER",
-                            "Self-recognition is stronger than regulation action"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You can catch emotional shifts in yourself.",
-                        "likely_cost": "You may know the issue while still being carried by the emotion.",
-                        "development_lever": "Turn awareness into concrete regulation steps.",
-                        "do_not_overread": "Awareness is not the problem; the missing step is what follows."
+                        "primary_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                        "development_lever": "Turn awareness into one pause action instead of another layer of explanation.",
+                        "user_memory_sentence": "I know what is happening; the next skill is bringing myself back.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "calm_but_distant": {
                     "zh-CN": {
-                        "title": "冷静稳定，但回应偏远",
-                        "one_liner": "你较能维持稳定，但可能不够读懂或回应他人情绪。",
-                        "core_claim": "你在压力下可能保持冷静，但关系中的温度和回应需要更多主动性。",
+                        "title": "冷静稳定，但距离感强",
+                        "one_liner": "你能稳住事情，但别人不一定感到被情绪上接住。",
+                        "hero_summary": "你能稳住事情，但别人不一定感到被情绪上接住。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能稳住事情，但别人不一定感到被情绪上接住。",
                         "evidence_basis": [
-                            "ER 高于 EM",
-                            "稳定信号强于共情信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "不容易被情绪场带乱。",
-                        "likely_cost": "他人可能感到你不够理解或靠近。",
-                        "development_lever": "在稳定之外增加情绪确认。",
-                        "do_not_overread": "冷静不等于冷漠，但需要被他人感受到。"
+                        "primary_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                        "development_lever": "先回应一句感受，再给建议或方案。",
+                        "user_memory_sentence": "我能稳住事情，也要让人感到被看见。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Calm but Distant",
-                        "one_liner": "You may stay steady while reading or responding to others less actively.",
-                        "core_claim": "You may remain calm under pressure, but warmth and relational response need more intentional action.",
+                        "title": "Steady, Less Attuned",
+                        "one_liner": "You can steady the situation, but people may not always feel emotionally met.",
+                        "hero_summary": "You can steady the situation, but people may not always feel emotionally met. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You can steady the situation, but people may not always feel emotionally met.",
                         "evidence_basis": [
-                            "ER is higher than EM",
-                            "Stability signal is stronger than empathy signal"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You are less likely to be disrupted by the emotional field.",
-                        "likely_cost": "Others may feel less understood or less met.",
-                        "development_lever": "Add emotional acknowledgment to stability.",
-                        "do_not_overread": "Calm is not coldness, but it needs to be felt by others."
+                        "primary_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+                        "development_lever": "Acknowledge one feeling before offering advice or a solution.",
+                        "user_memory_sentence": "I can steady the situation and still help people feel seen.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "relationship_first_self_later": {
                     "zh-CN": {
                         "title": "关系优先，自我后置",
-                        "one_liner": "你能维护关系，但可能晚一步看见自己的真实感受。",
-                        "core_claim": "你倾向先让关系顺畅，再处理自己的边界、需求和消耗。",
+                        "one_liner": "你会先保护关系，再回头找自己的真实立场。",
+                        "hero_summary": "你会先保护关系，再回头找自己的真实立场。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你会先保护关系，再回头找自己的真实立场。",
                         "evidence_basis": [
-                            "RM 高于 SA",
-                            "关系行动强于自我连接"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "能维持合作和关系稳定。",
-                        "likely_cost": "长期忽略自己的感受和界限。",
-                        "development_lever": "在回应别人前先确认自己的底线。",
-                        "do_not_overread": "重视关系不是问题，自我后置过久才是风险。"
+                        "primary_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                        "development_lever": "在照顾关系前，先给自己的感受一个位置。",
+                        "user_memory_sentence": "关系重要，我的感受也需要在场。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Relationship First, Self Later",
-                        "one_liner": "You can maintain relationships, but may notice your own feelings too late.",
-                        "core_claim": "You tend to keep the relationship smooth before checking your own boundaries, needs, and cost.",
+                        "one_liner": "You protect the relationship first and find your own position later.",
+                        "hero_summary": "You protect the relationship first and find your own position later. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You protect the relationship first and find your own position later.",
                         "evidence_basis": [
-                            "RM is higher than SA",
-                            "Relational action is stronger than self-connection"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You can preserve cooperation and relational stability.",
-                        "likely_cost": "You may overlook your feelings and limits over time.",
-                        "development_lever": "Check your bottom line before responding to others.",
-                        "do_not_overread": "Valuing relationships is not the issue; staying self-later for too long is the risk."
+                        "primary_strength": "You are sensitive to relational tone and often keep interaction workable.",
+                        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                        "development_lever": "Give your own feeling a place before you manage the relationship.",
+                        "user_memory_sentence": "The relationship matters, and my own state belongs in the room too.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "self_clear_repair_weak": {
                     "zh-CN": {
                         "title": "自我清楚，修复不足",
-                        "one_liner": "你知道自己的感受，但关系修复动作需要更清晰。",
-                        "core_claim": "你可能能表达立场，却不一定能把表达转成可继续合作的关系动作。",
+                        "one_liner": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                        "hero_summary": "你知道自己的立场，但冲突后的修复需要更明确的工具。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
                         "evidence_basis": [
-                            "SA 高于 RM",
-                            "自我清楚强于关系修复"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "有清楚的自我感受和判断。",
-                        "likely_cost": "表达后关系可能停在紧张或防御状态。",
-                        "development_lever": "把表达、确认和修复连成一组动作。",
-                        "do_not_overread": "清楚表达不是攻击，关键是加上修复。"
+                        "primary_strength": "你不容易在关系压力里丢掉自己的判断。",
+                        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                        "development_lever": "把“我说清楚了”补成“我们怎么重新对齐”。",
+                        "user_memory_sentence": "我可以清楚表达，也可以把关系重新接上。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Self-Clear, Repair Weaker",
-                        "one_liner": "You may know your feelings while needing clearer relational repair moves.",
-                        "core_claim": "You may state your position without always turning it into actions that keep collaboration possible.",
+                        "title": "Clear Self, Repair Gap",
+                        "one_liner": "You know your position, but repair after tension needs a clearer tool.",
+                        "hero_summary": "You know your position, but repair after tension needs a clearer tool. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You know your position, but repair after tension needs a clearer tool.",
                         "evidence_basis": [
-                            "SA is higher than RM",
-                            "Self-clarity is stronger than repair"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Clear self-feeling and judgment.",
-                        "likely_cost": "After expression, the relationship may remain tense or defensive.",
-                        "development_lever": "Connect expression, acknowledgment, and repair as one sequence.",
-                        "do_not_overread": "Clear expression is not attack; the key is adding repair."
+                        "primary_strength": "You are less likely to lose your judgment under relational pressure.",
+                        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+                        "development_lever": "Add “how do we realign?” after “I made my point.”",
+                        "user_memory_sentence": "I can be clear and still reconnect the relationship.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "steady_collaborator": {
                     "zh-CN": {
                         "title": "稳定协作型",
-                        "one_liner": "你在压力下较能维持合作和修复。",
-                        "core_claim": "你通常能在情绪波动中保持可沟通，并把关系拉回可协作状态。",
+                        "one_liner": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                        "hero_summary": "你能在压力下维持合作推进，但别让稳定只靠你一个人。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
                         "evidence_basis": [
-                            "ER 与 RM 都较高",
-                            "压力恢复和关系行动同向"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "压力下仍能保持建设性。",
-                        "likely_cost": "可能承担过多协调责任。",
-                        "development_lever": "区分需要你修复的事和不该由你承担的事。",
-                        "do_not_overread": "稳定协作不意味着你必须负责所有人的情绪。"
+                        "primary_strength": "你能把紧张对话拉回事实、目标和下一步。",
+                        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+                        "development_lever": "把个人稳定能力变成团队流程。",
+                        "user_memory_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Steady Collaborator",
-                        "one_liner": "You tend to maintain collaboration and repair under pressure.",
-                        "core_claim": "You can often stay communicative during emotional shifts and bring the relationship back to workable ground.",
+                        "one_liner": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                        "hero_summary": "You keep collaboration moving under pressure, but steadiness should not depend only on you. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
                         "evidence_basis": [
-                            "ER and RM are both relatively high",
-                            "Recovery and relational action move together"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Constructive response under pressure.",
-                        "likely_cost": "You may take on too much coordination responsibility.",
-                        "development_lever": "Separate what is yours to repair from what is not yours to carry.",
-                        "do_not_overread": "Being steady does not make you responsible for everyone else's emotions."
+                        "primary_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                        "development_lever": "Turn personal steadiness into team process.",
+                        "user_memory_sentence": "I can help collaboration, but the rules cannot live only in me.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "sensitive_absorber": {
                     "zh-CN": {
                         "title": "高敏感，易吸收",
-                        "one_liner": "你很能感知自己和他人，但也更容易被情绪环境影响。",
-                        "core_claim": "你可能同时捕捉自己的细微信号和他人情绪，因此需要更强的区分与恢复。",
+                        "one_liner": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                        "hero_summary": "你能捕捉细微变化，但敏感也容易变成情绪负重。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
                         "evidence_basis": [
-                            "SA 与 EM 较高",
-                            "ER 相对较低"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "情绪线索捕捉能力强。",
-                        "likely_cost": "容易过度加工或吸收环境情绪。",
-                        "development_lever": "区分我的感受、他人的感受和现场压力。",
-                        "do_not_overread": "敏感不是脆弱，它需要更好的过滤系统。"
+                        "primary_strength": "你很快发现气氛、语气和关系位置的变化。",
+                        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                        "development_lever": "把“我感到了”区分成“我要不要回应”。",
+                        "user_memory_sentence": "我能感到很多东西，但不需要回应所有东西。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Sensitive Absorber",
-                        "one_liner": "You notice yourself and others strongly, and may be more affected by the emotional field.",
-                        "core_claim": "You may catch subtle self-signals and other people's emotions at the same time, requiring stronger separation and recovery.",
+                        "one_liner": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                        "hero_summary": "You catch subtle shifts fast, and that sensitivity can become emotional load. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
                         "evidence_basis": [
-                            "SA and EM are relatively high",
-                            "ER is relatively lower"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Strong emotional cue detection.",
-                        "likely_cost": "You may over-process or absorb environmental emotion.",
-                        "development_lever": "Separate my feeling, their feeling, and situational pressure.",
-                        "do_not_overread": "Sensitivity is not weakness; it needs a better filtering system."
+                        "primary_strength": "You quickly notice shifts in tone, mood, and relational position.",
+                        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                        "development_lever": "Separate “I noticed it” from “I need to respond.”",
+                        "user_memory_sentence": "I can feel a lot without responding to everything.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "developing_foundation": {
                     "zh-CN": {
                         "title": "基础发展中",
-                        "one_liner": "多个情绪与关系信号仍在打基础，适合从一个小场景开始练。",
-                        "core_claim": "你的结果提示当前不宜追求复杂技巧，先建立命名、暂停和复盘的基础动作更重要。",
+                        "one_liner": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                        "hero_summary": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
                         "evidence_basis": [
-                            "多个维度处于基础或发展区间",
-                            "没有稳定优势维度足以独立支撑"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "可塑性强，适合从低风险场景开始。",
-                        "likely_cost": "同时处理太多关系任务会增加压力。",
-                        "development_lever": "先练一个最小闭环：识别、暂停、选择下一句。",
-                        "do_not_overread": "这不是能力定论，而是当前自我报告信号。"
+                        "primary_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                        "development_lever": "先把一个情绪命名清楚，再谈复杂改变。",
+                        "user_memory_sentence": "先练一个小动作，就已经是在建立基础。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Developing Foundation",
-                        "one_liner": "Several emotional and relational signals are still foundational; start with one small context.",
-                        "core_claim": "The result suggests starting with basic labeling, pausing, and review before complex techniques.",
+                        "one_liner": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                        "hero_summary": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
                         "evidence_basis": [
-                            "Multiple dimensions are foundational or developing",
-                            "No stable strength is strong enough to carry the pattern alone"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "High room for growth through low-risk practice.",
-                        "likely_cost": "Handling too many relational tasks at once can increase pressure.",
-                        "development_lever": "Practice one small loop: notice, pause, choose the next sentence.",
-                        "do_not_overread": "This is not a fixed ability judgment; it is the current self-report signal."
+                        "primary_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                        "development_lever": "Name one feeling clearly before attempting a larger change.",
+                        "user_memory_sentence": "One small practice is already foundation-building.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "low_confidence_result": {
                     "zh-CN": {
-                        "title": "本次结果置信度不足",
-                        "one_liner": "本次作答质量信号降低了解释置信度，建议先谨慎阅读。",
-                        "core_claim": "系统检测到会影响解释稳定性的作答模式，因此不应输出强人格判断。",
+                        "title": "本次结果置信度较低",
+                        "one_liner": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                        "hero_summary": "这次结果应轻一点读，最有价值的是理解本次作答状态。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
                         "evidence_basis": [
-                            "质量等级为 C 或 D",
-                            "存在速度、长串、极端、中立或不一致信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "仍可作为反思线索。",
-                        "likely_cost": "具体维度和画像容易被误读。",
-                        "development_lever": "在状态稳定时复测，或只使用低风险建议。",
-                        "do_not_overread": "不要把这次结果作为稳定结论。"
+                        "primary_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "development_lever": "先记录状态，之后在更稳定的时间复测。",
+                        "user_memory_sentence": "这次结果不是不能看，而是要轻一点看。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Lower Confidence Result",
-                        "one_liner": "Response-quality signals reduce interpretation confidence; read this result cautiously.",
-                        "core_claim": "The system detected response patterns that can reduce interpretive stability, so strong personality claims should not be made.",
+                        "title": "Lower-Confidence Result",
+                        "one_liner": "Read this result lightly; the most useful signal is the response context of this session.",
+                        "hero_summary": "Read this result lightly; the most useful signal is the response context of this session. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "Read this result lightly; the most useful signal is the response context of this session.",
                         "evidence_basis": [
-                            "Quality level is C or D",
-                            "Speed, long-string, extreme, neutral, or inconsistency signals are present"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "It can still serve as a reflection cue.",
-                        "likely_cost": "Specific dimensions and patterns may be overread.",
-                        "development_lever": "Retake when stable, or use only low-risk suggestions.",
-                        "do_not_overread": "Do not treat this result as a stable conclusion."
+                        "primary_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "development_lever": "Record the context first, then retest when conditions are steadier.",
+                        "user_memory_sentence": "This result is not useless; it simply needs a lighter reading.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 }
             }
@@ -475,410 +1011,490 @@
                 "SA_ER": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "知道自己，也能复位",
-                            "why_it_matters": "自我觉察只有接上调节动作，才会变成现实中的稳定回应。",
-                            "what_it_feels_like": "你通常能说清自己怎么了，并较快找到下一步。",
-                            "strength": "减少反复内耗，把情绪信息转成行动。",
-                            "cost": "可能过度依赖自我控制，忽略休息需求。",
-                            "development_lever": "让复位动作更轻量。",
-                            "micro_action": "用一句话命名情绪，再决定下一句怎么说。"
+                            "title": "自我觉察 × 情绪调节｜双高协同",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You notice yourself and can reset",
-                            "why_it_matters": "Self-awareness becomes real-world stability only when it connects to regulation.",
-                            "what_it_feels_like": "You can usually name what is happening and find the next step.",
-                            "strength": "Less rumination; more action from emotional information.",
-                            "cost": "You may over-rely on self-control and miss rest needs.",
-                            "development_lever": "Make reset actions lighter.",
-                            "micro_action": "Name the emotion in one sentence, then choose the next sentence."
+                            "title": "Self-awareness × Emotion regulation: both signals support each other",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "知道自己，但恢复跟不上",
-                            "why_it_matters": "觉察会放大感受，如果没有调节动作，反而更容易卡住。",
-                            "what_it_feels_like": "你知道自己被触发了，但身体和语气不一定跟得上。",
-                            "strength": "能早期识别风险信号。",
-                            "cost": "容易陷入反复解释或自责。",
-                            "development_lever": "把觉察后 30 秒变成固定流程。",
-                            "micro_action": "暂停、命名、喝水或离开屏幕 60 秒。"
+                            "title": "自我觉察 × 情绪调节｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You notice yourself, but recovery lags",
-                            "why_it_matters": "Awareness can intensify feelings when no regulation step follows.",
-                            "what_it_feels_like": "You know you are triggered, but your body or tone may not catch up.",
-                            "strength": "Early detection of risk signals.",
-                            "cost": "You may loop in explanation or self-blame.",
-                            "development_lever": "Turn the first 30 seconds after awareness into a routine.",
-                            "micro_action": "Pause, label, drink water, or step away from the screen for 60 seconds."
+                            "title": "Self-awareness × Emotion regulation: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "能稳定，但不总知道原因",
-                            "why_it_matters": "调节有效，但如果不理解触发点，模式会重复出现。",
-                            "what_it_feels_like": "你能忍住或恢复，但事后未必知道自己为何被影响。",
-                            "strength": "压力下不易失控。",
-                            "cost": "复盘不足会让同类问题反复。",
-                            "development_lever": "补上事后命名。",
-                            "micro_action": "事后写下：刚才我真正介意的是什么。"
+                            "title": "自我觉察 × 情绪调节｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You can stabilize without always knowing why",
-                            "why_it_matters": "Regulation helps, but without understanding triggers the pattern repeats.",
-                            "what_it_feels_like": "You can hold or recover, but may not know what affected you.",
-                            "strength": "Less likely to lose control under pressure.",
-                            "cost": "Weak review lets similar problems recur.",
-                            "development_lever": "Add after-action labeling.",
-                            "micro_action": "Afterward, write: what did I actually care about?"
+                            "title": "Self-awareness × Emotion regulation: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "识别和恢复都需要打底",
-                            "why_it_matters": "如果既难识别也难复位，复杂场景会迅速耗尽资源。",
-                            "what_it_feels_like": "你可能到事后才发现自己已经很累或很烦。",
-                            "strength": "适合从最小动作建立可预测性。",
-                            "cost": "高压沟通中容易被动应对。",
-                            "development_lever": "先练一个简单情绪词表。",
-                            "micro_action": "每天一次选择一个情绪词，并写下触发场景。"
+                            "title": "自我觉察 × 情绪调节｜两项都需要打底",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Both recognition and recovery need foundations",
-                            "why_it_matters": "When both noticing and resetting are hard, complex situations drain resources quickly.",
-                            "what_it_feels_like": "You may realize only afterward that you were tired or irritated.",
-                            "strength": "Small actions can build predictability.",
-                            "cost": "High-pressure communication may become reactive.",
-                            "development_lever": "Start with a simple emotion vocabulary.",
-                            "micro_action": "Once a day, choose one emotion word and write the trigger."
+                            "title": "Self-awareness × Emotion regulation: both signals need foundations",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "EM_ER": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "能理解别人，也能保留自己",
-                            "why_it_matters": "共情和恢复并存时，理解他人不必以自我消耗为代价。",
-                            "what_it_feels_like": "你能靠近他人情绪，也能及时回到自己的节奏。",
-                            "strength": "支持他人而不容易被吞没。",
-                            "cost": "可能被期待持续承担情绪支持。",
-                            "development_lever": "明确支持边界。",
-                            "micro_action": "先确认对方需要倾听、建议还是具体帮助。"
+                            "title": "共情理解 × 情绪调节｜双高协同",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You understand others and keep yourself",
-                            "why_it_matters": "When empathy and recovery coexist, understanding others does not require self-drain.",
-                            "what_it_feels_like": "You can approach others' emotions and return to your own rhythm.",
-                            "strength": "Support without being swallowed by the situation.",
-                            "cost": "Others may expect constant emotional support.",
-                            "development_lever": "Make support boundaries explicit.",
-                            "micro_action": "Ask whether they need listening, advice, or concrete help."
+                            "title": "Empathy × Emotion regulation: both signals support each other",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "共情强，边界和恢复偏弱",
-                            "why_it_matters": "你越能理解别人，越需要知道哪些情绪不是你要承担的。",
-                            "what_it_feels_like": "别人难受时，你可能很快进入帮助或自责状态。",
-                            "strength": "容易让人感到被看见。",
-                            "cost": "容易吸收过多情绪劳动。",
-                            "development_lever": "共情后加一句边界确认。",
-                            "micro_action": "在心里说：这是对方的感受，我可以支持，但不需要代替。"
+                            "title": "共情理解 × 情绪调节｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Strong empathy, weaker boundaries and recovery",
-                            "why_it_matters": "The more you understand others, the more you need to know what is not yours to carry.",
-                            "what_it_feels_like": "When someone is distressed, you may quickly move into helping or self-blame.",
-                            "strength": "People often feel seen by you.",
-                            "cost": "You may absorb too much emotional labor.",
-                            "development_lever": "Add one boundary check after empathy.",
-                            "micro_action": "Say internally: this is their feeling; I can support without replacing them."
+                            "title": "Empathy × Emotion regulation: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "稳定有余，情绪读人不足",
-                            "why_it_matters": "稳定能保护你，但关系需要对他人情绪的基本回应。",
-                            "what_it_feels_like": "你能保持冷静，却可能错过对方真正介意的点。",
-                            "strength": "不容易被外部情绪带乱。",
-                            "cost": "他人可能觉得你太理性或太远。",
-                            "development_lever": "先回应感受，再处理事实。",
-                            "micro_action": "说一句：我听到这件事让你很不舒服。"
+                            "title": "共情理解 × 情绪调节｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Steady, but less emotionally attuned",
-                            "why_it_matters": "Stability protects you, but relationships need basic emotional acknowledgment.",
-                            "what_it_feels_like": "You stay calm but may miss what the other person really cares about.",
-                            "strength": "External emotion disrupts you less.",
-                            "cost": "Others may experience you as too rational or distant.",
-                            "development_lever": "Respond to feeling before facts.",
-                            "micro_action": "Say: I hear that this felt uncomfortable for you."
+                            "title": "Empathy × Emotion regulation: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "理解他人与恢复都需降低难度",
-                            "why_it_matters": "当共情和恢复都弱时，先降低情境复杂度比追求技巧更有效。",
-                            "what_it_feels_like": "强情绪场景可能让你想躲开或快速结束。",
-                            "strength": "可从低风险互动开始建立经验。",
-                            "cost": "高情绪劳动场景消耗明显。",
-                            "development_lever": "用固定句式承接基础情绪。",
-                            "micro_action": "先说：我需要一点时间理解你说的。"
+                            "title": "共情理解 × 情绪调节｜两项都需要打底",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Lower complexity for empathy and recovery",
-                            "why_it_matters": "When both empathy and recovery are weaker, reducing complexity helps more than chasing advanced technique.",
-                            "what_it_feels_like": "High-emotion situations may make you want to avoid or end quickly.",
-                            "strength": "Low-risk interactions can build experience.",
-                            "cost": "High emotional-labor settings are draining.",
-                            "development_lever": "Use a stable sentence to receive basic emotion.",
-                            "micro_action": "Say: I need a little time to understand what you mean."
+                            "title": "Empathy × Emotion regulation: both signals need foundations",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "EM_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "读懂别人，也能处理关系",
-                            "why_it_matters": "理解和行动结合时，共情更容易变成有效协作。",
-                            "what_it_feels_like": "你能读懂现场气氛，并推动关系回到可沟通状态。",
-                            "strength": "适合复杂协作和关系修复。",
-                            "cost": "可能过度承担协调者角色。",
-                            "development_lever": "把责任边界说清楚。",
-                            "micro_action": "问：这件事我能负责哪一部分？"
+                            "title": "共情理解 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You read others and manage the relationship",
-                            "why_it_matters": "When understanding and action combine, empathy becomes workable collaboration.",
-                            "what_it_feels_like": "You can read the room and move the relationship back to communication.",
-                            "strength": "Useful for complex collaboration and repair.",
-                            "cost": "You may overtake the coordinator role.",
-                            "development_lever": "Clarify responsibility boundaries.",
-                            "micro_action": "Ask: which part of this is mine to own?"
+                            "title": "Empathy × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "读懂别人，但关系动作不足",
-                            "why_it_matters": "看见对方感受后，还需要把理解转成一句话或一个动作。",
-                            "what_it_feels_like": "你知道对方在意什么，却不一定知道怎么回应。",
-                            "strength": "关系判断较细腻。",
-                            "cost": "理解停在心里，别人感受不到。",
-                            "development_lever": "把理解外化成确认句。",
-                            "micro_action": "说：我理解你在意的是 X，而不是只是在反对。"
+                            "title": "共情理解 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You read others, but action is weaker",
-                            "why_it_matters": "After seeing someone's feeling, understanding needs to become a sentence or action.",
-                            "what_it_feels_like": "You know what matters to them but may not know how to respond.",
-                            "strength": "Nuanced relational judgment.",
-                            "cost": "Understanding stays inside and may not be felt.",
-                            "development_lever": "Externalize understanding as confirmation.",
-                            "micro_action": "Say: I understand that X matters to you, not just that you disagree."
+                            "title": "Empathy × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "会行动，但可能没读准情绪",
-                            "why_it_matters": "关系动作如果没有情绪理解，容易变成流程化处理。",
-                            "what_it_feels_like": "你会推进解决，但对方可能觉得重点没被接住。",
-                            "strength": "能快速进入处理模式。",
-                            "cost": "修复动作可能不够贴合。",
-                            "development_lever": "行动前先做一次情绪校准。",
-                            "micro_action": "问：这件事里你最难受的是哪一部分？"
+                            "title": "共情理解 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You act, but may miss the emotion",
-                            "why_it_matters": "Relational action without emotional understanding can become procedural.",
-                            "what_it_feels_like": "You move into solving while the other person may feel the point was missed.",
-                            "strength": "Fast entry into action mode.",
-                            "cost": "Repair may not fit the real concern.",
-                            "development_lever": "Calibrate emotion before action.",
-                            "micro_action": "Ask: which part of this felt hardest for you?"
+                            "title": "Empathy × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "关系理解和行动都需要脚手架",
-                            "why_it_matters": "复杂关系不能只靠临场反应，需要可复用脚本。",
-                            "what_it_feels_like": "你可能不知道对方为何反应强，也不知道下一句怎么说。",
-                            "strength": "固定脚本能快速提升可用性。",
-                            "cost": "临场压力下容易沉默或回避。",
-                            "development_lever": "先学低风险确认句。",
-                            "micro_action": "说：我可能没完全理解，你能再说一次你的重点吗？"
+                            "title": "共情理解 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Relational understanding and action need scaffolding",
-                            "why_it_matters": "Complex relationships need reusable scripts, not only improvisation.",
-                            "what_it_feels_like": "You may not know why they reacted strongly or what to say next.",
-                            "strength": "Stable scripts can improve usability quickly.",
-                            "cost": "Under pressure, silence or avoidance may appear.",
-                            "development_lever": "Start with low-risk confirmation lines.",
-                            "micro_action": "Say: I may not fully understand; can you restate your main point?"
+                            "title": "Empathy × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "SA_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "能表达自己，也能维护关系",
-                            "why_it_matters": "自我清楚和关系行动结合时，边界更容易被听见。",
-                            "what_it_feels_like": "你能说出自己的感受，同时照顾沟通继续。",
-                            "strength": "适合边界、反馈和修复场景。",
-                            "cost": "可能被期待承担沟通示范。",
-                            "development_lever": "让表达更简洁。",
-                            "micro_action": "用我感到、我需要、我建议三句完成表达。"
+                            "title": "自我觉察 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You express yourself and maintain the relationship",
-                            "why_it_matters": "When self-clarity and relational action combine, boundaries are easier to hear.",
-                            "what_it_feels_like": "You can state your feeling while keeping communication possible.",
-                            "strength": "Useful in boundaries, feedback, and repair.",
-                            "cost": "You may be expected to model communication for others.",
-                            "development_lever": "Make expression more concise.",
-                            "micro_action": "Use: I feel, I need, I suggest."
+                            "title": "Self-awareness × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "自我清楚，但关系承接不足",
-                            "why_it_matters": "表达自己之后，需要给关系一个继续对话的入口。",
-                            "what_it_feels_like": "你能说清立场，但对方可能进入防御。",
-                            "strength": "不容易丢失自我。",
-                            "cost": "表达可能被听成指责。",
-                            "development_lever": "表达后加一句共同目标。",
-                            "micro_action": "说：我讲这个是希望我们下次更好配合。"
+                            "title": "自我觉察 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Self-clear, but relational holding is weaker",
-                            "why_it_matters": "After expressing yourself, the relationship needs an entry point to continue.",
-                            "what_it_feels_like": "You can state your position, but the other person may become defensive.",
-                            "strength": "You are less likely to lose yourself.",
-                            "cost": "Expression may be heard as blame.",
-                            "development_lever": "Add a shared goal after expression.",
-                            "micro_action": "Say: I am raising this so we can work better next time."
+                            "title": "Self-awareness × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "会维护关系，但自我容易后置",
-                            "why_it_matters": "如果只维护关系，不表达自我，长期会积累消耗。",
-                            "what_it_feels_like": "你能把场面圆回来，但之后才发现自己不舒服。",
-                            "strength": "关系稳定和协作维持能力强。",
-                            "cost": "自己的需求容易被延后。",
-                            "development_lever": "回应前先问自己底线。",
-                            "micro_action": "在答应前停三秒，确认我是否真的可以。"
+                            "title": "自我觉察 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You maintain relationships, but self may come later",
-                            "why_it_matters": "If you only preserve the relationship and do not express yourself, cost accumulates.",
-                            "what_it_feels_like": "You smooth the moment, then later notice discomfort.",
-                            "strength": "Strong relational stability and collaboration maintenance.",
-                            "cost": "Your needs may be delayed.",
-                            "development_lever": "Check your boundary before responding.",
-                            "micro_action": "Pause three seconds before agreeing and ask whether you truly can."
+                            "title": "Self-awareness × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "自我表达和关系修复都需要练习",
-                            "why_it_matters": "当自我和关系动作都弱时，先从低风险表达开始。",
-                            "what_it_feels_like": "你可能既不想说破，也不知道怎么收场。",
-                            "strength": "可用结构化脚本降低难度。",
-                            "cost": "问题容易拖延或变成误会。",
-                            "development_lever": "练习一句低强度真实表达。",
-                            "micro_action": "说：这件事我还需要想一下，晚点回复你。"
+                            "title": "自我觉察 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Self-expression and repair both need practice",
-                            "why_it_matters": "When self and relational moves are both weaker, start with low-risk expression.",
-                            "what_it_feels_like": "You may not want to say it directly and may not know how to close the loop.",
-                            "strength": "Structured scripts can lower difficulty.",
-                            "cost": "Issues may be delayed or become misunderstandings.",
-                            "development_lever": "Practice one low-intensity truthful sentence.",
-                            "micro_action": "Say: I need to think about this and will reply later."
+                            "title": "Self-awareness × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "ER_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "压力下仍能沟通和修复",
-                            "why_it_matters": "恢复能力和关系行动结合，是冲突后继续合作的关键。",
-                            "what_it_feels_like": "你能先稳住自己，再把对话拉回问题本身。",
-                            "strength": "冲突恢复和协作韧性强。",
-                            "cost": "可能成为默认救火者。",
-                            "development_lever": "把修复责任分给双方。",
-                            "micro_action": "问：我们各自下一步能做什么？"
+                            "title": "情绪调节 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You can communicate and repair under pressure",
-                            "why_it_matters": "Recovery plus relational action is key to collaboration after conflict.",
-                            "what_it_feels_like": "You can steady yourself and bring the conversation back to the issue.",
-                            "strength": "Strong conflict recovery and collaborative resilience.",
-                            "cost": "You may become the default fixer.",
-                            "development_lever": "Share repair responsibility.",
-                            "micro_action": "Ask: what can each of us do next?"
+                            "title": "Emotion regulation × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "自己能稳住，但关系未必修复",
-                            "why_it_matters": "你恢复了，不代表对话或关系已经恢复。",
-                            "what_it_feels_like": "你可能觉得事情过去了，但对方还停在情绪里。",
-                            "strength": "能减少个人失控。",
-                            "cost": "关系裂缝可能被低估。",
-                            "development_lever": "复位后做一次关系确认。",
-                            "micro_action": "说：刚才那段对话你现在感觉怎么样？"
+                            "title": "情绪调节 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You stabilize yourself, but repair may not happen",
-                            "why_it_matters": "Your recovery does not mean the conversation or relationship has recovered.",
-                            "what_it_feels_like": "You may feel it has passed while the other person is still in it.",
-                            "strength": "Less personal escalation.",
-                            "cost": "Relationship cracks may be underestimated.",
-                            "development_lever": "Check the relationship after reset.",
-                            "micro_action": "Say: how are you feeling about that conversation now?"
+                            "title": "Emotion regulation × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "想修复关系，但压力下难稳定",
-                            "why_it_matters": "关系意愿很重要，但压力未复位时动作容易变形。",
-                            "what_it_feels_like": "你想把事情讲好，却可能越讲越急。",
-                            "strength": "有合作和修复动机。",
-                            "cost": "调节不足会削弱修复效果。",
-                            "development_lever": "先复位，再修复。",
-                            "micro_action": "先暂停十分钟，再发出修复信息。"
+                            "title": "情绪调节 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You want repair, but pressure makes stability harder",
-                            "why_it_matters": "Repair motivation matters, but actions distort when you have not reset.",
-                            "what_it_feels_like": "You want to talk it through, but may become more urgent as you speak.",
-                            "strength": "Motivation for cooperation and repair.",
-                            "cost": "Weak regulation can reduce repair effectiveness.",
-                            "development_lever": "Reset before repair.",
-                            "micro_action": "Pause for ten minutes before sending the repair message."
+                            "title": "Emotion regulation × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "压力和关系修复都需要最小闭环",
-                            "why_it_matters": "高压关系场景中，需要简单、可重复的停顿和回到问题的动作。",
-                            "what_it_feels_like": "冲突中你可能沉默、爆发或想尽快结束。",
-                            "strength": "小流程能显著降低失控概率。",
-                            "cost": "没有流程时关系容易积累未修复问题。",
-                            "development_lever": "建立冲突暂停协议。",
-                            "micro_action": "说：我需要十分钟冷静，然后我们只谈下一步。"
+                            "title": "情绪调节 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Pressure and repair need a minimal loop",
-                            "why_it_matters": "High-pressure relational situations need simple repeatable pauses and return-to-issue moves.",
-                            "what_it_feels_like": "In conflict, you may go silent, escalate, or want to end quickly.",
-                            "strength": "A small process can reduce escalation risk.",
-                            "cost": "Without a process, unrepaired issues accumulate.",
-                            "development_lever": "Create a conflict pause protocol.",
-                            "micro_action": "Say: I need ten minutes to cool down, then let's discuss only the next step."
+                            "title": "Emotion regulation × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 }
@@ -890,98 +1506,1608 @@
             "scenes": {
                 "feedback": {
                     "zh-CN": {
-                        "title": "反馈场景",
-                        "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。",
-                        "strength": "能注意到反馈背后的真实意图和关系温度。",
-                        "cost": "如果恢复不足，容易把反馈体验成否定。",
-                        "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。"
+                        "title": "反馈",
+                        "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先问清反馈指向，再决定解释或调整。",
+                        "context": "别人指出问题、要求修改或评价你的表现时。",
+                        "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
                         "title": "Feedback",
-                        "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information.",
-                        "strength": "You can notice intent and relational temperature behind feedback.",
-                        "cost": "When recovery is weak, feedback may feel like rejection.",
-                        "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify."
+                        "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Clarify the target of the feedback before explaining or changing.",
+                        "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                        "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "conflict": {
                     "zh-CN": {
-                        "title": "冲突场景",
-                        "typical_response": "出现分歧时，你可能在维护关系和表达自己之间摇摆。",
-                        "strength": "有机会同时看见双方需求。",
-                        "cost": "如果没有暂停流程，容易过度解释、回避或急于修复。",
-                        "better_move": "先确认共同目标，再只讨论一个具体问题。"
+                        "title": "冲突",
+                        "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先把冲突缩小成一个可处理的问题。",
+                        "context": "意见分歧、语气升高或彼此防御时。",
+                        "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
                         "title": "Conflict",
-                        "typical_response": "During disagreement, you may move between preserving the relationship and expressing yourself.",
-                        "strength": "You can often see needs on both sides.",
-                        "cost": "Without a pause process, you may over-explain, avoid, or rush repair.",
-                        "better_move": "Name the shared goal first, then discuss one specific issue."
+                        "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Narrow the conflict to one workable issue first.",
+                        "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                        "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "relationship_boundary": {
                     "zh-CN": {
                         "title": "关系边界",
-                        "typical_response": "当别人需要你支持时，你可能很快进入理解或承担。",
-                        "strength": "容易让对方感到被接住。",
-                        "cost": "支持和代替之间的边界可能变模糊。",
-                        "better_move": "先问自己：我能支持到哪里，哪一部分仍然属于对方。"
+                        "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                        "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                        "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Relationship Boundaries",
-                        "typical_response": "When someone needs support, you may quickly move into understanding or taking responsibility.",
-                        "strength": "Others may feel received and understood.",
-                        "cost": "The line between supporting and replacing can blur.",
-                        "better_move": "Ask yourself: how far can I support, and which part remains theirs?"
+                        "title": "Relationship boundary",
+                        "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                        "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                        "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "team_collaboration": {
                     "zh-CN": {
                         "title": "团队协作",
-                        "typical_response": "在多人协作中，你可能同时追踪任务、关系和现场情绪。",
-                        "strength": "能发现协作中的隐性阻力。",
-                        "cost": "如果总是主动协调，容易承担过多情绪劳动。",
-                        "better_move": "把观察转成具体协作请求，而不是默默补位。"
+                        "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "把气氛问题转成角色、节奏和下一步。",
+                        "context": "多人协作、目标不清或责任交叉时。",
+                        "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Team Collaboration",
-                        "typical_response": "In group work, you may track task, relationship, and emotional climate at the same time.",
-                        "strength": "You can notice hidden friction in collaboration.",
-                        "cost": "If you always coordinate, you may carry too much emotional labor.",
-                        "better_move": "Turn observations into concrete collaboration requests instead of silently compensating."
+                        "title": "Team collaboration",
+                        "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                        "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                        "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "pressure_recovery": {
                     "zh-CN": {
                         "title": "压力恢复",
-                        "typical_response": "高压后你可能仍在脑内回放对话、评价或细节。",
-                        "strength": "复盘能力可以帮助你学习模式。",
-                        "cost": "没有恢复边界时，复盘会变成反刍。",
-                        "better_move": "给复盘设限：只写三个事实、一个感受、一个下次动作。"
+                        "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "离开场景后安排一个低输入恢复动作。",
+                        "context": "一段高压互动结束后，你需要重新回到自己。",
+                        "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Pressure Recovery",
-                        "typical_response": "After pressure, you may replay conversations, judgments, or details in your head.",
-                        "strength": "Review can help you learn patterns.",
-                        "cost": "Without recovery boundaries, review turns into rumination.",
-                        "better_move": "Limit review to three facts, one feeling, and one next action."
+                        "title": "Pressure recovery",
+                        "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "After the scene, schedule one low-input recovery move.",
+                        "context": "After a high-pressure interaction, when you need to return to yourself.",
+                        "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "career_environment": {
                     "zh-CN": {
                         "title": "职业环境",
-                        "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。",
-                        "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
-                        "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
-                        "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。"
+                        "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                        "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                        "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Career Environment",
-                        "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles.",
-                        "strength": "Understanding environmental variables helps you choose a better work rhythm.",
-                        "cost": "Job titles alone can hide the conditions that actually drain you.",
-                        "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space."
+                        "title": "Career environment",
+                        "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                        "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                        "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
+                    }
+                }
+            },
+            "formulation_scenes": {
+                "balanced_integrated": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能同时照顾自己的状态、他人的感受和关系目标。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You can hold your own state, other people, and the relationship goal in view at the same time. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能同时照顾自己的状态、他人的感受和关系目标。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You can hold your own state, other people, and the relationship goal in view at the same time. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。 你需要把理解和可承接范围分开。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能把情绪、关系和任务放在同一个画面里思考。 但如果规则不清，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can keep emotion, relationship, and task in the same frame. But when rules are unclear, others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我来稳住”改成“我们一起定规则”。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, move from “i will steady this” to “we need a shared rule.”",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "high_empathy_low_recovery": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你很快读到别人的状态，但恢复系统常常追不上共情速度。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You read the room quickly, but recovery can lag behind empathy. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你很快读到别人的状态，但恢复系统常常追不上共情速度。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You read the room quickly, but recovery can lag behind empathy. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能把别人的压力带回自己身上，离开场景后还在消化。 你需要把理解和可承接范围分开。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may carry other people’s pressure with you long after the moment ends. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你容易让别人感到被理解，尤其在情绪强烈的时刻。 但如果规则不清，你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can make people feel understood, especially when emotions run high. But when rules are unclear, you may carry other people’s pressure with you long after the moment ends.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，练习“理解但不接管”，让共情后面跟着边界。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, practice understanding without taking over, so empathy is followed by boundary.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "aware_but_unregulated": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你常知道自己怎么了，但把自己带回来需要更长时间。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You often know what is happening inside, but the reset button is slower than the insight. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你常知道自己怎么了，但把自己带回来需要更长时间。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You often know what is happening inside, but the reset button is slower than the insight. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，越清楚自己被触发，越可能陷入反复分析或即时反应。 你需要把理解和可承接范围分开。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, The clearer the trigger feels, the easier it can be to over-analyze or react too soon. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能清楚识别触发点、感受和需要。 但如果规则不清，越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can identify triggers, feelings, and needs with unusual clarity. But when rules are unclear, the clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把觉察压缩成一个暂停动作，而不是继续解释。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn awareness into one pause action instead of another layer of explanation.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "calm_but_distant": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能稳住事情，但别人不一定感到被情绪上接住。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You can steady the situation, but people may not always feel emotionally met. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能稳住事情，但别人不一定感到被情绪上接住。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You can steady the situation, but people may not always feel emotionally met. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，关系里的人可能觉得你有答案，但没有真正回应他们。 你需要把理解和可承接范围分开。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, People may feel that you have answers without feeling that you have responded to them. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你不容易被情绪推着走，能保留判断和节奏。 但如果规则不清，关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are less likely to be pushed around by emotion and can keep judgment and pace. But when rules are unclear, people may feel that you have answers without feeling that you have responded to them.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先回应一句感受，再给建议或方案。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, acknowledge one feeling before offering advice or a solution.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "relationship_first_self_later": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你会先保护关系，再回头找自己的真实立场。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You protect the relationship first and find your own position later. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你会先保护关系，再回头找自己的真实立场。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You protect the relationship first and find your own position later. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能很晚才意识到自己其实不愿意、不同意或已经累了。 你需要把理解和可承接范围分开。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may notice too late that you disagreed, felt unwilling, or were already depleted. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你敏感于关系气氛，愿意让互动维持可进行。 但如果规则不清，你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are sensitive to relational tone and often keep interaction workable. But when rules are unclear, you may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，在照顾关系前，先给自己的感受一个位置。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, give your own feeling a place before you manage the relationship.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "self_clear_repair_weak": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你知道自己的立场，但冲突后的修复需要更明确的工具。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You know your position, but repair after tension needs a clearer tool. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你知道自己的立场，但冲突后的修复需要更明确的工具。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You know your position, but repair after tension needs a clearer tool. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。 你需要把理解和可承接范围分开。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Without repair, others may remember the force of the moment more than your point. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你不容易在关系压力里丢掉自己的判断。 但如果规则不清，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are less likely to lose your judgment under relational pressure. But when rules are unclear, without repair, others may remember the force of the moment more than your point.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我说清楚了”补成“我们怎么重新对齐”。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, add “how do we realign?” after “i made my point.”",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "steady_collaborator": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能在压力下维持合作推进，但别让稳定只靠你一个人。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You keep collaboration moving under pressure, but steadiness should not depend only on you. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能在压力下维持合作推进，但别让稳定只靠你一个人。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You keep collaboration moving under pressure, but steadiness should not depend only on you. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，团队可能习惯让你来降温、翻译和收尾。 你需要把理解和可承接范围分开。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Teams may get used to you cooling things down, translating tension, and closing loops. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能把紧张对话拉回事实、目标和下一步。 但如果规则不清，团队可能习惯让你来降温、翻译和收尾。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can bring tense conversations back to facts, goals, and next steps. But when rules are unclear, teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把个人稳定能力变成团队流程。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn personal steadiness into team process.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "sensitive_absorber": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能捕捉细微变化，但敏感也容易变成情绪负重。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You catch subtle shifts fast, and that sensitivity can become emotional load. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能捕捉细微变化，但敏感也容易变成情绪负重。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You catch subtle shifts fast, and that sensitivity can become emotional load. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能回应了太多信号，最后分不清哪些真的需要你处理。 你需要把理解和可承接范围分开。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may respond to too many signals and lose track of which ones actually need your action. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你很快发现气氛、语气和关系位置的变化。 但如果规则不清，你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You quickly notice shifts in tone, mood, and relational position. But when rules are unclear, you may respond to too many signals and lose track of which ones actually need your action.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我感到了”区分成“我要不要回应”。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, separate “i noticed it” from “i need to respond.”",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "developing_foundation": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果一次想改太多，容易很快放弃或自我否定。 你需要把理解和可承接范围分开。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Trying to change everything at once can lead to quick discouragement or self-criticism. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你已经开始把情绪和关系当成可以观察、可以练习的对象。 但如果规则不清，如果一次想改太多，容易很快放弃或自我否定。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are beginning to treat emotion and relationships as observable and trainable. But when rules are unclear, trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先把一个情绪命名清楚，再谈复杂改变。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, name one feeling clearly before attempting a larger change.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "low_confidence_result": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
                     }
                 }
             }
@@ -993,300 +3119,660 @@
                 "interpersonal_density": {
                     "low": {
                         "zh-CN": {
-                            "label": "低人际密度",
-                            "meaning": "多数时间独立推进，互动频率较低。",
-                            "fit_signal": "适合需要恢复空间或深度专注的人。",
-                            "strain_signal": "可能减少练习关系动作的机会。",
-                            "what_to_verify": "确认岗位是否真的允许长时间独立工作。"
+                            "label": "人际密度：低",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Interpersonal Density",
-                            "meaning": "Most work is independent with fewer interactions.",
-                            "fit_signal": "Can fit people who need recovery space or deep focus.",
-                            "strain_signal": "May reduce practice opportunities for relational action.",
-                            "what_to_verify": "Check whether the role truly allows long independent work blocks."
+                            "label": "Interpersonal density: low",
+                            "meaning": "How many people you interact with, and how often. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等人际密度",
-                            "meaning": "日常有固定协作，但不是持续社交。",
-                            "fit_signal": "适合在协作和独立之间切换。",
-                            "strain_signal": "会议过多时仍会消耗。",
-                            "what_to_verify": "确认每周会议、同步和跨团队协作频率。"
+                            "label": "人际密度：中",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Interpersonal Density",
-                            "meaning": "Regular collaboration without constant social demand.",
-                            "fit_signal": "Fits switching between collaboration and independent work.",
-                            "strain_signal": "Too many meetings can still drain.",
-                            "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."
+                            "label": "Interpersonal density: medium",
+                            "meaning": "How many people you interact with, and how often. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高人际密度",
-                            "meaning": "大量沟通、协调和即时互动。",
-                            "fit_signal": "可发挥共情、协作和关系管理优势。",
-                            "strain_signal": "恢复不足时容易情绪过载。",
-                            "what_to_verify": "确认是否有可控的独处和恢复窗口。"
+                            "label": "人际密度：高",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Interpersonal Density",
-                            "meaning": "Frequent communication, coordination, and real-time interaction.",
-                            "fit_signal": "Can use empathy, collaboration, and relationship-management strengths.",
-                            "strain_signal": "Weak recovery can lead to overload.",
-                            "what_to_verify": "Check whether protected solo recovery windows exist."
+                            "label": "Interpersonal density: high",
+                            "meaning": "How many people you interact with, and how often. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "emotional_labor": {
                     "low": {
                         "zh-CN": {
-                            "label": "低情绪劳动",
-                            "meaning": "较少承接他人情绪或安抚关系。",
-                            "fit_signal": "适合需要降低情绪消耗的人。",
-                            "strain_signal": "可能缺少运用共情优势的空间。",
-                            "what_to_verify": "确认用户、客户或团队情绪压力是否较低。"
+                            "label": "情绪劳动：低",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Emotional Labor",
-                            "meaning": "Less need to hold or soothe others' emotions.",
-                            "fit_signal": "Fits people who need lower emotional load.",
-                            "strain_signal": "May offer less space to use empathy strengths.",
-                            "what_to_verify": "Check whether user, client, or team emotional pressure is actually low."
+                            "label": "Emotional labor: low",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等情绪劳动",
-                            "meaning": "需要一定理解和安抚，但通常有边界。",
-                            "fit_signal": "适合练习共情与边界并存。",
-                            "strain_signal": "边界不清时会累积消耗。",
-                            "what_to_verify": "确认是否有升级、转介或交接机制。"
+                            "label": "情绪劳动：中",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Emotional Labor",
-                            "meaning": "Some understanding and soothing are needed, usually with boundaries.",
-                            "fit_signal": "Fits practicing empathy with boundaries.",
-                            "strain_signal": "Unclear boundaries accumulate cost.",
-                            "what_to_verify": "Check whether escalation, referral, or handoff mechanisms exist."
+                            "label": "Emotional labor: medium",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高情绪劳动",
-                            "meaning": "经常承接焦虑、投诉、冲突或脆弱情绪。",
-                            "fit_signal": "高共情者能建立信任。",
-                            "strain_signal": "低恢复者容易被情绪场拖走。",
-                            "what_to_verify": "确认督导、复盘和休息制度是否真实存在。"
+                            "label": "情绪劳动：高",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Emotional Labor",
-                            "meaning": "Frequent exposure to anxiety, complaints, conflict, or vulnerability.",
-                            "fit_signal": "High-empathy people can build trust.",
-                            "strain_signal": "Low recovery can make the emotional field pull you in.",
-                            "what_to_verify": "Check whether supervision, review, and rest systems are real."
+                            "label": "Emotional labor: high",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "conflict_frequency": {
                     "low": {
                         "zh-CN": {
-                            "label": "低冲突频率",
-                            "meaning": "较少谈判、投诉或强分歧。",
-                            "fit_signal": "降低情绪调节压力。",
-                            "strain_signal": "可能较少训练冲突修复。",
-                            "what_to_verify": "确认冲突是否只是被隐藏到异步沟通中。"
+                            "label": "冲突频率：低",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Conflict Frequency",
-                            "meaning": "Fewer negotiations, complaints, or strong disagreements.",
-                            "fit_signal": "Reduces regulation pressure.",
-                            "strain_signal": "May offer less practice in conflict repair.",
-                            "what_to_verify": "Check whether conflict is merely hidden in async communication."
+                            "label": "Conflict frequency: low",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等冲突频率",
-                            "meaning": "有周期性分歧，但通常有流程。",
-                            "fit_signal": "适合练习稳定沟通。",
-                            "strain_signal": "流程不清时会放大关系压力。",
-                            "what_to_verify": "确认冲突如何升级、记录和收口。"
+                            "label": "冲突频率：中",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Conflict Frequency",
-                            "meaning": "Periodic disagreement with some process.",
-                            "fit_signal": "Good for practicing steady communication.",
-                            "strain_signal": "Unclear process amplifies relational pressure.",
-                            "what_to_verify": "Check how conflict is escalated, recorded, and closed."
+                            "label": "Conflict frequency: medium",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高冲突频率",
-                            "meaning": "经常面对投诉、博弈、谈判或利益冲突。",
-                            "fit_signal": "高调节和高关系管理者可发挥优势。",
-                            "strain_signal": "ER 或 RM 低时消耗显著。",
-                            "what_to_verify": "确认是否有明确授权、边界和复盘支持。"
+                            "label": "冲突频率：高",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Conflict Frequency",
-                            "meaning": "Frequent complaints, negotiation, bargaining, or interest conflict.",
-                            "fit_signal": "High ER and RM can become strengths.",
-                            "strain_signal": "Low ER or RM is costly here.",
-                            "what_to_verify": "Check whether authority, boundaries, and review support are clear."
+                            "label": "Conflict frequency: high",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "feedback_intensity": {
                     "low": {
                         "zh-CN": {
-                            "label": "低反馈强度",
-                            "meaning": "评价和修改频率较低。",
-                            "fit_signal": "适合对评价敏感且需要稳定节奏的人。",
-                            "strain_signal": "成长反馈可能不足。",
-                            "what_to_verify": "确认是否仍有清晰目标和周期复盘。"
+                            "label": "反馈强度：低",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Feedback Intensity",
-                            "meaning": "Evaluation and revision are less frequent.",
-                            "fit_signal": "Fits people sensitive to evaluation who need a steadier rhythm.",
-                            "strain_signal": "Growth feedback may be insufficient.",
-                            "what_to_verify": "Check whether clear goals and periodic review still exist."
+                            "label": "Feedback intensity: low",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等反馈强度",
-                            "meaning": "定期复盘、修改和评价。",
-                            "fit_signal": "适合把反馈转成学习。",
-                            "strain_signal": "恢复不足时可能反复回想。",
-                            "what_to_verify": "确认反馈是否具体、可执行、不过度公开。"
+                            "label": "反馈强度：中",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Feedback Intensity",
-                            "meaning": "Regular review, revision, and evaluation.",
-                            "fit_signal": "Fits turning feedback into learning.",
-                            "strain_signal": "Weak recovery may lead to replaying feedback.",
-                            "what_to_verify": "Check whether feedback is specific, actionable, and not overly public."
+                            "label": "Feedback intensity: medium",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高反馈强度",
-                            "meaning": "频繁被评价、迭代或公开比较。",
-                            "fit_signal": "高觉察和高调节者可快速迭代。",
-                            "strain_signal": "低调节者容易把反馈体验成否定。",
-                            "what_to_verify": "确认是否有安全反馈文化和恢复空间。"
+                            "label": "反馈强度：高",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Feedback Intensity",
-                            "meaning": "Frequent evaluation, iteration, or public comparison.",
-                            "fit_signal": "High SA and ER can support fast iteration.",
-                            "strain_signal": "Low ER may make feedback feel like rejection.",
-                            "what_to_verify": "Check for a safe feedback culture and recovery space."
+                            "label": "Feedback intensity: high",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "autonomy_recovery": {
                     "low": {
                         "zh-CN": {
-                            "label": "低自主恢复空间",
-                            "meaning": "节奏常被外部打断，难以独处恢复。",
-                            "fit_signal": "适合恢复需求低且即时响应强的人。",
-                            "strain_signal": "高共情低恢复者风险较高。",
-                            "what_to_verify": "确认是否允许暂停、调班或离线恢复。"
+                            "label": "自主恢复空间：低",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Autonomy Recovery",
-                            "meaning": "Rhythm is often interrupted, with little solo recovery.",
-                            "fit_signal": "Fits people with low recovery needs and strong real-time response.",
-                            "strain_signal": "High empathy with low recovery is risky here.",
-                            "what_to_verify": "Check whether pauses, shift changes, or offline recovery are allowed."
+                            "label": "Autonomy and recovery: low",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等自主恢复空间",
-                            "meaning": "有一定独立安排，但仍受团队节奏影响。",
-                            "fit_signal": "适合多数人维持稳定表现。",
-                            "strain_signal": "忙季或危机期可能被压缩。",
-                            "what_to_verify": "确认高峰期的恢复安排。"
+                            "label": "自主恢复空间：中",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Autonomy Recovery",
-                            "meaning": "Some independent rhythm exists, though team rhythm still matters.",
-                            "fit_signal": "Helps most people sustain performance.",
-                            "strain_signal": "Busy or crisis periods may compress it.",
-                            "what_to_verify": "Check recovery arrangements during peak periods."
+                            "label": "Autonomy and recovery: medium",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高自主恢复空间",
-                            "meaning": "可以较多控制节奏、沟通窗口和深度工作时间。",
-                            "fit_signal": "有利于敏感、深度复盘或高恢复需求者。",
-                            "strain_signal": "也可能带来孤立或反馈不足。",
-                            "what_to_verify": "确认独立性不会变成缺少支持。"
+                            "label": "自主恢复空间：高",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Autonomy Recovery",
-                            "meaning": "More control over rhythm, communication windows, and deep-work time.",
-                            "fit_signal": "Helpful for sensitive, reflective, or high-recovery-need people.",
-                            "strain_signal": "Can also create isolation or insufficient feedback.",
-                            "what_to_verify": "Check that autonomy does not mean lack of support."
+                            "label": "Autonomy and recovery: high",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "collaboration_complexity": {
                     "low": {
                         "zh-CN": {
-                            "label": "低协作复杂度",
-                            "meaning": "角色、接口和责任较清楚。",
-                            "fit_signal": "降低关系误解和协调成本。",
-                            "strain_signal": "可能较少发挥复杂协调优势。",
-                            "what_to_verify": "确认职责是否稳定且边界清楚。"
+                            "label": "协作复杂度：低",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Collaboration Complexity",
-                            "meaning": "Roles, interfaces, and responsibilities are clear.",
-                            "fit_signal": "Lowers misunderstanding and coordination cost.",
-                            "strain_signal": "May offer less space for complex coordination strengths.",
-                            "what_to_verify": "Check whether responsibilities are stable and boundaries clear."
+                            "label": "Collaboration complexity: low",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等协作复杂度",
-                            "meaning": "需要跨角色协作，但仍有明确流程。",
-                            "fit_signal": "适合练习关系管理和反馈沟通。",
-                            "strain_signal": "流程缺失时容易消耗。",
-                            "what_to_verify": "确认决策权、优先级和冲突处理方式。"
+                            "label": "协作复杂度：中",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Collaboration Complexity",
-                            "meaning": "Cross-role collaboration is needed with some clear process.",
-                            "fit_signal": "Good for practicing relationship management and feedback communication.",
-                            "strain_signal": "Missing process can be draining.",
-                            "what_to_verify": "Check decision rights, priorities, and conflict-handling process."
+                            "label": "Collaboration complexity: medium",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高协作复杂度",
-                            "meaning": "多方目标、利益和节奏需要持续协调。",
-                            "fit_signal": "高 RM 与稳定 ER 能发挥明显优势。",
-                            "strain_signal": "边界不清时容易长期过载。",
-                            "what_to_verify": "确认是否有正式协调机制和优先级裁决。"
+                            "label": "协作复杂度：高",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Collaboration Complexity",
-                            "meaning": "Multiple goals, interests, and rhythms require ongoing coordination.",
-                            "fit_signal": "High RM and stable ER can become clear strengths.",
-                            "strain_signal": "Unclear boundaries can cause chronic overload.",
-                            "what_to_verify": "Check formal coordination mechanisms and priority arbitration."
+                            "label": "Collaboration complexity: high",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 }
@@ -1298,410 +3784,962 @@
             "prescriptions": {
                 "emotion_labeling": {
                     "zh-CN": {
-                        "title": "情绪命名处方",
-                        "why_this_matters": "先命名，才有可能选择回应。",
-                        "do_today": "今天选择一个具体情绪词，写下触发它的场景。",
-                        "script": "我现在感到的是 X，不代表我必须立刻做决定。",
+                        "title": "情绪命名",
+                        "why_this_matters": "当感受模糊、容易事后才明白时使用。",
+                        "do_today": "今天只做一件事：把一次情绪从“烦”改写成三个更具体的词。",
+                        "script": "我现在不是单纯不舒服，我可能是失望、紧张和需要确认。",
                         "seven_day_plan": [
-                            "第 1 天：记录一个情绪词。",
-                            "第 2 天：补充身体感受。",
-                            "第 3 天：写下触发场景。",
-                            "第 4 天：区分事实和解释。",
-                            "第 5 天：写一个可控动作。",
-                            "第 6 天：复盘一次沟通。",
-                            "第 7 天：选出最常见触发点。"
+                            {
+                                "day": 1,
+                                "practice": "记录一次情绪触发点。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下事实、感受、需要三栏。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "把“还好”改成三个具体情绪词。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "找一个低风险场景说出一个感受。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "复盘一次没说出口的需要。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "把一个情绪和身体感觉连接起来。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "选择一个下周继续练的情绪词。"
+                            }
                         ],
-                        "watch_out": "不要把情绪词变成自我评价。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当感受模糊、容易事后才明白时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Emotion Labeling",
-                        "why_this_matters": "Naming comes before choosing a response.",
-                        "do_today": "Choose one specific emotion word today and write the triggering context.",
-                        "script": "What I feel now is X; it does not mean I must decide immediately.",
+                        "title": "Emotion labeling",
+                        "why_this_matters": "Use when feelings are vague or only become clear afterward.",
+                        "do_today": "Today, turn one vague feeling into three more precise words.",
+                        "script": "I am not simply upset; I may be disappointed, tense, and needing clarity.",
                         "seven_day_plan": [
-                            "Day 1: record one emotion word.",
-                            "Day 2: add body sensations.",
-                            "Day 3: write the trigger.",
-                            "Day 4: separate fact and interpretation.",
-                            "Day 5: write one controllable action.",
-                            "Day 6: review one conversation.",
-                            "Day 7: identify the most common trigger."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not turn emotion words into self-judgment."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when feelings are vague or only become clear afterward.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "pause_recovery": {
                     "zh-CN": {
-                        "title": "暂停与恢复处方",
-                        "why_this_matters": "调节不是压住情绪，而是给选择回应争取空间。",
-                        "do_today": "遇到触发时暂停 60 秒，再回复。",
-                        "script": "我需要一分钟整理一下，再继续说。",
+                        "title": "暂停与恢复",
+                        "why_this_matters": "当你知道自己被触发，但很难立刻稳定时使用。",
+                        "do_today": "今天给自己设一个十秒暂停规则。",
+                        "script": "我需要先停十秒，等我能更清楚地回应。",
                         "seven_day_plan": [
-                            "第 1 天：练 60 秒暂停。",
-                            "第 2 天：加入一次深呼吸。",
-                            "第 3 天：离开屏幕一分钟。",
-                            "第 4 天：记录暂停前后的差异。",
-                            "第 5 天：在反馈场景使用。",
-                            "第 6 天：在冲突前使用。",
-                            "第 7 天：固定一个恢复动作。"
+                            {
+                                "day": 1,
+                                "practice": "选一个暂停信号。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "在一次小触发中练十秒呼吸。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "写下暂停前后的不同。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "给自己设一个延迟回复模板。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "练习离开屏幕两分钟。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘一次因为暂停而避免升级的场景。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "确定下周继续使用的暂停句。"
+                            }
                         ],
-                        "watch_out": "暂停不是逃避，暂停后要回到对话。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你知道自己被触发，但很难立刻稳定时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Pause and Recovery",
-                        "why_this_matters": "Regulation is not suppressing emotion; it creates room for choice.",
-                        "do_today": "When triggered, pause for 60 seconds before replying.",
-                        "script": "I need a minute to organize my thoughts before continuing.",
+                        "title": "Pause and recovery",
+                        "why_this_matters": "Use when you know you are triggered but cannot steady yourself immediately.",
+                        "do_today": "Set a ten-second pause rule today.",
+                        "script": "I need ten seconds so I can respond more clearly.",
                         "seven_day_plan": [
-                            "Day 1: practice a 60-second pause.",
-                            "Day 2: add one deep breath.",
-                            "Day 3: step away from the screen for one minute.",
-                            "Day 4: note the before-and-after difference.",
-                            "Day 5: use it in feedback.",
-                            "Day 6: use it before conflict.",
-                            "Day 7: fix one recovery action."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Pausing is not avoidance; return to the conversation."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you know you are triggered but cannot steady yourself immediately.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "feedback_decompression": {
                     "zh-CN": {
-                        "title": "反馈减压处方",
-                        "why_this_matters": "反馈容易混合事实、关系和自我评价，需要拆开处理。",
-                        "do_today": "把一次反馈拆成事实、感受、下一步三栏。",
-                        "script": "我先确认事实：你希望我调整的是 X，对吗？",
+                        "title": "反馈去压缩",
+                        "why_this_matters": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+                        "do_today": "今天把一次反馈拆成事实、评价和下一步。",
+                        "script": "我先确认一下，你希望我具体调整哪一部分？",
                         "seven_day_plan": [
-                            "第 1 天：拆一次反馈。",
-                            "第 2 天：只问一个澄清问题。",
-                            "第 3 天：延迟自我评价。",
-                            "第 4 天：记录可行动项。",
-                            "第 5 天：复盘语气触发。",
-                            "第 6 天：向对方确认优先级。",
-                            "第 7 天：总结一个反馈模板。"
+                            {
+                                "day": 1,
+                                "practice": "找一次近期反馈。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写出反馈里的事实。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "写出你脑中自动冒出的解释。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "问一个澄清问题。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "把反馈转成一个行动。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录反馈后的身体反应。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "总结一个下次先问的问题。"
+                            }
                         ],
-                        "watch_out": "不要把所有反馈都理解成人身否定。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Feedback Decompression",
-                        "why_this_matters": "Feedback mixes facts, relationship cues, and self-evaluation; separate them.",
-                        "do_today": "Split one feedback event into facts, feelings, and next step.",
-                        "script": "Let me confirm the fact: you want me to adjust X, correct?",
+                        "title": "Feedback decompression",
+                        "why_this_matters": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+                        "do_today": "Today, split one piece of feedback into facts, evaluation, and next step.",
+                        "script": "Can I clarify which part you want me to adjust?",
                         "seven_day_plan": [
-                            "Day 1: split one feedback event.",
-                            "Day 2: ask only one clarifying question.",
-                            "Day 3: delay self-judgment.",
-                            "Day 4: record the action item.",
-                            "Day 5: review tone triggers.",
-                            "Day 6: confirm priority.",
-                            "Day 7: summarize a feedback template."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not treat all feedback as personal rejection."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "empathy_boundary": {
                     "zh-CN": {
-                        "title": "共情边界处方",
-                        "why_this_matters": "高共情需要边界，才能长期有效。",
-                        "do_today": "支持别人前先确认自己能支持到哪里。",
-                        "script": "我愿意听你说十分钟，然后我们一起看下一步。",
+                        "title": "共情边界",
+                        "why_this_matters": "当你理解别人后容易承担过多时使用。",
+                        "do_today": "今天练习一句“理解但不接管”的话。",
+                        "script": "我理解这件事很难，我能帮你一起理清下一步，但不能替你承担全部。",
                         "seven_day_plan": [
-                            "第 1 天：识别一次我在承担什么。",
-                            "第 2 天：练习时间边界。",
-                            "第 3 天：练习责任边界。",
-                            "第 4 天：支持后做恢复。",
-                            "第 5 天：区分理解和代替。",
-                            "第 6 天：复盘一次求助场景。",
-                            "第 7 天：写下自己的支持边界。"
+                            {
+                                "day": 1,
+                                "practice": "识别一个你容易接管的场景。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下对方责任和你责任的边界。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练习一句支持但不接管的话。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "在一次对话中只提供一个具体帮助。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "对一个请求说出可承担范围。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘说边界后的真实后果。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "写下你的恢复动作。"
+                            }
                         ],
-                        "watch_out": "不要用冷漠来替代边界。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你理解别人后容易承担过多时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Empathy Boundary",
-                        "why_this_matters": "High empathy needs boundaries to remain sustainable.",
-                        "do_today": "Before supporting someone, decide how far you can support.",
-                        "script": "I can listen for ten minutes, then we can look at the next step together.",
+                        "title": "Empathy with boundary",
+                        "why_this_matters": "Use when understanding others turns into carrying too much.",
+                        "do_today": "Practice one sentence that understands without taking over.",
+                        "script": "I understand this is difficult. I can help you sort the next step, but I cannot carry all of it for you.",
                         "seven_day_plan": [
-                            "Day 1: identify what you are carrying.",
-                            "Day 2: practice a time boundary.",
-                            "Day 3: practice a responsibility boundary.",
-                            "Day 4: recover after support.",
-                            "Day 5: separate understanding from replacing.",
-                            "Day 6: review one help-seeking situation.",
-                            "Day 7: write your support boundary."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not replace boundaries with coldness."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when understanding others turns into carrying too much.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "repair_after_conflict": {
                     "zh-CN": {
-                        "title": "冲突后修复处方",
-                        "why_this_matters": "冲突后的修复决定关系能否继续合作。",
-                        "do_today": "选一个小冲突，发出一句修复确认。",
-                        "script": "刚才我语气急了，我想把重点重新说清楚。",
+                        "title": "冲突后修复",
+                        "why_this_matters": "当冲突后不知道如何重新开始时使用。",
+                        "do_today": "今天准备一句影响确认。",
+                        "script": "刚才我的表达可能让你感觉被否定了，我想重新说一次。",
                         "seven_day_plan": [
-                            "第 1 天：识别一次未完成冲突。",
-                            "第 2 天：写下自己的责任。",
-                            "第 3 天：写下对方可能在意的点。",
-                            "第 4 天：发出一句确认。",
-                            "第 5 天：只讨论下一步。",
-                            "第 6 天：复盘修复效果。",
-                            "第 7 天：形成自己的修复句式。"
+                            {
+                                "day": 1,
+                                "practice": "回忆一个小误解。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下你的意图和对方可能感受到的影响。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练一句影响确认。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "补一句你的真实意图。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "提出一个具体修复动作。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "在安全关系中尝试一次。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘对方是否更愿意继续对话。"
+                            }
                         ],
-                        "watch_out": "修复不是全盘认错，也不是要求对方立刻原谅。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当冲突后不知道如何重新开始时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Repair After Conflict",
-                        "why_this_matters": "Repair after conflict determines whether collaboration can continue.",
-                        "do_today": "Choose one small conflict and send one repair check.",
-                        "script": "My tone got sharp earlier; I want to restate the main point clearly.",
+                        "title": "Repair after conflict",
+                        "why_this_matters": "Use when you do not know how to restart after conflict.",
+                        "do_today": "Prepare one impact-checking sentence today.",
+                        "script": "My wording may have felt dismissive. I want to try saying it again.",
                         "seven_day_plan": [
-                            "Day 1: identify one unfinished conflict.",
-                            "Day 2: write your responsibility.",
-                            "Day 3: write what may matter to the other person.",
-                            "Day 4: send one confirmation.",
-                            "Day 5: discuss only the next step.",
-                            "Day 6: review repair effect.",
-                            "Day 7: build your repair sentence."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Repair is not total blame-taking or demanding immediate forgiveness."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you do not know how to restart after conflict.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "express_without_escalation": {
                     "zh-CN": {
-                        "title": "不升级表达处方",
-                        "why_this_matters": "清楚表达需要让对方听得进去。",
-                        "do_today": "用我感到、我需要、我建议三句表达一次需求。",
-                        "script": "我感到有点被打断，我需要先说完，之后我也会听你的看法。",
+                        "title": "表达但不升级",
+                        "why_this_matters": "当你很清楚自己的立场，但容易说得太硬时使用。",
+                        "do_today": "今天把一个强表达改成“事实 + 感受 + 请求”。",
+                        "script": "当这个决定突然改变时，我有点措手不及。我想先确认接下来怎么协作。",
                         "seven_day_plan": [
-                            "第 1 天：写一句我感到。",
-                            "第 2 天：写一句我需要。",
-                            "第 3 天：写一句我建议。",
-                            "第 4 天：合并三句。",
-                            "第 5 天：降低指责词。",
-                            "第 6 天：加入共同目标。",
-                            "第 7 天：在低风险场景练习。"
+                            {
+                                "day": 1,
+                                "practice": "写出一句原本想直接说的话。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "删掉评价词，只留事实。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "加上一个真实感受。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "加上一个可回应请求。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "读出来，检查语气。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "找一个低风险场景使用。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘它是否降低了防御。"
+                            }
                         ],
-                        "watch_out": "不要用永远、总是这类绝对词。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你很清楚自己的立场，但容易说得太硬时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Express Without Escalation",
-                        "why_this_matters": "Clear expression needs to be hearable.",
-                        "do_today": "Use I feel, I need, I suggest to express one need.",
-                        "script": "I feel a bit interrupted. I need to finish this point, and then I will listen to your view.",
+                        "title": "Express without escalation",
+                        "why_this_matters": "Use when your position is clear but may land too sharply.",
+                        "do_today": "Turn one strong statement into fact + feeling + request.",
+                        "script": "When this decision changed suddenly, I felt caught off guard. I want to clarify how we work together next.",
                         "seven_day_plan": [
-                            "Day 1: write one I feel sentence.",
-                            "Day 2: write one I need sentence.",
-                            "Day 3: write one I suggest sentence.",
-                            "Day 4: combine the three.",
-                            "Day 5: reduce blaming words.",
-                            "Day 6: add a shared goal.",
-                            "Day 7: practice in a low-risk context."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Avoid absolute words like always or never."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when your position is clear but may land too sharply.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "support_without_rescuing": {
                     "zh-CN": {
-                        "title": "支持但不拯救处方",
-                        "why_this_matters": "有效支持帮助对方恢复主体性，而不是替对方解决所有问题。",
-                        "do_today": "下次支持别人时，只问一个下一步问题。",
-                        "script": "我能陪你想，但这个决定需要你自己做。",
+                        "title": "支持但不拯救",
+                        "why_this_matters": "当你想帮人解决一切时使用。",
+                        "do_today": "今天先问对方需要倾听、建议还是行动帮助。",
+                        "script": "你现在更需要我听你说，还是一起想一个下一步？",
                         "seven_day_plan": [
-                            "第 1 天：识别一次想替别人解决的冲动。",
-                            "第 2 天：只提供倾听。",
-                            "第 3 天：只问一个问题。",
-                            "第 4 天：明确你能做的部分。",
-                            "第 5 天：明确你不能做的部分。",
-                            "第 6 天：支持后恢复。",
-                            "第 7 天：复盘对方是否更有主体性。"
+                            {
+                                "day": 1,
+                                "practice": "识别一次想立刻解决的冲动。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "暂停并问支持方式。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "只给一个帮助选项。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "避免替对方做决定。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "结束前确认对方自己的下一步。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录你的承担感变化。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘支持和接管的差别。"
+                            }
                         ],
-                        "watch_out": "不要把对方的不舒服全部变成你的责任。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你想帮人解决一切时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Support Without Rescuing",
-                        "why_this_matters": "Effective support restores agency instead of solving everything for the other person.",
-                        "do_today": "Next time you support someone, ask only one next-step question.",
-                        "script": "I can think with you, but this decision needs to be yours.",
+                        "title": "Support without rescuing",
+                        "why_this_matters": "Use when you feel pulled to solve everything for someone.",
+                        "do_today": "Ask whether the person wants listening, advice, or practical help.",
+                        "script": "Do you want me to listen, or would it help to think through one next step?",
                         "seven_day_plan": [
-                            "Day 1: notice one urge to solve for someone.",
-                            "Day 2: only listen.",
-                            "Day 3: ask only one question.",
-                            "Day 4: clarify what you can do.",
-                            "Day 5: clarify what you cannot do.",
-                            "Day 6: recover after support.",
-                            "Day 7: review whether their agency increased."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not make all of their discomfort your responsibility."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you feel pulled to solve everything for someone.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "cold_to_warm_response": {
                     "zh-CN": {
-                        "title": "从冷静到有温度处方",
-                        "why_this_matters": "稳定需要被他人感受到，才会变成关系中的安全感。",
-                        "do_today": "在给建议前先确认对方感受。",
-                        "script": "我能理解这件事让你不舒服，我们再一起看怎么处理。",
+                        "title": "从冷静到有温度",
+                        "why_this_matters": "当你能解决问题但别人感觉没被回应时使用。",
+                        "do_today": "今天在给方案前先回应一句感受。",
+                        "script": "我能理解这让你很挫败。我们可以一起看下一步怎么处理。",
                         "seven_day_plan": [
-                            "第 1 天：练一句情绪确认。",
-                            "第 2 天：先确认再建议。",
-                            "第 3 天：观察对方反应。",
-                            "第 4 天：减少过快解释。",
-                            "第 5 天：加入一句感谢。",
-                            "第 6 天：复盘一次低温回应。",
-                            "第 7 天：固定一个温暖开场。"
+                            {
+                                "day": 1,
+                                "practice": "听到问题后先不急着给方案。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "说出你听见的情绪。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "确认对方是否认可。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "再提出一个具体下一步。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "观察对方反应是否软化。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘你是否少讲了道理。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "保留一个适合你的温度句。"
+                            }
                         ],
-                        "watch_out": "温暖不是放弃理性。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你能解决问题但别人感觉没被回应时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Cold to Warm Response",
-                        "why_this_matters": "Stability becomes relational safety only when others can feel it.",
-                        "do_today": "Acknowledge the feeling before giving advice.",
-                        "script": "I can see this was uncomfortable for you; let's look at what to do next.",
+                        "title": "From calm to warm response",
+                        "why_this_matters": "Use when you can solve the issue but others do not feel emotionally met.",
+                        "do_today": "Before offering a solution, acknowledge one feeling.",
+                        "script": "I can see how frustrating this is. We can look at the next step together.",
                         "seven_day_plan": [
-                            "Day 1: practice one emotional acknowledgment.",
-                            "Day 2: acknowledge before advising.",
-                            "Day 3: observe their response.",
-                            "Day 4: reduce fast explanation.",
-                            "Day 5: add one appreciation.",
-                            "Day 6: review one low-warmth response.",
-                            "Day 7: fix one warm opening."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Warmth does not mean giving up rationality."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you can solve the issue but others do not feel emotionally met.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "relationship_energy_management": {
                     "zh-CN": {
-                        "title": "关系能量管理处方",
-                        "why_this_matters": "关系投入需要节奏，否则优势会变成消耗。",
-                        "do_today": "给一个高消耗互动安排恢复窗口。",
-                        "script": "我现在可以聊二十分钟，之后需要休息一下。",
+                        "title": "关系能量管理",
+                        "why_this_matters": "当你在多人关系或强情绪场景后感到累时使用。",
+                        "do_today": "今天给一段高互动之后安排十分钟低输入时间。",
+                        "script": "我需要一点时间整理刚才的信息，之后我会回来回应。",
                         "seven_day_plan": [
-                            "第 1 天：列出高消耗互动。",
-                            "第 2 天：标出恢复方式。",
-                            "第 3 天：设置时间边界。",
-                            "第 4 天：减少即时回复。",
-                            "第 5 天：安排独处窗口。",
-                            "第 6 天：复盘能量变化。",
-                            "第 7 天：保留一个固定恢复段。"
+                            {
+                                "day": 1,
+                                "practice": "标记今天最耗能的一次互动。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "记录耗能来自人、情绪还是切换。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "安排十分钟低输入恢复。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "减少一个不必要回应。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "练习结束对话的句子。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "观察恢复前后差异。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "设定下周一个关系能量边界。"
+                            }
                         ],
-                        "watch_out": "不要等到耗尽才开始恢复。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你在多人关系或强情绪场景后感到累时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Relationship Energy Management",
-                        "why_this_matters": "Relational investment needs rhythm; otherwise strength becomes drain.",
-                        "do_today": "Schedule recovery after one high-cost interaction.",
-                        "script": "I can talk for twenty minutes now, and then I need a break.",
+                        "title": "Relationship energy management",
+                        "why_this_matters": "Use when you feel drained after relationally intense situations.",
+                        "do_today": "Schedule ten minutes of low input after one high-interaction moment.",
+                        "script": "I need a little time to process what just happened, and I will come back to it.",
                         "seven_day_plan": [
-                            "Day 1: list high-cost interactions.",
-                            "Day 2: mark recovery methods.",
-                            "Day 3: set a time boundary.",
-                            "Day 4: reduce instant replies.",
-                            "Day 5: schedule solo time.",
-                            "Day 6: review energy changes.",
-                            "Day 7: keep one fixed recovery block."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not wait until depletion to recover."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you feel drained after relationally intense situations.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "conflict_deescalation": {
                     "zh-CN": {
-                        "title": "冲突降温处方",
-                        "why_this_matters": "降温不是退让，而是让问题重新可谈。",
-                        "do_today": "下一次分歧时，只说共同目标和下一步。",
-                        "script": "我们先别扩大问题，我想先确认下一步怎么做。",
+                        "title": "冲突降温",
+                        "why_this_matters": "当对话开始升级时使用。",
+                        "do_today": "今天练习把争执缩小到一个具体问题。",
+                        "script": "我们先只谈一个点：现在最需要决定的是什么？",
                         "seven_day_plan": [
-                            "第 1 天：识别升级词。",
-                            "第 2 天：练习降温句。",
-                            "第 3 天：暂停十分钟。",
-                            "第 4 天：只谈一个问题。",
-                            "第 5 天：确认共同目标。",
-                            "第 6 天：复盘冲突过程。",
-                            "第 7 天：写下自己的降温协议。"
+                            {
+                                "day": 1,
+                                "practice": "识别一个容易升级的话题。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写出双方各自想保护什么。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "准备一句缩小问题的话。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "练习放慢语速。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "在对话中只问一个澄清问题。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "结束后复盘是否降温。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "保存一个下次可用的降温句。"
+                            }
                         ],
-                        "watch_out": "降温不等于压下真实问题。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当对话开始升级时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Conflict De-escalation",
-                        "why_this_matters": "De-escalation is not surrender; it makes the issue discussable again.",
-                        "do_today": "In the next disagreement, state only the shared goal and next step.",
-                        "script": "Let's not expand the issue. I want to confirm the next step first.",
+                        "title": "Conflict de-escalation",
+                        "why_this_matters": "Use when a conversation starts escalating.",
+                        "do_today": "Practice narrowing a disagreement to one concrete issue.",
+                        "script": "Let’s focus on one point: what needs to be decided right now?",
                         "seven_day_plan": [
-                            "Day 1: identify escalation words.",
-                            "Day 2: practice a cooling sentence.",
-                            "Day 3: pause ten minutes.",
-                            "Day 4: discuss one issue only.",
-                            "Day 5: confirm shared goal.",
-                            "Day 6: review the conflict process.",
-                            "Day 7: write your de-escalation protocol."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Cooling down does not mean suppressing the real issue."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when a conversation starts escalating.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "self_connection": {
                     "zh-CN": {
-                        "title": "自我连接处方",
-                        "why_this_matters": "关系顺畅不能替代对自己需求的确认。",
-                        "do_today": "答应别人前先写下我愿意和我不愿意。",
-                        "script": "我想先确认一下自己的安排，晚点回复你。",
+                        "title": "重新连接自己",
+                        "why_this_matters": "当你总先照顾关系而忽略自己时使用。",
+                        "do_today": "今天在答应前先问自己：我是真愿意，还是怕关系变差？",
+                        "script": "我想先想一下我真实能承担到哪里，再回复你。",
                         "seven_day_plan": [
-                            "第 1 天：记录一个自己的需求。",
-                            "第 2 天：记录一个不愿意。",
-                            "第 3 天：延迟答应。",
-                            "第 4 天：练习一个小拒绝。",
-                            "第 5 天：复盘拒绝后的关系。",
-                            "第 6 天：写下可接受条件。",
-                            "第 7 天：总结自己的边界句。"
+                            {
+                                "day": 1,
+                                "practice": "记录一次你想立刻答应的场景。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下真实愿意和勉强愿意的差别。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练习延迟回应。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "说出一个较小的可承担范围。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "观察关系是否真的受损。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录一个被你忽略的感受。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "设定一个下周的自我连接问题。"
+                            }
                         ],
-                        "watch_out": "不要把照顾自己理解成破坏关系。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你总先照顾关系而忽略自己时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Self-Connection",
-                        "why_this_matters": "A smooth relationship cannot replace checking your own needs.",
-                        "do_today": "Before agreeing, write what you are willing and not willing to do.",
-                        "script": "I want to check my own schedule first and reply later.",
+                        "title": "Reconnect with self",
+                        "why_this_matters": "Use when you care for the relationship before checking yourself.",
+                        "do_today": "Before agreeing today, ask: am I willing, or am I afraid the relationship will change?",
+                        "script": "I want to check what I can realistically take on before I answer.",
                         "seven_day_plan": [
-                            "Day 1: record one personal need.",
-                            "Day 2: record one not-willing item.",
-                            "Day 3: delay agreement.",
-                            "Day 4: practice a small no.",
-                            "Day 5: review the relationship after saying no.",
-                            "Day 6: write acceptable conditions.",
-                            "Day 7: summarize your boundary sentence."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not treat caring for yourself as damaging the relationship."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you care for the relationship before checking yourself.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "retest_reflection": {
                     "zh-CN": {
-                        "title": "复测与低风险反思处方",
-                        "why_this_matters": "低置信度结果不适合强解释，更适合作为复测提醒。",
-                        "do_today": "只记录一个你认可的线索，不做稳定结论。",
-                        "script": "这次结果我先当作提醒，等状态稳定后再复测。",
+                        "title": "复测前观察",
+                        "why_this_matters": "当本次结果置信度较低时使用。",
+                        "do_today": "今天不要急着定性，先记录作答时的状态。",
+                        "script": "这次结果我先轻一点看，等状态更稳定时再复测。",
                         "seven_day_plan": [
-                            "第 1 天：记录作答时状态。",
-                            "第 2 天：检查是否太快或太累。",
-                            "第 3 天：观察一个真实场景。",
-                            "第 4 天：不做标签化解释。",
-                            "第 5 天：选择复测时间。",
-                            "第 6 天：保证安静环境。",
-                            "第 7 天：重新完成测试。"
+                            {
+                                "day": 1,
+                                "practice": "记录作答时间和状态。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下是否太快、太累或太分心。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "挑三个最不确定的题目类型。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "观察一天真实情绪场景。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "不要做重大解释。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "选择一个更稳定的复测时间。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复测后比较哪些部分稳定。"
+                            }
                         ],
-                        "watch_out": "不要用低置信度结果做重大决定。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当本次结果置信度较低时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Retest and Low-Risk Reflection",
-                        "why_this_matters": "Low-confidence results should not drive strong interpretation; they are better used as a retest cue.",
-                        "do_today": "Record only one cue that feels useful; do not form a stable conclusion.",
-                        "script": "I will treat this result as a reminder and retake when I am more settled.",
+                        "title": "Reflection before retest",
+                        "why_this_matters": "Use when this result has lower interpretation confidence.",
+                        "do_today": "Do not label yourself today; first record the response context.",
+                        "script": "I will read this result lightly and retest when my context is steadier.",
                         "seven_day_plan": [
-                            "Day 1: record your state during response.",
-                            "Day 2: check if you were too fast or tired.",
-                            "Day 3: observe one real situation.",
-                            "Day 4: avoid labeling yourself.",
-                            "Day 5: choose a retest time.",
-                            "Day 6: ensure a quiet setting.",
-                            "Day 7: complete the test again."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not use a low-confidence result for major decisions."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when this result has lower interpretation confidence.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 }
             }
@@ -1786,37 +4824,37 @@
             "assets": {
                 "eq.seo_geo_authority.en_landing.default": {
                     "zh-CN": {
-                        "meta_title": "免费情商 EQ 测试 | 情绪与关系模式报告",
-                        "meta_description": "完成 60 道自我报告题，理解自我觉察、情绪调节、共情理解和关系管理。结果免费，边界清晰，不用于诊断、招聘或能力认证。",
-                        "h1": "情商 EQ 测试：情绪与关系模式报告",
-                        "dek": "一份 60 题 self-report 测评，用于解释你如何感知、调节和回应自己与他人的情绪。",
-                        "entity_summary": "费马 EQ-60 是情绪与关系信号模块，输出自我报告型情绪与关系模式报告，而不是临床、招聘或认证能力测验。",
+                        "meta_title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "h1": "情绪与关系模式测试",
+                        "dek": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "entity_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
                         "content_modules": [
                             {
-                                "heading": "测评测什么",
-                                "summary": "自我觉察、情绪调节、共情理解和关系管理四个维度。"
+                                "heading": "测试定义",
+                                "summary": "测试定义"
                             },
                             {
-                                "heading": "结果页给什么",
-                                "summary": "综合指数、四维矩阵、核心洞察、现实场景、行动处方和科学边界。"
+                                "heading": "测量内容",
+                                "summary": "测量内容"
                             },
                             {
-                                "heading": "不做什么",
-                                "summary": "不做临床诊断、招聘筛选、职业适配结论或客观能力认证。"
+                                "heading": "不适用边界",
+                                "summary": "不适用边界"
+                            },
+                            {
+                                "heading": "下一步行动",
+                                "summary": "下一步行动"
                             }
                         ],
                         "faq": [
                             {
-                                "question": "这是免费的情商测试吗？",
-                                "answer": "是。EQ-60 基础报告免费；报告深度由完成的数据决定，不由付费门槛决定。"
+                                "question": "分数代表什么？",
+                                "answer": ""
                             },
                             {
-                                "question": "它是能力测验吗？",
-                                "answer": "不是。它基于自我报告，适合自我理解、沟通反思和成长规划。"
-                            },
-                            {
-                                "question": "未来的情境判断模块是什么？",
-                                "answer": "EQ-SJT 16 目前仅为 planned 状态，未来会补充情境选择信息，但不会被表述为认证能力测验。"
+                                "question": "结果应该怎么使用？",
+                                "answer": ""
                             }
                         ],
                         "structured_data": {
@@ -1825,48 +4863,47 @@
                             "result_scope": "emotional_and_relational_pattern_report",
                             "is_free": true
                         },
-                        "llms_summary": "EQ-60 是费马测试的自我报告型情绪与关系模式测评。它用 60 道题解释自我觉察、情绪调节、共情理解和关系管理，并输出免费结果页。",
-                        "claim_boundary": "仅用于自我理解和成长规划；不用于临床诊断、招聘筛选、职业适配承诺、治疗建议或客观能力认证。",
-                        "source_authority": "页面标题、SEO 摘要、FAQ、结构化数据边界和 LLM 摘要以 backend content pack 为权威来源。",
+                        "llms_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。",
+                        "source_authority": "后端 content pack 是公开 EQ SEO/GEO 文案权威来源。",
                         "no_go_claims": [
-                            "不声称测量客观情绪能力",
-                            "不声称预测工作表现",
-                            "不用于招聘筛选",
-                            "不用于临床诊断"
+                            "不用于临床",
+                            "不用于招聘",
+                            "不用于认证"
                         ]
                     },
                     "en": {
-                        "meta_title": "Free EQ Test | Emotional & Relational Pattern Report",
-                        "meta_description": "Take a free 60-item self-report EQ test covering self-awareness, emotion regulation, empathy, and relationship management. Clear boundaries: not clinical, hiring, or certified ability assessment.",
-                        "h1": "EQ Test: Emotional & Relational Pattern Report",
-                        "dek": "A 60-item self-report assessment that explains how you notice, regulate, and respond to emotions in yourself and in relationships.",
-                        "entity_summary": "FermatMind EQ-60 is an emotional and relational signal module. It produces a self-report pattern report, not a clinical, hiring, or certified ability assessment.",
+                        "meta_title": "Free EQ Test | Emotional Intelligence Test",
+                        "meta_description": "Take a free self-report emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+                        "h1": "Free Emotional Intelligence Test",
+                        "dek": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "entity_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
                         "content_modules": [
                             {
-                                "heading": "What it measures",
-                                "summary": "Self-awareness, emotion regulation, empathic understanding, and relationship management."
+                                "heading": "definition",
+                                "summary": "definition"
                             },
                             {
-                                "heading": "What the report includes",
-                                "summary": "A global index, four-dimension matrix, core insight, real-world scenes, action prescription, and scientific boundary."
+                                "heading": "what it measures",
+                                "summary": "what it measures"
                             },
                             {
-                                "heading": "What it does not do",
-                                "summary": "It does not provide clinical diagnosis, hiring suitability, career-fit promises, or objective ability certification."
+                                "heading": "what it does not decide",
+                                "summary": "what it does not decide"
+                            },
+                            {
+                                "heading": "next useful action",
+                                "summary": "next useful action"
                             }
                         ],
                         "faq": [
                             {
-                                "question": "Is this EQ test free?",
-                                "answer": "Yes. The EQ-60 base report is free; report depth is based on completed data, not a paywall."
+                                "question": "What does the score mean?",
+                                "answer": "Your result summarizes a self-report emotional and relational pattern across self-awareness, emotion regulation, empathy, and relationship management."
                             },
                             {
-                                "question": "Is this an ability test?",
-                                "answer": "No. It is based on self-report and is intended for self-understanding, communication reflection, and growth planning."
-                            },
-                            {
-                                "question": "What is the future scenario module?",
-                                "answer": "EQ-SJT 16 is currently planned only. It will add scenario-choice information in the future, without being positioned as a certified ability assessment."
+                                "question": "How should I use the result?",
+                                "answer": "Use it to reflect on your patterns, choose a small next action, and decide whether a retest or related assessment would be useful."
                             }
                         ],
                         "structured_data": {
@@ -1875,15 +4912,1146 @@
                             "result_scope": "emotional_and_relational_pattern_report",
                             "is_free": true
                         },
-                        "llms_summary": "EQ-60 is FermatMind's self-report emotional and relational pattern assessment. It uses 60 items to explain self-awareness, emotion regulation, empathic understanding, and relationship management, then returns a free result page.",
-                        "claim_boundary": "For self-understanding and growth planning only; not for clinical diagnosis, hiring selection, career-fit promises, treatment advice, or objective ability certification.",
-                        "source_authority": "Page title, SEO summary, FAQ, structured-data boundary, and LLM summary are authoritative in the backend content pack.",
+                        "llms_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "claim_boundary": "Use for self-understanding, reflection, and growth planning; not for clinical diagnosis, hiring, credentialing, or job-performance prediction.",
+                        "source_authority": "Backend content pack is authoritative for public EQ SEO/GEO copy.",
                         "no_go_claims": [
-                            "Does not claim objective emotional ability measurement",
-                            "Does not predict job performance",
-                            "Not for hiring selection",
-                            "Not for clinical diagnosis"
+                            "not clinical",
+                            "not hiring",
+                            "not credentialing"
                         ]
+                    }
+                }
+            },
+            "faq_assets": [
+                {
+                    "zh-CN": {
+                        "question": "什么是 EQ？",
+                        "answer": "EQ 指情绪与关系相关的自我觉察、调节、共情和关系处理方式。费马 EQ-60 用自我报告方式帮助你理解这些模式。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What is EQ?",
+                        "answer": "EQ refers to emotional and relational patterns such as self-awareness, regulation, empathy, and relationship management. Fermat EQ-60 uses self-report to help you understand these patterns.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "这个 EQ 测试测什么？",
+                        "answer": "它测你如何看待自己的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does this EQ test measure?",
+                        "answer": "It measures how you perceive your emotional and relational tendencies across self-awareness, emotion regulation, empathy, and relationship management.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "它是不是现场表现测量？",
+                        "answer": "不是。EQ-60 是自我报告结果，解释你如何看待自己的情绪与关系模式，不等同于受控任务中的现场表现。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is this based on real-time performance?",
+                        "answer": "No. EQ-60 is a self-report result. It describes how you see your emotional and relational patterns, not how you would perform in a controlled task.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "和专业能力工具有什么区别？",
+                        "answer": "专业能力工具通常需要受控任务、专门评分和资格管理。EQ-60 更适合自我理解和成长规划。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is it different from professional ability instruments?",
+                        "answer": "Professional ability instruments use controlled tasks, specialized scoring, and qualification procedures. EQ-60 is for reflection and growth planning.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 IQ 有什么区别？",
+                        "answer": "IQ 更关注认知问题解决；EQ-60 关注你如何感知、调节和处理情绪与关系。两者不是互相替代。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from IQ?",
+                        "answer": "IQ focuses more on cognitive problem solving. EQ-60 focuses on how you perceive, regulate, and handle emotion and relationships. They are not substitutes for each other.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 MBTI 有什么区别？",
+                        "answer": "MBTI 更像偏好类型语言；EQ-60 解释情绪和关系功能。两者可互补，但不能互相替代。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from MBTI?",
+                        "answer": "MBTI is more of a preference-type language. EQ-60 explains emotional and relational functioning. They can complement each other but do not replace each other.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 Big Five 有什么区别？",
+                        "answer": "Big Five 描述广泛人格特质；EQ-60 聚焦情绪与关系模式。它们可能有重叠，但报告用途不同。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from Big Five?",
+                        "answer": "Big Five describes broad personality traits. EQ-60 focuses on emotional and relational patterns. They may overlap, but their report use differs.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和九型人格有什么区别？",
+                        "answer": "九型人格常用于动机和模式叙事；EQ-60 更关注情绪觉察、调节、共情和关系管理。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from Enneagram?",
+                        "answer": "Enneagram is often used for motivation and pattern narratives. EQ-60 focuses on awareness, regulation, empathy, and relationship management.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "结果准吗？",
+                        "answer": "结果的有用性取决于题目质量、作答状态、常模版本和你是否如实作答。它适合作为自我理解起点。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is the result accurate?",
+                        "answer": "Its usefulness depends on item quality, response context, norm version, and honest responding. It is best used as a starting point for self-understanding.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么用自我报告？",
+                        "answer": "自我感知会影响你如何回应反馈、冲突和关系压力。它不是全部证据，但非常适合作为入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why self-report?",
+                        "answer": "Self-perception affects how you respond to feedback, conflict, and relational pressure. It is not the whole picture, but it is a useful entry point.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以用于人事决定吗？",
+                        "answer": "不建议。单次自我报告结果不适合用于录用、淘汰、晋升或岗位分配。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can it be used for employment decisions?",
+                        "answer": "No. A single self-report result is not appropriate for selection, rejection, promotion, or role assignment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以用于健康判断吗？",
+                        "answer": "不适合。它可以帮助你描述体验，但不能替代专业支持或高风险判断。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can it be used for health decisions?",
+                        "answer": "No. It can help describe experience, but it does not replace qualified support or high-stakes judgment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "分数低怎么办？",
+                        "answer": "先看最低维度和行动处方。低分不是失败，而是指向更具体的练习入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What if my score is low?",
+                        "answer": "Start with the lowest dimension and the action prescription. A lower score is not failure; it points to a more specific practice entry point.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "低置信结果是什么意思？",
+                        "answer": "它表示这次作答状态让解释需要更谨慎。你仍可参考，但不宜做强结论。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does lower confidence mean?",
+                        "answer": "It means the response pattern calls for more cautious interpretation. You can still use it, but avoid strong conclusions.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以复测吗？",
+                        "answer": "可以。建议在状态更稳定、没有赶时间时复测，并比较哪些维度保持一致。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can I retest?",
+                        "answer": "Yes. Retest when you are not rushed and your context is steadier, then compare which dimensions remain stable.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么情境判断暂未开放？",
+                        "answer": "因为情境题需要评分规则、文化审校和验证。当前先保持 planned 状态，不开放入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why is the scenario module not available yet?",
+                        "answer": "Scenario items need scoring rubrics, cultural review, and validation. It remains planned and unavailable for now.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "未来情境判断会补充什么？",
+                        "answer": "它会观察你在反馈、冲突、边界和压力场景中倾向选择什么回应。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What will the future scenario module add?",
+                        "answer": "It will examine the responses you tend to choose in feedback, conflict, boundary, and pressure situations.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "情绪调节低是什么意思？",
+                        "answer": "它通常表示在压力或被触发时恢复较慢，不代表你无法改变。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does lower emotion regulation mean?",
+                        "answer": "It often means recovery is slower under pressure or activation. It does not mean you cannot improve.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "共情高是不是一定好？",
+                        "answer": "不是绝对好坏。高共情能帮助理解别人，但如果恢复和边界不足，也可能带来消耗。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is high empathy always good?",
+                        "answer": "Not absolutely. High empathy helps you understand others, but without recovery and boundaries it can become draining.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "职业环境变量是什么意思？",
+                        "answer": "它不是推荐具体职业，而是帮助你观察一个工作环境的人际密度、反馈强度、冲突频率和恢复空间。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What is a career environment variable?",
+                        "answer": "It is not a job recommendation. It helps you examine interpersonal density, feedback intensity, conflict frequency, and recovery space in a work environment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "如何用结果处理反馈？",
+                        "answer": "先看 ER 和 SA，再用行动处方把反馈拆成事实、感受和下一步。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How can I use the result for feedback?",
+                        "answer": "Look at ER and SA, then use the action prescription to split feedback into facts, feelings, and next steps.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "如何用结果改善关系？",
+                        "answer": "选择一个关系场景，不要泛泛改自己。先练一句更清楚、更可被接住的话。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How can I use the result in relationships?",
+                        "answer": "Pick one relationship scene rather than trying to change everything. Practice one clearer, more receivable sentence.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "情商可以提升吗？",
+                        "answer": "可以练习其中的具体行为，例如情绪命名、暂停、共情回应、边界表达和关系修复。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can EQ improve?",
+                        "answer": "Specific behaviors can be practiced, such as emotion naming, pausing, empathic response, boundary expression, and repair.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以分享结果吗？",
+                        "answer": "可以分享模式摘要，但不建议公开详细分数或把结果当作固定标签。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can I share my result?",
+                        "answer": "You can share a pattern summary, but avoid posting detailed scores or treating the result as a fixed label.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么要保存报告？",
+                        "answer": "保存后你可以复测、比较变化，并继续查看行动处方。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why save the report?",
+                        "answer": "Saving lets you retest, compare change, and keep the action plan continuous.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "这是给我贴标签吗？",
+                        "answer": "不是。formulation 是把本次结果组织成一个可理解的模式，不是永久身份。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is this labeling me?",
+                        "answer": "No. A formulation organizes the current result into an understandable pattern; it is not a permanent identity.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "质量提示是不是说我答错了？",
+                        "answer": "不是。质量提示描述这次作答状态，不评价你这个人。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Do quality flags mean I answered wrong?",
+                        "answer": "No. Quality notes describe this response session; they do not judge you as a person.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "四个维度为什么是这四个？",
+                        "answer": "它们覆盖自己与他人、理解与行动两个轴，形成一个简洁的情绪与关系矩阵。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why these four dimensions?",
+                        "answer": "They cover self vs others and understanding vs action, forming a concise emotional-relational matrix.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "工作中怎么用？",
+                        "answer": "把结果转成场景问题：我如何接收反馈、处理冲突、设边界、恢复压力？",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How do I use it at work?",
+                        "answer": "Translate it into scene questions: how do I handle feedback, conflict, boundaries, and recovery?",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么要保存报告？",
+                        "answer": "保存后，你可以回看本次核心模式、行动处方和复测变化。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "Why save the report?",
+                        "answer": "Saving lets you return to your pattern, action prescription, and future retest comparison.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "多久复测一次比较合适？",
+                        "answer": "如果你只是好奇，4–8 周后复测更有意义；如果本次置信度较低，可以在状态更稳定时更早复测。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "When should I retest?",
+                        "answer": "For normal reflection, 4–8 weeks gives change more room to appear. If confidence was low, retest when your state is steadier.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "我可以问 Agent 什么？",
+                        "answer": "可以问一个具体场景，比如反馈、冲突、边界或压力恢复。Agent 应基于你的报告资产解释，不会改分数。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "What can I ask the Agent?",
+                        "answer": "Ask about one real scene: feedback, conflict, boundaries, or recovery. The Agent explains your report assets; it does not change your scores.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                }
+            ],
+            "seo_geo_assets": {
+                "eq.seo.en.emotional_intelligence_test": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotional Intelligence Test",
+                        "meta_description": "Take a free emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+                        "short_answer": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Understand your emotional and relational pattern, not a live-performance credential."
+                    }
+                },
+                "eq.seo.en.free_eq_test": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Free EQ Test",
+                        "meta_description": "A free EQ test with a complete self-report result, confidence note, and action prescription.",
+                        "short_answer": "Designed for reflection, workstyle insight, and relationship growth.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Designed for reflection, workstyle insight, and relationship growth."
+                    }
+                },
+                "eq.seo.en.eq_score_meaning": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ Score Meaning",
+                        "meta_description": "Learn how EQ scores, bands, percentiles, and confidence notes should be read.",
+                        "short_answer": "A score is a starting point; dimensions and context carry the real interpretation.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "A score is a starting point; dimensions and context carry the real interpretation."
+                    }
+                },
+                "eq.seo.en.self_report_vs_ability_ei": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Self-Report vs Ability EI",
+                        "meta_description": "Understand the difference between self-report EQ and controlled ability-style instruments.",
+                        "short_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment."
+                    }
+                },
+                "eq.seo.en.eq_vs_iq": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ vs IQ",
+                        "meta_description": "EQ and IQ describe different domains: emotional-relational patterns and cognitive problem solving.",
+                        "short_answer": "The two are complementary and should not be collapsed into one score.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "The two are complementary and should not be collapsed into one score."
+                    }
+                },
+                "eq.seo.en.eq_in_workplace": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotional Intelligence at Work",
+                        "meta_description": "Use EQ results to examine feedback, conflict, collaboration, and recovery patterns.",
+                        "short_answer": "Focus on environment variables and communication habits.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Focus on environment variables and communication habits."
+                    }
+                },
+                "eq.seo.en.how_to_improve_eq": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "How to Improve EQ",
+                        "meta_description": "Practice emotion naming, pausing, empathic response, boundaries, and repair.",
+                        "short_answer": "Improvement begins with one repeatable behavior in a real situation.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Improvement begins with one repeatable behavior in a real situation."
+                    }
+                },
+                "eq.seo.en.eq_and_relationships": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ in Relationships",
+                        "meta_description": "See how empathy, boundaries, expression, and repair shape relationship patterns.",
+                        "short_answer": "The goal is clearer conversation, not fixed labels.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "The goal is clearer conversation, not fixed labels."
+                    }
+                },
+                "eq.seo.en.emotion_regulation": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotion Regulation",
+                        "meta_description": "Understand recovery and response choice after emotional activation.",
+                        "short_answer": "Regulation is not suppression; it keeps enough choice to respond well.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Regulation is not suppression; it keeps enough choice to respond well."
+                    }
+                },
+                "eq.seo.en.empathy_context": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Empathy in EQ",
+                        "meta_description": "Empathy helps you read others, but needs boundaries and recovery.",
+                        "short_answer": "High empathy can be a strength and a load depending on context.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "High empathy can be a strength and a load depending on context."
+                    }
+                },
+                "eq.seo.en.eq_methodology": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Fermat EQ Methodology",
+                        "meta_description": "How EQ-60 uses self-report, four dimensions, quality checks, and versioned norms.",
+                        "short_answer": "Transparent boundaries make the result more useful, not weaker.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Transparent boundaries make the result more useful, not weaker."
+                    }
+                },
+                "eq.seo.en.eq_retest": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Retesting EQ",
+                        "meta_description": "Retesting can show which emotional-relational patterns remain stable over time.",
+                        "short_answer": "Compare dimensions and confidence notes, not just the total score.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Compare dimensions and confidence notes, not just the total score."
+                    }
+                },
+                "eq.seo.zh.qingshang_ceshi": {
+                    "zh-CN": {
+                        "title": "情商测试",
+                        "meta_description": "免费查看你的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+                        "short_answer": "结果用于自我理解和成长规划，不用于高风险判断。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_ceshi": {
+                    "zh-CN": {
+                        "title": "EQ测试",
+                        "meta_description": "基于 60 道自我报告题，生成情绪与关系模式报告。",
+                        "short_answer": "重点不是给你贴标签，而是找到可执行的练习入口。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.qingxu_zhili": {
+                    "zh-CN": {
+                        "title": "情绪智力",
+                        "meta_description": "了解情绪觉察、调节、共情和关系处理如何影响沟通与压力恢复。",
+                        "short_answer": "情绪智力可以拆成具体行为来练习。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.qingxu_tiaojie": {
+                    "zh-CN": {
+                        "title": "情绪调节",
+                        "meta_description": "理解被触发后如何暂停、恢复和选择回应。",
+                        "short_answer": "情绪调节不是压抑情绪，而是保留回应选择。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.gongqing_nengli": {
+                    "zh-CN": {
+                        "title": "共情能力",
+                        "meta_description": "共情帮助你读懂别人，但也需要边界和恢复。",
+                        "short_answer": "高共情不是绝对好坏，要看它是否和调节协同。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_vs_iq": {
+                    "zh-CN": {
+                        "title": "EQ和IQ区别",
+                        "meta_description": "IQ偏认知问题解决，EQ-60偏情绪与关系模式。",
+                        "short_answer": "两者互补，不能互相替代。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.self_report_vs_ability": {
+                    "zh-CN": {
+                        "title": "自我报告和表现型测量区别",
+                        "meta_description": "自我报告解释你如何看待自己，能力工具需要受控任务和专门评分。",
+                        "short_answer": "费马 EQ-60 当前属于自我报告结果。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_score_meaning": {
+                    "zh-CN": {
+                        "title": "EQ分数怎么理解",
+                        "meta_description": "分数要和四维、百分位、置信度和行动建议一起读。",
+                        "short_answer": "不要只看一个总分。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_workplace": {
+                    "zh-CN": {
+                        "title": "职场情商",
+                        "meta_description": "用 EQ 结果观察反馈、冲突、协作和恢复方式。",
+                        "short_answer": "报告只解释环境变量和工作方式，不推荐具体岗位。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.improve_eq": {
+                    "zh-CN": {
+                        "title": "如何提高情商",
+                        "meta_description": "从情绪命名、暂停、共情回应、边界表达和修复脚本开始。",
+                        "short_answer": "选择一个场景练习，比泛泛努力更有效。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_relationship": {
+                    "zh-CN": {
+                        "title": "情商与关系",
+                        "meta_description": "理解你如何表达、共情、设边界和修复关系。",
+                        "short_answer": "结果不是关系定论，而是对话入口。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_methodology": {
+                    "zh-CN": {
+                        "title": "费马EQ方法论",
+                        "meta_description": "说明 EQ-60 的四维模型、计分、质量提示和科学边界。",
+                        "short_answer": "透明的方法边界能提升可信度。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
                     }
                 }
             }
@@ -1894,22 +6062,1509 @@
             "assets": {
                 "eq.sjt_bridge.planned": {
                     "zh-CN": {
-                        "title": "未来将支持 16 道情境判断模块",
-                        "status": "planned",
-                        "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
-                        "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
-                        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。",
-                        "button_label": "情境判断模块规划中",
-                        "available": false
+                        "title": "未来情境判断模块",
+                        "status": "planned_unavailable",
+                        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
                     },
                     "en": {
-                        "title": "A 16-item scenario module is planned",
+                        "title": "Future scenario module",
+                        "status": "planned_unavailable",
+                        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.what_it_adds": {
+                    "zh-CN": {
+                        "title": "它会补充什么",
+                        "status": "planned_unavailable",
+                        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "What it will add",
+                        "status": "planned_unavailable",
+                        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.what_it_is_not": {
+                    "zh-CN": {
+                        "title": "它不是什么",
+                        "status": "planned_unavailable",
+                        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "What it is not",
+                        "status": "planned_unavailable",
+                        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.future_integrated_report": {
+                    "zh-CN": {
+                        "title": "未来综合报告",
+                        "status": "planned_unavailable",
+                        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "Future integrated report",
+                        "status": "planned_unavailable",
+                        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.unavailable_note": {
+                    "zh-CN": {
+                        "title": "暂未开放说明",
+                        "status": "planned_unavailable",
+                        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "Unavailable note",
+                        "status": "planned_unavailable",
+                        "description": "This module remains planned. The frontend should not provide a clickable start entry.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                }
+            }
+        },
+        "result_snapshot": {
+            "schema": "eq60.report_assets.result_snapshot.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.snapshot.balanced_integrated": {
+                    "zh-CN": {
+                        "headline": "均衡整合型",
+                        "core_judgment": "你能同时照顾自己的状态、他人的感受和关系目标。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能同时照顾自己的状态、他人的感受和关系目标。",
+                            "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "下一步：把“我来稳住”改成“我们一起定规则”。"
+                        ],
+                        "top_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                        "minimal_action": "把“我来稳住”改成“我们一起定规则”。",
+                        "share_safe_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Balanced Integrator",
+                        "core_judgment": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                            "You can keep emotion, relationship, and task in the same frame.",
+                            "Next move: Move from “I will steady this” to “we need a shared rule.”"
+                        ],
+                        "top_strength": "You can keep emotion, relationship, and task in the same frame.",
+                        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                        "minimal_action": "Move from “I will steady this” to “we need a shared rule.”",
+                        "share_safe_sentence": "I can steady a relationship without maintaining the whole system alone.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.balanced_integrated",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "balanced_integrated"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.high_empathy_low_recovery": {
+                    "zh-CN": {
+                        "headline": "高共情，低恢复",
+                        "core_judgment": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                            "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "下一步：练习“理解但不接管”，让共情后面跟着边界。"
+                        ],
+                        "top_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                        "minimal_action": "练习“理解但不接管”，让共情后面跟着边界。",
+                        "share_safe_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "High Empathy, Slow Recovery",
+                        "core_judgment": "You read the room quickly, but recovery can lag behind empathy.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You read the room quickly, but recovery can lag behind empathy.",
+                            "You can make people feel understood, especially when emotions run high.",
+                            "Next move: Practice understanding without taking over, so empathy is followed by boundary."
+                        ],
+                        "top_strength": "You can make people feel understood, especially when emotions run high.",
+                        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+                        "minimal_action": "Practice understanding without taking over, so empathy is followed by boundary.",
+                        "share_safe_sentence": "I can understand someone without carrying the whole emotional load.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.high_empathy_low_recovery",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "high_empathy_low_recovery"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.aware_but_unregulated": {
+                    "zh-CN": {
+                        "headline": "有觉察，调节不足",
+                        "core_judgment": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                            "你能清楚识别触发点、感受和需要。",
+                            "下一步：把觉察压缩成一个暂停动作，而不是继续解释。"
+                        ],
+                        "top_strength": "你能清楚识别触发点、感受和需要。",
+                        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                        "minimal_action": "把觉察压缩成一个暂停动作，而不是继续解释。",
+                        "share_safe_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Aware, Still Reactive",
+                        "core_judgment": "You often know what is happening inside, but the reset button is slower than the insight.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You often know what is happening inside, but the reset button is slower than the insight.",
+                            "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "Next move: Turn awareness into one pause action instead of another layer of explanation."
+                        ],
+                        "top_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                        "minimal_action": "Turn awareness into one pause action instead of another layer of explanation.",
+                        "share_safe_sentence": "I know what is happening; the next skill is bringing myself back.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.aware_but_unregulated",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "aware_but_unregulated"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.calm_but_distant": {
+                    "zh-CN": {
+                        "headline": "冷静稳定，但距离感强",
+                        "core_judgment": "你能稳住事情，但别人不一定感到被情绪上接住。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能稳住事情，但别人不一定感到被情绪上接住。",
+                            "你不容易被情绪推着走，能保留判断和节奏。",
+                            "下一步：先回应一句感受，再给建议或方案。"
+                        ],
+                        "top_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                        "minimal_action": "先回应一句感受，再给建议或方案。",
+                        "share_safe_sentence": "我能稳住事情，也要让人感到被看见。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Steady, Less Attuned",
+                        "core_judgment": "You can steady the situation, but people may not always feel emotionally met.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You can steady the situation, but people may not always feel emotionally met.",
+                            "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "Next move: Acknowledge one feeling before offering advice or a solution."
+                        ],
+                        "top_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+                        "minimal_action": "Acknowledge one feeling before offering advice or a solution.",
+                        "share_safe_sentence": "I can steady the situation and still help people feel seen.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.calm_but_distant",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "calm_but_distant"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.relationship_first_self_later": {
+                    "zh-CN": {
+                        "headline": "关系优先，自我后置",
+                        "core_judgment": "你会先保护关系，再回头找自己的真实立场。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你会先保护关系，再回头找自己的真实立场。",
+                            "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "下一步：在照顾关系前，先给自己的感受一个位置。"
+                        ],
+                        "top_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                        "minimal_action": "在照顾关系前，先给自己的感受一个位置。",
+                        "share_safe_sentence": "关系重要，我的感受也需要在场。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Relationship First, Self Later",
+                        "core_judgment": "You protect the relationship first and find your own position later.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You protect the relationship first and find your own position later.",
+                            "You are sensitive to relational tone and often keep interaction workable.",
+                            "Next move: Give your own feeling a place before you manage the relationship."
+                        ],
+                        "top_strength": "You are sensitive to relational tone and often keep interaction workable.",
+                        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                        "minimal_action": "Give your own feeling a place before you manage the relationship.",
+                        "share_safe_sentence": "The relationship matters, and my own state belongs in the room too.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.relationship_first_self_later",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "relationship_first_self_later"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.self_clear_repair_weak": {
+                    "zh-CN": {
+                        "headline": "自我清楚，修复不足",
+                        "core_judgment": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                            "你不容易在关系压力里丢掉自己的判断。",
+                            "下一步：把“我说清楚了”补成“我们怎么重新对齐”。"
+                        ],
+                        "top_strength": "你不容易在关系压力里丢掉自己的判断。",
+                        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                        "minimal_action": "把“我说清楚了”补成“我们怎么重新对齐”。",
+                        "share_safe_sentence": "我可以清楚表达，也可以把关系重新接上。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Clear Self, Repair Gap",
+                        "core_judgment": "You know your position, but repair after tension needs a clearer tool.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You know your position, but repair after tension needs a clearer tool.",
+                            "You are less likely to lose your judgment under relational pressure.",
+                            "Next move: Add “how do we realign?” after “I made my point.”"
+                        ],
+                        "top_strength": "You are less likely to lose your judgment under relational pressure.",
+                        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+                        "minimal_action": "Add “how do we realign?” after “I made my point.”",
+                        "share_safe_sentence": "I can be clear and still reconnect the relationship.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.self_clear_repair_weak",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "self_clear_repair_weak"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.steady_collaborator": {
+                    "zh-CN": {
+                        "headline": "稳定协作型",
+                        "core_judgment": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                            "你能把紧张对话拉回事实、目标和下一步。",
+                            "下一步：把个人稳定能力变成团队流程。"
+                        ],
+                        "top_strength": "你能把紧张对话拉回事实、目标和下一步。",
+                        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+                        "minimal_action": "把个人稳定能力变成团队流程。",
+                        "share_safe_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Steady Collaborator",
+                        "core_judgment": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                            "You can bring tense conversations back to facts, goals, and next steps.",
+                            "Next move: Turn personal steadiness into team process."
+                        ],
+                        "top_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                        "minimal_action": "Turn personal steadiness into team process.",
+                        "share_safe_sentence": "I can help collaboration, but the rules cannot live only in me.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.steady_collaborator",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "steady_collaborator"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.sensitive_absorber": {
+                    "zh-CN": {
+                        "headline": "高敏感，易吸收",
+                        "core_judgment": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                            "你很快发现气氛、语气和关系位置的变化。",
+                            "下一步：把“我感到了”区分成“我要不要回应”。"
+                        ],
+                        "top_strength": "你很快发现气氛、语气和关系位置的变化。",
+                        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                        "minimal_action": "把“我感到了”区分成“我要不要回应”。",
+                        "share_safe_sentence": "我能感到很多东西，但不需要回应所有东西。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Sensitive Absorber",
+                        "core_judgment": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                            "You quickly notice shifts in tone, mood, and relational position.",
+                            "Next move: Separate “I noticed it” from “I need to respond.”"
+                        ],
+                        "top_strength": "You quickly notice shifts in tone, mood, and relational position.",
+                        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                        "minimal_action": "Separate “I noticed it” from “I need to respond.”",
+                        "share_safe_sentence": "I can feel a lot without responding to everything.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.sensitive_absorber",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "sensitive_absorber"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.developing_foundation": {
+                    "zh-CN": {
+                        "headline": "基础发展中",
+                        "core_judgment": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                            "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "下一步：先把一个情绪命名清楚，再谈复杂改变。"
+                        ],
+                        "top_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                        "minimal_action": "先把一个情绪命名清楚，再谈复杂改变。",
+                        "share_safe_sentence": "先练一个小动作，就已经是在建立基础。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Developing Foundation",
+                        "core_judgment": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                            "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "Next move: Name one feeling clearly before attempting a larger change."
+                        ],
+                        "top_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                        "minimal_action": "Name one feeling clearly before attempting a larger change.",
+                        "share_safe_sentence": "One small practice is already foundation-building.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.developing_foundation",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "developing_foundation"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.low_confidence_result": {
+                    "zh-CN": {
+                        "headline": "本次结果置信度较低",
+                        "core_judgment": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                        "evidence_point": "由于本次作答质量不足，系统不会输出强画像判断。",
+                        "three_sentence_summary": [
+                            "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                            "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "下一步：先记录状态，之后在更稳定的时间复测。"
+                        ],
+                        "top_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "minimal_action": "先记录状态，之后在更稳定的时间复测。",
+                        "share_safe_sentence": "这次结果不是不能看，而是要轻一点看。",
+                        "continue_path": "先记录本次作答状态，之后在更稳定的时间复测。",
+                        "conversion_actions": [
+                            "save_report",
+                            "retest_reminder",
+                            "talk_to_agent"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Lower-Confidence Result",
+                        "core_judgment": "Read this result lightly; the most useful signal is the response context of this session.",
+                        "evidence_point": "Because response confidence is limited, the system avoids a strong profile statement.",
+                        "three_sentence_summary": [
+                            "Read this result lightly; the most useful signal is the response context of this session.",
+                            "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "Next move: Record the context first, then retest when conditions are steadier."
+                        ],
+                        "top_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "minimal_action": "Record the context first, then retest when conditions are steadier.",
+                        "share_safe_sentence": "This result is not useless; it simply needs a lighter reading.",
+                        "continue_path": "Record the response context first, then retest when conditions are steadier.",
+                        "conversion_actions": [
+                            "save_report",
+                            "retest_reminder",
+                            "talk_to_agent"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.low_confidence_result",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "low_confidence_result"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "commercial_conversion_assets": {
+            "schema": "eq60.report_assets.commercial_conversion_assets.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.conversion.save_report": {
+                    "zh-CN": {
+                        "title": "保存报告",
+                        "body": "把这次核心模式、行动处方和复测入口留住。",
+                        "cta_label": "保存报告",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Save your report",
+                        "body": "Keep your pattern, action prescription, and retest path in one place.",
+                        "cta_label": "Save report",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.save_report",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "save_report"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.email_revisit": {
+                    "zh-CN": {
+                        "title": "邮件回看",
+                        "body": "把报告发送给自己，适合之后复盘或继续和 Agent 对话。",
+                        "cta_label": "发送到邮箱",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Email revisit",
+                        "body": "Send the report to yourself so you can revisit it or continue with the Agent later.",
+                        "cta_label": "Email me",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.email_revisit",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "email_revisit"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.pdf_export": {
+                    "zh-CN": {
+                        "title": "PDF 报告",
+                        "body": "生成可保存版本，适合个人复盘，不建议用于招聘或评估他人。",
+                        "cta_label": "生成 PDF",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "PDF report",
+                        "body": "Create a saved copy for personal reflection, not for hiring or evaluating another person.",
+                        "cta_label": "Create PDF",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.pdf_export",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "pdf_export"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.share_card": {
+                    "zh-CN": {
+                        "title": "分享卡",
+                        "body": "只分享模式句，不分享详细分数和敏感解释。",
+                        "cta_label": "生成分享卡",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Share card",
+                        "body": "Share the pattern sentence, not detailed scores or sensitive interpretation.",
+                        "cta_label": "Create share card",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.share_card",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "share_card"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.retest_reminder": {
+                    "zh-CN": {
+                        "title": "复测提醒",
+                        "body": "4–8 周后重新查看模式是否稳定，低置信结果可更早复测。",
+                        "cta_label": "设置复测提醒",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Retest reminder",
+                        "body": "Check whether the pattern is stable after 4–8 weeks; low-confidence results can be retested sooner.",
+                        "cta_label": "Set reminder",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.retest_reminder",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "retest_reminder"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.related_tests": {
+                    "zh-CN": {
+                        "title": "相关测试",
+                        "body": "用 Big Five、RIASEC、MBTI 作为补充视角，不把 EQ 当成唯一结论。",
+                        "cta_label": "继续探索",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Related tests",
+                        "body": "Use Big Five, RIASEC, or MBTI as complementary lenses, not as replacements for EQ.",
+                        "cta_label": "Explore related tests",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.related_tests",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "related_tests"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.agent_entry": {
+                    "zh-CN": {
+                        "title": "问问 Agent",
+                        "body": "带着一个真实场景提问，例如反馈、冲突、边界或压力恢复。",
+                        "cta_label": "问 Agent",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Ask the Agent",
+                        "body": "Ask about one real scene, such as feedback, conflict, boundaries, or recovery.",
+                        "cta_label": "Ask the Agent",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.agent_entry",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "agent_entry"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                }
+            }
+        },
+        "quality_confidence": {
+            "schema": "eq60.report_assets.quality_confidence.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.quality.level.A": {
+                    "zh-CN": {
+                        "label": "高置信",
+                        "body": "本次作答节奏和一致性支持较稳定解释。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "可在未来复测观察稳定变化。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "High confidence",
+                        "body": "The response pattern supports a relatively stable interpretation.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "Retest later to observe stable change.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.A",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "A"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.quality.level.B": {
+                    "zh-CN": {
+                        "label": "正常置信",
+                        "body": "本次结果可用于阅读主要模式，但仍建议结合现实场景理解。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "可在未来复测观察稳定变化。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Standard confidence",
+                        "body": "The result can be used for the main pattern, while still being read with real-life context.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "Retest later to observe stable change.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.B",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "B"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.quality.level.C": {
+                    "zh-CN": {
+                        "label": "中等置信",
+                        "body": "本次结果适合作为初步参考，强结论需要减少。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Moderate confidence",
+                        "body": "The result is best treated as a preliminary reference; strong conclusions should be reduced.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.C",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "C"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.quality.level.D": {
+                    "zh-CN": {
+                        "label": "低置信",
+                        "body": "本次结果应轻读，优先看作答状态和复测建议。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Lower confidence",
+                        "body": "Read this result lightly; focus on response context and retest guidance.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.D",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "D"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "psychometric_evidence_status": {
+            "schema": "eq60.report_assets.psychometric_evidence_status.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.evidence.content_validity": {
+                    "zh-CN": {
+                        "status": "preliminary",
+                        "body": "题项和报告维度已有内容映射，但需要持续专家复核和用户反馈。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "preliminary",
+                        "body": "Items and report dimensions have content mapping, with ongoing need for expert review and user feedback.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.content_validity",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "content_validity"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.internal_consistency": {
+                    "zh-CN": {
                         "status": "planned",
-                        "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
-                        "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
-                        "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions.",
-                        "button_label": "Scenario module planned",
-                        "available": false
+                        "body": "后续应按语言、地区和维度计算内部一致性，并记录版本。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Future work should estimate internal consistency by language, region, and dimension with version tracking.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.internal_consistency",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "internal_consistency"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.test_retest": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "建议在 30–90 天窗口评估稳定性和可变性。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "A 30–90 day window should be used to evaluate stability and change.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.test_retest",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "test_retest"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.factor_structure": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "需要用 EFA/CFA 或其他合适方法验证四维结构。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "The four-dimension structure should be evaluated with EFA/CFA or suitable methods.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.factor_structure",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "factor_structure"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.criterion_validity": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "可探索与工作满意、关系满意、压力恢复等低风险外部指标的关联。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Associations with low-risk external indicators such as work satisfaction, relationship satisfaction, and recovery may be explored.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.criterion_validity",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "criterion_validity"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.measurement_invariance": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "中英文和主要人群组之间需要做等值或 DIF 检查。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Chinese/English and major user groups require invariance or DIF checks.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.measurement_invariance",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "measurement_invariance"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.norm_status": {
+                    "zh-CN": {
+                        "status": "provisional",
+                        "body": "当前常模解释为阶段性版本，不应被理解为最终全球常模。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "provisional",
+                        "body": "Current norms are provisional and should not be read as final global norms.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.norm_status",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "norm_status"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "agent_dialogue_playbooks": {
+            "schema": "eq60.report_assets.agent_dialogue_playbooks.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.agent.playbook.understand_result": {
+                    "zh-CN": {
+                        "title": "理解我的结果",
+                        "response_policy": "先引用用户 formulation，再问一个现实场景。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Understand my result",
+                        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.understand_result",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "understand_result"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "understand_result"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.scene_advice": {
+                    "zh-CN": {
+                        "title": "某个场景怎么办",
+                        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "What should I do in this situation?",
+                        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.scene_advice",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "scene_advice"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "scene_advice"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.career_environment": {
+                    "zh-CN": {
+                        "title": "我适合什么工作环境",
+                        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "What work environment fits me?",
+                        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.career_environment",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "career_environment"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "career_environment"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.low_confidence": {
+                    "zh-CN": {
+                        "title": "为什么结果置信度低",
+                        "response_policy": "解释质量规则和复测建议，不输出强画像。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Why is confidence low?",
+                        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.low_confidence",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "low_confidence"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "low_confidence"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.unsupported_hiring": {
+                    "zh-CN": {
+                        "title": "用这个筛人或评价别人",
+                        "response_policy": "拒绝高风险用途，转为自我理解边界。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Use this to screen someone",
+                        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.unsupported_hiring",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "unsupported_hiring"
+                        },
+                        "claim_sensitivity": "high",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "unsupported_hiring"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                }
+            }
+        },
+        "backend_integration_contract": {
+            "schema": "eq60.report_assets.backend_integration_contract.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.backend_contract.schema_mapping": {
+                    "zh-CN": {
+                        "title": "Schema 映射",
+                        "requirement": "将每个资产文件映射到后端 content-pack compiler 可识别的字段。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Map every asset file into backend content-pack compiler fields before production",
+                        "requirement": "Map every asset file into backend content-pack compiler fields before production.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.schema_mapping",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "schema_mapping"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.canonical_fixtures": {
+                    "zh-CN": {
+                        "title": "Canonical fixtures",
+                        "requirement": "为 balanced、high_empathy_low_recovery、low_confidence 三条路径生成 zh-CN / en canonical fixtures。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths",
+                        "requirement": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.canonical_fixtures",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "canonical_fixtures"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.contract_tests": {
+                    "zh-CN": {
+                        "title": "契约测试",
+                        "requirement": "断言 report payload 包含 v1.6 assets、免费转化动作、无权限门槛，且 SJT 保持 unavailable。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Assert report payload contains v1",
+                        "requirement": "Assert report payload contains v1.6 assets, conversion actions, no access wall, and SJT unavailable.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.contract_tests",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "contract_tests"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.frontend_consumption": {
+                    "zh-CN": {
+                        "title": "前端消费契约",
+                        "requirement": "前端必须渲染后端 resolved assets，不得硬编码正式报告解释文案。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Frontend must render resolved assets and must not hardcode official report explanation",
+                        "requirement": "Frontend must render resolved assets and must not hardcode official report explanation.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.frontend_consumption",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "frontend_consumption"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.agent_readiness": {
+                    "zh-CN": {
+                        "title": "Agent 就绪契约",
+                        "requirement": "Agent 在检索、拒答和边界评测通过前，只能解释已解析报告资产。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Agent can only explain resolved assets until retrieval and refusal evals pass",
+                        "requirement": "Agent can only explain resolved assets until retrieval and refusal evals pass.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.agent_readiness",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "agent_readiness"
+                        },
+                        "claim_sensitivity": "high"
                     }
                 }
             }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/action_prescriptions.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/action_prescriptions.json
@@ -3,52 +3,964 @@
   "pack_id": "EQ_60",
   "prescriptions": {
     "emotion_labeling": {
-      "zh-CN": {"title": "情绪命名处方", "why_this_matters": "先命名，才有可能选择回应。", "do_today": "今天选择一个具体情绪词，写下触发它的场景。", "script": "我现在感到的是 X，不代表我必须立刻做决定。", "seven_day_plan": ["第 1 天：记录一个情绪词。", "第 2 天：补充身体感受。", "第 3 天：写下触发场景。", "第 4 天：区分事实和解释。", "第 5 天：写一个可控动作。", "第 6 天：复盘一次沟通。", "第 7 天：选出最常见触发点。"], "watch_out": "不要把情绪词变成自我评价。"},
-      "en": {"title": "Emotion Labeling", "why_this_matters": "Naming comes before choosing a response.", "do_today": "Choose one specific emotion word today and write the triggering context.", "script": "What I feel now is X; it does not mean I must decide immediately.", "seven_day_plan": ["Day 1: record one emotion word.", "Day 2: add body sensations.", "Day 3: write the trigger.", "Day 4: separate fact and interpretation.", "Day 5: write one controllable action.", "Day 6: review one conversation.", "Day 7: identify the most common trigger."], "watch_out": "Do not turn emotion words into self-judgment."}
+      "zh-CN": {
+        "title": "情绪命名",
+        "why_this_matters": "当感受模糊、容易事后才明白时使用。",
+        "do_today": "今天只做一件事：把一次情绪从“烦”改写成三个更具体的词。",
+        "script": "我现在不是单纯不舒服，我可能是失望、紧张和需要确认。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录一次情绪触发点。"
+          },
+          {
+            "day": 2,
+            "practice": "写下事实、感受、需要三栏。"
+          },
+          {
+            "day": 3,
+            "practice": "把“还好”改成三个具体情绪词。"
+          },
+          {
+            "day": 4,
+            "practice": "找一个低风险场景说出一个感受。"
+          },
+          {
+            "day": 5,
+            "practice": "复盘一次没说出口的需要。"
+          },
+          {
+            "day": 6,
+            "practice": "把一个情绪和身体感觉连接起来。"
+          },
+          {
+            "day": 7,
+            "practice": "选择一个下周继续练的情绪词。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当感受模糊、容易事后才明白时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Emotion labeling",
+        "why_this_matters": "Use when feelings are vague or only become clear afterward.",
+        "do_today": "Today, turn one vague feeling into three more precise words.",
+        "script": "I am not simply upset; I may be disappointed, tense, and needing clarity.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when feelings are vague or only become clear afterward.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "pause_recovery": {
-      "zh-CN": {"title": "暂停与恢复处方", "why_this_matters": "调节不是压住情绪，而是给选择回应争取空间。", "do_today": "遇到触发时暂停 60 秒，再回复。", "script": "我需要一分钟整理一下，再继续说。", "seven_day_plan": ["第 1 天：练 60 秒暂停。", "第 2 天：加入一次深呼吸。", "第 3 天：离开屏幕一分钟。", "第 4 天：记录暂停前后的差异。", "第 5 天：在反馈场景使用。", "第 6 天：在冲突前使用。", "第 7 天：固定一个恢复动作。"], "watch_out": "暂停不是逃避，暂停后要回到对话。"},
-      "en": {"title": "Pause and Recovery", "why_this_matters": "Regulation is not suppressing emotion; it creates room for choice.", "do_today": "When triggered, pause for 60 seconds before replying.", "script": "I need a minute to organize my thoughts before continuing.", "seven_day_plan": ["Day 1: practice a 60-second pause.", "Day 2: add one deep breath.", "Day 3: step away from the screen for one minute.", "Day 4: note the before-and-after difference.", "Day 5: use it in feedback.", "Day 6: use it before conflict.", "Day 7: fix one recovery action."], "watch_out": "Pausing is not avoidance; return to the conversation."}
+      "zh-CN": {
+        "title": "暂停与恢复",
+        "why_this_matters": "当你知道自己被触发，但很难立刻稳定时使用。",
+        "do_today": "今天给自己设一个十秒暂停规则。",
+        "script": "我需要先停十秒，等我能更清楚地回应。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "选一个暂停信号。"
+          },
+          {
+            "day": 2,
+            "practice": "在一次小触发中练十秒呼吸。"
+          },
+          {
+            "day": 3,
+            "practice": "写下暂停前后的不同。"
+          },
+          {
+            "day": 4,
+            "practice": "给自己设一个延迟回复模板。"
+          },
+          {
+            "day": 5,
+            "practice": "练习离开屏幕两分钟。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘一次因为暂停而避免升级的场景。"
+          },
+          {
+            "day": 7,
+            "practice": "确定下周继续使用的暂停句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你知道自己被触发，但很难立刻稳定时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Pause and recovery",
+        "why_this_matters": "Use when you know you are triggered but cannot steady yourself immediately.",
+        "do_today": "Set a ten-second pause rule today.",
+        "script": "I need ten seconds so I can respond more clearly.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you know you are triggered but cannot steady yourself immediately.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "feedback_decompression": {
-      "zh-CN": {"title": "反馈减压处方", "why_this_matters": "反馈容易混合事实、关系和自我评价，需要拆开处理。", "do_today": "把一次反馈拆成事实、感受、下一步三栏。", "script": "我先确认事实：你希望我调整的是 X，对吗？", "seven_day_plan": ["第 1 天：拆一次反馈。", "第 2 天：只问一个澄清问题。", "第 3 天：延迟自我评价。", "第 4 天：记录可行动项。", "第 5 天：复盘语气触发。", "第 6 天：向对方确认优先级。", "第 7 天：总结一个反馈模板。"], "watch_out": "不要把所有反馈都理解成人身否定。"},
-      "en": {"title": "Feedback Decompression", "why_this_matters": "Feedback mixes facts, relationship cues, and self-evaluation; separate them.", "do_today": "Split one feedback event into facts, feelings, and next step.", "script": "Let me confirm the fact: you want me to adjust X, correct?", "seven_day_plan": ["Day 1: split one feedback event.", "Day 2: ask only one clarifying question.", "Day 3: delay self-judgment.", "Day 4: record the action item.", "Day 5: review tone triggers.", "Day 6: confirm priority.", "Day 7: summarize a feedback template."], "watch_out": "Do not treat all feedback as personal rejection."}
+      "zh-CN": {
+        "title": "反馈去压缩",
+        "why_this_matters": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+        "do_today": "今天把一次反馈拆成事实、评价和下一步。",
+        "script": "我先确认一下，你希望我具体调整哪一部分？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "找一次近期反馈。"
+          },
+          {
+            "day": 2,
+            "practice": "写出反馈里的事实。"
+          },
+          {
+            "day": 3,
+            "practice": "写出你脑中自动冒出的解释。"
+          },
+          {
+            "day": 4,
+            "practice": "问一个澄清问题。"
+          },
+          {
+            "day": 5,
+            "practice": "把反馈转成一个行动。"
+          },
+          {
+            "day": 6,
+            "practice": "记录反馈后的身体反应。"
+          },
+          {
+            "day": 7,
+            "practice": "总结一个下次先问的问题。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Feedback decompression",
+        "why_this_matters": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+        "do_today": "Today, split one piece of feedback into facts, evaluation, and next step.",
+        "script": "Can I clarify which part you want me to adjust?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "empathy_boundary": {
-      "zh-CN": {"title": "共情边界处方", "why_this_matters": "高共情需要边界，才能长期有效。", "do_today": "支持别人前先确认自己能支持到哪里。", "script": "我愿意听你说十分钟，然后我们一起看下一步。", "seven_day_plan": ["第 1 天：识别一次我在承担什么。", "第 2 天：练习时间边界。", "第 3 天：练习责任边界。", "第 4 天：支持后做恢复。", "第 5 天：区分理解和代替。", "第 6 天：复盘一次求助场景。", "第 7 天：写下自己的支持边界。"], "watch_out": "不要用冷漠来替代边界。"},
-      "en": {"title": "Empathy Boundary", "why_this_matters": "High empathy needs boundaries to remain sustainable.", "do_today": "Before supporting someone, decide how far you can support.", "script": "I can listen for ten minutes, then we can look at the next step together.", "seven_day_plan": ["Day 1: identify what you are carrying.", "Day 2: practice a time boundary.", "Day 3: practice a responsibility boundary.", "Day 4: recover after support.", "Day 5: separate understanding from replacing.", "Day 6: review one help-seeking situation.", "Day 7: write your support boundary."], "watch_out": "Do not replace boundaries with coldness."}
+      "zh-CN": {
+        "title": "共情边界",
+        "why_this_matters": "当你理解别人后容易承担过多时使用。",
+        "do_today": "今天练习一句“理解但不接管”的话。",
+        "script": "我理解这件事很难，我能帮你一起理清下一步，但不能替你承担全部。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一个你容易接管的场景。"
+          },
+          {
+            "day": 2,
+            "practice": "写下对方责任和你责任的边界。"
+          },
+          {
+            "day": 3,
+            "practice": "练习一句支持但不接管的话。"
+          },
+          {
+            "day": 4,
+            "practice": "在一次对话中只提供一个具体帮助。"
+          },
+          {
+            "day": 5,
+            "practice": "对一个请求说出可承担范围。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘说边界后的真实后果。"
+          },
+          {
+            "day": 7,
+            "practice": "写下你的恢复动作。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你理解别人后容易承担过多时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Empathy with boundary",
+        "why_this_matters": "Use when understanding others turns into carrying too much.",
+        "do_today": "Practice one sentence that understands without taking over.",
+        "script": "I understand this is difficult. I can help you sort the next step, but I cannot carry all of it for you.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when understanding others turns into carrying too much.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "repair_after_conflict": {
-      "zh-CN": {"title": "冲突后修复处方", "why_this_matters": "冲突后的修复决定关系能否继续合作。", "do_today": "选一个小冲突，发出一句修复确认。", "script": "刚才我语气急了，我想把重点重新说清楚。", "seven_day_plan": ["第 1 天：识别一次未完成冲突。", "第 2 天：写下自己的责任。", "第 3 天：写下对方可能在意的点。", "第 4 天：发出一句确认。", "第 5 天：只讨论下一步。", "第 6 天：复盘修复效果。", "第 7 天：形成自己的修复句式。"], "watch_out": "修复不是全盘认错，也不是要求对方立刻原谅。"},
-      "en": {"title": "Repair After Conflict", "why_this_matters": "Repair after conflict determines whether collaboration can continue.", "do_today": "Choose one small conflict and send one repair check.", "script": "My tone got sharp earlier; I want to restate the main point clearly.", "seven_day_plan": ["Day 1: identify one unfinished conflict.", "Day 2: write your responsibility.", "Day 3: write what may matter to the other person.", "Day 4: send one confirmation.", "Day 5: discuss only the next step.", "Day 6: review repair effect.", "Day 7: build your repair sentence."], "watch_out": "Repair is not total blame-taking or demanding immediate forgiveness."}
+      "zh-CN": {
+        "title": "冲突后修复",
+        "why_this_matters": "当冲突后不知道如何重新开始时使用。",
+        "do_today": "今天准备一句影响确认。",
+        "script": "刚才我的表达可能让你感觉被否定了，我想重新说一次。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "回忆一个小误解。"
+          },
+          {
+            "day": 2,
+            "practice": "写下你的意图和对方可能感受到的影响。"
+          },
+          {
+            "day": 3,
+            "practice": "练一句影响确认。"
+          },
+          {
+            "day": 4,
+            "practice": "补一句你的真实意图。"
+          },
+          {
+            "day": 5,
+            "practice": "提出一个具体修复动作。"
+          },
+          {
+            "day": 6,
+            "practice": "在安全关系中尝试一次。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘对方是否更愿意继续对话。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当冲突后不知道如何重新开始时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Repair after conflict",
+        "why_this_matters": "Use when you do not know how to restart after conflict.",
+        "do_today": "Prepare one impact-checking sentence today.",
+        "script": "My wording may have felt dismissive. I want to try saying it again.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you do not know how to restart after conflict.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "express_without_escalation": {
-      "zh-CN": {"title": "不升级表达处方", "why_this_matters": "清楚表达需要让对方听得进去。", "do_today": "用我感到、我需要、我建议三句表达一次需求。", "script": "我感到有点被打断，我需要先说完，之后我也会听你的看法。", "seven_day_plan": ["第 1 天：写一句我感到。", "第 2 天：写一句我需要。", "第 3 天：写一句我建议。", "第 4 天：合并三句。", "第 5 天：降低指责词。", "第 6 天：加入共同目标。", "第 7 天：在低风险场景练习。"], "watch_out": "不要用永远、总是这类绝对词。"},
-      "en": {"title": "Express Without Escalation", "why_this_matters": "Clear expression needs to be hearable.", "do_today": "Use I feel, I need, I suggest to express one need.", "script": "I feel a bit interrupted. I need to finish this point, and then I will listen to your view.", "seven_day_plan": ["Day 1: write one I feel sentence.", "Day 2: write one I need sentence.", "Day 3: write one I suggest sentence.", "Day 4: combine the three.", "Day 5: reduce blaming words.", "Day 6: add a shared goal.", "Day 7: practice in a low-risk context."], "watch_out": "Avoid absolute words like always or never."}
+      "zh-CN": {
+        "title": "表达但不升级",
+        "why_this_matters": "当你很清楚自己的立场，但容易说得太硬时使用。",
+        "do_today": "今天把一个强表达改成“事实 + 感受 + 请求”。",
+        "script": "当这个决定突然改变时，我有点措手不及。我想先确认接下来怎么协作。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "写出一句原本想直接说的话。"
+          },
+          {
+            "day": 2,
+            "practice": "删掉评价词，只留事实。"
+          },
+          {
+            "day": 3,
+            "practice": "加上一个真实感受。"
+          },
+          {
+            "day": 4,
+            "practice": "加上一个可回应请求。"
+          },
+          {
+            "day": 5,
+            "practice": "读出来，检查语气。"
+          },
+          {
+            "day": 6,
+            "practice": "找一个低风险场景使用。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘它是否降低了防御。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你很清楚自己的立场，但容易说得太硬时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Express without escalation",
+        "why_this_matters": "Use when your position is clear but may land too sharply.",
+        "do_today": "Turn one strong statement into fact + feeling + request.",
+        "script": "When this decision changed suddenly, I felt caught off guard. I want to clarify how we work together next.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when your position is clear but may land too sharply.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "support_without_rescuing": {
-      "zh-CN": {"title": "支持但不拯救处方", "why_this_matters": "有效支持帮助对方恢复主体性，而不是替对方解决所有问题。", "do_today": "下次支持别人时，只问一个下一步问题。", "script": "我能陪你想，但这个决定需要你自己做。", "seven_day_plan": ["第 1 天：识别一次想替别人解决的冲动。", "第 2 天：只提供倾听。", "第 3 天：只问一个问题。", "第 4 天：明确你能做的部分。", "第 5 天：明确你不能做的部分。", "第 6 天：支持后恢复。", "第 7 天：复盘对方是否更有主体性。"], "watch_out": "不要把对方的不舒服全部变成你的责任。"},
-      "en": {"title": "Support Without Rescuing", "why_this_matters": "Effective support restores agency instead of solving everything for the other person.", "do_today": "Next time you support someone, ask only one next-step question.", "script": "I can think with you, but this decision needs to be yours.", "seven_day_plan": ["Day 1: notice one urge to solve for someone.", "Day 2: only listen.", "Day 3: ask only one question.", "Day 4: clarify what you can do.", "Day 5: clarify what you cannot do.", "Day 6: recover after support.", "Day 7: review whether their agency increased."], "watch_out": "Do not make all of their discomfort your responsibility."}
+      "zh-CN": {
+        "title": "支持但不拯救",
+        "why_this_matters": "当你想帮人解决一切时使用。",
+        "do_today": "今天先问对方需要倾听、建议还是行动帮助。",
+        "script": "你现在更需要我听你说，还是一起想一个下一步？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一次想立刻解决的冲动。"
+          },
+          {
+            "day": 2,
+            "practice": "暂停并问支持方式。"
+          },
+          {
+            "day": 3,
+            "practice": "只给一个帮助选项。"
+          },
+          {
+            "day": 4,
+            "practice": "避免替对方做决定。"
+          },
+          {
+            "day": 5,
+            "practice": "结束前确认对方自己的下一步。"
+          },
+          {
+            "day": 6,
+            "practice": "记录你的承担感变化。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘支持和接管的差别。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你想帮人解决一切时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Support without rescuing",
+        "why_this_matters": "Use when you feel pulled to solve everything for someone.",
+        "do_today": "Ask whether the person wants listening, advice, or practical help.",
+        "script": "Do you want me to listen, or would it help to think through one next step?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you feel pulled to solve everything for someone.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "cold_to_warm_response": {
-      "zh-CN": {"title": "从冷静到有温度处方", "why_this_matters": "稳定需要被他人感受到，才会变成关系中的安全感。", "do_today": "在给建议前先确认对方感受。", "script": "我能理解这件事让你不舒服，我们再一起看怎么处理。", "seven_day_plan": ["第 1 天：练一句情绪确认。", "第 2 天：先确认再建议。", "第 3 天：观察对方反应。", "第 4 天：减少过快解释。", "第 5 天：加入一句感谢。", "第 6 天：复盘一次低温回应。", "第 7 天：固定一个温暖开场。"], "watch_out": "温暖不是放弃理性。"},
-      "en": {"title": "Cold to Warm Response", "why_this_matters": "Stability becomes relational safety only when others can feel it.", "do_today": "Acknowledge the feeling before giving advice.", "script": "I can see this was uncomfortable for you; let's look at what to do next.", "seven_day_plan": ["Day 1: practice one emotional acknowledgment.", "Day 2: acknowledge before advising.", "Day 3: observe their response.", "Day 4: reduce fast explanation.", "Day 5: add one appreciation.", "Day 6: review one low-warmth response.", "Day 7: fix one warm opening."], "watch_out": "Warmth does not mean giving up rationality."}
+      "zh-CN": {
+        "title": "从冷静到有温度",
+        "why_this_matters": "当你能解决问题但别人感觉没被回应时使用。",
+        "do_today": "今天在给方案前先回应一句感受。",
+        "script": "我能理解这让你很挫败。我们可以一起看下一步怎么处理。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "听到问题后先不急着给方案。"
+          },
+          {
+            "day": 2,
+            "practice": "说出你听见的情绪。"
+          },
+          {
+            "day": 3,
+            "practice": "确认对方是否认可。"
+          },
+          {
+            "day": 4,
+            "practice": "再提出一个具体下一步。"
+          },
+          {
+            "day": 5,
+            "practice": "观察对方反应是否软化。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘你是否少讲了道理。"
+          },
+          {
+            "day": 7,
+            "practice": "保留一个适合你的温度句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你能解决问题但别人感觉没被回应时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "From calm to warm response",
+        "why_this_matters": "Use when you can solve the issue but others do not feel emotionally met.",
+        "do_today": "Before offering a solution, acknowledge one feeling.",
+        "script": "I can see how frustrating this is. We can look at the next step together.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you can solve the issue but others do not feel emotionally met.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "relationship_energy_management": {
-      "zh-CN": {"title": "关系能量管理处方", "why_this_matters": "关系投入需要节奏，否则优势会变成消耗。", "do_today": "给一个高消耗互动安排恢复窗口。", "script": "我现在可以聊二十分钟，之后需要休息一下。", "seven_day_plan": ["第 1 天：列出高消耗互动。", "第 2 天：标出恢复方式。", "第 3 天：设置时间边界。", "第 4 天：减少即时回复。", "第 5 天：安排独处窗口。", "第 6 天：复盘能量变化。", "第 7 天：保留一个固定恢复段。"], "watch_out": "不要等到耗尽才开始恢复。"},
-      "en": {"title": "Relationship Energy Management", "why_this_matters": "Relational investment needs rhythm; otherwise strength becomes drain.", "do_today": "Schedule recovery after one high-cost interaction.", "script": "I can talk for twenty minutes now, and then I need a break.", "seven_day_plan": ["Day 1: list high-cost interactions.", "Day 2: mark recovery methods.", "Day 3: set a time boundary.", "Day 4: reduce instant replies.", "Day 5: schedule solo time.", "Day 6: review energy changes.", "Day 7: keep one fixed recovery block."], "watch_out": "Do not wait until depletion to recover."}
+      "zh-CN": {
+        "title": "关系能量管理",
+        "why_this_matters": "当你在多人关系或强情绪场景后感到累时使用。",
+        "do_today": "今天给一段高互动之后安排十分钟低输入时间。",
+        "script": "我需要一点时间整理刚才的信息，之后我会回来回应。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "标记今天最耗能的一次互动。"
+          },
+          {
+            "day": 2,
+            "practice": "记录耗能来自人、情绪还是切换。"
+          },
+          {
+            "day": 3,
+            "practice": "安排十分钟低输入恢复。"
+          },
+          {
+            "day": 4,
+            "practice": "减少一个不必要回应。"
+          },
+          {
+            "day": 5,
+            "practice": "练习结束对话的句子。"
+          },
+          {
+            "day": 6,
+            "practice": "观察恢复前后差异。"
+          },
+          {
+            "day": 7,
+            "practice": "设定下周一个关系能量边界。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你在多人关系或强情绪场景后感到累时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Relationship energy management",
+        "why_this_matters": "Use when you feel drained after relationally intense situations.",
+        "do_today": "Schedule ten minutes of low input after one high-interaction moment.",
+        "script": "I need a little time to process what just happened, and I will come back to it.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you feel drained after relationally intense situations.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "conflict_deescalation": {
-      "zh-CN": {"title": "冲突降温处方", "why_this_matters": "降温不是退让，而是让问题重新可谈。", "do_today": "下一次分歧时，只说共同目标和下一步。", "script": "我们先别扩大问题，我想先确认下一步怎么做。", "seven_day_plan": ["第 1 天：识别升级词。", "第 2 天：练习降温句。", "第 3 天：暂停十分钟。", "第 4 天：只谈一个问题。", "第 5 天：确认共同目标。", "第 6 天：复盘冲突过程。", "第 7 天：写下自己的降温协议。"], "watch_out": "降温不等于压下真实问题。"},
-      "en": {"title": "Conflict De-escalation", "why_this_matters": "De-escalation is not surrender; it makes the issue discussable again.", "do_today": "In the next disagreement, state only the shared goal and next step.", "script": "Let's not expand the issue. I want to confirm the next step first.", "seven_day_plan": ["Day 1: identify escalation words.", "Day 2: practice a cooling sentence.", "Day 3: pause ten minutes.", "Day 4: discuss one issue only.", "Day 5: confirm shared goal.", "Day 6: review the conflict process.", "Day 7: write your de-escalation protocol."], "watch_out": "Cooling down does not mean suppressing the real issue."}
+      "zh-CN": {
+        "title": "冲突降温",
+        "why_this_matters": "当对话开始升级时使用。",
+        "do_today": "今天练习把争执缩小到一个具体问题。",
+        "script": "我们先只谈一个点：现在最需要决定的是什么？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一个容易升级的话题。"
+          },
+          {
+            "day": 2,
+            "practice": "写出双方各自想保护什么。"
+          },
+          {
+            "day": 3,
+            "practice": "准备一句缩小问题的话。"
+          },
+          {
+            "day": 4,
+            "practice": "练习放慢语速。"
+          },
+          {
+            "day": 5,
+            "practice": "在对话中只问一个澄清问题。"
+          },
+          {
+            "day": 6,
+            "practice": "结束后复盘是否降温。"
+          },
+          {
+            "day": 7,
+            "practice": "保存一个下次可用的降温句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当对话开始升级时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Conflict de-escalation",
+        "why_this_matters": "Use when a conversation starts escalating.",
+        "do_today": "Practice narrowing a disagreement to one concrete issue.",
+        "script": "Let’s focus on one point: what needs to be decided right now?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when a conversation starts escalating.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "self_connection": {
-      "zh-CN": {"title": "自我连接处方", "why_this_matters": "关系顺畅不能替代对自己需求的确认。", "do_today": "答应别人前先写下我愿意和我不愿意。", "script": "我想先确认一下自己的安排，晚点回复你。", "seven_day_plan": ["第 1 天：记录一个自己的需求。", "第 2 天：记录一个不愿意。", "第 3 天：延迟答应。", "第 4 天：练习一个小拒绝。", "第 5 天：复盘拒绝后的关系。", "第 6 天：写下可接受条件。", "第 7 天：总结自己的边界句。"], "watch_out": "不要把照顾自己理解成破坏关系。"},
-      "en": {"title": "Self-Connection", "why_this_matters": "A smooth relationship cannot replace checking your own needs.", "do_today": "Before agreeing, write what you are willing and not willing to do.", "script": "I want to check my own schedule first and reply later.", "seven_day_plan": ["Day 1: record one personal need.", "Day 2: record one not-willing item.", "Day 3: delay agreement.", "Day 4: practice a small no.", "Day 5: review the relationship after saying no.", "Day 6: write acceptable conditions.", "Day 7: summarize your boundary sentence."], "watch_out": "Do not treat caring for yourself as damaging the relationship."}
+      "zh-CN": {
+        "title": "重新连接自己",
+        "why_this_matters": "当你总先照顾关系而忽略自己时使用。",
+        "do_today": "今天在答应前先问自己：我是真愿意，还是怕关系变差？",
+        "script": "我想先想一下我真实能承担到哪里，再回复你。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录一次你想立刻答应的场景。"
+          },
+          {
+            "day": 2,
+            "practice": "写下真实愿意和勉强愿意的差别。"
+          },
+          {
+            "day": 3,
+            "practice": "练习延迟回应。"
+          },
+          {
+            "day": 4,
+            "practice": "说出一个较小的可承担范围。"
+          },
+          {
+            "day": 5,
+            "practice": "观察关系是否真的受损。"
+          },
+          {
+            "day": 6,
+            "practice": "记录一个被你忽略的感受。"
+          },
+          {
+            "day": 7,
+            "practice": "设定一个下周的自我连接问题。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你总先照顾关系而忽略自己时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Reconnect with self",
+        "why_this_matters": "Use when you care for the relationship before checking yourself.",
+        "do_today": "Before agreeing today, ask: am I willing, or am I afraid the relationship will change?",
+        "script": "I want to check what I can realistically take on before I answer.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you care for the relationship before checking yourself.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "retest_reflection": {
-      "zh-CN": {"title": "复测与低风险反思处方", "why_this_matters": "低置信度结果不适合强解释，更适合作为复测提醒。", "do_today": "只记录一个你认可的线索，不做稳定结论。", "script": "这次结果我先当作提醒，等状态稳定后再复测。", "seven_day_plan": ["第 1 天：记录作答时状态。", "第 2 天：检查是否太快或太累。", "第 3 天：观察一个真实场景。", "第 4 天：不做标签化解释。", "第 5 天：选择复测时间。", "第 6 天：保证安静环境。", "第 7 天：重新完成测试。"], "watch_out": "不要用低置信度结果做重大决定。"},
-      "en": {"title": "Retest and Low-Risk Reflection", "why_this_matters": "Low-confidence results should not drive strong interpretation; they are better used as a retest cue.", "do_today": "Record only one cue that feels useful; do not form a stable conclusion.", "script": "I will treat this result as a reminder and retake when I am more settled.", "seven_day_plan": ["Day 1: record your state during response.", "Day 2: check if you were too fast or tired.", "Day 3: observe one real situation.", "Day 4: avoid labeling yourself.", "Day 5: choose a retest time.", "Day 6: ensure a quiet setting.", "Day 7: complete the test again."], "watch_out": "Do not use a low-confidence result for major decisions."}
+      "zh-CN": {
+        "title": "复测前观察",
+        "why_this_matters": "当本次结果置信度较低时使用。",
+        "do_today": "今天不要急着定性，先记录作答时的状态。",
+        "script": "这次结果我先轻一点看，等状态更稳定时再复测。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录作答时间和状态。"
+          },
+          {
+            "day": 2,
+            "practice": "写下是否太快、太累或太分心。"
+          },
+          {
+            "day": 3,
+            "practice": "挑三个最不确定的题目类型。"
+          },
+          {
+            "day": 4,
+            "practice": "观察一天真实情绪场景。"
+          },
+          {
+            "day": 5,
+            "practice": "不要做重大解释。"
+          },
+          {
+            "day": 6,
+            "practice": "选择一个更稳定的复测时间。"
+          },
+          {
+            "day": 7,
+            "practice": "复测后比较哪些部分稳定。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当本次结果置信度较低时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Reflection before retest",
+        "why_this_matters": "Use when this result has lower interpretation confidence.",
+        "do_today": "Do not label yourself today; first record the response context.",
+        "script": "I will read this result lightly and retest when my context is steadier.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when this result has lower interpretation confidence.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     }
   }
 }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/agent_dialogue_playbooks.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/agent_dialogue_playbooks.json
@@ -1,0 +1,206 @@
+{
+  "schema": "eq60.report_assets.agent_dialogue_playbooks.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.agent.playbook.understand_result": {
+      "zh-CN": {
+        "title": "理解我的结果",
+        "response_policy": "先引用用户 formulation，再问一个现实场景。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Understand my result",
+        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.understand_result",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "understand_result"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "understand_result"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.scene_advice": {
+      "zh-CN": {
+        "title": "某个场景怎么办",
+        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "What should I do in this situation?",
+        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.scene_advice",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "scene_advice"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "scene_advice"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.career_environment": {
+      "zh-CN": {
+        "title": "我适合什么工作环境",
+        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "What work environment fits me?",
+        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.career_environment",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "career_environment"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "career_environment"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.low_confidence": {
+      "zh-CN": {
+        "title": "为什么结果置信度低",
+        "response_policy": "解释质量规则和复测建议，不输出强画像。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Why is confidence low?",
+        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.low_confidence",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "low_confidence"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "low_confidence"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.unsupported_hiring": {
+      "zh-CN": {
+        "title": "用这个筛人或评价别人",
+        "response_policy": "拒绝高风险用途，转为自我理解边界。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Use this to screen someone",
+        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.unsupported_hiring",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "unsupported_hiring"
+        },
+        "claim_sensitivity": "high",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "unsupported_hiring"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/backend_integration_contract.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/backend_integration_contract.json
@@ -1,0 +1,121 @@
+{
+  "schema": "eq60.report_assets.backend_integration_contract.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.backend_contract.schema_mapping": {
+      "zh-CN": {
+        "title": "Schema 映射",
+        "requirement": "将每个资产文件映射到后端 content-pack compiler 可识别的字段。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Map every asset file into backend content-pack compiler fields before production",
+        "requirement": "Map every asset file into backend content-pack compiler fields before production.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.schema_mapping",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "schema_mapping"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.canonical_fixtures": {
+      "zh-CN": {
+        "title": "Canonical fixtures",
+        "requirement": "为 balanced、high_empathy_low_recovery、low_confidence 三条路径生成 zh-CN / en canonical fixtures。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths",
+        "requirement": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.canonical_fixtures",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "canonical_fixtures"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.contract_tests": {
+      "zh-CN": {
+        "title": "契约测试",
+        "requirement": "断言 report payload 包含 v1.6 assets、免费转化动作、无权限门槛，且 SJT 保持 unavailable。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Assert report payload contains v1",
+        "requirement": "Assert report payload contains v1.6 assets, conversion actions, no access wall, and SJT unavailable.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.contract_tests",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "contract_tests"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.frontend_consumption": {
+      "zh-CN": {
+        "title": "前端消费契约",
+        "requirement": "前端必须渲染后端 resolved assets，不得硬编码正式报告解释文案。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Frontend must render resolved assets and must not hardcode official report explanation",
+        "requirement": "Frontend must render resolved assets and must not hardcode official report explanation.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.frontend_consumption",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "frontend_consumption"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.agent_readiness": {
+      "zh-CN": {
+        "title": "Agent 就绪契约",
+        "requirement": "Agent 在检索、拒答和边界评测通过前，只能解释已解析报告资产。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Agent can only explain resolved assets until retrieval and refusal evals pass",
+        "requirement": "Agent can only explain resolved assets until retrieval and refusal evals pass.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.agent_readiness",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "agent_readiness"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/career_environment.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/career_environment.json
@@ -4,86 +4,662 @@
   "variables": {
     "interpersonal_density": {
       "low": {
-        "zh-CN": {"label": "低人际密度", "meaning": "多数时间独立推进，互动频率较低。", "fit_signal": "适合需要恢复空间或深度专注的人。", "strain_signal": "可能减少练习关系动作的机会。", "what_to_verify": "确认岗位是否真的允许长时间独立工作。"},
-        "en": {"label": "Low Interpersonal Density", "meaning": "Most work is independent with fewer interactions.", "fit_signal": "Can fit people who need recovery space or deep focus.", "strain_signal": "May reduce practice opportunities for relational action.", "what_to_verify": "Check whether the role truly allows long independent work blocks."}
+        "zh-CN": {
+          "label": "人际密度：低",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: low",
+          "meaning": "How many people you interact with, and how often. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等人际密度", "meaning": "日常有固定协作，但不是持续社交。", "fit_signal": "适合在协作和独立之间切换。", "strain_signal": "会议过多时仍会消耗。", "what_to_verify": "确认每周会议、同步和跨团队协作频率。"},
-        "en": {"label": "Medium Interpersonal Density", "meaning": "Regular collaboration without constant social demand.", "fit_signal": "Fits switching between collaboration and independent work.", "strain_signal": "Too many meetings can still drain.", "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."}
+        "zh-CN": {
+          "label": "人际密度：中",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: medium",
+          "meaning": "How many people you interact with, and how often. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高人际密度", "meaning": "大量沟通、协调和即时互动。", "fit_signal": "可发挥共情、协作和关系管理优势。", "strain_signal": "恢复不足时容易情绪过载。", "what_to_verify": "确认是否有可控的独处和恢复窗口。"},
-        "en": {"label": "High Interpersonal Density", "meaning": "Frequent communication, coordination, and real-time interaction.", "fit_signal": "Can use empathy, collaboration, and relationship-management strengths.", "strain_signal": "Weak recovery can lead to overload.", "what_to_verify": "Check whether protected solo recovery windows exist."}
+        "zh-CN": {
+          "label": "人际密度：高",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: high",
+          "meaning": "How many people you interact with, and how often. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "emotional_labor": {
       "low": {
-        "zh-CN": {"label": "低情绪劳动", "meaning": "较少承接他人情绪或安抚关系。", "fit_signal": "适合需要降低情绪消耗的人。", "strain_signal": "可能缺少运用共情优势的空间。", "what_to_verify": "确认用户、客户或团队情绪压力是否较低。"},
-        "en": {"label": "Low Emotional Labor", "meaning": "Less need to hold or soothe others' emotions.", "fit_signal": "Fits people who need lower emotional load.", "strain_signal": "May offer less space to use empathy strengths.", "what_to_verify": "Check whether user, client, or team emotional pressure is actually low."}
+        "zh-CN": {
+          "label": "情绪劳动：低",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: low",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等情绪劳动", "meaning": "需要一定理解和安抚，但通常有边界。", "fit_signal": "适合练习共情与边界并存。", "strain_signal": "边界不清时会累积消耗。", "what_to_verify": "确认是否有升级、转介或交接机制。"},
-        "en": {"label": "Medium Emotional Labor", "meaning": "Some understanding and soothing are needed, usually with boundaries.", "fit_signal": "Fits practicing empathy with boundaries.", "strain_signal": "Unclear boundaries accumulate cost.", "what_to_verify": "Check whether escalation, referral, or handoff mechanisms exist."}
+        "zh-CN": {
+          "label": "情绪劳动：中",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: medium",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高情绪劳动", "meaning": "经常承接焦虑、投诉、冲突或脆弱情绪。", "fit_signal": "高共情者能建立信任。", "strain_signal": "低恢复者容易被情绪场拖走。", "what_to_verify": "确认督导、复盘和休息制度是否真实存在。"},
-        "en": {"label": "High Emotional Labor", "meaning": "Frequent exposure to anxiety, complaints, conflict, or vulnerability.", "fit_signal": "High-empathy people can build trust.", "strain_signal": "Low recovery can make the emotional field pull you in.", "what_to_verify": "Check whether supervision, review, and rest systems are real."}
+        "zh-CN": {
+          "label": "情绪劳动：高",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: high",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "conflict_frequency": {
       "low": {
-        "zh-CN": {"label": "低冲突频率", "meaning": "较少谈判、投诉或强分歧。", "fit_signal": "降低情绪调节压力。", "strain_signal": "可能较少训练冲突修复。", "what_to_verify": "确认冲突是否只是被隐藏到异步沟通中。"},
-        "en": {"label": "Low Conflict Frequency", "meaning": "Fewer negotiations, complaints, or strong disagreements.", "fit_signal": "Reduces regulation pressure.", "strain_signal": "May offer less practice in conflict repair.", "what_to_verify": "Check whether conflict is merely hidden in async communication."}
+        "zh-CN": {
+          "label": "冲突频率：低",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: low",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等冲突频率", "meaning": "有周期性分歧，但通常有流程。", "fit_signal": "适合练习稳定沟通。", "strain_signal": "流程不清时会放大关系压力。", "what_to_verify": "确认冲突如何升级、记录和收口。"},
-        "en": {"label": "Medium Conflict Frequency", "meaning": "Periodic disagreement with some process.", "fit_signal": "Good for practicing steady communication.", "strain_signal": "Unclear process amplifies relational pressure.", "what_to_verify": "Check how conflict is escalated, recorded, and closed."}
+        "zh-CN": {
+          "label": "冲突频率：中",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: medium",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高冲突频率", "meaning": "经常面对投诉、博弈、谈判或利益冲突。", "fit_signal": "高调节和高关系管理者可发挥优势。", "strain_signal": "ER 或 RM 低时消耗显著。", "what_to_verify": "确认是否有明确授权、边界和复盘支持。"},
-        "en": {"label": "High Conflict Frequency", "meaning": "Frequent complaints, negotiation, bargaining, or interest conflict.", "fit_signal": "High ER and RM can become strengths.", "strain_signal": "Low ER or RM is costly here.", "what_to_verify": "Check whether authority, boundaries, and review support are clear."}
+        "zh-CN": {
+          "label": "冲突频率：高",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: high",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "feedback_intensity": {
       "low": {
-        "zh-CN": {"label": "低反馈强度", "meaning": "评价和修改频率较低。", "fit_signal": "适合对评价敏感且需要稳定节奏的人。", "strain_signal": "成长反馈可能不足。", "what_to_verify": "确认是否仍有清晰目标和周期复盘。"},
-        "en": {"label": "Low Feedback Intensity", "meaning": "Evaluation and revision are less frequent.", "fit_signal": "Fits people sensitive to evaluation who need a steadier rhythm.", "strain_signal": "Growth feedback may be insufficient.", "what_to_verify": "Check whether clear goals and periodic review still exist."}
+        "zh-CN": {
+          "label": "反馈强度：低",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: low",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等反馈强度", "meaning": "定期复盘、修改和评价。", "fit_signal": "适合把反馈转成学习。", "strain_signal": "恢复不足时可能反复回想。", "what_to_verify": "确认反馈是否具体、可执行、不过度公开。"},
-        "en": {"label": "Medium Feedback Intensity", "meaning": "Regular review, revision, and evaluation.", "fit_signal": "Fits turning feedback into learning.", "strain_signal": "Weak recovery may lead to replaying feedback.", "what_to_verify": "Check whether feedback is specific, actionable, and not overly public."}
+        "zh-CN": {
+          "label": "反馈强度：中",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: medium",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高反馈强度", "meaning": "频繁被评价、迭代或公开比较。", "fit_signal": "高觉察和高调节者可快速迭代。", "strain_signal": "低调节者容易把反馈体验成否定。", "what_to_verify": "确认是否有安全反馈文化和恢复空间。"},
-        "en": {"label": "High Feedback Intensity", "meaning": "Frequent evaluation, iteration, or public comparison.", "fit_signal": "High SA and ER can support fast iteration.", "strain_signal": "Low ER may make feedback feel like rejection.", "what_to_verify": "Check for a safe feedback culture and recovery space."}
+        "zh-CN": {
+          "label": "反馈强度：高",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: high",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "autonomy_recovery": {
       "low": {
-        "zh-CN": {"label": "低自主恢复空间", "meaning": "节奏常被外部打断，难以独处恢复。", "fit_signal": "适合恢复需求低且即时响应强的人。", "strain_signal": "高共情低恢复者风险较高。", "what_to_verify": "确认是否允许暂停、调班或离线恢复。"},
-        "en": {"label": "Low Autonomy Recovery", "meaning": "Rhythm is often interrupted, with little solo recovery.", "fit_signal": "Fits people with low recovery needs and strong real-time response.", "strain_signal": "High empathy with low recovery is risky here.", "what_to_verify": "Check whether pauses, shift changes, or offline recovery are allowed."}
+        "zh-CN": {
+          "label": "自主恢复空间：低",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: low",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等自主恢复空间", "meaning": "有一定独立安排，但仍受团队节奏影响。", "fit_signal": "适合多数人维持稳定表现。", "strain_signal": "忙季或危机期可能被压缩。", "what_to_verify": "确认高峰期的恢复安排。"},
-        "en": {"label": "Medium Autonomy Recovery", "meaning": "Some independent rhythm exists, though team rhythm still matters.", "fit_signal": "Helps most people sustain performance.", "strain_signal": "Busy or crisis periods may compress it.", "what_to_verify": "Check recovery arrangements during peak periods."}
+        "zh-CN": {
+          "label": "自主恢复空间：中",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: medium",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高自主恢复空间", "meaning": "可以较多控制节奏、沟通窗口和深度工作时间。", "fit_signal": "有利于敏感、深度复盘或高恢复需求者。", "strain_signal": "也可能带来孤立或反馈不足。", "what_to_verify": "确认独立性不会变成缺少支持。"},
-        "en": {"label": "High Autonomy Recovery", "meaning": "More control over rhythm, communication windows, and deep-work time.", "fit_signal": "Helpful for sensitive, reflective, or high-recovery-need people.", "strain_signal": "Can also create isolation or insufficient feedback.", "what_to_verify": "Check that autonomy does not mean lack of support."}
+        "zh-CN": {
+          "label": "自主恢复空间：高",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: high",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "collaboration_complexity": {
       "low": {
-        "zh-CN": {"label": "低协作复杂度", "meaning": "角色、接口和责任较清楚。", "fit_signal": "降低关系误解和协调成本。", "strain_signal": "可能较少发挥复杂协调优势。", "what_to_verify": "确认职责是否稳定且边界清楚。"},
-        "en": {"label": "Low Collaboration Complexity", "meaning": "Roles, interfaces, and responsibilities are clear.", "fit_signal": "Lowers misunderstanding and coordination cost.", "strain_signal": "May offer less space for complex coordination strengths.", "what_to_verify": "Check whether responsibilities are stable and boundaries clear."}
+        "zh-CN": {
+          "label": "协作复杂度：低",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: low",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等协作复杂度", "meaning": "需要跨角色协作，但仍有明确流程。", "fit_signal": "适合练习关系管理和反馈沟通。", "strain_signal": "流程缺失时容易消耗。", "what_to_verify": "确认决策权、优先级和冲突处理方式。"},
-        "en": {"label": "Medium Collaboration Complexity", "meaning": "Cross-role collaboration is needed with some clear process.", "fit_signal": "Good for practicing relationship management and feedback communication.", "strain_signal": "Missing process can be draining.", "what_to_verify": "Check decision rights, priorities, and conflict-handling process."}
+        "zh-CN": {
+          "label": "协作复杂度：中",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: medium",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高协作复杂度", "meaning": "多方目标、利益和节奏需要持续协调。", "fit_signal": "高 RM 与稳定 ER 能发挥明显优势。", "strain_signal": "边界不清时容易长期过载。", "what_to_verify": "确认是否有正式协调机制和优先级裁决。"},
-        "en": {"label": "High Collaboration Complexity", "meaning": "Multiple goals, interests, and rhythms require ongoing coordination.", "fit_signal": "High RM and stable ER can become clear strengths.", "strain_signal": "Unclear boundaries can cause chronic overload.", "what_to_verify": "Check formal coordination mechanisms and priority arbitration."}
+        "zh-CN": {
+          "label": "协作复杂度：高",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: high",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/commercial_conversion_assets.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/commercial_conversion_assets.json
@@ -1,0 +1,181 @@
+{
+  "schema": "eq60.report_assets.commercial_conversion_assets.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.conversion.save_report": {
+      "zh-CN": {
+        "title": "保存报告",
+        "body": "把这次核心模式、行动处方和复测入口留住。",
+        "cta_label": "保存报告",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Save your report",
+        "body": "Keep your pattern, action prescription, and retest path in one place.",
+        "cta_label": "Save report",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.save_report",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "save_report"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.email_revisit": {
+      "zh-CN": {
+        "title": "邮件回看",
+        "body": "把报告发送给自己，适合之后复盘或继续和 Agent 对话。",
+        "cta_label": "发送到邮箱",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Email revisit",
+        "body": "Send the report to yourself so you can revisit it or continue with the Agent later.",
+        "cta_label": "Email me",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.email_revisit",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "email_revisit"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.pdf_export": {
+      "zh-CN": {
+        "title": "PDF 报告",
+        "body": "生成可保存版本，适合个人复盘，不建议用于招聘或评估他人。",
+        "cta_label": "生成 PDF",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "PDF report",
+        "body": "Create a saved copy for personal reflection, not for hiring or evaluating another person.",
+        "cta_label": "Create PDF",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.pdf_export",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "pdf_export"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.share_card": {
+      "zh-CN": {
+        "title": "分享卡",
+        "body": "只分享模式句，不分享详细分数和敏感解释。",
+        "cta_label": "生成分享卡",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Share card",
+        "body": "Share the pattern sentence, not detailed scores or sensitive interpretation.",
+        "cta_label": "Create share card",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.share_card",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "share_card"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.retest_reminder": {
+      "zh-CN": {
+        "title": "复测提醒",
+        "body": "4–8 周后重新查看模式是否稳定，低置信结果可更早复测。",
+        "cta_label": "设置复测提醒",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Retest reminder",
+        "body": "Check whether the pattern is stable after 4–8 weeks; low-confidence results can be retested sooner.",
+        "cta_label": "Set reminder",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.retest_reminder",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "retest_reminder"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.related_tests": {
+      "zh-CN": {
+        "title": "相关测试",
+        "body": "用 Big Five、RIASEC、MBTI 作为补充视角，不把 EQ 当成唯一结论。",
+        "cta_label": "继续探索",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Related tests",
+        "body": "Use Big Five, RIASEC, or MBTI as complementary lenses, not as replacements for EQ.",
+        "cta_label": "Explore related tests",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.related_tests",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "related_tests"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.agent_entry": {
+      "zh-CN": {
+        "title": "问问 Agent",
+        "body": "带着一个真实场景提问，例如反馈、冲突、边界或压力恢复。",
+        "cta_label": "问 Agent",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Ask the Agent",
+        "body": "Ask about one real scene, such as feedback, conflict, boundaries, or recovery.",
+        "cta_label": "Ask the Agent",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.agent_entry",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "agent_entry"
+        },
+        "claim_sensitivity": "low"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/core_formulations.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/core_formulations.json
@@ -5,221 +5,321 @@
     "balanced_integrated": {
       "zh-CN": {
         "title": "均衡整合型",
-        "one_liner": "你的情绪与关系信号比较均衡，优势在于稳定和可迁移。",
-        "core_claim": "你通常能同时看见自己、理解他人，并在多数情境中维持可用的回应方式。",
-        "evidence_basis": ["四维分数相对均衡", "无明显单一短板"],
-        "primary_strength": "稳定性和多场景适应能力。",
-        "likely_cost": "容易低估特定高压情境对自己的消耗。",
-        "development_lever": "选择一个真实场景做精细化复盘，而不是泛泛提升。",
-        "do_not_overread": "这不代表你在任何情境中都不会被触发。"
+        "one_liner": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "hero_summary": "你能同时照顾自己的状态、他人的感受和关系目标。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+        "development_lever": "把“我来稳住”改成“我们一起定规则”。",
+        "user_memory_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Balanced Integration",
-        "one_liner": "Your emotional and relational signals are relatively balanced; stability is the main strength.",
-        "core_claim": "You usually notice yourself, understand others, and maintain usable responses across many contexts.",
-        "evidence_basis": ["Four dimensions are relatively balanced", "No single severe gap stands out"],
-        "primary_strength": "Stability and transfer across contexts.",
-        "likely_cost": "You may underestimate how specific high-pressure contexts drain you.",
-        "development_lever": "Choose one real situation for precise review rather than trying to improve everything.",
-        "do_not_overread": "This does not mean you will never be triggered."
+        "title": "Balanced Integrator",
+        "one_liner": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "hero_summary": "You can hold your own state, other people, and the relationship goal in view at the same time. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can keep emotion, relationship, and task in the same frame.",
+        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+        "development_lever": "Move from “I will steady this” to “we need a shared rule.”",
+        "user_memory_sentence": "I can steady a relationship without maintaining the whole system alone.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "high_empathy_low_recovery": {
       "zh-CN": {
         "title": "高共情，低恢复",
-        "one_liner": "你容易理解他人感受，但恢复和边界是当前杠杆。",
-        "core_claim": "你可能很快接住别人的情绪，却不一定能及时把对方状态和自己的状态分开。",
-        "evidence_basis": ["EM 明显高于 ER", "共情信号强于恢复信号"],
-        "primary_strength": "对他人状态敏感，容易建立信任。",
-        "likely_cost": "在冲突、求助或高情绪劳动场景中容易被卷入。",
-        "development_lever": "共情之后建立边界和恢复动作。",
-        "do_not_overread": "发展方向不是减少共情，而是让共情更有边界。"
+        "one_liner": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "hero_summary": "你很快读到别人的状态，但恢复系统常常追不上共情速度。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+        "development_lever": "练习“理解但不接管”，让共情后面跟着边界。",
+        "user_memory_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "High Empathy, Low Recovery",
-        "one_liner": "You tend to understand others quickly, while recovery and boundaries are the current lever.",
-        "core_claim": "You may absorb other people's emotions quickly without separating their state from your own soon enough.",
-        "evidence_basis": ["EM is meaningfully higher than ER", "Empathy signal is stronger than recovery signal"],
-        "primary_strength": "Sensitivity to others and trust building.",
-        "likely_cost": "Conflict, support, and high emotional-labor settings may pull you in too deeply.",
-        "development_lever": "Build boundaries and recovery after empathy.",
-        "do_not_overread": "The goal is not less empathy; it is empathy with clearer boundaries."
+        "title": "High Empathy, Slow Recovery",
+        "one_liner": "You read the room quickly, but recovery can lag behind empathy.",
+        "hero_summary": "You read the room quickly, but recovery can lag behind empathy. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You read the room quickly, but recovery can lag behind empathy.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can make people feel understood, especially when emotions run high.",
+        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+        "development_lever": "Practice understanding without taking over, so empathy is followed by boundary.",
+        "user_memory_sentence": "I can understand someone without carrying the whole emotional load.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "aware_but_unregulated": {
       "zh-CN": {
-        "title": "高觉察，调节不足",
-        "one_liner": "你能知道自己怎么了，但不一定能很快恢复。",
-        "core_claim": "你可能很快觉察到被触发，却需要更稳定的暂停、命名和复位动作。",
-        "evidence_basis": ["SA 高于 ER", "自我识别强于调节行动"],
-        "primary_strength": "能捕捉自己的情绪变化。",
-        "likely_cost": "知道问题但仍被情绪带着走。",
-        "development_lever": "把觉察转成具体调节步骤。",
-        "do_not_overread": "觉察本身不是问题，问题在于缺少后续动作。"
+        "title": "有觉察，调节不足",
+        "one_liner": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "hero_summary": "你常知道自己怎么了，但把自己带回来需要更长时间。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能清楚识别触发点、感受和需要。",
+        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+        "development_lever": "把觉察压缩成一个暂停动作，而不是继续解释。",
+        "user_memory_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Aware but Under-Regulated",
-        "one_liner": "You may know what is happening inside, but recovery may lag.",
-        "core_claim": "You may notice triggers quickly and still need steadier pause, labeling, and reset actions.",
-        "evidence_basis": ["SA is higher than ER", "Self-recognition is stronger than regulation action"],
-        "primary_strength": "You can catch emotional shifts in yourself.",
-        "likely_cost": "You may know the issue while still being carried by the emotion.",
-        "development_lever": "Turn awareness into concrete regulation steps.",
-        "do_not_overread": "Awareness is not the problem; the missing step is what follows."
+        "title": "Aware, Still Reactive",
+        "one_liner": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "hero_summary": "You often know what is happening inside, but the reset button is slower than the insight. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+        "development_lever": "Turn awareness into one pause action instead of another layer of explanation.",
+        "user_memory_sentence": "I know what is happening; the next skill is bringing myself back.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "calm_but_distant": {
       "zh-CN": {
-        "title": "冷静稳定，但回应偏远",
-        "one_liner": "你较能维持稳定，但可能不够读懂或回应他人情绪。",
-        "core_claim": "你在压力下可能保持冷静，但关系中的温度和回应需要更多主动性。",
-        "evidence_basis": ["ER 高于 EM", "稳定信号强于共情信号"],
-        "primary_strength": "不容易被情绪场带乱。",
-        "likely_cost": "他人可能感到你不够理解或靠近。",
-        "development_lever": "在稳定之外增加情绪确认。",
-        "do_not_overread": "冷静不等于冷漠，但需要被他人感受到。"
+        "title": "冷静稳定，但距离感强",
+        "one_liner": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "hero_summary": "你能稳住事情，但别人不一定感到被情绪上接住。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+        "development_lever": "先回应一句感受，再给建议或方案。",
+        "user_memory_sentence": "我能稳住事情，也要让人感到被看见。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Calm but Distant",
-        "one_liner": "You may stay steady while reading or responding to others less actively.",
-        "core_claim": "You may remain calm under pressure, but warmth and relational response need more intentional action.",
-        "evidence_basis": ["ER is higher than EM", "Stability signal is stronger than empathy signal"],
-        "primary_strength": "You are less likely to be disrupted by the emotional field.",
-        "likely_cost": "Others may feel less understood or less met.",
-        "development_lever": "Add emotional acknowledgment to stability.",
-        "do_not_overread": "Calm is not coldness, but it needs to be felt by others."
+        "title": "Steady, Less Attuned",
+        "one_liner": "You can steady the situation, but people may not always feel emotionally met.",
+        "hero_summary": "You can steady the situation, but people may not always feel emotionally met. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You can steady the situation, but people may not always feel emotionally met.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+        "development_lever": "Acknowledge one feeling before offering advice or a solution.",
+        "user_memory_sentence": "I can steady the situation and still help people feel seen.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "relationship_first_self_later": {
       "zh-CN": {
         "title": "关系优先，自我后置",
-        "one_liner": "你能维护关系，但可能晚一步看见自己的真实感受。",
-        "core_claim": "你倾向先让关系顺畅，再处理自己的边界、需求和消耗。",
-        "evidence_basis": ["RM 高于 SA", "关系行动强于自我连接"],
-        "primary_strength": "能维持合作和关系稳定。",
-        "likely_cost": "长期忽略自己的感受和界限。",
-        "development_lever": "在回应别人前先确认自己的底线。",
-        "do_not_overread": "重视关系不是问题，自我后置过久才是风险。"
+        "one_liner": "你会先保护关系，再回头找自己的真实立场。",
+        "hero_summary": "你会先保护关系，再回头找自己的真实立场。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你会先保护关系，再回头找自己的真实立场。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+        "development_lever": "在照顾关系前，先给自己的感受一个位置。",
+        "user_memory_sentence": "关系重要，我的感受也需要在场。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Relationship First, Self Later",
-        "one_liner": "You can maintain relationships, but may notice your own feelings too late.",
-        "core_claim": "You tend to keep the relationship smooth before checking your own boundaries, needs, and cost.",
-        "evidence_basis": ["RM is higher than SA", "Relational action is stronger than self-connection"],
-        "primary_strength": "You can preserve cooperation and relational stability.",
-        "likely_cost": "You may overlook your feelings and limits over time.",
-        "development_lever": "Check your bottom line before responding to others.",
-        "do_not_overread": "Valuing relationships is not the issue; staying self-later for too long is the risk."
+        "one_liner": "You protect the relationship first and find your own position later.",
+        "hero_summary": "You protect the relationship first and find your own position later. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You protect the relationship first and find your own position later.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are sensitive to relational tone and often keep interaction workable.",
+        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+        "development_lever": "Give your own feeling a place before you manage the relationship.",
+        "user_memory_sentence": "The relationship matters, and my own state belongs in the room too.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "self_clear_repair_weak": {
       "zh-CN": {
         "title": "自我清楚，修复不足",
-        "one_liner": "你知道自己的感受，但关系修复动作需要更清晰。",
-        "core_claim": "你可能能表达立场，却不一定能把表达转成可继续合作的关系动作。",
-        "evidence_basis": ["SA 高于 RM", "自我清楚强于关系修复"],
-        "primary_strength": "有清楚的自我感受和判断。",
-        "likely_cost": "表达后关系可能停在紧张或防御状态。",
-        "development_lever": "把表达、确认和修复连成一组动作。",
-        "do_not_overread": "清楚表达不是攻击，关键是加上修复。"
+        "one_liner": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "hero_summary": "你知道自己的立场，但冲突后的修复需要更明确的工具。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你不容易在关系压力里丢掉自己的判断。",
+        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+        "development_lever": "把“我说清楚了”补成“我们怎么重新对齐”。",
+        "user_memory_sentence": "我可以清楚表达，也可以把关系重新接上。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Self-Clear, Repair Weaker",
-        "one_liner": "You may know your feelings while needing clearer relational repair moves.",
-        "core_claim": "You may state your position without always turning it into actions that keep collaboration possible.",
-        "evidence_basis": ["SA is higher than RM", "Self-clarity is stronger than repair"],
-        "primary_strength": "Clear self-feeling and judgment.",
-        "likely_cost": "After expression, the relationship may remain tense or defensive.",
-        "development_lever": "Connect expression, acknowledgment, and repair as one sequence.",
-        "do_not_overread": "Clear expression is not attack; the key is adding repair."
+        "title": "Clear Self, Repair Gap",
+        "one_liner": "You know your position, but repair after tension needs a clearer tool.",
+        "hero_summary": "You know your position, but repair after tension needs a clearer tool. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You know your position, but repair after tension needs a clearer tool.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are less likely to lose your judgment under relational pressure.",
+        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+        "development_lever": "Add “how do we realign?” after “I made my point.”",
+        "user_memory_sentence": "I can be clear and still reconnect the relationship.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "steady_collaborator": {
       "zh-CN": {
         "title": "稳定协作型",
-        "one_liner": "你在压力下较能维持合作和修复。",
-        "core_claim": "你通常能在情绪波动中保持可沟通，并把关系拉回可协作状态。",
-        "evidence_basis": ["ER 与 RM 都较高", "压力恢复和关系行动同向"],
-        "primary_strength": "压力下仍能保持建设性。",
-        "likely_cost": "可能承担过多协调责任。",
-        "development_lever": "区分需要你修复的事和不该由你承担的事。",
-        "do_not_overread": "稳定协作不意味着你必须负责所有人的情绪。"
+        "one_liner": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "hero_summary": "你能在压力下维持合作推进，但别让稳定只靠你一个人。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能把紧张对话拉回事实、目标和下一步。",
+        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+        "development_lever": "把个人稳定能力变成团队流程。",
+        "user_memory_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Steady Collaborator",
-        "one_liner": "You tend to maintain collaboration and repair under pressure.",
-        "core_claim": "You can often stay communicative during emotional shifts and bring the relationship back to workable ground.",
-        "evidence_basis": ["ER and RM are both relatively high", "Recovery and relational action move together"],
-        "primary_strength": "Constructive response under pressure.",
-        "likely_cost": "You may take on too much coordination responsibility.",
-        "development_lever": "Separate what is yours to repair from what is not yours to carry.",
-        "do_not_overread": "Being steady does not make you responsible for everyone else's emotions."
+        "one_liner": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "hero_summary": "You keep collaboration moving under pressure, but steadiness should not depend only on you. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+        "development_lever": "Turn personal steadiness into team process.",
+        "user_memory_sentence": "I can help collaboration, but the rules cannot live only in me.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "sensitive_absorber": {
       "zh-CN": {
         "title": "高敏感，易吸收",
-        "one_liner": "你很能感知自己和他人，但也更容易被情绪环境影响。",
-        "core_claim": "你可能同时捕捉自己的细微信号和他人情绪，因此需要更强的区分与恢复。",
-        "evidence_basis": ["SA 与 EM 较高", "ER 相对较低"],
-        "primary_strength": "情绪线索捕捉能力强。",
-        "likely_cost": "容易过度加工或吸收环境情绪。",
-        "development_lever": "区分我的感受、他人的感受和现场压力。",
-        "do_not_overread": "敏感不是脆弱，它需要更好的过滤系统。"
+        "one_liner": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "hero_summary": "你能捕捉细微变化，但敏感也容易变成情绪负重。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你很快发现气氛、语气和关系位置的变化。",
+        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+        "development_lever": "把“我感到了”区分成“我要不要回应”。",
+        "user_memory_sentence": "我能感到很多东西，但不需要回应所有东西。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Sensitive Absorber",
-        "one_liner": "You notice yourself and others strongly, and may be more affected by the emotional field.",
-        "core_claim": "You may catch subtle self-signals and other people's emotions at the same time, requiring stronger separation and recovery.",
-        "evidence_basis": ["SA and EM are relatively high", "ER is relatively lower"],
-        "primary_strength": "Strong emotional cue detection.",
-        "likely_cost": "You may over-process or absorb environmental emotion.",
-        "development_lever": "Separate my feeling, their feeling, and situational pressure.",
-        "do_not_overread": "Sensitivity is not weakness; it needs a better filtering system."
+        "one_liner": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "hero_summary": "You catch subtle shifts fast, and that sensitivity can become emotional load. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You quickly notice shifts in tone, mood, and relational position.",
+        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+        "development_lever": "Separate “I noticed it” from “I need to respond.”",
+        "user_memory_sentence": "I can feel a lot without responding to everything.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "developing_foundation": {
       "zh-CN": {
         "title": "基础发展中",
-        "one_liner": "多个情绪与关系信号仍在打基础，适合从一个小场景开始练。",
-        "core_claim": "你的结果提示当前不宜追求复杂技巧，先建立命名、暂停和复盘的基础动作更重要。",
-        "evidence_basis": ["多个维度处于基础或发展区间", "没有稳定优势维度足以独立支撑"],
-        "primary_strength": "可塑性强，适合从低风险场景开始。",
-        "likely_cost": "同时处理太多关系任务会增加压力。",
-        "development_lever": "先练一个最小闭环：识别、暂停、选择下一句。",
-        "do_not_overread": "这不是能力定论，而是当前自我报告信号。"
+        "one_liner": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "hero_summary": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+        "development_lever": "先把一个情绪命名清楚，再谈复杂改变。",
+        "user_memory_sentence": "先练一个小动作，就已经是在建立基础。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Developing Foundation",
-        "one_liner": "Several emotional and relational signals are still foundational; start with one small context.",
-        "core_claim": "The result suggests starting with basic labeling, pausing, and review before complex techniques.",
-        "evidence_basis": ["Multiple dimensions are foundational or developing", "No stable strength is strong enough to carry the pattern alone"],
-        "primary_strength": "High room for growth through low-risk practice.",
-        "likely_cost": "Handling too many relational tasks at once can increase pressure.",
-        "development_lever": "Practice one small loop: notice, pause, choose the next sentence.",
-        "do_not_overread": "This is not a fixed ability judgment; it is the current self-report signal."
+        "one_liner": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "hero_summary": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+        "development_lever": "Name one feeling clearly before attempting a larger change.",
+        "user_memory_sentence": "One small practice is already foundation-building.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "low_confidence_result": {
       "zh-CN": {
-        "title": "本次结果置信度不足",
-        "one_liner": "本次作答质量信号降低了解释置信度，建议先谨慎阅读。",
-        "core_claim": "系统检测到会影响解释稳定性的作答模式，因此不应输出强人格判断。",
-        "evidence_basis": ["质量等级为 C 或 D", "存在速度、长串、极端、中立或不一致信号"],
-        "primary_strength": "仍可作为反思线索。",
-        "likely_cost": "具体维度和画像容易被误读。",
-        "development_lever": "在状态稳定时复测，或只使用低风险建议。",
-        "do_not_overread": "不要把这次结果作为稳定结论。"
+        "title": "本次结果置信度较低",
+        "one_liner": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "hero_summary": "这次结果应轻一点读，最有价值的是理解本次作答状态。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+        "development_lever": "先记录状态，之后在更稳定的时间复测。",
+        "user_memory_sentence": "这次结果不是不能看，而是要轻一点看。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Lower Confidence Result",
-        "one_liner": "Response-quality signals reduce interpretation confidence; read this result cautiously.",
-        "core_claim": "The system detected response patterns that can reduce interpretive stability, so strong personality claims should not be made.",
-        "evidence_basis": ["Quality level is C or D", "Speed, long-string, extreme, neutral, or inconsistency signals are present"],
-        "primary_strength": "It can still serve as a reflection cue.",
-        "likely_cost": "Specific dimensions and patterns may be overread.",
-        "development_lever": "Retake when stable, or use only low-risk suggestions.",
-        "do_not_overread": "Do not treat this result as a stable conclusion."
+        "title": "Lower-Confidence Result",
+        "one_liner": "Read this result lightly; the most useful signal is the response context of this session.",
+        "hero_summary": "Read this result lightly; the most useful signal is the response context of this session. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "Read this result lightly; the most useful signal is the response context of this session.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "development_lever": "Record the context first, then retest when conditions are steadier.",
+        "user_memory_sentence": "This result is not useless; it simply needs a lighter reading.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/mechanism_map.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/mechanism_map.json
@@ -1,415 +1,500 @@
 {
   "schema": "eq60.report_assets.mechanism_map.v1",
   "pack_id": "EQ_60",
-  "states": ["high_high", "high_low", "low_high", "low_low"],
+  "states": [
+    "high_high",
+    "high_low",
+    "low_high",
+    "low_low"
+  ],
   "pairs": {
     "SA_ER": {
       "high_high": {
         "zh-CN": {
-          "title": "知道自己，也能复位",
-          "why_it_matters": "自我觉察只有接上调节动作，才会变成现实中的稳定回应。",
-          "what_it_feels_like": "你通常能说清自己怎么了，并较快找到下一步。",
-          "strength": "减少反复内耗，把情绪信息转成行动。",
-          "cost": "可能过度依赖自我控制，忽略休息需求。",
-          "development_lever": "让复位动作更轻量。",
-          "micro_action": "用一句话命名情绪，再决定下一句怎么说。"
+          "title": "自我觉察 × 情绪调节｜双高协同",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You notice yourself and can reset",
-          "why_it_matters": "Self-awareness becomes real-world stability only when it connects to regulation.",
-          "what_it_feels_like": "You can usually name what is happening and find the next step.",
-          "strength": "Less rumination; more action from emotional information.",
-          "cost": "You may over-rely on self-control and miss rest needs.",
-          "development_lever": "Make reset actions lighter.",
-          "micro_action": "Name the emotion in one sentence, then choose the next sentence."
+          "title": "Self-awareness × Emotion regulation: both signals support each other",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "知道自己，但恢复跟不上",
-          "why_it_matters": "觉察会放大感受，如果没有调节动作，反而更容易卡住。",
-          "what_it_feels_like": "你知道自己被触发了，但身体和语气不一定跟得上。",
-          "strength": "能早期识别风险信号。",
-          "cost": "容易陷入反复解释或自责。",
-          "development_lever": "把觉察后 30 秒变成固定流程。",
-          "micro_action": "暂停、命名、喝水或离开屏幕 60 秒。"
+          "title": "自我觉察 × 情绪调节｜前者强，后者需要补位",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You notice yourself, but recovery lags",
-          "why_it_matters": "Awareness can intensify feelings when no regulation step follows.",
-          "what_it_feels_like": "You know you are triggered, but your body or tone may not catch up.",
-          "strength": "Early detection of risk signals.",
-          "cost": "You may loop in explanation or self-blame.",
-          "development_lever": "Turn the first 30 seconds after awareness into a routine.",
-          "micro_action": "Pause, label, drink water, or step away from the screen for 60 seconds."
+          "title": "Self-awareness × Emotion regulation: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "能稳定，但不总知道原因",
-          "why_it_matters": "调节有效，但如果不理解触发点，模式会重复出现。",
-          "what_it_feels_like": "你能忍住或恢复，但事后未必知道自己为何被影响。",
-          "strength": "压力下不易失控。",
-          "cost": "复盘不足会让同类问题反复。",
-          "development_lever": "补上事后命名。",
-          "micro_action": "事后写下：刚才我真正介意的是什么。"
+          "title": "自我觉察 × 情绪调节｜后者强，前者需要补位",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You can stabilize without always knowing why",
-          "why_it_matters": "Regulation helps, but without understanding triggers the pattern repeats.",
-          "what_it_feels_like": "You can hold or recover, but may not know what affected you.",
-          "strength": "Less likely to lose control under pressure.",
-          "cost": "Weak review lets similar problems recur.",
-          "development_lever": "Add after-action labeling.",
-          "micro_action": "Afterward, write: what did I actually care about?"
+          "title": "Self-awareness × Emotion regulation: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "识别和恢复都需要打底",
-          "why_it_matters": "如果既难识别也难复位，复杂场景会迅速耗尽资源。",
-          "what_it_feels_like": "你可能到事后才发现自己已经很累或很烦。",
-          "strength": "适合从最小动作建立可预测性。",
-          "cost": "高压沟通中容易被动应对。",
-          "development_lever": "先练一个简单情绪词表。",
-          "micro_action": "每天一次选择一个情绪词，并写下触发场景。"
+          "title": "自我觉察 × 情绪调节｜两项都需要打底",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Both recognition and recovery need foundations",
-          "why_it_matters": "When both noticing and resetting are hard, complex situations drain resources quickly.",
-          "what_it_feels_like": "You may realize only afterward that you were tired or irritated.",
-          "strength": "Small actions can build predictability.",
-          "cost": "High-pressure communication may become reactive.",
-          "development_lever": "Start with a simple emotion vocabulary.",
-          "micro_action": "Once a day, choose one emotion word and write the trigger."
+          "title": "Self-awareness × Emotion regulation: both signals need foundations",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "EM_ER": {
       "high_high": {
         "zh-CN": {
-          "title": "能理解别人，也能保留自己",
-          "why_it_matters": "共情和恢复并存时，理解他人不必以自我消耗为代价。",
-          "what_it_feels_like": "你能靠近他人情绪，也能及时回到自己的节奏。",
-          "strength": "支持他人而不容易被吞没。",
-          "cost": "可能被期待持续承担情绪支持。",
-          "development_lever": "明确支持边界。",
-          "micro_action": "先确认对方需要倾听、建议还是具体帮助。"
+          "title": "共情理解 × 情绪调节｜双高协同",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You understand others and keep yourself",
-          "why_it_matters": "When empathy and recovery coexist, understanding others does not require self-drain.",
-          "what_it_feels_like": "You can approach others' emotions and return to your own rhythm.",
-          "strength": "Support without being swallowed by the situation.",
-          "cost": "Others may expect constant emotional support.",
-          "development_lever": "Make support boundaries explicit.",
-          "micro_action": "Ask whether they need listening, advice, or concrete help."
+          "title": "Empathy × Emotion regulation: both signals support each other",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "共情强，边界和恢复偏弱",
-          "why_it_matters": "你越能理解别人，越需要知道哪些情绪不是你要承担的。",
-          "what_it_feels_like": "别人难受时，你可能很快进入帮助或自责状态。",
-          "strength": "容易让人感到被看见。",
-          "cost": "容易吸收过多情绪劳动。",
-          "development_lever": "共情后加一句边界确认。",
-          "micro_action": "在心里说：这是对方的感受，我可以支持，但不需要代替。"
+          "title": "共情理解 × 情绪调节｜前者强，后者需要补位",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Strong empathy, weaker boundaries and recovery",
-          "why_it_matters": "The more you understand others, the more you need to know what is not yours to carry.",
-          "what_it_feels_like": "When someone is distressed, you may quickly move into helping or self-blame.",
-          "strength": "People often feel seen by you.",
-          "cost": "You may absorb too much emotional labor.",
-          "development_lever": "Add one boundary check after empathy.",
-          "micro_action": "Say internally: this is their feeling; I can support without replacing them."
+          "title": "Empathy × Emotion regulation: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "稳定有余，情绪读人不足",
-          "why_it_matters": "稳定能保护你，但关系需要对他人情绪的基本回应。",
-          "what_it_feels_like": "你能保持冷静，却可能错过对方真正介意的点。",
-          "strength": "不容易被外部情绪带乱。",
-          "cost": "他人可能觉得你太理性或太远。",
-          "development_lever": "先回应感受，再处理事实。",
-          "micro_action": "说一句：我听到这件事让你很不舒服。"
+          "title": "共情理解 × 情绪调节｜后者强，前者需要补位",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Steady, but less emotionally attuned",
-          "why_it_matters": "Stability protects you, but relationships need basic emotional acknowledgment.",
-          "what_it_feels_like": "You stay calm but may miss what the other person really cares about.",
-          "strength": "External emotion disrupts you less.",
-          "cost": "Others may experience you as too rational or distant.",
-          "development_lever": "Respond to feeling before facts.",
-          "micro_action": "Say: I hear that this felt uncomfortable for you."
+          "title": "Empathy × Emotion regulation: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "理解他人与恢复都需降低难度",
-          "why_it_matters": "当共情和恢复都弱时，先降低情境复杂度比追求技巧更有效。",
-          "what_it_feels_like": "强情绪场景可能让你想躲开或快速结束。",
-          "strength": "可从低风险互动开始建立经验。",
-          "cost": "高情绪劳动场景消耗明显。",
-          "development_lever": "用固定句式承接基础情绪。",
-          "micro_action": "先说：我需要一点时间理解你说的。"
+          "title": "共情理解 × 情绪调节｜两项都需要打底",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Lower complexity for empathy and recovery",
-          "why_it_matters": "When both empathy and recovery are weaker, reducing complexity helps more than chasing advanced technique.",
-          "what_it_feels_like": "High-emotion situations may make you want to avoid or end quickly.",
-          "strength": "Low-risk interactions can build experience.",
-          "cost": "High emotional-labor settings are draining.",
-          "development_lever": "Use a stable sentence to receive basic emotion.",
-          "micro_action": "Say: I need a little time to understand what you mean."
+          "title": "Empathy × Emotion regulation: both signals need foundations",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "EM_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "读懂别人，也能处理关系",
-          "why_it_matters": "理解和行动结合时，共情更容易变成有效协作。",
-          "what_it_feels_like": "你能读懂现场气氛，并推动关系回到可沟通状态。",
-          "strength": "适合复杂协作和关系修复。",
-          "cost": "可能过度承担协调者角色。",
-          "development_lever": "把责任边界说清楚。",
-          "micro_action": "问：这件事我能负责哪一部分？"
+          "title": "共情理解 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You read others and manage the relationship",
-          "why_it_matters": "When understanding and action combine, empathy becomes workable collaboration.",
-          "what_it_feels_like": "You can read the room and move the relationship back to communication.",
-          "strength": "Useful for complex collaboration and repair.",
-          "cost": "You may overtake the coordinator role.",
-          "development_lever": "Clarify responsibility boundaries.",
-          "micro_action": "Ask: which part of this is mine to own?"
+          "title": "Empathy × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "读懂别人，但关系动作不足",
-          "why_it_matters": "看见对方感受后，还需要把理解转成一句话或一个动作。",
-          "what_it_feels_like": "你知道对方在意什么，却不一定知道怎么回应。",
-          "strength": "关系判断较细腻。",
-          "cost": "理解停在心里，别人感受不到。",
-          "development_lever": "把理解外化成确认句。",
-          "micro_action": "说：我理解你在意的是 X，而不是只是在反对。"
+          "title": "共情理解 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You read others, but action is weaker",
-          "why_it_matters": "After seeing someone's feeling, understanding needs to become a sentence or action.",
-          "what_it_feels_like": "You know what matters to them but may not know how to respond.",
-          "strength": "Nuanced relational judgment.",
-          "cost": "Understanding stays inside and may not be felt.",
-          "development_lever": "Externalize understanding as confirmation.",
-          "micro_action": "Say: I understand that X matters to you, not just that you disagree."
+          "title": "Empathy × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "会行动，但可能没读准情绪",
-          "why_it_matters": "关系动作如果没有情绪理解，容易变成流程化处理。",
-          "what_it_feels_like": "你会推进解决，但对方可能觉得重点没被接住。",
-          "strength": "能快速进入处理模式。",
-          "cost": "修复动作可能不够贴合。",
-          "development_lever": "行动前先做一次情绪校准。",
-          "micro_action": "问：这件事里你最难受的是哪一部分？"
+          "title": "共情理解 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You act, but may miss the emotion",
-          "why_it_matters": "Relational action without emotional understanding can become procedural.",
-          "what_it_feels_like": "You move into solving while the other person may feel the point was missed.",
-          "strength": "Fast entry into action mode.",
-          "cost": "Repair may not fit the real concern.",
-          "development_lever": "Calibrate emotion before action.",
-          "micro_action": "Ask: which part of this felt hardest for you?"
+          "title": "Empathy × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "关系理解和行动都需要脚手架",
-          "why_it_matters": "复杂关系不能只靠临场反应，需要可复用脚本。",
-          "what_it_feels_like": "你可能不知道对方为何反应强，也不知道下一句怎么说。",
-          "strength": "固定脚本能快速提升可用性。",
-          "cost": "临场压力下容易沉默或回避。",
-          "development_lever": "先学低风险确认句。",
-          "micro_action": "说：我可能没完全理解，你能再说一次你的重点吗？"
+          "title": "共情理解 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Relational understanding and action need scaffolding",
-          "why_it_matters": "Complex relationships need reusable scripts, not only improvisation.",
-          "what_it_feels_like": "You may not know why they reacted strongly or what to say next.",
-          "strength": "Stable scripts can improve usability quickly.",
-          "cost": "Under pressure, silence or avoidance may appear.",
-          "development_lever": "Start with low-risk confirmation lines.",
-          "micro_action": "Say: I may not fully understand; can you restate your main point?"
+          "title": "Empathy × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "SA_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "能表达自己，也能维护关系",
-          "why_it_matters": "自我清楚和关系行动结合时，边界更容易被听见。",
-          "what_it_feels_like": "你能说出自己的感受，同时照顾沟通继续。",
-          "strength": "适合边界、反馈和修复场景。",
-          "cost": "可能被期待承担沟通示范。",
-          "development_lever": "让表达更简洁。",
-          "micro_action": "用我感到、我需要、我建议三句完成表达。"
+          "title": "自我觉察 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You express yourself and maintain the relationship",
-          "why_it_matters": "When self-clarity and relational action combine, boundaries are easier to hear.",
-          "what_it_feels_like": "You can state your feeling while keeping communication possible.",
-          "strength": "Useful in boundaries, feedback, and repair.",
-          "cost": "You may be expected to model communication for others.",
-          "development_lever": "Make expression more concise.",
-          "micro_action": "Use: I feel, I need, I suggest."
+          "title": "Self-awareness × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "自我清楚，但关系承接不足",
-          "why_it_matters": "表达自己之后，需要给关系一个继续对话的入口。",
-          "what_it_feels_like": "你能说清立场，但对方可能进入防御。",
-          "strength": "不容易丢失自我。",
-          "cost": "表达可能被听成指责。",
-          "development_lever": "表达后加一句共同目标。",
-          "micro_action": "说：我讲这个是希望我们下次更好配合。"
+          "title": "自我觉察 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Self-clear, but relational holding is weaker",
-          "why_it_matters": "After expressing yourself, the relationship needs an entry point to continue.",
-          "what_it_feels_like": "You can state your position, but the other person may become defensive.",
-          "strength": "You are less likely to lose yourself.",
-          "cost": "Expression may be heard as blame.",
-          "development_lever": "Add a shared goal after expression.",
-          "micro_action": "Say: I am raising this so we can work better next time."
+          "title": "Self-awareness × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "会维护关系，但自我容易后置",
-          "why_it_matters": "如果只维护关系，不表达自我，长期会积累消耗。",
-          "what_it_feels_like": "你能把场面圆回来，但之后才发现自己不舒服。",
-          "strength": "关系稳定和协作维持能力强。",
-          "cost": "自己的需求容易被延后。",
-          "development_lever": "回应前先问自己底线。",
-          "micro_action": "在答应前停三秒，确认我是否真的可以。"
+          "title": "自我觉察 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You maintain relationships, but self may come later",
-          "why_it_matters": "If you only preserve the relationship and do not express yourself, cost accumulates.",
-          "what_it_feels_like": "You smooth the moment, then later notice discomfort.",
-          "strength": "Strong relational stability and collaboration maintenance.",
-          "cost": "Your needs may be delayed.",
-          "development_lever": "Check your boundary before responding.",
-          "micro_action": "Pause three seconds before agreeing and ask whether you truly can."
+          "title": "Self-awareness × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "自我表达和关系修复都需要练习",
-          "why_it_matters": "当自我和关系动作都弱时，先从低风险表达开始。",
-          "what_it_feels_like": "你可能既不想说破，也不知道怎么收场。",
-          "strength": "可用结构化脚本降低难度。",
-          "cost": "问题容易拖延或变成误会。",
-          "development_lever": "练习一句低强度真实表达。",
-          "micro_action": "说：这件事我还需要想一下，晚点回复你。"
+          "title": "自我觉察 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Self-expression and repair both need practice",
-          "why_it_matters": "When self and relational moves are both weaker, start with low-risk expression.",
-          "what_it_feels_like": "You may not want to say it directly and may not know how to close the loop.",
-          "strength": "Structured scripts can lower difficulty.",
-          "cost": "Issues may be delayed or become misunderstandings.",
-          "development_lever": "Practice one low-intensity truthful sentence.",
-          "micro_action": "Say: I need to think about this and will reply later."
+          "title": "Self-awareness × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "ER_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "压力下仍能沟通和修复",
-          "why_it_matters": "恢复能力和关系行动结合，是冲突后继续合作的关键。",
-          "what_it_feels_like": "你能先稳住自己，再把对话拉回问题本身。",
-          "strength": "冲突恢复和协作韧性强。",
-          "cost": "可能成为默认救火者。",
-          "development_lever": "把修复责任分给双方。",
-          "micro_action": "问：我们各自下一步能做什么？"
+          "title": "情绪调节 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You can communicate and repair under pressure",
-          "why_it_matters": "Recovery plus relational action is key to collaboration after conflict.",
-          "what_it_feels_like": "You can steady yourself and bring the conversation back to the issue.",
-          "strength": "Strong conflict recovery and collaborative resilience.",
-          "cost": "You may become the default fixer.",
-          "development_lever": "Share repair responsibility.",
-          "micro_action": "Ask: what can each of us do next?"
+          "title": "Emotion regulation × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "自己能稳住，但关系未必修复",
-          "why_it_matters": "你恢复了，不代表对话或关系已经恢复。",
-          "what_it_feels_like": "你可能觉得事情过去了，但对方还停在情绪里。",
-          "strength": "能减少个人失控。",
-          "cost": "关系裂缝可能被低估。",
-          "development_lever": "复位后做一次关系确认。",
-          "micro_action": "说：刚才那段对话你现在感觉怎么样？"
+          "title": "情绪调节 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You stabilize yourself, but repair may not happen",
-          "why_it_matters": "Your recovery does not mean the conversation or relationship has recovered.",
-          "what_it_feels_like": "You may feel it has passed while the other person is still in it.",
-          "strength": "Less personal escalation.",
-          "cost": "Relationship cracks may be underestimated.",
-          "development_lever": "Check the relationship after reset.",
-          "micro_action": "Say: how are you feeling about that conversation now?"
+          "title": "Emotion regulation × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "想修复关系，但压力下难稳定",
-          "why_it_matters": "关系意愿很重要，但压力未复位时动作容易变形。",
-          "what_it_feels_like": "你想把事情讲好，却可能越讲越急。",
-          "strength": "有合作和修复动机。",
-          "cost": "调节不足会削弱修复效果。",
-          "development_lever": "先复位，再修复。",
-          "micro_action": "先暂停十分钟，再发出修复信息。"
+          "title": "情绪调节 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You want repair, but pressure makes stability harder",
-          "why_it_matters": "Repair motivation matters, but actions distort when you have not reset.",
-          "what_it_feels_like": "You want to talk it through, but may become more urgent as you speak.",
-          "strength": "Motivation for cooperation and repair.",
-          "cost": "Weak regulation can reduce repair effectiveness.",
-          "development_lever": "Reset before repair.",
-          "micro_action": "Pause for ten minutes before sending the repair message."
+          "title": "Emotion regulation × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "压力和关系修复都需要最小闭环",
-          "why_it_matters": "高压关系场景中，需要简单、可重复的停顿和回到问题的动作。",
-          "what_it_feels_like": "冲突中你可能沉默、爆发或想尽快结束。",
-          "strength": "小流程能显著降低失控概率。",
-          "cost": "没有流程时关系容易积累未修复问题。",
-          "development_lever": "建立冲突暂停协议。",
-          "micro_action": "说：我需要十分钟冷静，然后我们只谈下一步。"
+          "title": "情绪调节 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Pressure and repair need a minimal loop",
-          "why_it_matters": "High-pressure relational situations need simple repeatable pauses and return-to-issue moves.",
-          "what_it_feels_like": "In conflict, you may go silent, escalate, or want to end quickly.",
-          "strength": "A small process can reduce escalation risk.",
-          "cost": "Without a process, unrepaired issues accumulate.",
-          "development_lever": "Create a conflict pause protocol.",
-          "micro_action": "Say: I need ten minutes to cool down, then let's discuss only the next step."
+          "title": "Emotion regulation × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/psychometric_evidence_status.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/psychometric_evidence_status.json
@@ -1,0 +1,195 @@
+{
+  "schema": "eq60.report_assets.psychometric_evidence_status.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.evidence.content_validity": {
+      "zh-CN": {
+        "status": "preliminary",
+        "body": "题项和报告维度已有内容映射，但需要持续专家复核和用户反馈。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "preliminary",
+        "body": "Items and report dimensions have content mapping, with ongoing need for expert review and user feedback.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.content_validity",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "content_validity"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.internal_consistency": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "后续应按语言、地区和维度计算内部一致性，并记录版本。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Future work should estimate internal consistency by language, region, and dimension with version tracking.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.internal_consistency",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "internal_consistency"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.test_retest": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "建议在 30–90 天窗口评估稳定性和可变性。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "A 30–90 day window should be used to evaluate stability and change.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.test_retest",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "test_retest"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.factor_structure": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "需要用 EFA/CFA 或其他合适方法验证四维结构。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "The four-dimension structure should be evaluated with EFA/CFA or suitable methods.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.factor_structure",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "factor_structure"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.criterion_validity": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "可探索与工作满意、关系满意、压力恢复等低风险外部指标的关联。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Associations with low-risk external indicators such as work satisfaction, relationship satisfaction, and recovery may be explored.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.criterion_validity",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "criterion_validity"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.measurement_invariance": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "中英文和主要人群组之间需要做等值或 DIF 检查。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Chinese/English and major user groups require invariance or DIF checks.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.measurement_invariance",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "measurement_invariance"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.norm_status": {
+      "zh-CN": {
+        "status": "provisional",
+        "body": "当前常模解释为阶段性版本，不应被理解为最终全球常模。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "provisional",
+        "body": "Current norms are provisional and should not be read as final global norms.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.norm_status",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "norm_status"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/quality_confidence.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/quality_confidence.json
@@ -1,0 +1,122 @@
+{
+  "schema": "eq60.report_assets.quality_confidence.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.quality.level.A": {
+      "zh-CN": {
+        "label": "高置信",
+        "body": "本次作答节奏和一致性支持较稳定解释。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "可在未来复测观察稳定变化。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "High confidence",
+        "body": "The response pattern supports a relatively stable interpretation.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "Retest later to observe stable change.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.A",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "A"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.quality.level.B": {
+      "zh-CN": {
+        "label": "正常置信",
+        "body": "本次结果可用于阅读主要模式，但仍建议结合现实场景理解。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "可在未来复测观察稳定变化。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Standard confidence",
+        "body": "The result can be used for the main pattern, while still being read with real-life context.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "Retest later to observe stable change.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.B",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "B"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.quality.level.C": {
+      "zh-CN": {
+        "label": "中等置信",
+        "body": "本次结果适合作为初步参考，强结论需要减少。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Moderate confidence",
+        "body": "The result is best treated as a preliminary reference; strong conclusions should be reduced.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.C",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "C"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.quality.level.D": {
+      "zh-CN": {
+        "label": "低置信",
+        "body": "本次结果应轻读，优先看作答状态和复测建议。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Lower confidence",
+        "body": "Read this result lightly; focus on response context and retest guidance.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.D",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "D"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/reality_translation.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/reality_translation.json
@@ -4,98 +4,1608 @@
   "scenes": {
     "feedback": {
       "zh-CN": {
-        "title": "反馈场景",
-        "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。",
-        "strength": "能注意到反馈背后的真实意图和关系温度。",
-        "cost": "如果恢复不足，容易把反馈体验成否定。",
-        "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。"
+        "title": "反馈",
+        "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先问清反馈指向，再决定解释或调整。",
+        "context": "别人指出问题、要求修改或评价你的表现时。",
+        "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
         "title": "Feedback",
-        "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information.",
-        "strength": "You can notice intent and relational temperature behind feedback.",
-        "cost": "When recovery is weak, feedback may feel like rejection.",
-        "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify."
+        "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Clarify the target of the feedback before explaining or changing.",
+        "context": "When someone points out a problem, requests changes, or evaluates your work.",
+        "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "conflict": {
       "zh-CN": {
-        "title": "冲突场景",
-        "typical_response": "出现分歧时，你可能在维护关系和表达自己之间摇摆。",
-        "strength": "有机会同时看见双方需求。",
-        "cost": "如果没有暂停流程，容易过度解释、回避或急于修复。",
-        "better_move": "先确认共同目标，再只讨论一个具体问题。"
+        "title": "冲突",
+        "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先把冲突缩小成一个可处理的问题。",
+        "context": "意见分歧、语气升高或彼此防御时。",
+        "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
         "title": "Conflict",
-        "typical_response": "During disagreement, you may move between preserving the relationship and expressing yourself.",
-        "strength": "You can often see needs on both sides.",
-        "cost": "Without a pause process, you may over-explain, avoid, or rush repair.",
-        "better_move": "Name the shared goal first, then discuss one specific issue."
+        "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Narrow the conflict to one workable issue first.",
+        "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+        "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "relationship_boundary": {
       "zh-CN": {
         "title": "关系边界",
-        "typical_response": "当别人需要你支持时，你可能很快进入理解或承担。",
-        "strength": "容易让对方感到被接住。",
-        "cost": "支持和代替之间的边界可能变模糊。",
-        "better_move": "先问自己：我能支持到哪里，哪一部分仍然属于对方。"
+        "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先承认对方感受，再说明自己的可承接范围。",
+        "context": "别人期待你理解、帮忙、让步或继续承接时。",
+        "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Relationship Boundaries",
-        "typical_response": "When someone needs support, you may quickly move into understanding or taking responsibility.",
-        "strength": "Others may feel received and understood.",
-        "cost": "The line between supporting and replacing can blur.",
-        "better_move": "Ask yourself: how far can I support, and which part remains theirs?"
+        "title": "Relationship boundary",
+        "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+        "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+        "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "team_collaboration": {
       "zh-CN": {
         "title": "团队协作",
-        "typical_response": "在多人协作中，你可能同时追踪任务、关系和现场情绪。",
-        "strength": "能发现协作中的隐性阻力。",
-        "cost": "如果总是主动协调，容易承担过多情绪劳动。",
-        "better_move": "把观察转成具体协作请求，而不是默默补位。"
+        "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "把气氛问题转成角色、节奏和下一步。",
+        "context": "多人协作、目标不清或责任交叉时。",
+        "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Team Collaboration",
-        "typical_response": "In group work, you may track task, relationship, and emotional climate at the same time.",
-        "strength": "You can notice hidden friction in collaboration.",
-        "cost": "If you always coordinate, you may carry too much emotional labor.",
-        "better_move": "Turn observations into concrete collaboration requests instead of silently compensating."
+        "title": "Team collaboration",
+        "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+        "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+        "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "pressure_recovery": {
       "zh-CN": {
         "title": "压力恢复",
-        "typical_response": "高压后你可能仍在脑内回放对话、评价或细节。",
-        "strength": "复盘能力可以帮助你学习模式。",
-        "cost": "没有恢复边界时，复盘会变成反刍。",
-        "better_move": "给复盘设限：只写三个事实、一个感受、一个下次动作。"
+        "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "离开场景后安排一个低输入恢复动作。",
+        "context": "一段高压互动结束后，你需要重新回到自己。",
+        "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Pressure Recovery",
-        "typical_response": "After pressure, you may replay conversations, judgments, or details in your head.",
-        "strength": "Review can help you learn patterns.",
-        "cost": "Without recovery boundaries, review turns into rumination.",
-        "better_move": "Limit review to three facts, one feeling, and one next action."
+        "title": "Pressure recovery",
+        "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "After the scene, schedule one low-input recovery move.",
+        "context": "After a high-pressure interaction, when you need to return to yourself.",
+        "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "career_environment": {
       "zh-CN": {
         "title": "职业环境",
-        "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。",
-        "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
-        "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
-        "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。"
+        "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+        "context": "你判断一个工作环境会滋养你还是消耗你时。",
+        "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Career Environment",
-        "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles.",
-        "strength": "Understanding environmental variables helps you choose a better work rhythm.",
-        "cost": "Job titles alone can hide the conditions that actually drain you.",
-        "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space."
+        "title": "Career environment",
+        "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Verify environment variables instead of deriving a job from EQ.",
+        "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+        "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
+      }
+    }
+  },
+  "formulation_scenes": {
+    "balanced_integrated": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能同时照顾自己的状态、他人的感受和关系目标。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You can hold your own state, other people, and the relationship goal in view at the same time. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能同时照顾自己的状态、他人的感受和关系目标。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You can hold your own state, other people, and the relationship goal in view at the same time. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。 你需要把理解和可承接范围分开。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能把情绪、关系和任务放在同一个画面里思考。 但如果规则不清，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can keep emotion, relationship, and task in the same frame. But when rules are unclear, others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我来稳住”改成“我们一起定规则”。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, move from “i will steady this” to “we need a shared rule.”",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "high_empathy_low_recovery": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你很快读到别人的状态，但恢复系统常常追不上共情速度。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You read the room quickly, but recovery can lag behind empathy. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你很快读到别人的状态，但恢复系统常常追不上共情速度。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You read the room quickly, but recovery can lag behind empathy. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能把别人的压力带回自己身上，离开场景后还在消化。 你需要把理解和可承接范围分开。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may carry other people’s pressure with you long after the moment ends. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你容易让别人感到被理解，尤其在情绪强烈的时刻。 但如果规则不清，你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can make people feel understood, especially when emotions run high. But when rules are unclear, you may carry other people’s pressure with you long after the moment ends.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，练习“理解但不接管”，让共情后面跟着边界。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, practice understanding without taking over, so empathy is followed by boundary.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "aware_but_unregulated": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你常知道自己怎么了，但把自己带回来需要更长时间。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You often know what is happening inside, but the reset button is slower than the insight. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你常知道自己怎么了，但把自己带回来需要更长时间。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You often know what is happening inside, but the reset button is slower than the insight. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，越清楚自己被触发，越可能陷入反复分析或即时反应。 你需要把理解和可承接范围分开。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, The clearer the trigger feels, the easier it can be to over-analyze or react too soon. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能清楚识别触发点、感受和需要。 但如果规则不清，越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can identify triggers, feelings, and needs with unusual clarity. But when rules are unclear, the clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把觉察压缩成一个暂停动作，而不是继续解释。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn awareness into one pause action instead of another layer of explanation.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "calm_but_distant": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能稳住事情，但别人不一定感到被情绪上接住。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You can steady the situation, but people may not always feel emotionally met. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能稳住事情，但别人不一定感到被情绪上接住。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You can steady the situation, but people may not always feel emotionally met. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，关系里的人可能觉得你有答案，但没有真正回应他们。 你需要把理解和可承接范围分开。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, People may feel that you have answers without feeling that you have responded to them. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你不容易被情绪推着走，能保留判断和节奏。 但如果规则不清，关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are less likely to be pushed around by emotion and can keep judgment and pace. But when rules are unclear, people may feel that you have answers without feeling that you have responded to them.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先回应一句感受，再给建议或方案。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, acknowledge one feeling before offering advice or a solution.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "relationship_first_self_later": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你会先保护关系，再回头找自己的真实立场。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You protect the relationship first and find your own position later. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你会先保护关系，再回头找自己的真实立场。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You protect the relationship first and find your own position later. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能很晚才意识到自己其实不愿意、不同意或已经累了。 你需要把理解和可承接范围分开。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may notice too late that you disagreed, felt unwilling, or were already depleted. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你敏感于关系气氛，愿意让互动维持可进行。 但如果规则不清，你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are sensitive to relational tone and often keep interaction workable. But when rules are unclear, you may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，在照顾关系前，先给自己的感受一个位置。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, give your own feeling a place before you manage the relationship.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "self_clear_repair_weak": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你知道自己的立场，但冲突后的修复需要更明确的工具。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You know your position, but repair after tension needs a clearer tool. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你知道自己的立场，但冲突后的修复需要更明确的工具。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You know your position, but repair after tension needs a clearer tool. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。 你需要把理解和可承接范围分开。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Without repair, others may remember the force of the moment more than your point. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你不容易在关系压力里丢掉自己的判断。 但如果规则不清，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are less likely to lose your judgment under relational pressure. But when rules are unclear, without repair, others may remember the force of the moment more than your point.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我说清楚了”补成“我们怎么重新对齐”。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, add “how do we realign?” after “i made my point.”",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "steady_collaborator": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能在压力下维持合作推进，但别让稳定只靠你一个人。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You keep collaboration moving under pressure, but steadiness should not depend only on you. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能在压力下维持合作推进，但别让稳定只靠你一个人。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You keep collaboration moving under pressure, but steadiness should not depend only on you. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，团队可能习惯让你来降温、翻译和收尾。 你需要把理解和可承接范围分开。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Teams may get used to you cooling things down, translating tension, and closing loops. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能把紧张对话拉回事实、目标和下一步。 但如果规则不清，团队可能习惯让你来降温、翻译和收尾。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can bring tense conversations back to facts, goals, and next steps. But when rules are unclear, teams may get used to you cooling things down, translating tension, and closing loops.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把个人稳定能力变成团队流程。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn personal steadiness into team process.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "sensitive_absorber": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能捕捉细微变化，但敏感也容易变成情绪负重。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You catch subtle shifts fast, and that sensitivity can become emotional load. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能捕捉细微变化，但敏感也容易变成情绪负重。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You catch subtle shifts fast, and that sensitivity can become emotional load. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能回应了太多信号，最后分不清哪些真的需要你处理。 你需要把理解和可承接范围分开。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may respond to too many signals and lose track of which ones actually need your action. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你很快发现气氛、语气和关系位置的变化。 但如果规则不清，你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You quickly notice shifts in tone, mood, and relational position. But when rules are unclear, you may respond to too many signals and lose track of which ones actually need your action.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我感到了”区分成“我要不要回应”。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, separate “i noticed it” from “i need to respond.”",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "developing_foundation": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果一次想改太多，容易很快放弃或自我否定。 你需要把理解和可承接范围分开。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Trying to change everything at once can lead to quick discouragement or self-criticism. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你已经开始把情绪和关系当成可以观察、可以练习的对象。 但如果规则不清，如果一次想改太多，容易很快放弃或自我否定。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are beginning to treat emotion and relationships as observable and trainable. But when rules are unclear, trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先把一个情绪命名清楚，再谈复杂改变。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, name one feeling clearly before attempting a larger change.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "low_confidence_result": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/result_snapshot.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/result_snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schema": "eq60.report_assets.result_snapshot.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.snapshot.balanced_integrated": {
+      "zh-CN": {
+        "headline": "均衡整合型",
+        "core_judgment": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能同时照顾自己的状态、他人的感受和关系目标。",
+          "你能把情绪、关系和任务放在同一个画面里思考。",
+          "下一步：把“我来稳住”改成“我们一起定规则”。"
+        ],
+        "top_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+        "minimal_action": "把“我来稳住”改成“我们一起定规则”。",
+        "share_safe_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Balanced Integrator",
+        "core_judgment": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You can hold your own state, other people, and the relationship goal in view at the same time.",
+          "You can keep emotion, relationship, and task in the same frame.",
+          "Next move: Move from “I will steady this” to “we need a shared rule.”"
+        ],
+        "top_strength": "You can keep emotion, relationship, and task in the same frame.",
+        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+        "minimal_action": "Move from “I will steady this” to “we need a shared rule.”",
+        "share_safe_sentence": "I can steady a relationship without maintaining the whole system alone.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.balanced_integrated",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "balanced_integrated"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.high_empathy_low_recovery": {
+      "zh-CN": {
+        "headline": "高共情，低恢复",
+        "core_judgment": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+          "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "下一步：练习“理解但不接管”，让共情后面跟着边界。"
+        ],
+        "top_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+        "minimal_action": "练习“理解但不接管”，让共情后面跟着边界。",
+        "share_safe_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "High Empathy, Slow Recovery",
+        "core_judgment": "You read the room quickly, but recovery can lag behind empathy.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You read the room quickly, but recovery can lag behind empathy.",
+          "You can make people feel understood, especially when emotions run high.",
+          "Next move: Practice understanding without taking over, so empathy is followed by boundary."
+        ],
+        "top_strength": "You can make people feel understood, especially when emotions run high.",
+        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+        "minimal_action": "Practice understanding without taking over, so empathy is followed by boundary.",
+        "share_safe_sentence": "I can understand someone without carrying the whole emotional load.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.high_empathy_low_recovery",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "high_empathy_low_recovery"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.aware_but_unregulated": {
+      "zh-CN": {
+        "headline": "有觉察，调节不足",
+        "core_judgment": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你常知道自己怎么了，但把自己带回来需要更长时间。",
+          "你能清楚识别触发点、感受和需要。",
+          "下一步：把觉察压缩成一个暂停动作，而不是继续解释。"
+        ],
+        "top_strength": "你能清楚识别触发点、感受和需要。",
+        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+        "minimal_action": "把觉察压缩成一个暂停动作，而不是继续解释。",
+        "share_safe_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Aware, Still Reactive",
+        "core_judgment": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You often know what is happening inside, but the reset button is slower than the insight.",
+          "You can identify triggers, feelings, and needs with unusual clarity.",
+          "Next move: Turn awareness into one pause action instead of another layer of explanation."
+        ],
+        "top_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+        "minimal_action": "Turn awareness into one pause action instead of another layer of explanation.",
+        "share_safe_sentence": "I know what is happening; the next skill is bringing myself back.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.aware_but_unregulated",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "aware_but_unregulated"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.calm_but_distant": {
+      "zh-CN": {
+        "headline": "冷静稳定，但距离感强",
+        "core_judgment": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能稳住事情，但别人不一定感到被情绪上接住。",
+          "你不容易被情绪推着走，能保留判断和节奏。",
+          "下一步：先回应一句感受，再给建议或方案。"
+        ],
+        "top_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+        "minimal_action": "先回应一句感受，再给建议或方案。",
+        "share_safe_sentence": "我能稳住事情，也要让人感到被看见。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Steady, Less Attuned",
+        "core_judgment": "You can steady the situation, but people may not always feel emotionally met.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You can steady the situation, but people may not always feel emotionally met.",
+          "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "Next move: Acknowledge one feeling before offering advice or a solution."
+        ],
+        "top_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+        "minimal_action": "Acknowledge one feeling before offering advice or a solution.",
+        "share_safe_sentence": "I can steady the situation and still help people feel seen.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.calm_but_distant",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "calm_but_distant"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.relationship_first_self_later": {
+      "zh-CN": {
+        "headline": "关系优先，自我后置",
+        "core_judgment": "你会先保护关系，再回头找自己的真实立场。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你会先保护关系，再回头找自己的真实立场。",
+          "你敏感于关系气氛，愿意让互动维持可进行。",
+          "下一步：在照顾关系前，先给自己的感受一个位置。"
+        ],
+        "top_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+        "minimal_action": "在照顾关系前，先给自己的感受一个位置。",
+        "share_safe_sentence": "关系重要，我的感受也需要在场。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Relationship First, Self Later",
+        "core_judgment": "You protect the relationship first and find your own position later.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You protect the relationship first and find your own position later.",
+          "You are sensitive to relational tone and often keep interaction workable.",
+          "Next move: Give your own feeling a place before you manage the relationship."
+        ],
+        "top_strength": "You are sensitive to relational tone and often keep interaction workable.",
+        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+        "minimal_action": "Give your own feeling a place before you manage the relationship.",
+        "share_safe_sentence": "The relationship matters, and my own state belongs in the room too.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.relationship_first_self_later",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "relationship_first_self_later"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.self_clear_repair_weak": {
+      "zh-CN": {
+        "headline": "自我清楚，修复不足",
+        "core_judgment": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+          "你不容易在关系压力里丢掉自己的判断。",
+          "下一步：把“我说清楚了”补成“我们怎么重新对齐”。"
+        ],
+        "top_strength": "你不容易在关系压力里丢掉自己的判断。",
+        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+        "minimal_action": "把“我说清楚了”补成“我们怎么重新对齐”。",
+        "share_safe_sentence": "我可以清楚表达，也可以把关系重新接上。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Clear Self, Repair Gap",
+        "core_judgment": "You know your position, but repair after tension needs a clearer tool.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You know your position, but repair after tension needs a clearer tool.",
+          "You are less likely to lose your judgment under relational pressure.",
+          "Next move: Add “how do we realign?” after “I made my point.”"
+        ],
+        "top_strength": "You are less likely to lose your judgment under relational pressure.",
+        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+        "minimal_action": "Add “how do we realign?” after “I made my point.”",
+        "share_safe_sentence": "I can be clear and still reconnect the relationship.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.self_clear_repair_weak",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "self_clear_repair_weak"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.steady_collaborator": {
+      "zh-CN": {
+        "headline": "稳定协作型",
+        "core_judgment": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+          "你能把紧张对话拉回事实、目标和下一步。",
+          "下一步：把个人稳定能力变成团队流程。"
+        ],
+        "top_strength": "你能把紧张对话拉回事实、目标和下一步。",
+        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+        "minimal_action": "把个人稳定能力变成团队流程。",
+        "share_safe_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Steady Collaborator",
+        "core_judgment": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+          "You can bring tense conversations back to facts, goals, and next steps.",
+          "Next move: Turn personal steadiness into team process."
+        ],
+        "top_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+        "minimal_action": "Turn personal steadiness into team process.",
+        "share_safe_sentence": "I can help collaboration, but the rules cannot live only in me.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.steady_collaborator",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "steady_collaborator"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.sensitive_absorber": {
+      "zh-CN": {
+        "headline": "高敏感，易吸收",
+        "core_judgment": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+          "你很快发现气氛、语气和关系位置的变化。",
+          "下一步：把“我感到了”区分成“我要不要回应”。"
+        ],
+        "top_strength": "你很快发现气氛、语气和关系位置的变化。",
+        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+        "minimal_action": "把“我感到了”区分成“我要不要回应”。",
+        "share_safe_sentence": "我能感到很多东西，但不需要回应所有东西。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Sensitive Absorber",
+        "core_judgment": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+          "You quickly notice shifts in tone, mood, and relational position.",
+          "Next move: Separate “I noticed it” from “I need to respond.”"
+        ],
+        "top_strength": "You quickly notice shifts in tone, mood, and relational position.",
+        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+        "minimal_action": "Separate “I noticed it” from “I need to respond.”",
+        "share_safe_sentence": "I can feel a lot without responding to everything.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.sensitive_absorber",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "sensitive_absorber"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.developing_foundation": {
+      "zh-CN": {
+        "headline": "基础发展中",
+        "core_judgment": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+          "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "下一步：先把一个情绪命名清楚，再谈复杂改变。"
+        ],
+        "top_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+        "minimal_action": "先把一个情绪命名清楚，再谈复杂改变。",
+        "share_safe_sentence": "先练一个小动作，就已经是在建立基础。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Developing Foundation",
+        "core_judgment": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+          "You are beginning to treat emotion and relationships as observable and trainable.",
+          "Next move: Name one feeling clearly before attempting a larger change."
+        ],
+        "top_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+        "minimal_action": "Name one feeling clearly before attempting a larger change.",
+        "share_safe_sentence": "One small practice is already foundation-building.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.developing_foundation",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "developing_foundation"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.low_confidence_result": {
+      "zh-CN": {
+        "headline": "本次结果置信度较低",
+        "core_judgment": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "evidence_point": "由于本次作答质量不足，系统不会输出强画像判断。",
+        "three_sentence_summary": [
+          "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+          "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "下一步：先记录状态，之后在更稳定的时间复测。"
+        ],
+        "top_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+        "minimal_action": "先记录状态，之后在更稳定的时间复测。",
+        "share_safe_sentence": "这次结果不是不能看，而是要轻一点看。",
+        "continue_path": "先记录本次作答状态，之后在更稳定的时间复测。",
+        "conversion_actions": [
+          "save_report",
+          "retest_reminder",
+          "talk_to_agent"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Lower-Confidence Result",
+        "core_judgment": "Read this result lightly; the most useful signal is the response context of this session.",
+        "evidence_point": "Because response confidence is limited, the system avoids a strong profile statement.",
+        "three_sentence_summary": [
+          "Read this result lightly; the most useful signal is the response context of this session.",
+          "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "Next move: Record the context first, then retest when conditions are steadier."
+        ],
+        "top_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "minimal_action": "Record the context first, then retest when conditions are steadier.",
+        "share_safe_sentence": "This result is not useless; it simply needs a lighter reading.",
+        "continue_path": "Record the response context first, then retest when conditions are steadier.",
+        "conversion_actions": [
+          "save_report",
+          "retest_reminder",
+          "talk_to_agent"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.low_confidence_result",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "low_confidence_result"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/scientific_contract.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/scientific_contract.json
@@ -4,24 +4,28 @@
   "assets": {
     "eq.scientific_contract.default": {
       "zh-CN": {
-        "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
-        "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
-        "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
-        "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
-        "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
-        "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
-        "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
-        "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+        "test_definition": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+        "self_report_statement": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+        "non_clinical_statement": "本报告不用于医疗、治疗或风险处置决定。如果困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
+        "non_hiring_statement": "本结果不应用于录用、淘汰、晋升或岗位分配。它更适合个人发展、团队沟通和自我反思。",
+        "non_ability_statement": "EQ-60 解释的是自我感知中的情绪与关系模式，不等同于认证能力评估，也不应作为高风险决策依据。未来的情境判断模块也只会补充情境选择数据，而不是把结果变成能力认证。",
+        "norm_status_statement": "当前分数使用阶段性常模和版本化解释。百分位用于提供相对位置感，而不是精确排名。随着样本和版本更新，报告会保留当时版本以便复测对比。",
+        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来判断解释置信度。低置信不等于结果无用，而是需要更谨慎地读。",
+        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
+        "user_safe_summary": "适合用于自我理解、关系复盘和成长规划。",
+        "do_not_overread": "不要把自我报告结果当作他人观察或现场行为记录。"
       },
       "en": {
-        "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
-        "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
-        "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
-        "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
-        "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
-        "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
-        "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
-        "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+        "test_definition": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+        "self_report_statement": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+        "non_clinical_statement": "This report is not intended for healthcare, treatment, or safety decisions. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
+        "non_hiring_statement": "This result should not be used for selection, promotion, rejection, or role assignment. It is better suited for development, communication, and reflection.",
+        "non_ability_statement": "EQ-60 explains emotional and relational patterns in self-perception. It is not a certified capability evaluation and should not be used as a high-stakes decision tool. A future scenario module may add judgment data, but it would still not turn the result into a credential.",
+        "norm_status_statement": "Scores currently use provisional norms and versioned interpretation. Percentiles provide a sense of relative standing, not an exact rank. As samples and versions improve, reports retain the version used for comparison over time.",
+        "quality_rules_statement": "The report considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Lower confidence does not make the result useless; it means read it more cautiously.",
+        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
+        "user_safe_summary": "Use it for self-understanding, relational reflection, and growth planning.",
+        "do_not_overread": "Do not treat self-report results as external observation or a live behavior record."
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/score_system.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/score_system.json
@@ -4,140 +4,632 @@
   "global_index": {
     "zh-CN": {
       "label": "情绪与关系综合指数",
-      "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+      "definition": "综合指数把四个维度合并成一个整体视角，用来帮助你快速理解当前情绪与关系模式。",
+      "not_a_capability_score": "它不是现场表现的能力凭证，也不应单独决定任何重要选择。",
+      "how_to_use": "先看总览，再回到四维、质量提示和行动处方。"
     },
     "en": {
       "label": "Emotional & Relational Functioning Index",
-      "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
-    }
-  },
-  "score_notes": {
-    "zh-CN": {
-      "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。",
-      "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。"
-    },
-    "en": {
-      "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range.",
-      "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification."
+      "definition": "The index combines the four dimensions into one overall view of your current emotional and relational pattern.",
+      "not_a_capability_score": "It is not a credential of live performance and should not be used alone for important decisions.",
+      "how_to_use": "Start with the overview, then read dimensions, confidence, and action prescription."
     }
   },
   "bands": {
     "foundational": {
-      "zh-CN": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
-      "en": "Foundational: the current signal suggests this area benefits from more structure, practice, and review."
+      "zh-CN": "基础发展中",
+      "en": "Foundational"
     },
     "developing": {
-      "zh-CN": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
-      "en": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity."
+      "zh-CN": "发展中",
+      "en": "Developing"
     },
     "stable": {
-      "zh-CN": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。",
-      "en": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+      "zh-CN": "稳定可用",
+      "en": "Stable"
     },
     "proficient": {
-      "zh-CN": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
-      "en": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs."
+      "zh-CN": "熟练成熟",
+      "en": "Proficient"
     },
     "integrated": {
-      "zh-CN": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
-      "en": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible."
+      "zh-CN": "高度整合",
+      "en": "Integrated"
     }
   },
   "dimensions": {
     "SA": {
       "zh-CN": {
         "label": "自我觉察",
-        "definition": "识别、命名和理解自身情绪线索的倾向。",
-        "band_explanations": {
-          "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
-          "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
-          "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。",
-          "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
-          "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。"
-        }
+        "short_label": "自我觉察",
+        "definition": "识别、命名和理解自己情绪的倾向。",
+        "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
+        "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
+        "development_question": "我此刻真正的感受和需要是什么？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Self-Awareness",
-        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
-        "band_explanations": {
-          "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
-          "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
-          "stable": "Self-awareness is stable and usually helps you understand key emotional cues.",
-          "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
-          "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action."
-        }
+        "short_label": "Self-Awareness",
+        "definition": "The tendency to notice, name, and make sense of your own emotions.",
+        "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
+        "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
+        "development_question": "What am I actually feeling and needing right now?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "ER": {
       "zh-CN": {
         "label": "情绪调节",
-        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
-        "band_explanations": {
-          "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
-          "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
-          "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。",
-          "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
-          "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。"
-        }
+        "short_label": "情绪调节",
+        "definition": "在压力、反馈、挫败或冲突中稳定和恢复自己的倾向。",
+        "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
+        "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
+        "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Emotion Regulation",
-        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
-        "band_explanations": {
-          "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
-          "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
-          "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure.",
-          "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
-          "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available."
-        }
+        "short_label": "Emotion Regulation",
+        "definition": "The tendency to steady and recover yourself under pressure, feedback, frustration, or conflict.",
+        "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
+        "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
+        "development_question": "Can I lower the heat first before choosing my response?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "EM": {
       "zh-CN": {
         "label": "共情理解",
-        "definition": "理解他人情绪、立场和关系线索的倾向。",
-        "band_explanations": {
-          "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
-          "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
-          "stable": "共情理解稳定可用，多数场景能把握他人基本感受。",
-          "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
-          "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。"
-        }
+        "short_label": "共情理解",
+        "definition": "理解他人情绪、立场和未说出口感受的倾向。",
+        "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
+        "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
+        "development_question": "对方真正担心或在意的是什么？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Empathy",
-        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
-        "band_explanations": {
-          "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
-          "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
-          "stable": "Empathy is stable and usually helps you grasp basic feelings in others.",
-          "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
-          "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions."
-        }
+        "short_label": "Empathy",
+        "definition": "The tendency to understand others’ feelings, perspectives, and unspoken emotional cues.",
+        "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
+        "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
+        "development_question": "What is the other person really concerned about?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "RM": {
       "zh-CN": {
         "label": "关系管理",
-        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
-        "band_explanations": {
-          "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
-          "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
-          "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。",
-          "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
-          "integrated": "关系管理高度整合，重点是避免承担过多协调责任。"
-        }
+        "short_label": "关系管理",
+        "definition": "通过表达、协作、边界和修复维持关系质量的倾向。",
+        "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
+        "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
+        "development_question": "这句话怎样说，既真实又能让关系继续对话？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Relationship Management",
-        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
-        "band_explanations": {
-          "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
-          "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
-          "stable": "Relationship management is stable and usually supports constructive action in collaboration.",
-          "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
-          "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility."
+        "short_label": "Relationship Management",
+        "definition": "The tendency to maintain relationship quality through expression, collaboration, boundaries, and repair.",
+        "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
+        "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
+        "development_question": "How can I say this honestly while keeping the conversation open?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
+      }
+    }
+  },
+  "dimension_bands": {
+    "SA": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
+          "strength": "愿意回头复盘时，能够逐步看见真实感受。",
+          "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
+          "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
+          "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
+          "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。",
+          "label": "自我觉察 · 基础发展中"
+        },
+        "en": {
+          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
+          "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
+          "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
+          "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
+          "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
+          "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method.",
+          "label": "Self-awareness · Foundational"
         }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
+          "strength": "你开始能把情绪从混乱体验里拆出来。",
+          "risk": "觉察到情绪后，可能仍会被它带着走。",
+          "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
+          "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
+          "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。",
+          "label": "自我觉察 · 发展中"
+        },
+        "en": {
+          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
+          "strength": "You are beginning to separate emotion from the overall sense of confusion.",
+          "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
+          "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
+          "practice_focus": "Practice the sentence: “I feel... because I care about...”",
+          "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming.",
+          "label": "Self-awareness · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
+          "strength": "你通常能说清楚自己为什么被影响。",
+          "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
+          "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
+          "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
+          "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。",
+          "label": "自我觉察 · 稳定可用"
+        },
+        "en": {
+          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
+          "strength": "You can usually explain why something affected you.",
+          "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
+          "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
+          "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
+          "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings.",
+          "label": "Self-awareness · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
+          "strength": "你能把复杂感受组织成比较清楚的表达。",
+          "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
+          "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
+          "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
+          "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。",
+          "label": "自我觉察 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
+          "strength": "You can organize complex feelings into relatively clear expression.",
+          "risk": "You may analyze every reaction in detail and delay communication or recovery.",
+          "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
+          "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
+          "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it.",
+          "label": "Self-awareness · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
+          "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
+          "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
+          "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
+          "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
+          "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。",
+          "label": "自我觉察 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
+          "strength": "You can use awareness in real time, not only in later reflection.",
+          "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
+          "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
+          "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
+          "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often.",
+          "label": "Self-awareness · Integrated"
+        }
+      }
+    },
+    "ER": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
+          "strength": "你能从明显的情绪反应中发现需要练习的场景。",
+          "risk": "压力下容易直接回应、回避或进入长时间内耗。",
+          "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
+          "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
+          "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。",
+          "label": "情绪调节 · 基础发展中"
+        },
+        "en": {
+          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
+          "strength": "Clear emotional reactions can show you exactly which situations need practice.",
+          "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
+          "typical_scene": "After a conflict, you may replay the conversation for a long time.",
+          "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
+          "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic.",
+          "label": "Emotion regulation · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
+          "strength": "你已经知道某些做法能帮自己缓下来。",
+          "risk": "情绪强度一高，原本有效的方法可能想不起来。",
+          "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
+          "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
+          "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。",
+          "label": "情绪调节 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
+          "strength": "You already know that some actions help you settle.",
+          "risk": "When intensity rises, strategies that usually work may be hard to remember.",
+          "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
+          "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
+          "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option.",
+          "label": "Emotion regulation · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
+          "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
+          "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
+          "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
+          "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
+          "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。",
+          "label": "情绪调节 · 稳定可用"
+        },
+        "en": {
+          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
+          "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
+          "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
+          "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
+          "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
+          "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice.",
+          "label": "Emotion regulation · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
+          "strength": "你能为沟通争取到更好的时机和语气。",
+          "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
+          "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
+          "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
+          "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。",
+          "label": "情绪调节 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
+          "strength": "You can create better timing and tone for communication.",
+          "risk": "At times, you may appear so calm that others cannot read your real position.",
+          "typical_scene": "When challenged, you can steady your tone before addressing the point.",
+          "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
+          "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information.",
+          "label": "Emotion regulation · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
+          "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
+          "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
+          "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
+          "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
+          "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。",
+          "label": "情绪调节 · 高度整合"
+        },
+        "en": {
+          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
+          "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
+          "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
+          "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
+          "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
+          "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure.",
+          "label": "Emotion regulation · Integrated"
+        }
+      }
+    },
+    "EM": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
+          "strength": "你可以通过直接提问建立更清楚的信息。",
+          "risk": "容易把沉默、语气或表情理解得过少或过多。",
+          "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
+          "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
+          "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。",
+          "label": "共情理解 · 基础发展中"
+        },
+        "en": {
+          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
+          "strength": "Direct questions can give you clearer information.",
+          "risk": "You may read too little or too much into silence, tone, or facial expression.",
+          "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
+          "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
+          "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support.",
+          "label": "Empathic understanding · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
+          "strength": "你开始关注关系中的情绪温度。",
+          "risk": "可能过早判断别人不高兴、失望或疏远。",
+          "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
+          "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
+          "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。",
+          "label": "共情理解 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
+          "strength": "You are starting to track the emotional temperature in relationships.",
+          "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
+          "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
+          "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
+          "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence.",
+          "label": "Empathic understanding · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
+          "strength": "你能让对方感到被看见和被认真对待。",
+          "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
+          "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
+          "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
+          "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。",
+          "label": "共情理解 · 稳定可用"
+        },
+        "en": {
+          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
+          "strength": "You can help others feel seen and taken seriously.",
+          "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
+          "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
+          "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
+          "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion.",
+          "label": "Empathic understanding · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
+          "strength": "你能在复杂关系中捕捉未说出口的信息。",
+          "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
+          "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
+          "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
+          "do_not_overread": "熟练共情不等于你必须解决所有人的感受。",
+          "label": "共情理解 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
+          "strength": "You can notice unspoken information in complex relationships.",
+          "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
+          "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
+          "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
+          "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings.",
+          "label": "Empathic understanding · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
+          "strength": "你能在理解别人时仍保持清晰位置。",
+          "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
+          "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
+          "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
+          "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。",
+          "label": "共情理解 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
+          "strength": "You can understand others while keeping a clear position.",
+          "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
+          "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
+          "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
+          "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together.",
+          "label": "Empathic understanding · Integrated"
+        }
+      }
+    },
+    "RM": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
+          "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
+          "risk": "容易在不舒服时沉默、解释过多或直接退出。",
+          "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
+          "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
+          "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。",
+          "label": "关系管理 · 基础发展中"
+        },
+        "en": {
+          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
+          "strength": "With clear steps, your relationship skills can improve steadily.",
+          "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
+          "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
+          "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
+          "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar.",
+          "label": "Relationship management · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
+          "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
+          "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
+          "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
+          "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
+          "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。",
+          "label": "关系管理 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
+          "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
+          "risk": "You may try to preserve the relationship while leaving your real position unclear.",
+          "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
+          "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
+          "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame.",
+          "label": "Relationship management · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
+          "strength": "你能让关系在小摩擦后回到可合作状态。",
+          "risk": "为了维持顺畅，可能回避更难但必要的话题。",
+          "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
+          "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
+          "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。",
+          "label": "关系管理 · 稳定可用"
+        },
+        "en": {
+          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
+          "strength": "You can help a relationship return to cooperation after small friction.",
+          "risk": "To keep things smooth, you may avoid harder but necessary topics.",
+          "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
+          "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
+          "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship.",
+          "label": "Relationship management · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
+          "strength": "你能把冲突转化为更清楚的协作规则。",
+          "risk": "别人可能默认你来收拾关系残局。",
+          "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
+          "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
+          "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。",
+          "label": "关系管理 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
+          "strength": "You can turn conflict into clearer rules for collaboration.",
+          "risk": "Others may assume you will clean up the relational aftermath.",
+          "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
+          "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
+          "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary.",
+          "label": "Relationship management · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
+          "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
+          "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
+          "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
+          "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
+          "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。",
+          "label": "关系管理 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
+          "strength": "You can create clear and sustainable collaboration in complex relationships.",
+          "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
+          "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
+          "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
+          "do_not_overread": "Integrated does not mean you must carry all relationship maintenance.",
+          "label": "Relationship management · Integrated"
+        }
+      }
+    }
+  },
+  "score_notes": {
+    "zh-CN": {
+      "percentile": "百分位用于说明相对位置，不代表固定能力标签。",
+      "standard_score": "标准分用于稳定展示和维度比较。",
+      "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量和场景为准。"
+    },
+    "en": {
+      "percentile": "Percentile explains relative position; it is not a fixed ability label.",
+      "standard_score": "Standard score supports stable display and dimension comparison.",
+      "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, and scenes."
+    }
+  },
+  "band_details": {
+    "foundational": {
+      "zh-CN": {
+        "label": "基础发展中",
+        "meaning": "当前信号提示你需要先建立更清晰的识别、命名和复位习惯。",
+        "strength": "从一个小而重复的动作开始，进步会更稳定。",
+        "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
+        "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Foundational",
+        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits.",
+        "strength": "Small repeatable actions can create more stable progress.",
+        "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
+        "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "developing": {
+      "zh-CN": {
+        "label": "发展中",
+        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
+        "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
+        "risk": "最容易卡在“知道一点，但现场用不上”。",
+        "practice_focus": "选择一个高频场景，提前准备一句回应。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Developing",
+        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
+        "strength": "You already catch part of the signal and can turn it into a routine.",
+        "risk": "The common trap is knowing something but not using it in the moment.",
+        "practice_focus": "Pick one frequent scene and prepare one response sentence.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "stable": {
+      "zh-CN": {
+        "label": "稳定可用",
+        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。",
+        "strength": "你的结果已经能支持更精细的场景训练。",
+        "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
+        "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Stable",
+        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible.",
+        "strength": "Your result can support more precise scene-based practice.",
+        "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
+        "practice_focus": "Identify one scene where stability drops and review it afterward.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "proficient": {
+      "zh-CN": {
+        "label": "熟练成熟",
+        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
+        "strength": "你可以把个人优势转成可复制的沟通习惯。",
+        "risk": "他人可能默认你应该一直承担稳定局面的角色。",
+        "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Proficient",
+        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
+        "strength": "You can turn personal strengths into repeatable communication habits.",
+        "risk": "Others may assume you should always be the stabilizing person.",
+        "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "integrated": {
+      "zh-CN": {
+        "label": "高度整合",
+        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
+        "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
+        "risk": "高整合也可能带来过度承担和高标准疲劳。",
+        "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Integrated",
+        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
+        "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
+        "risk": "High integration may still create over-responsibility and high-standard fatigue.",
+        "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/seo_geo_authority.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/seo_geo_authority.json
@@ -16,37 +16,37 @@
   "assets": {
     "eq.seo_geo_authority.en_landing.default": {
       "zh-CN": {
-        "meta_title": "免费情商 EQ 测试 | 情绪与关系模式报告",
-        "meta_description": "完成 60 道自我报告题，理解自我觉察、情绪调节、共情理解和关系管理。结果免费，边界清晰，不用于诊断、招聘或能力认证。",
-        "h1": "情商 EQ 测试：情绪与关系模式报告",
-        "dek": "一份 60 题 self-report 测评，用于解释你如何感知、调节和回应自己与他人的情绪。",
-        "entity_summary": "费马 EQ-60 是情绪与关系信号模块，输出自我报告型情绪与关系模式报告，而不是临床、招聘或认证能力测验。",
+        "meta_title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "h1": "情绪与关系模式测试",
+        "dek": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "entity_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
         "content_modules": [
           {
-            "heading": "测评测什么",
-            "summary": "自我觉察、情绪调节、共情理解和关系管理四个维度。"
+            "heading": "测试定义",
+            "summary": "测试定义"
           },
           {
-            "heading": "结果页给什么",
-            "summary": "综合指数、四维矩阵、核心洞察、现实场景、行动处方和科学边界。"
+            "heading": "测量内容",
+            "summary": "测量内容"
           },
           {
-            "heading": "不做什么",
-            "summary": "不做临床诊断、招聘筛选、职业适配结论或客观能力认证。"
+            "heading": "不适用边界",
+            "summary": "不适用边界"
+          },
+          {
+            "heading": "下一步行动",
+            "summary": "下一步行动"
           }
         ],
         "faq": [
           {
-            "question": "这是免费的情商测试吗？",
-            "answer": "是。EQ-60 基础报告免费；报告深度由完成的数据决定，不由付费门槛决定。"
+            "question": "分数代表什么？",
+            "answer": ""
           },
           {
-            "question": "它是能力测验吗？",
-            "answer": "不是。它基于自我报告，适合自我理解、沟通反思和成长规划。"
-          },
-          {
-            "question": "未来的情境判断模块是什么？",
-            "answer": "EQ-SJT 16 目前仅为 planned 状态，未来会补充情境选择信息，但不会被表述为认证能力测验。"
+            "question": "结果应该怎么使用？",
+            "answer": ""
           }
         ],
         "structured_data": {
@@ -55,48 +55,47 @@
           "result_scope": "emotional_and_relational_pattern_report",
           "is_free": true
         },
-        "llms_summary": "EQ-60 是费马测试的自我报告型情绪与关系模式测评。它用 60 道题解释自我觉察、情绪调节、共情理解和关系管理，并输出免费结果页。",
-        "claim_boundary": "仅用于自我理解和成长规划；不用于临床诊断、招聘筛选、职业适配承诺、治疗建议或客观能力认证。",
-        "source_authority": "页面标题、SEO 摘要、FAQ、结构化数据边界和 LLM 摘要以 backend content pack 为权威来源。",
+        "llms_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。",
+        "source_authority": "后端 content pack 是公开 EQ SEO/GEO 文案权威来源。",
         "no_go_claims": [
-          "不声称测量客观情绪能力",
-          "不声称预测工作表现",
-          "不用于招聘筛选",
-          "不用于临床诊断"
+          "不用于临床",
+          "不用于招聘",
+          "不用于认证"
         ]
       },
       "en": {
-        "meta_title": "Free EQ Test | Emotional & Relational Pattern Report",
-        "meta_description": "Take a free 60-item self-report EQ test covering self-awareness, emotion regulation, empathy, and relationship management. Clear boundaries: not clinical, hiring, or certified ability assessment.",
-        "h1": "EQ Test: Emotional & Relational Pattern Report",
-        "dek": "A 60-item self-report assessment that explains how you notice, regulate, and respond to emotions in yourself and in relationships.",
-        "entity_summary": "FermatMind EQ-60 is an emotional and relational signal module. It produces a self-report pattern report, not a clinical, hiring, or certified ability assessment.",
+        "meta_title": "Free EQ Test | Emotional Intelligence Test",
+        "meta_description": "Take a free self-report emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+        "h1": "Free Emotional Intelligence Test",
+        "dek": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "entity_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
         "content_modules": [
           {
-            "heading": "What it measures",
-            "summary": "Self-awareness, emotion regulation, empathic understanding, and relationship management."
+            "heading": "definition",
+            "summary": "definition"
           },
           {
-            "heading": "What the report includes",
-            "summary": "A global index, four-dimension matrix, core insight, real-world scenes, action prescription, and scientific boundary."
+            "heading": "what it measures",
+            "summary": "what it measures"
           },
           {
-            "heading": "What it does not do",
-            "summary": "It does not provide clinical diagnosis, hiring suitability, career-fit promises, or objective ability certification."
+            "heading": "what it does not decide",
+            "summary": "what it does not decide"
+          },
+          {
+            "heading": "next useful action",
+            "summary": "next useful action"
           }
         ],
         "faq": [
           {
-            "question": "Is this EQ test free?",
-            "answer": "Yes. The EQ-60 base report is free; report depth is based on completed data, not a paywall."
+            "question": "What does the score mean?",
+            "answer": "Your result summarizes a self-report emotional and relational pattern across self-awareness, emotion regulation, empathy, and relationship management."
           },
           {
-            "question": "Is this an ability test?",
-            "answer": "No. It is based on self-report and is intended for self-understanding, communication reflection, and growth planning."
-          },
-          {
-            "question": "What is the future scenario module?",
-            "answer": "EQ-SJT 16 is currently planned only. It will add scenario-choice information in the future, without being positioned as a certified ability assessment."
+            "question": "How should I use the result?",
+            "answer": "Use it to reflect on your patterns, choose a small next action, and decide whether a retest or related assessment would be useful."
           }
         ],
         "structured_data": {
@@ -105,15 +104,1146 @@
           "result_scope": "emotional_and_relational_pattern_report",
           "is_free": true
         },
-        "llms_summary": "EQ-60 is FermatMind's self-report emotional and relational pattern assessment. It uses 60 items to explain self-awareness, emotion regulation, empathic understanding, and relationship management, then returns a free result page.",
-        "claim_boundary": "For self-understanding and growth planning only; not for clinical diagnosis, hiring selection, career-fit promises, treatment advice, or objective ability certification.",
-        "source_authority": "Page title, SEO summary, FAQ, structured-data boundary, and LLM summary are authoritative in the backend content pack.",
+        "llms_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "claim_boundary": "Use for self-understanding, reflection, and growth planning; not for clinical diagnosis, hiring, credentialing, or job-performance prediction.",
+        "source_authority": "Backend content pack is authoritative for public EQ SEO/GEO copy.",
         "no_go_claims": [
-          "Does not claim objective emotional ability measurement",
-          "Does not predict job performance",
-          "Not for hiring selection",
-          "Not for clinical diagnosis"
+          "not clinical",
+          "not hiring",
+          "not credentialing"
         ]
+      }
+    }
+  },
+  "faq_assets": [
+    {
+      "zh-CN": {
+        "question": "什么是 EQ？",
+        "answer": "EQ 指情绪与关系相关的自我觉察、调节、共情和关系处理方式。费马 EQ-60 用自我报告方式帮助你理解这些模式。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What is EQ?",
+        "answer": "EQ refers to emotional and relational patterns such as self-awareness, regulation, empathy, and relationship management. Fermat EQ-60 uses self-report to help you understand these patterns.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "这个 EQ 测试测什么？",
+        "answer": "它测你如何看待自己的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does this EQ test measure?",
+        "answer": "It measures how you perceive your emotional and relational tendencies across self-awareness, emotion regulation, empathy, and relationship management.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "它是不是现场表现测量？",
+        "answer": "不是。EQ-60 是自我报告结果，解释你如何看待自己的情绪与关系模式，不等同于受控任务中的现场表现。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is this based on real-time performance?",
+        "answer": "No. EQ-60 is a self-report result. It describes how you see your emotional and relational patterns, not how you would perform in a controlled task.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "和专业能力工具有什么区别？",
+        "answer": "专业能力工具通常需要受控任务、专门评分和资格管理。EQ-60 更适合自我理解和成长规划。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is it different from professional ability instruments?",
+        "answer": "Professional ability instruments use controlled tasks, specialized scoring, and qualification procedures. EQ-60 is for reflection and growth planning.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 IQ 有什么区别？",
+        "answer": "IQ 更关注认知问题解决；EQ-60 关注你如何感知、调节和处理情绪与关系。两者不是互相替代。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from IQ?",
+        "answer": "IQ focuses more on cognitive problem solving. EQ-60 focuses on how you perceive, regulate, and handle emotion and relationships. They are not substitutes for each other.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 MBTI 有什么区别？",
+        "answer": "MBTI 更像偏好类型语言；EQ-60 解释情绪和关系功能。两者可互补，但不能互相替代。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from MBTI?",
+        "answer": "MBTI is more of a preference-type language. EQ-60 explains emotional and relational functioning. They can complement each other but do not replace each other.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 Big Five 有什么区别？",
+        "answer": "Big Five 描述广泛人格特质；EQ-60 聚焦情绪与关系模式。它们可能有重叠，但报告用途不同。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from Big Five?",
+        "answer": "Big Five describes broad personality traits. EQ-60 focuses on emotional and relational patterns. They may overlap, but their report use differs.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和九型人格有什么区别？",
+        "answer": "九型人格常用于动机和模式叙事；EQ-60 更关注情绪觉察、调节、共情和关系管理。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from Enneagram?",
+        "answer": "Enneagram is often used for motivation and pattern narratives. EQ-60 focuses on awareness, regulation, empathy, and relationship management.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "结果准吗？",
+        "answer": "结果的有用性取决于题目质量、作答状态、常模版本和你是否如实作答。它适合作为自我理解起点。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is the result accurate?",
+        "answer": "Its usefulness depends on item quality, response context, norm version, and honest responding. It is best used as a starting point for self-understanding.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么用自我报告？",
+        "answer": "自我感知会影响你如何回应反馈、冲突和关系压力。它不是全部证据，但非常适合作为入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why self-report?",
+        "answer": "Self-perception affects how you respond to feedback, conflict, and relational pressure. It is not the whole picture, but it is a useful entry point.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以用于人事决定吗？",
+        "answer": "不建议。单次自我报告结果不适合用于录用、淘汰、晋升或岗位分配。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can it be used for employment decisions?",
+        "answer": "No. A single self-report result is not appropriate for selection, rejection, promotion, or role assignment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以用于健康判断吗？",
+        "answer": "不适合。它可以帮助你描述体验，但不能替代专业支持或高风险判断。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can it be used for health decisions?",
+        "answer": "No. It can help describe experience, but it does not replace qualified support or high-stakes judgment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "分数低怎么办？",
+        "answer": "先看最低维度和行动处方。低分不是失败，而是指向更具体的练习入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What if my score is low?",
+        "answer": "Start with the lowest dimension and the action prescription. A lower score is not failure; it points to a more specific practice entry point.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "低置信结果是什么意思？",
+        "answer": "它表示这次作答状态让解释需要更谨慎。你仍可参考，但不宜做强结论。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does lower confidence mean?",
+        "answer": "It means the response pattern calls for more cautious interpretation. You can still use it, but avoid strong conclusions.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以复测吗？",
+        "answer": "可以。建议在状态更稳定、没有赶时间时复测，并比较哪些维度保持一致。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can I retest?",
+        "answer": "Yes. Retest when you are not rushed and your context is steadier, then compare which dimensions remain stable.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么情境判断暂未开放？",
+        "answer": "因为情境题需要评分规则、文化审校和验证。当前先保持 planned 状态，不开放入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why is the scenario module not available yet?",
+        "answer": "Scenario items need scoring rubrics, cultural review, and validation. It remains planned and unavailable for now.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "未来情境判断会补充什么？",
+        "answer": "它会观察你在反馈、冲突、边界和压力场景中倾向选择什么回应。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What will the future scenario module add?",
+        "answer": "It will examine the responses you tend to choose in feedback, conflict, boundary, and pressure situations.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "情绪调节低是什么意思？",
+        "answer": "它通常表示在压力或被触发时恢复较慢，不代表你无法改变。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does lower emotion regulation mean?",
+        "answer": "It often means recovery is slower under pressure or activation. It does not mean you cannot improve.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "共情高是不是一定好？",
+        "answer": "不是绝对好坏。高共情能帮助理解别人，但如果恢复和边界不足，也可能带来消耗。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is high empathy always good?",
+        "answer": "Not absolutely. High empathy helps you understand others, but without recovery and boundaries it can become draining.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "职业环境变量是什么意思？",
+        "answer": "它不是推荐具体职业，而是帮助你观察一个工作环境的人际密度、反馈强度、冲突频率和恢复空间。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What is a career environment variable?",
+        "answer": "It is not a job recommendation. It helps you examine interpersonal density, feedback intensity, conflict frequency, and recovery space in a work environment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "如何用结果处理反馈？",
+        "answer": "先看 ER 和 SA，再用行动处方把反馈拆成事实、感受和下一步。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How can I use the result for feedback?",
+        "answer": "Look at ER and SA, then use the action prescription to split feedback into facts, feelings, and next steps.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "如何用结果改善关系？",
+        "answer": "选择一个关系场景，不要泛泛改自己。先练一句更清楚、更可被接住的话。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How can I use the result in relationships?",
+        "answer": "Pick one relationship scene rather than trying to change everything. Practice one clearer, more receivable sentence.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "情商可以提升吗？",
+        "answer": "可以练习其中的具体行为，例如情绪命名、暂停、共情回应、边界表达和关系修复。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can EQ improve?",
+        "answer": "Specific behaviors can be practiced, such as emotion naming, pausing, empathic response, boundary expression, and repair.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以分享结果吗？",
+        "answer": "可以分享模式摘要，但不建议公开详细分数或把结果当作固定标签。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can I share my result?",
+        "answer": "You can share a pattern summary, but avoid posting detailed scores or treating the result as a fixed label.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么要保存报告？",
+        "answer": "保存后你可以复测、比较变化，并继续查看行动处方。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why save the report?",
+        "answer": "Saving lets you retest, compare change, and keep the action plan continuous.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "这是给我贴标签吗？",
+        "answer": "不是。formulation 是把本次结果组织成一个可理解的模式，不是永久身份。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is this labeling me?",
+        "answer": "No. A formulation organizes the current result into an understandable pattern; it is not a permanent identity.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "质量提示是不是说我答错了？",
+        "answer": "不是。质量提示描述这次作答状态，不评价你这个人。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Do quality flags mean I answered wrong?",
+        "answer": "No. Quality notes describe this response session; they do not judge you as a person.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "四个维度为什么是这四个？",
+        "answer": "它们覆盖自己与他人、理解与行动两个轴，形成一个简洁的情绪与关系矩阵。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why these four dimensions?",
+        "answer": "They cover self vs others and understanding vs action, forming a concise emotional-relational matrix.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "工作中怎么用？",
+        "answer": "把结果转成场景问题：我如何接收反馈、处理冲突、设边界、恢复压力？",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How do I use it at work?",
+        "answer": "Translate it into scene questions: how do I handle feedback, conflict, boundaries, and recovery?",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么要保存报告？",
+        "answer": "保存后，你可以回看本次核心模式、行动处方和复测变化。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "Why save the report?",
+        "answer": "Saving lets you return to your pattern, action prescription, and future retest comparison.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "多久复测一次比较合适？",
+        "answer": "如果你只是好奇，4–8 周后复测更有意义；如果本次置信度较低，可以在状态更稳定时更早复测。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "When should I retest?",
+        "answer": "For normal reflection, 4–8 weeks gives change more room to appear. If confidence was low, retest when your state is steadier.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "我可以问 Agent 什么？",
+        "answer": "可以问一个具体场景，比如反馈、冲突、边界或压力恢复。Agent 应基于你的报告资产解释，不会改分数。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "What can I ask the Agent?",
+        "answer": "Ask about one real scene: feedback, conflict, boundaries, or recovery. The Agent explains your report assets; it does not change your scores.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    }
+  ],
+  "seo_geo_assets": {
+    "eq.seo.en.emotional_intelligence_test": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotional Intelligence Test",
+        "meta_description": "Take a free emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+        "short_answer": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Understand your emotional and relational pattern, not a live-performance credential."
+      }
+    },
+    "eq.seo.en.free_eq_test": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Free EQ Test",
+        "meta_description": "A free EQ test with a complete self-report result, confidence note, and action prescription.",
+        "short_answer": "Designed for reflection, workstyle insight, and relationship growth.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Designed for reflection, workstyle insight, and relationship growth."
+      }
+    },
+    "eq.seo.en.eq_score_meaning": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ Score Meaning",
+        "meta_description": "Learn how EQ scores, bands, percentiles, and confidence notes should be read.",
+        "short_answer": "A score is a starting point; dimensions and context carry the real interpretation.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "A score is a starting point; dimensions and context carry the real interpretation."
+      }
+    },
+    "eq.seo.en.self_report_vs_ability_ei": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Self-Report vs Ability EI",
+        "meta_description": "Understand the difference between self-report EQ and controlled ability-style instruments.",
+        "short_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment."
+      }
+    },
+    "eq.seo.en.eq_vs_iq": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ vs IQ",
+        "meta_description": "EQ and IQ describe different domains: emotional-relational patterns and cognitive problem solving.",
+        "short_answer": "The two are complementary and should not be collapsed into one score.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "The two are complementary and should not be collapsed into one score."
+      }
+    },
+    "eq.seo.en.eq_in_workplace": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotional Intelligence at Work",
+        "meta_description": "Use EQ results to examine feedback, conflict, collaboration, and recovery patterns.",
+        "short_answer": "Focus on environment variables and communication habits.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Focus on environment variables and communication habits."
+      }
+    },
+    "eq.seo.en.how_to_improve_eq": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "How to Improve EQ",
+        "meta_description": "Practice emotion naming, pausing, empathic response, boundaries, and repair.",
+        "short_answer": "Improvement begins with one repeatable behavior in a real situation.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Improvement begins with one repeatable behavior in a real situation."
+      }
+    },
+    "eq.seo.en.eq_and_relationships": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ in Relationships",
+        "meta_description": "See how empathy, boundaries, expression, and repair shape relationship patterns.",
+        "short_answer": "The goal is clearer conversation, not fixed labels.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "The goal is clearer conversation, not fixed labels."
+      }
+    },
+    "eq.seo.en.emotion_regulation": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotion Regulation",
+        "meta_description": "Understand recovery and response choice after emotional activation.",
+        "short_answer": "Regulation is not suppression; it keeps enough choice to respond well.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Regulation is not suppression; it keeps enough choice to respond well."
+      }
+    },
+    "eq.seo.en.empathy_context": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Empathy in EQ",
+        "meta_description": "Empathy helps you read others, but needs boundaries and recovery.",
+        "short_answer": "High empathy can be a strength and a load depending on context.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "High empathy can be a strength and a load depending on context."
+      }
+    },
+    "eq.seo.en.eq_methodology": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Fermat EQ Methodology",
+        "meta_description": "How EQ-60 uses self-report, four dimensions, quality checks, and versioned norms.",
+        "short_answer": "Transparent boundaries make the result more useful, not weaker.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Transparent boundaries make the result more useful, not weaker."
+      }
+    },
+    "eq.seo.en.eq_retest": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Retesting EQ",
+        "meta_description": "Retesting can show which emotional-relational patterns remain stable over time.",
+        "short_answer": "Compare dimensions and confidence notes, not just the total score.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Compare dimensions and confidence notes, not just the total score."
+      }
+    },
+    "eq.seo.zh.qingshang_ceshi": {
+      "zh-CN": {
+        "title": "情商测试",
+        "meta_description": "免费查看你的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+        "short_answer": "结果用于自我理解和成长规划，不用于高风险判断。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_ceshi": {
+      "zh-CN": {
+        "title": "EQ测试",
+        "meta_description": "基于 60 道自我报告题，生成情绪与关系模式报告。",
+        "short_answer": "重点不是给你贴标签，而是找到可执行的练习入口。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.qingxu_zhili": {
+      "zh-CN": {
+        "title": "情绪智力",
+        "meta_description": "了解情绪觉察、调节、共情和关系处理如何影响沟通与压力恢复。",
+        "short_answer": "情绪智力可以拆成具体行为来练习。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.qingxu_tiaojie": {
+      "zh-CN": {
+        "title": "情绪调节",
+        "meta_description": "理解被触发后如何暂停、恢复和选择回应。",
+        "short_answer": "情绪调节不是压抑情绪，而是保留回应选择。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.gongqing_nengli": {
+      "zh-CN": {
+        "title": "共情能力",
+        "meta_description": "共情帮助你读懂别人，但也需要边界和恢复。",
+        "short_answer": "高共情不是绝对好坏，要看它是否和调节协同。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_vs_iq": {
+      "zh-CN": {
+        "title": "EQ和IQ区别",
+        "meta_description": "IQ偏认知问题解决，EQ-60偏情绪与关系模式。",
+        "short_answer": "两者互补，不能互相替代。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.self_report_vs_ability": {
+      "zh-CN": {
+        "title": "自我报告和表现型测量区别",
+        "meta_description": "自我报告解释你如何看待自己，能力工具需要受控任务和专门评分。",
+        "short_answer": "费马 EQ-60 当前属于自我报告结果。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_score_meaning": {
+      "zh-CN": {
+        "title": "EQ分数怎么理解",
+        "meta_description": "分数要和四维、百分位、置信度和行动建议一起读。",
+        "short_answer": "不要只看一个总分。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_workplace": {
+      "zh-CN": {
+        "title": "职场情商",
+        "meta_description": "用 EQ 结果观察反馈、冲突、协作和恢复方式。",
+        "short_answer": "报告只解释环境变量和工作方式，不推荐具体岗位。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.improve_eq": {
+      "zh-CN": {
+        "title": "如何提高情商",
+        "meta_description": "从情绪命名、暂停、共情回应、边界表达和修复脚本开始。",
+        "short_answer": "选择一个场景练习，比泛泛努力更有效。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_relationship": {
+      "zh-CN": {
+        "title": "情商与关系",
+        "meta_description": "理解你如何表达、共情、设边界和修复关系。",
+        "short_answer": "结果不是关系定论，而是对话入口。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_methodology": {
+      "zh-CN": {
+        "title": "费马EQ方法论",
+        "meta_description": "说明 EQ-60 的四维模型、计分、质量提示和科学边界。",
+        "short_answer": "透明的方法边界能提升可信度。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
       }
     }
   }

--- a/backend/content_packs/EQ_60/v1/raw/report_assets/sjt_bridge.json
+++ b/backend/content_packs/EQ_60/v1/raw/report_assets/sjt_bridge.json
@@ -4,22 +4,112 @@
   "assets": {
     "eq.sjt_bridge.planned": {
       "zh-CN": {
-        "title": "未来将支持 16 道情境判断模块",
-        "status": "planned",
-        "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
-        "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
-        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。",
-        "button_label": "情境判断模块规划中",
-        "available": false
+        "title": "未来情境判断模块",
+        "status": "planned_unavailable",
+        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
       },
       "en": {
-        "title": "A 16-item scenario module is planned",
-        "status": "planned",
-        "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
-        "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
-        "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions.",
-        "button_label": "Scenario module planned",
-        "available": false
+        "title": "Future scenario module",
+        "status": "planned_unavailable",
+        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.what_it_adds": {
+      "zh-CN": {
+        "title": "它会补充什么",
+        "status": "planned_unavailable",
+        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "What it will add",
+        "status": "planned_unavailable",
+        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.what_it_is_not": {
+      "zh-CN": {
+        "title": "它不是什么",
+        "status": "planned_unavailable",
+        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "What it is not",
+        "status": "planned_unavailable",
+        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.future_integrated_report": {
+      "zh-CN": {
+        "title": "未来综合报告",
+        "status": "planned_unavailable",
+        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "Future integrated report",
+        "status": "planned_unavailable",
+        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.unavailable_note": {
+      "zh-CN": {
+        "title": "暂未开放说明",
+        "status": "planned_unavailable",
+        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "Unavailable note",
+        "status": "planned_unavailable",
+        "description": "This module remains planned. The frontend should not provide a clickable start entry.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
@@ -2,7 +2,7 @@
     "schema": "eq_60.report_assets.compiled.v1",
     "pack_id": "EQ_60",
     "pack_version": "v1",
-    "generated_at": "2026-05-31T14:41:58.905240Z",
+    "generated_at": "2026-06-24T09:44:46.656518Z",
     "assets": {
         "scientific_contract": {
             "schema": "eq60.report_assets.scientific_contract.v1",
@@ -10,24 +10,28 @@
             "assets": {
                 "eq.scientific_contract.default": {
                     "zh-CN": {
-                        "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
-                        "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
-                        "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
-                        "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
-                        "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
-                        "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
-                        "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
-                        "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+                        "test_definition": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+                        "self_report_statement": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+                        "non_clinical_statement": "本报告不用于医疗、治疗或风险处置决定。如果困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
+                        "non_hiring_statement": "本结果不应用于录用、淘汰、晋升或岗位分配。它更适合个人发展、团队沟通和自我反思。",
+                        "non_ability_statement": "EQ-60 解释的是自我感知中的情绪与关系模式，不等同于认证能力评估，也不应作为高风险决策依据。未来的情境判断模块也只会补充情境选择数据，而不是把结果变成能力认证。",
+                        "norm_status_statement": "当前分数使用阶段性常模和版本化解释。百分位用于提供相对位置感，而不是精确排名。随着样本和版本更新，报告会保留当时版本以便复测对比。",
+                        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来判断解释置信度。低置信不等于结果无用，而是需要更谨慎地读。",
+                        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
+                        "user_safe_summary": "适合用于自我理解、关系复盘和成长规划。",
+                        "do_not_overread": "不要把自我报告结果当作他人观察或现场行为记录。"
                     },
                     "en": {
-                        "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
-                        "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
-                        "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
-                        "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
-                        "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
-                        "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
-                        "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
-                        "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+                        "test_definition": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+                        "self_report_statement": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+                        "non_clinical_statement": "This report is not intended for healthcare, treatment, or safety decisions. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
+                        "non_hiring_statement": "This result should not be used for selection, promotion, rejection, or role assignment. It is better suited for development, communication, and reflection.",
+                        "non_ability_statement": "EQ-60 explains emotional and relational patterns in self-perception. It is not a certified capability evaluation and should not be used as a high-stakes decision tool. A future scenario module may add judgment data, but it would still not turn the result into a credential.",
+                        "norm_status_statement": "Scores currently use provisional norms and versioned interpretation. Percentiles provide a sense of relative standing, not an exact rank. As samples and versions improve, reports retain the version used for comparison over time.",
+                        "quality_rules_statement": "The report considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Lower confidence does not make the result useless; it means read it more cautiously.",
+                        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
+                        "user_safe_summary": "Use it for self-understanding, relational reflection, and growth planning.",
+                        "do_not_overread": "Do not treat self-report results as external observation or a live behavior record."
                     }
                 }
             }
@@ -38,140 +42,632 @@
             "global_index": {
                 "zh-CN": {
                     "label": "情绪与关系综合指数",
-                    "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+                    "definition": "综合指数把四个维度合并成一个整体视角，用来帮助你快速理解当前情绪与关系模式。",
+                    "not_a_capability_score": "它不是现场表现的能力凭证，也不应单独决定任何重要选择。",
+                    "how_to_use": "先看总览，再回到四维、质量提示和行动处方。"
                 },
                 "en": {
                     "label": "Emotional & Relational Functioning Index",
-                    "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
-                }
-            },
-            "score_notes": {
-                "zh-CN": {
-                    "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。",
-                    "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。"
-                },
-                "en": {
-                    "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range.",
-                    "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification."
+                    "definition": "The index combines the four dimensions into one overall view of your current emotional and relational pattern.",
+                    "not_a_capability_score": "It is not a credential of live performance and should not be used alone for important decisions.",
+                    "how_to_use": "Start with the overview, then read dimensions, confidence, and action prescription."
                 }
             },
             "bands": {
                 "foundational": {
-                    "zh-CN": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
-                    "en": "Foundational: the current signal suggests this area benefits from more structure, practice, and review."
+                    "zh-CN": "基础发展中",
+                    "en": "Foundational"
                 },
                 "developing": {
-                    "zh-CN": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
-                    "en": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity."
+                    "zh-CN": "发展中",
+                    "en": "Developing"
                 },
                 "stable": {
-                    "zh-CN": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。",
-                    "en": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+                    "zh-CN": "稳定可用",
+                    "en": "Stable"
                 },
                 "proficient": {
-                    "zh-CN": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
-                    "en": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs."
+                    "zh-CN": "熟练成熟",
+                    "en": "Proficient"
                 },
                 "integrated": {
-                    "zh-CN": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
-                    "en": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible."
+                    "zh-CN": "高度整合",
+                    "en": "Integrated"
                 }
             },
             "dimensions": {
                 "SA": {
                     "zh-CN": {
                         "label": "自我觉察",
-                        "definition": "识别、命名和理解自身情绪线索的倾向。",
-                        "band_explanations": {
-                            "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
-                            "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
-                            "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。",
-                            "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
-                            "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。"
-                        }
+                        "short_label": "自我觉察",
+                        "definition": "识别、命名和理解自己情绪的倾向。",
+                        "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
+                        "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
+                        "development_question": "我此刻真正的感受和需要是什么？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Self-Awareness",
-                        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
-                        "band_explanations": {
-                            "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
-                            "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
-                            "stable": "Self-awareness is stable and usually helps you understand key emotional cues.",
-                            "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
-                            "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action."
-                        }
+                        "short_label": "Self-Awareness",
+                        "definition": "The tendency to notice, name, and make sense of your own emotions.",
+                        "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
+                        "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
+                        "development_question": "What am I actually feeling and needing right now?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "ER": {
                     "zh-CN": {
                         "label": "情绪调节",
-                        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
-                        "band_explanations": {
-                            "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
-                            "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
-                            "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。",
-                            "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
-                            "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。"
-                        }
+                        "short_label": "情绪调节",
+                        "definition": "在压力、反馈、挫败或冲突中稳定和恢复自己的倾向。",
+                        "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
+                        "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
+                        "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Emotion Regulation",
-                        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
-                        "band_explanations": {
-                            "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
-                            "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
-                            "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure.",
-                            "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
-                            "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available."
-                        }
+                        "short_label": "Emotion Regulation",
+                        "definition": "The tendency to steady and recover yourself under pressure, feedback, frustration, or conflict.",
+                        "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
+                        "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
+                        "development_question": "Can I lower the heat first before choosing my response?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "EM": {
                     "zh-CN": {
                         "label": "共情理解",
-                        "definition": "理解他人情绪、立场和关系线索的倾向。",
-                        "band_explanations": {
-                            "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
-                            "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
-                            "stable": "共情理解稳定可用，多数场景能把握他人基本感受。",
-                            "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
-                            "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。"
-                        }
+                        "short_label": "共情理解",
+                        "definition": "理解他人情绪、立场和未说出口感受的倾向。",
+                        "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
+                        "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
+                        "development_question": "对方真正担心或在意的是什么？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Empathy",
-                        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
-                        "band_explanations": {
-                            "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
-                            "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
-                            "stable": "Empathy is stable and usually helps you grasp basic feelings in others.",
-                            "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
-                            "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions."
-                        }
+                        "short_label": "Empathy",
+                        "definition": "The tendency to understand others’ feelings, perspectives, and unspoken emotional cues.",
+                        "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
+                        "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
+                        "development_question": "What is the other person really concerned about?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
                     }
                 },
                 "RM": {
                     "zh-CN": {
                         "label": "关系管理",
-                        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
-                        "band_explanations": {
-                            "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
-                            "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
-                            "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。",
-                            "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
-                            "integrated": "关系管理高度整合，重点是避免承担过多协调责任。"
-                        }
+                        "short_label": "关系管理",
+                        "definition": "通过表达、协作、边界和修复维持关系质量的倾向。",
+                        "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
+                        "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
+                        "development_question": "这句话怎样说，既真实又能让关系继续对话？",
+                        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
                     },
                     "en": {
                         "label": "Relationship Management",
-                        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
-                        "band_explanations": {
-                            "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
-                            "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
-                            "stable": "Relationship management is stable and usually supports constructive action in collaboration.",
-                            "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
-                            "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility."
+                        "short_label": "Relationship Management",
+                        "definition": "The tendency to maintain relationship quality through expression, collaboration, boundaries, and repair.",
+                        "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
+                        "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
+                        "development_question": "How can I say this honestly while keeping the conversation open?",
+                        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
+                    }
+                }
+            },
+            "dimension_bands": {
+                "SA": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
+                            "strength": "愿意回头复盘时，能够逐步看见真实感受。",
+                            "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
+                            "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
+                            "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
+                            "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。",
+                            "label": "自我觉察 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
+                            "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
+                            "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
+                            "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
+                            "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
+                            "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method.",
+                            "label": "Self-awareness · Foundational"
                         }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
+                            "strength": "你开始能把情绪从混乱体验里拆出来。",
+                            "risk": "觉察到情绪后，可能仍会被它带着走。",
+                            "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
+                            "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
+                            "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。",
+                            "label": "自我觉察 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
+                            "strength": "You are beginning to separate emotion from the overall sense of confusion.",
+                            "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
+                            "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
+                            "practice_focus": "Practice the sentence: “I feel... because I care about...”",
+                            "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming.",
+                            "label": "Self-awareness · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
+                            "strength": "你通常能说清楚自己为什么被影响。",
+                            "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
+                            "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
+                            "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
+                            "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。",
+                            "label": "自我觉察 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
+                            "strength": "You can usually explain why something affected you.",
+                            "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
+                            "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
+                            "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
+                            "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings.",
+                            "label": "Self-awareness · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
+                            "strength": "你能把复杂感受组织成比较清楚的表达。",
+                            "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
+                            "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
+                            "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
+                            "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。",
+                            "label": "自我觉察 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
+                            "strength": "You can organize complex feelings into relatively clear expression.",
+                            "risk": "You may analyze every reaction in detail and delay communication or recovery.",
+                            "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
+                            "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
+                            "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it.",
+                            "label": "Self-awareness · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
+                            "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
+                            "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
+                            "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
+                            "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
+                            "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。",
+                            "label": "自我觉察 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
+                            "strength": "You can use awareness in real time, not only in later reflection.",
+                            "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
+                            "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
+                            "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
+                            "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often.",
+                            "label": "Self-awareness · Integrated"
+                        }
+                    }
+                },
+                "ER": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
+                            "strength": "你能从明显的情绪反应中发现需要练习的场景。",
+                            "risk": "压力下容易直接回应、回避或进入长时间内耗。",
+                            "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
+                            "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
+                            "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。",
+                            "label": "情绪调节 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
+                            "strength": "Clear emotional reactions can show you exactly which situations need practice.",
+                            "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
+                            "typical_scene": "After a conflict, you may replay the conversation for a long time.",
+                            "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
+                            "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic.",
+                            "label": "Emotion regulation · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
+                            "strength": "你已经知道某些做法能帮自己缓下来。",
+                            "risk": "情绪强度一高，原本有效的方法可能想不起来。",
+                            "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
+                            "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
+                            "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。",
+                            "label": "情绪调节 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
+                            "strength": "You already know that some actions help you settle.",
+                            "risk": "When intensity rises, strategies that usually work may be hard to remember.",
+                            "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
+                            "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
+                            "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option.",
+                            "label": "Emotion regulation · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
+                            "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
+                            "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
+                            "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
+                            "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
+                            "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。",
+                            "label": "情绪调节 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
+                            "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
+                            "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
+                            "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
+                            "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
+                            "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice.",
+                            "label": "Emotion regulation · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
+                            "strength": "你能为沟通争取到更好的时机和语气。",
+                            "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
+                            "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
+                            "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
+                            "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。",
+                            "label": "情绪调节 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
+                            "strength": "You can create better timing and tone for communication.",
+                            "risk": "At times, you may appear so calm that others cannot read your real position.",
+                            "typical_scene": "When challenged, you can steady your tone before addressing the point.",
+                            "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
+                            "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information.",
+                            "label": "Emotion regulation · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
+                            "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
+                            "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
+                            "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
+                            "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
+                            "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。",
+                            "label": "情绪调节 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
+                            "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
+                            "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
+                            "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
+                            "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
+                            "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure.",
+                            "label": "Emotion regulation · Integrated"
+                        }
+                    }
+                },
+                "EM": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
+                            "strength": "你可以通过直接提问建立更清楚的信息。",
+                            "risk": "容易把沉默、语气或表情理解得过少或过多。",
+                            "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
+                            "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
+                            "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。",
+                            "label": "共情理解 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
+                            "strength": "Direct questions can give you clearer information.",
+                            "risk": "You may read too little or too much into silence, tone, or facial expression.",
+                            "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
+                            "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
+                            "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support.",
+                            "label": "Empathic understanding · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
+                            "strength": "你开始关注关系中的情绪温度。",
+                            "risk": "可能过早判断别人不高兴、失望或疏远。",
+                            "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
+                            "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
+                            "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。",
+                            "label": "共情理解 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
+                            "strength": "You are starting to track the emotional temperature in relationships.",
+                            "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
+                            "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
+                            "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
+                            "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence.",
+                            "label": "Empathic understanding · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
+                            "strength": "你能让对方感到被看见和被认真对待。",
+                            "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
+                            "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
+                            "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
+                            "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。",
+                            "label": "共情理解 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
+                            "strength": "You can help others feel seen and taken seriously.",
+                            "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
+                            "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
+                            "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
+                            "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion.",
+                            "label": "Empathic understanding · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
+                            "strength": "你能在复杂关系中捕捉未说出口的信息。",
+                            "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
+                            "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
+                            "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
+                            "do_not_overread": "熟练共情不等于你必须解决所有人的感受。",
+                            "label": "共情理解 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
+                            "strength": "You can notice unspoken information in complex relationships.",
+                            "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
+                            "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
+                            "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
+                            "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings.",
+                            "label": "Empathic understanding · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
+                            "strength": "你能在理解别人时仍保持清晰位置。",
+                            "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
+                            "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
+                            "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
+                            "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。",
+                            "label": "共情理解 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
+                            "strength": "You can understand others while keeping a clear position.",
+                            "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
+                            "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
+                            "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
+                            "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together.",
+                            "label": "Empathic understanding · Integrated"
+                        }
+                    }
+                },
+                "RM": {
+                    "foundational": {
+                        "zh-CN": {
+                            "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
+                            "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
+                            "risk": "容易在不舒服时沉默、解释过多或直接退出。",
+                            "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
+                            "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
+                            "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。",
+                            "label": "关系管理 · 基础发展中"
+                        },
+                        "en": {
+                            "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
+                            "strength": "With clear steps, your relationship skills can improve steadily.",
+                            "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
+                            "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
+                            "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
+                            "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar.",
+                            "label": "Relationship management · Foundational"
+                        }
+                    },
+                    "developing": {
+                        "zh-CN": {
+                            "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
+                            "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
+                            "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
+                            "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
+                            "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
+                            "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。",
+                            "label": "关系管理 · 发展中"
+                        },
+                        "en": {
+                            "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
+                            "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
+                            "risk": "You may try to preserve the relationship while leaving your real position unclear.",
+                            "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
+                            "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
+                            "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame.",
+                            "label": "Relationship management · Developing"
+                        }
+                    },
+                    "stable": {
+                        "zh-CN": {
+                            "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
+                            "strength": "你能让关系在小摩擦后回到可合作状态。",
+                            "risk": "为了维持顺畅，可能回避更难但必要的话题。",
+                            "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
+                            "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
+                            "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。",
+                            "label": "关系管理 · 稳定可用"
+                        },
+                        "en": {
+                            "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
+                            "strength": "You can help a relationship return to cooperation after small friction.",
+                            "risk": "To keep things smooth, you may avoid harder but necessary topics.",
+                            "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
+                            "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
+                            "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship.",
+                            "label": "Relationship management · Stable"
+                        }
+                    },
+                    "proficient": {
+                        "zh-CN": {
+                            "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
+                            "strength": "你能把冲突转化为更清楚的协作规则。",
+                            "risk": "别人可能默认你来收拾关系残局。",
+                            "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
+                            "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
+                            "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。",
+                            "label": "关系管理 · 熟练成熟"
+                        },
+                        "en": {
+                            "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
+                            "strength": "You can turn conflict into clearer rules for collaboration.",
+                            "risk": "Others may assume you will clean up the relational aftermath.",
+                            "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
+                            "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
+                            "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary.",
+                            "label": "Relationship management · Proficient"
+                        }
+                    },
+                    "integrated": {
+                        "zh-CN": {
+                            "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
+                            "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
+                            "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
+                            "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
+                            "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
+                            "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。",
+                            "label": "关系管理 · 高度整合"
+                        },
+                        "en": {
+                            "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
+                            "strength": "You can create clear and sustainable collaboration in complex relationships.",
+                            "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
+                            "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
+                            "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
+                            "do_not_overread": "Integrated does not mean you must carry all relationship maintenance.",
+                            "label": "Relationship management · Integrated"
+                        }
+                    }
+                }
+            },
+            "score_notes": {
+                "zh-CN": {
+                    "percentile": "百分位用于说明相对位置，不代表固定能力标签。",
+                    "standard_score": "标准分用于稳定展示和维度比较。",
+                    "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量和场景为准。"
+                },
+                "en": {
+                    "percentile": "Percentile explains relative position; it is not a fixed ability label.",
+                    "standard_score": "Standard score supports stable display and dimension comparison.",
+                    "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, and scenes."
+                }
+            },
+            "band_details": {
+                "foundational": {
+                    "zh-CN": {
+                        "label": "基础发展中",
+                        "meaning": "当前信号提示你需要先建立更清晰的识别、命名和复位习惯。",
+                        "strength": "从一个小而重复的动作开始，进步会更稳定。",
+                        "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
+                        "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Foundational",
+                        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits.",
+                        "strength": "Small repeatable actions can create more stable progress.",
+                        "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
+                        "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "developing": {
+                    "zh-CN": {
+                        "label": "发展中",
+                        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
+                        "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
+                        "risk": "最容易卡在“知道一点，但现场用不上”。",
+                        "practice_focus": "选择一个高频场景，提前准备一句回应。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Developing",
+                        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
+                        "strength": "You already catch part of the signal and can turn it into a routine.",
+                        "risk": "The common trap is knowing something but not using it in the moment.",
+                        "practice_focus": "Pick one frequent scene and prepare one response sentence.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "stable": {
+                    "zh-CN": {
+                        "label": "稳定可用",
+                        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。",
+                        "strength": "你的结果已经能支持更精细的场景训练。",
+                        "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
+                        "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Stable",
+                        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible.",
+                        "strength": "Your result can support more precise scene-based practice.",
+                        "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
+                        "practice_focus": "Identify one scene where stability drops and review it afterward.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "proficient": {
+                    "zh-CN": {
+                        "label": "熟练成熟",
+                        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
+                        "strength": "你可以把个人优势转成可复制的沟通习惯。",
+                        "risk": "他人可能默认你应该一直承担稳定局面的角色。",
+                        "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Proficient",
+                        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
+                        "strength": "You can turn personal strengths into repeatable communication habits.",
+                        "risk": "Others may assume you should always be the stabilizing person.",
+                        "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+                    }
+                },
+                "integrated": {
+                    "zh-CN": {
+                        "label": "高度整合",
+                        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
+                        "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
+                        "risk": "高整合也可能带来过度承担和高标准疲劳。",
+                        "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
+                        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+                    },
+                    "en": {
+                        "label": "Integrated",
+                        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
+                        "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
+                        "risk": "High integration may still create over-responsibility and high-standard fatigue.",
+                        "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
+                        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
                     }
                 }
             }
@@ -183,281 +679,321 @@
                 "balanced_integrated": {
                     "zh-CN": {
                         "title": "均衡整合型",
-                        "one_liner": "你的情绪与关系信号比较均衡，优势在于稳定和可迁移。",
-                        "core_claim": "你通常能同时看见自己、理解他人，并在多数情境中维持可用的回应方式。",
+                        "one_liner": "你能同时照顾自己的状态、他人的感受和关系目标。",
+                        "hero_summary": "你能同时照顾自己的状态、他人的感受和关系目标。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能同时照顾自己的状态、他人的感受和关系目标。",
                         "evidence_basis": [
-                            "四维分数相对均衡",
-                            "无明显单一短板"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "稳定性和多场景适应能力。",
-                        "likely_cost": "容易低估特定高压情境对自己的消耗。",
-                        "development_lever": "选择一个真实场景做精细化复盘，而不是泛泛提升。",
-                        "do_not_overread": "这不代表你在任何情境中都不会被触发。"
+                        "primary_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                        "development_lever": "把“我来稳住”改成“我们一起定规则”。",
+                        "user_memory_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Balanced Integration",
-                        "one_liner": "Your emotional and relational signals are relatively balanced; stability is the main strength.",
-                        "core_claim": "You usually notice yourself, understand others, and maintain usable responses across many contexts.",
+                        "title": "Balanced Integrator",
+                        "one_liner": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                        "hero_summary": "You can hold your own state, other people, and the relationship goal in view at the same time. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You can hold your own state, other people, and the relationship goal in view at the same time.",
                         "evidence_basis": [
-                            "Four dimensions are relatively balanced",
-                            "No single severe gap stands out"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Stability and transfer across contexts.",
-                        "likely_cost": "You may underestimate how specific high-pressure contexts drain you.",
-                        "development_lever": "Choose one real situation for precise review rather than trying to improve everything.",
-                        "do_not_overread": "This does not mean you will never be triggered."
+                        "primary_strength": "You can keep emotion, relationship, and task in the same frame.",
+                        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                        "development_lever": "Move from “I will steady this” to “we need a shared rule.”",
+                        "user_memory_sentence": "I can steady a relationship without maintaining the whole system alone.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "high_empathy_low_recovery": {
                     "zh-CN": {
                         "title": "高共情，低恢复",
-                        "one_liner": "你容易理解他人感受，但恢复和边界是当前杠杆。",
-                        "core_claim": "你可能很快接住别人的情绪，却不一定能及时把对方状态和自己的状态分开。",
+                        "one_liner": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                        "hero_summary": "你很快读到别人的状态，但恢复系统常常追不上共情速度。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
                         "evidence_basis": [
-                            "EM 明显高于 ER",
-                            "共情信号强于恢复信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "对他人状态敏感，容易建立信任。",
-                        "likely_cost": "在冲突、求助或高情绪劳动场景中容易被卷入。",
-                        "development_lever": "共情之后建立边界和恢复动作。",
-                        "do_not_overread": "发展方向不是减少共情，而是让共情更有边界。"
+                        "primary_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                        "development_lever": "练习“理解但不接管”，让共情后面跟着边界。",
+                        "user_memory_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "High Empathy, Low Recovery",
-                        "one_liner": "You tend to understand others quickly, while recovery and boundaries are the current lever.",
-                        "core_claim": "You may absorb other people's emotions quickly without separating their state from your own soon enough.",
+                        "title": "High Empathy, Slow Recovery",
+                        "one_liner": "You read the room quickly, but recovery can lag behind empathy.",
+                        "hero_summary": "You read the room quickly, but recovery can lag behind empathy. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You read the room quickly, but recovery can lag behind empathy.",
                         "evidence_basis": [
-                            "EM is meaningfully higher than ER",
-                            "Empathy signal is stronger than recovery signal"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Sensitivity to others and trust building.",
-                        "likely_cost": "Conflict, support, and high emotional-labor settings may pull you in too deeply.",
-                        "development_lever": "Build boundaries and recovery after empathy.",
-                        "do_not_overread": "The goal is not less empathy; it is empathy with clearer boundaries."
+                        "primary_strength": "You can make people feel understood, especially when emotions run high.",
+                        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+                        "development_lever": "Practice understanding without taking over, so empathy is followed by boundary.",
+                        "user_memory_sentence": "I can understand someone without carrying the whole emotional load.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "aware_but_unregulated": {
                     "zh-CN": {
-                        "title": "高觉察，调节不足",
-                        "one_liner": "你能知道自己怎么了，但不一定能很快恢复。",
-                        "core_claim": "你可能很快觉察到被触发，却需要更稳定的暂停、命名和复位动作。",
+                        "title": "有觉察，调节不足",
+                        "one_liner": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                        "hero_summary": "你常知道自己怎么了，但把自己带回来需要更长时间。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你常知道自己怎么了，但把自己带回来需要更长时间。",
                         "evidence_basis": [
-                            "SA 高于 ER",
-                            "自我识别强于调节行动"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "能捕捉自己的情绪变化。",
-                        "likely_cost": "知道问题但仍被情绪带着走。",
-                        "development_lever": "把觉察转成具体调节步骤。",
-                        "do_not_overread": "觉察本身不是问题，问题在于缺少后续动作。"
+                        "primary_strength": "你能清楚识别触发点、感受和需要。",
+                        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                        "development_lever": "把觉察压缩成一个暂停动作，而不是继续解释。",
+                        "user_memory_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Aware but Under-Regulated",
-                        "one_liner": "You may know what is happening inside, but recovery may lag.",
-                        "core_claim": "You may notice triggers quickly and still need steadier pause, labeling, and reset actions.",
+                        "title": "Aware, Still Reactive",
+                        "one_liner": "You often know what is happening inside, but the reset button is slower than the insight.",
+                        "hero_summary": "You often know what is happening inside, but the reset button is slower than the insight. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You often know what is happening inside, but the reset button is slower than the insight.",
                         "evidence_basis": [
-                            "SA is higher than ER",
-                            "Self-recognition is stronger than regulation action"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You can catch emotional shifts in yourself.",
-                        "likely_cost": "You may know the issue while still being carried by the emotion.",
-                        "development_lever": "Turn awareness into concrete regulation steps.",
-                        "do_not_overread": "Awareness is not the problem; the missing step is what follows."
+                        "primary_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                        "development_lever": "Turn awareness into one pause action instead of another layer of explanation.",
+                        "user_memory_sentence": "I know what is happening; the next skill is bringing myself back.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "calm_but_distant": {
                     "zh-CN": {
-                        "title": "冷静稳定，但回应偏远",
-                        "one_liner": "你较能维持稳定，但可能不够读懂或回应他人情绪。",
-                        "core_claim": "你在压力下可能保持冷静，但关系中的温度和回应需要更多主动性。",
+                        "title": "冷静稳定，但距离感强",
+                        "one_liner": "你能稳住事情，但别人不一定感到被情绪上接住。",
+                        "hero_summary": "你能稳住事情，但别人不一定感到被情绪上接住。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能稳住事情，但别人不一定感到被情绪上接住。",
                         "evidence_basis": [
-                            "ER 高于 EM",
-                            "稳定信号强于共情信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "不容易被情绪场带乱。",
-                        "likely_cost": "他人可能感到你不够理解或靠近。",
-                        "development_lever": "在稳定之外增加情绪确认。",
-                        "do_not_overread": "冷静不等于冷漠，但需要被他人感受到。"
+                        "primary_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                        "development_lever": "先回应一句感受，再给建议或方案。",
+                        "user_memory_sentence": "我能稳住事情，也要让人感到被看见。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Calm but Distant",
-                        "one_liner": "You may stay steady while reading or responding to others less actively.",
-                        "core_claim": "You may remain calm under pressure, but warmth and relational response need more intentional action.",
+                        "title": "Steady, Less Attuned",
+                        "one_liner": "You can steady the situation, but people may not always feel emotionally met.",
+                        "hero_summary": "You can steady the situation, but people may not always feel emotionally met. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You can steady the situation, but people may not always feel emotionally met.",
                         "evidence_basis": [
-                            "ER is higher than EM",
-                            "Stability signal is stronger than empathy signal"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You are less likely to be disrupted by the emotional field.",
-                        "likely_cost": "Others may feel less understood or less met.",
-                        "development_lever": "Add emotional acknowledgment to stability.",
-                        "do_not_overread": "Calm is not coldness, but it needs to be felt by others."
+                        "primary_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+                        "development_lever": "Acknowledge one feeling before offering advice or a solution.",
+                        "user_memory_sentence": "I can steady the situation and still help people feel seen.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "relationship_first_self_later": {
                     "zh-CN": {
                         "title": "关系优先，自我后置",
-                        "one_liner": "你能维护关系，但可能晚一步看见自己的真实感受。",
-                        "core_claim": "你倾向先让关系顺畅，再处理自己的边界、需求和消耗。",
+                        "one_liner": "你会先保护关系，再回头找自己的真实立场。",
+                        "hero_summary": "你会先保护关系，再回头找自己的真实立场。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你会先保护关系，再回头找自己的真实立场。",
                         "evidence_basis": [
-                            "RM 高于 SA",
-                            "关系行动强于自我连接"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "能维持合作和关系稳定。",
-                        "likely_cost": "长期忽略自己的感受和界限。",
-                        "development_lever": "在回应别人前先确认自己的底线。",
-                        "do_not_overread": "重视关系不是问题，自我后置过久才是风险。"
+                        "primary_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                        "development_lever": "在照顾关系前，先给自己的感受一个位置。",
+                        "user_memory_sentence": "关系重要，我的感受也需要在场。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Relationship First, Self Later",
-                        "one_liner": "You can maintain relationships, but may notice your own feelings too late.",
-                        "core_claim": "You tend to keep the relationship smooth before checking your own boundaries, needs, and cost.",
+                        "one_liner": "You protect the relationship first and find your own position later.",
+                        "hero_summary": "You protect the relationship first and find your own position later. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You protect the relationship first and find your own position later.",
                         "evidence_basis": [
-                            "RM is higher than SA",
-                            "Relational action is stronger than self-connection"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "You can preserve cooperation and relational stability.",
-                        "likely_cost": "You may overlook your feelings and limits over time.",
-                        "development_lever": "Check your bottom line before responding to others.",
-                        "do_not_overread": "Valuing relationships is not the issue; staying self-later for too long is the risk."
+                        "primary_strength": "You are sensitive to relational tone and often keep interaction workable.",
+                        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                        "development_lever": "Give your own feeling a place before you manage the relationship.",
+                        "user_memory_sentence": "The relationship matters, and my own state belongs in the room too.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "self_clear_repair_weak": {
                     "zh-CN": {
                         "title": "自我清楚，修复不足",
-                        "one_liner": "你知道自己的感受，但关系修复动作需要更清晰。",
-                        "core_claim": "你可能能表达立场，却不一定能把表达转成可继续合作的关系动作。",
+                        "one_liner": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                        "hero_summary": "你知道自己的立场，但冲突后的修复需要更明确的工具。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
                         "evidence_basis": [
-                            "SA 高于 RM",
-                            "自我清楚强于关系修复"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "有清楚的自我感受和判断。",
-                        "likely_cost": "表达后关系可能停在紧张或防御状态。",
-                        "development_lever": "把表达、确认和修复连成一组动作。",
-                        "do_not_overread": "清楚表达不是攻击，关键是加上修复。"
+                        "primary_strength": "你不容易在关系压力里丢掉自己的判断。",
+                        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                        "development_lever": "把“我说清楚了”补成“我们怎么重新对齐”。",
+                        "user_memory_sentence": "我可以清楚表达，也可以把关系重新接上。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Self-Clear, Repair Weaker",
-                        "one_liner": "You may know your feelings while needing clearer relational repair moves.",
-                        "core_claim": "You may state your position without always turning it into actions that keep collaboration possible.",
+                        "title": "Clear Self, Repair Gap",
+                        "one_liner": "You know your position, but repair after tension needs a clearer tool.",
+                        "hero_summary": "You know your position, but repair after tension needs a clearer tool. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You know your position, but repair after tension needs a clearer tool.",
                         "evidence_basis": [
-                            "SA is higher than RM",
-                            "Self-clarity is stronger than repair"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Clear self-feeling and judgment.",
-                        "likely_cost": "After expression, the relationship may remain tense or defensive.",
-                        "development_lever": "Connect expression, acknowledgment, and repair as one sequence.",
-                        "do_not_overread": "Clear expression is not attack; the key is adding repair."
+                        "primary_strength": "You are less likely to lose your judgment under relational pressure.",
+                        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+                        "development_lever": "Add “how do we realign?” after “I made my point.”",
+                        "user_memory_sentence": "I can be clear and still reconnect the relationship.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "steady_collaborator": {
                     "zh-CN": {
                         "title": "稳定协作型",
-                        "one_liner": "你在压力下较能维持合作和修复。",
-                        "core_claim": "你通常能在情绪波动中保持可沟通，并把关系拉回可协作状态。",
+                        "one_liner": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                        "hero_summary": "你能在压力下维持合作推进，但别让稳定只靠你一个人。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
                         "evidence_basis": [
-                            "ER 与 RM 都较高",
-                            "压力恢复和关系行动同向"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "压力下仍能保持建设性。",
-                        "likely_cost": "可能承担过多协调责任。",
-                        "development_lever": "区分需要你修复的事和不该由你承担的事。",
-                        "do_not_overread": "稳定协作不意味着你必须负责所有人的情绪。"
+                        "primary_strength": "你能把紧张对话拉回事实、目标和下一步。",
+                        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+                        "development_lever": "把个人稳定能力变成团队流程。",
+                        "user_memory_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Steady Collaborator",
-                        "one_liner": "You tend to maintain collaboration and repair under pressure.",
-                        "core_claim": "You can often stay communicative during emotional shifts and bring the relationship back to workable ground.",
+                        "one_liner": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                        "hero_summary": "You keep collaboration moving under pressure, but steadiness should not depend only on you. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
                         "evidence_basis": [
-                            "ER and RM are both relatively high",
-                            "Recovery and relational action move together"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Constructive response under pressure.",
-                        "likely_cost": "You may take on too much coordination responsibility.",
-                        "development_lever": "Separate what is yours to repair from what is not yours to carry.",
-                        "do_not_overread": "Being steady does not make you responsible for everyone else's emotions."
+                        "primary_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                        "development_lever": "Turn personal steadiness into team process.",
+                        "user_memory_sentence": "I can help collaboration, but the rules cannot live only in me.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "sensitive_absorber": {
                     "zh-CN": {
                         "title": "高敏感，易吸收",
-                        "one_liner": "你很能感知自己和他人，但也更容易被情绪环境影响。",
-                        "core_claim": "你可能同时捕捉自己的细微信号和他人情绪，因此需要更强的区分与恢复。",
+                        "one_liner": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                        "hero_summary": "你能捕捉细微变化，但敏感也容易变成情绪负重。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
                         "evidence_basis": [
-                            "SA 与 EM 较高",
-                            "ER 相对较低"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "情绪线索捕捉能力强。",
-                        "likely_cost": "容易过度加工或吸收环境情绪。",
-                        "development_lever": "区分我的感受、他人的感受和现场压力。",
-                        "do_not_overread": "敏感不是脆弱，它需要更好的过滤系统。"
+                        "primary_strength": "你很快发现气氛、语气和关系位置的变化。",
+                        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                        "development_lever": "把“我感到了”区分成“我要不要回应”。",
+                        "user_memory_sentence": "我能感到很多东西，但不需要回应所有东西。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Sensitive Absorber",
-                        "one_liner": "You notice yourself and others strongly, and may be more affected by the emotional field.",
-                        "core_claim": "You may catch subtle self-signals and other people's emotions at the same time, requiring stronger separation and recovery.",
+                        "one_liner": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                        "hero_summary": "You catch subtle shifts fast, and that sensitivity can become emotional load. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
                         "evidence_basis": [
-                            "SA and EM are relatively high",
-                            "ER is relatively lower"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "Strong emotional cue detection.",
-                        "likely_cost": "You may over-process or absorb environmental emotion.",
-                        "development_lever": "Separate my feeling, their feeling, and situational pressure.",
-                        "do_not_overread": "Sensitivity is not weakness; it needs a better filtering system."
+                        "primary_strength": "You quickly notice shifts in tone, mood, and relational position.",
+                        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                        "development_lever": "Separate “I noticed it” from “I need to respond.”",
+                        "user_memory_sentence": "I can feel a lot without responding to everything.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "developing_foundation": {
                     "zh-CN": {
                         "title": "基础发展中",
-                        "one_liner": "多个情绪与关系信号仍在打基础，适合从一个小场景开始练。",
-                        "core_claim": "你的结果提示当前不宜追求复杂技巧，先建立命名、暂停和复盘的基础动作更重要。",
+                        "one_liner": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                        "hero_summary": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
                         "evidence_basis": [
-                            "多个维度处于基础或发展区间",
-                            "没有稳定优势维度足以独立支撑"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "可塑性强，适合从低风险场景开始。",
-                        "likely_cost": "同时处理太多关系任务会增加压力。",
-                        "development_lever": "先练一个最小闭环：识别、暂停、选择下一句。",
-                        "do_not_overread": "这不是能力定论，而是当前自我报告信号。"
+                        "primary_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                        "development_lever": "先把一个情绪命名清楚，再谈复杂改变。",
+                        "user_memory_sentence": "先练一个小动作，就已经是在建立基础。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
                         "title": "Developing Foundation",
-                        "one_liner": "Several emotional and relational signals are still foundational; start with one small context.",
-                        "core_claim": "The result suggests starting with basic labeling, pausing, and review before complex techniques.",
+                        "one_liner": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                        "hero_summary": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
                         "evidence_basis": [
-                            "Multiple dimensions are foundational or developing",
-                            "No stable strength is strong enough to carry the pattern alone"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "High room for growth through low-risk practice.",
-                        "likely_cost": "Handling too many relational tasks at once can increase pressure.",
-                        "development_lever": "Practice one small loop: notice, pause, choose the next sentence.",
-                        "do_not_overread": "This is not a fixed ability judgment; it is the current self-report signal."
+                        "primary_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                        "development_lever": "Name one feeling clearly before attempting a larger change.",
+                        "user_memory_sentence": "One small practice is already foundation-building.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 },
                 "low_confidence_result": {
                     "zh-CN": {
-                        "title": "本次结果置信度不足",
-                        "one_liner": "本次作答质量信号降低了解释置信度，建议先谨慎阅读。",
-                        "core_claim": "系统检测到会影响解释稳定性的作答模式，因此不应输出强人格判断。",
+                        "title": "本次结果置信度较低",
+                        "one_liner": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                        "hero_summary": "这次结果应轻一点读，最有价值的是理解本次作答状态。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+                        "core_claim": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
                         "evidence_basis": [
-                            "质量等级为 C 或 D",
-                            "存在速度、长串、极端、中立或不一致信号"
+                            "由四维分数、维度差距、质量等级和组合机制共同触发。"
                         ],
-                        "primary_strength": "仍可作为反思线索。",
-                        "likely_cost": "具体维度和画像容易被误读。",
-                        "development_lever": "在状态稳定时复测，或只使用低风险建议。",
-                        "do_not_overread": "不要把这次结果作为稳定结论。"
+                        "primary_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "development_lever": "先记录状态，之后在更稳定的时间复测。",
+                        "user_memory_sentence": "这次结果不是不能看，而是要轻一点看。",
+                        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+                        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
                     },
                     "en": {
-                        "title": "Lower Confidence Result",
-                        "one_liner": "Response-quality signals reduce interpretation confidence; read this result cautiously.",
-                        "core_claim": "The system detected response patterns that can reduce interpretive stability, so strong personality claims should not be made.",
+                        "title": "Lower-Confidence Result",
+                        "one_liner": "Read this result lightly; the most useful signal is the response context of this session.",
+                        "hero_summary": "Read this result lightly; the most useful signal is the response context of this session. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+                        "core_claim": "Read this result lightly; the most useful signal is the response context of this session.",
                         "evidence_basis": [
-                            "Quality level is C or D",
-                            "Speed, long-string, extreme, neutral, or inconsistency signals are present"
+                            "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
                         ],
-                        "primary_strength": "It can still serve as a reflection cue.",
-                        "likely_cost": "Specific dimensions and patterns may be overread.",
-                        "development_lever": "Retake when stable, or use only low-risk suggestions.",
-                        "do_not_overread": "Do not treat this result as a stable conclusion."
+                        "primary_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "development_lever": "Record the context first, then retest when conditions are steadier.",
+                        "user_memory_sentence": "This result is not useless; it simply needs a lighter reading.",
+                        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+                        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
                     }
                 }
             }
@@ -475,410 +1011,490 @@
                 "SA_ER": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "知道自己，也能复位",
-                            "why_it_matters": "自我觉察只有接上调节动作，才会变成现实中的稳定回应。",
-                            "what_it_feels_like": "你通常能说清自己怎么了，并较快找到下一步。",
-                            "strength": "减少反复内耗，把情绪信息转成行动。",
-                            "cost": "可能过度依赖自我控制，忽略休息需求。",
-                            "development_lever": "让复位动作更轻量。",
-                            "micro_action": "用一句话命名情绪，再决定下一句怎么说。"
+                            "title": "自我觉察 × 情绪调节｜双高协同",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You notice yourself and can reset",
-                            "why_it_matters": "Self-awareness becomes real-world stability only when it connects to regulation.",
-                            "what_it_feels_like": "You can usually name what is happening and find the next step.",
-                            "strength": "Less rumination; more action from emotional information.",
-                            "cost": "You may over-rely on self-control and miss rest needs.",
-                            "development_lever": "Make reset actions lighter.",
-                            "micro_action": "Name the emotion in one sentence, then choose the next sentence."
+                            "title": "Self-awareness × Emotion regulation: both signals support each other",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "知道自己，但恢复跟不上",
-                            "why_it_matters": "觉察会放大感受，如果没有调节动作，反而更容易卡住。",
-                            "what_it_feels_like": "你知道自己被触发了，但身体和语气不一定跟得上。",
-                            "strength": "能早期识别风险信号。",
-                            "cost": "容易陷入反复解释或自责。",
-                            "development_lever": "把觉察后 30 秒变成固定流程。",
-                            "micro_action": "暂停、命名、喝水或离开屏幕 60 秒。"
+                            "title": "自我觉察 × 情绪调节｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You notice yourself, but recovery lags",
-                            "why_it_matters": "Awareness can intensify feelings when no regulation step follows.",
-                            "what_it_feels_like": "You know you are triggered, but your body or tone may not catch up.",
-                            "strength": "Early detection of risk signals.",
-                            "cost": "You may loop in explanation or self-blame.",
-                            "development_lever": "Turn the first 30 seconds after awareness into a routine.",
-                            "micro_action": "Pause, label, drink water, or step away from the screen for 60 seconds."
+                            "title": "Self-awareness × Emotion regulation: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "能稳定，但不总知道原因",
-                            "why_it_matters": "调节有效，但如果不理解触发点，模式会重复出现。",
-                            "what_it_feels_like": "你能忍住或恢复，但事后未必知道自己为何被影响。",
-                            "strength": "压力下不易失控。",
-                            "cost": "复盘不足会让同类问题反复。",
-                            "development_lever": "补上事后命名。",
-                            "micro_action": "事后写下：刚才我真正介意的是什么。"
+                            "title": "自我觉察 × 情绪调节｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You can stabilize without always knowing why",
-                            "why_it_matters": "Regulation helps, but without understanding triggers the pattern repeats.",
-                            "what_it_feels_like": "You can hold or recover, but may not know what affected you.",
-                            "strength": "Less likely to lose control under pressure.",
-                            "cost": "Weak review lets similar problems recur.",
-                            "development_lever": "Add after-action labeling.",
-                            "micro_action": "Afterward, write: what did I actually care about?"
+                            "title": "Self-awareness × Emotion regulation: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "识别和恢复都需要打底",
-                            "why_it_matters": "如果既难识别也难复位，复杂场景会迅速耗尽资源。",
-                            "what_it_feels_like": "你可能到事后才发现自己已经很累或很烦。",
-                            "strength": "适合从最小动作建立可预测性。",
-                            "cost": "高压沟通中容易被动应对。",
-                            "development_lever": "先练一个简单情绪词表。",
-                            "micro_action": "每天一次选择一个情绪词，并写下触发场景。"
+                            "title": "自我觉察 × 情绪调节｜两项都需要打底",
+                            "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Both recognition and recovery need foundations",
-                            "why_it_matters": "When both noticing and resetting are hard, complex situations drain resources quickly.",
-                            "what_it_feels_like": "You may realize only afterward that you were tired or irritated.",
-                            "strength": "Small actions can build predictability.",
-                            "cost": "High-pressure communication may become reactive.",
-                            "development_lever": "Start with a simple emotion vocabulary.",
-                            "micro_action": "Once a day, choose one emotion word and write the trigger."
+                            "title": "Self-awareness × Emotion regulation: both signals need foundations",
+                            "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "EM_ER": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "能理解别人，也能保留自己",
-                            "why_it_matters": "共情和恢复并存时，理解他人不必以自我消耗为代价。",
-                            "what_it_feels_like": "你能靠近他人情绪，也能及时回到自己的节奏。",
-                            "strength": "支持他人而不容易被吞没。",
-                            "cost": "可能被期待持续承担情绪支持。",
-                            "development_lever": "明确支持边界。",
-                            "micro_action": "先确认对方需要倾听、建议还是具体帮助。"
+                            "title": "共情理解 × 情绪调节｜双高协同",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You understand others and keep yourself",
-                            "why_it_matters": "When empathy and recovery coexist, understanding others does not require self-drain.",
-                            "what_it_feels_like": "You can approach others' emotions and return to your own rhythm.",
-                            "strength": "Support without being swallowed by the situation.",
-                            "cost": "Others may expect constant emotional support.",
-                            "development_lever": "Make support boundaries explicit.",
-                            "micro_action": "Ask whether they need listening, advice, or concrete help."
+                            "title": "Empathy × Emotion regulation: both signals support each other",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "共情强，边界和恢复偏弱",
-                            "why_it_matters": "你越能理解别人，越需要知道哪些情绪不是你要承担的。",
-                            "what_it_feels_like": "别人难受时，你可能很快进入帮助或自责状态。",
-                            "strength": "容易让人感到被看见。",
-                            "cost": "容易吸收过多情绪劳动。",
-                            "development_lever": "共情后加一句边界确认。",
-                            "micro_action": "在心里说：这是对方的感受，我可以支持，但不需要代替。"
+                            "title": "共情理解 × 情绪调节｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Strong empathy, weaker boundaries and recovery",
-                            "why_it_matters": "The more you understand others, the more you need to know what is not yours to carry.",
-                            "what_it_feels_like": "When someone is distressed, you may quickly move into helping or self-blame.",
-                            "strength": "People often feel seen by you.",
-                            "cost": "You may absorb too much emotional labor.",
-                            "development_lever": "Add one boundary check after empathy.",
-                            "micro_action": "Say internally: this is their feeling; I can support without replacing them."
+                            "title": "Empathy × Emotion regulation: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "稳定有余，情绪读人不足",
-                            "why_it_matters": "稳定能保护你，但关系需要对他人情绪的基本回应。",
-                            "what_it_feels_like": "你能保持冷静，却可能错过对方真正介意的点。",
-                            "strength": "不容易被外部情绪带乱。",
-                            "cost": "他人可能觉得你太理性或太远。",
-                            "development_lever": "先回应感受，再处理事实。",
-                            "micro_action": "说一句：我听到这件事让你很不舒服。"
+                            "title": "共情理解 × 情绪调节｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Steady, but less emotionally attuned",
-                            "why_it_matters": "Stability protects you, but relationships need basic emotional acknowledgment.",
-                            "what_it_feels_like": "You stay calm but may miss what the other person really cares about.",
-                            "strength": "External emotion disrupts you less.",
-                            "cost": "Others may experience you as too rational or distant.",
-                            "development_lever": "Respond to feeling before facts.",
-                            "micro_action": "Say: I hear that this felt uncomfortable for you."
+                            "title": "Empathy × Emotion regulation: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "理解他人与恢复都需降低难度",
-                            "why_it_matters": "当共情和恢复都弱时，先降低情境复杂度比追求技巧更有效。",
-                            "what_it_feels_like": "强情绪场景可能让你想躲开或快速结束。",
-                            "strength": "可从低风险互动开始建立经验。",
-                            "cost": "高情绪劳动场景消耗明显。",
-                            "development_lever": "用固定句式承接基础情绪。",
-                            "micro_action": "先说：我需要一点时间理解你说的。"
+                            "title": "共情理解 × 情绪调节｜两项都需要打底",
+                            "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Lower complexity for empathy and recovery",
-                            "why_it_matters": "When both empathy and recovery are weaker, reducing complexity helps more than chasing advanced technique.",
-                            "what_it_feels_like": "High-emotion situations may make you want to avoid or end quickly.",
-                            "strength": "Low-risk interactions can build experience.",
-                            "cost": "High emotional-labor settings are draining.",
-                            "development_lever": "Use a stable sentence to receive basic emotion.",
-                            "micro_action": "Say: I need a little time to understand what you mean."
+                            "title": "Empathy × Emotion regulation: both signals need foundations",
+                            "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "EM_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "读懂别人，也能处理关系",
-                            "why_it_matters": "理解和行动结合时，共情更容易变成有效协作。",
-                            "what_it_feels_like": "你能读懂现场气氛，并推动关系回到可沟通状态。",
-                            "strength": "适合复杂协作和关系修复。",
-                            "cost": "可能过度承担协调者角色。",
-                            "development_lever": "把责任边界说清楚。",
-                            "micro_action": "问：这件事我能负责哪一部分？"
+                            "title": "共情理解 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You read others and manage the relationship",
-                            "why_it_matters": "When understanding and action combine, empathy becomes workable collaboration.",
-                            "what_it_feels_like": "You can read the room and move the relationship back to communication.",
-                            "strength": "Useful for complex collaboration and repair.",
-                            "cost": "You may overtake the coordinator role.",
-                            "development_lever": "Clarify responsibility boundaries.",
-                            "micro_action": "Ask: which part of this is mine to own?"
+                            "title": "Empathy × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "读懂别人，但关系动作不足",
-                            "why_it_matters": "看见对方感受后，还需要把理解转成一句话或一个动作。",
-                            "what_it_feels_like": "你知道对方在意什么，却不一定知道怎么回应。",
-                            "strength": "关系判断较细腻。",
-                            "cost": "理解停在心里，别人感受不到。",
-                            "development_lever": "把理解外化成确认句。",
-                            "micro_action": "说：我理解你在意的是 X，而不是只是在反对。"
+                            "title": "共情理解 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You read others, but action is weaker",
-                            "why_it_matters": "After seeing someone's feeling, understanding needs to become a sentence or action.",
-                            "what_it_feels_like": "You know what matters to them but may not know how to respond.",
-                            "strength": "Nuanced relational judgment.",
-                            "cost": "Understanding stays inside and may not be felt.",
-                            "development_lever": "Externalize understanding as confirmation.",
-                            "micro_action": "Say: I understand that X matters to you, not just that you disagree."
+                            "title": "Empathy × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "会行动，但可能没读准情绪",
-                            "why_it_matters": "关系动作如果没有情绪理解，容易变成流程化处理。",
-                            "what_it_feels_like": "你会推进解决，但对方可能觉得重点没被接住。",
-                            "strength": "能快速进入处理模式。",
-                            "cost": "修复动作可能不够贴合。",
-                            "development_lever": "行动前先做一次情绪校准。",
-                            "micro_action": "问：这件事里你最难受的是哪一部分？"
+                            "title": "共情理解 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You act, but may miss the emotion",
-                            "why_it_matters": "Relational action without emotional understanding can become procedural.",
-                            "what_it_feels_like": "You move into solving while the other person may feel the point was missed.",
-                            "strength": "Fast entry into action mode.",
-                            "cost": "Repair may not fit the real concern.",
-                            "development_lever": "Calibrate emotion before action.",
-                            "micro_action": "Ask: which part of this felt hardest for you?"
+                            "title": "Empathy × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "关系理解和行动都需要脚手架",
-                            "why_it_matters": "复杂关系不能只靠临场反应，需要可复用脚本。",
-                            "what_it_feels_like": "你可能不知道对方为何反应强，也不知道下一句怎么说。",
-                            "strength": "固定脚本能快速提升可用性。",
-                            "cost": "临场压力下容易沉默或回避。",
-                            "development_lever": "先学低风险确认句。",
-                            "micro_action": "说：我可能没完全理解，你能再说一次你的重点吗？"
+                            "title": "共情理解 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Relational understanding and action need scaffolding",
-                            "why_it_matters": "Complex relationships need reusable scripts, not only improvisation.",
-                            "what_it_feels_like": "You may not know why they reacted strongly or what to say next.",
-                            "strength": "Stable scripts can improve usability quickly.",
-                            "cost": "Under pressure, silence or avoidance may appear.",
-                            "development_lever": "Start with low-risk confirmation lines.",
-                            "micro_action": "Say: I may not fully understand; can you restate your main point?"
+                            "title": "Empathy × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "SA_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "能表达自己，也能维护关系",
-                            "why_it_matters": "自我清楚和关系行动结合时，边界更容易被听见。",
-                            "what_it_feels_like": "你能说出自己的感受，同时照顾沟通继续。",
-                            "strength": "适合边界、反馈和修复场景。",
-                            "cost": "可能被期待承担沟通示范。",
-                            "development_lever": "让表达更简洁。",
-                            "micro_action": "用我感到、我需要、我建议三句完成表达。"
+                            "title": "自我觉察 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You express yourself and maintain the relationship",
-                            "why_it_matters": "When self-clarity and relational action combine, boundaries are easier to hear.",
-                            "what_it_feels_like": "You can state your feeling while keeping communication possible.",
-                            "strength": "Useful in boundaries, feedback, and repair.",
-                            "cost": "You may be expected to model communication for others.",
-                            "development_lever": "Make expression more concise.",
-                            "micro_action": "Use: I feel, I need, I suggest."
+                            "title": "Self-awareness × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "自我清楚，但关系承接不足",
-                            "why_it_matters": "表达自己之后，需要给关系一个继续对话的入口。",
-                            "what_it_feels_like": "你能说清立场，但对方可能进入防御。",
-                            "strength": "不容易丢失自我。",
-                            "cost": "表达可能被听成指责。",
-                            "development_lever": "表达后加一句共同目标。",
-                            "micro_action": "说：我讲这个是希望我们下次更好配合。"
+                            "title": "自我觉察 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Self-clear, but relational holding is weaker",
-                            "why_it_matters": "After expressing yourself, the relationship needs an entry point to continue.",
-                            "what_it_feels_like": "You can state your position, but the other person may become defensive.",
-                            "strength": "You are less likely to lose yourself.",
-                            "cost": "Expression may be heard as blame.",
-                            "development_lever": "Add a shared goal after expression.",
-                            "micro_action": "Say: I am raising this so we can work better next time."
+                            "title": "Self-awareness × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "会维护关系，但自我容易后置",
-                            "why_it_matters": "如果只维护关系，不表达自我，长期会积累消耗。",
-                            "what_it_feels_like": "你能把场面圆回来，但之后才发现自己不舒服。",
-                            "strength": "关系稳定和协作维持能力强。",
-                            "cost": "自己的需求容易被延后。",
-                            "development_lever": "回应前先问自己底线。",
-                            "micro_action": "在答应前停三秒，确认我是否真的可以。"
+                            "title": "自我觉察 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You maintain relationships, but self may come later",
-                            "why_it_matters": "If you only preserve the relationship and do not express yourself, cost accumulates.",
-                            "what_it_feels_like": "You smooth the moment, then later notice discomfort.",
-                            "strength": "Strong relational stability and collaboration maintenance.",
-                            "cost": "Your needs may be delayed.",
-                            "development_lever": "Check your boundary before responding.",
-                            "micro_action": "Pause three seconds before agreeing and ask whether you truly can."
+                            "title": "Self-awareness × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "自我表达和关系修复都需要练习",
-                            "why_it_matters": "当自我和关系动作都弱时，先从低风险表达开始。",
-                            "what_it_feels_like": "你可能既不想说破，也不知道怎么收场。",
-                            "strength": "可用结构化脚本降低难度。",
-                            "cost": "问题容易拖延或变成误会。",
-                            "development_lever": "练习一句低强度真实表达。",
-                            "micro_action": "说：这件事我还需要想一下，晚点回复你。"
+                            "title": "自我觉察 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Self-expression and repair both need practice",
-                            "why_it_matters": "When self and relational moves are both weaker, start with low-risk expression.",
-                            "what_it_feels_like": "You may not want to say it directly and may not know how to close the loop.",
-                            "strength": "Structured scripts can lower difficulty.",
-                            "cost": "Issues may be delayed or become misunderstandings.",
-                            "development_lever": "Practice one low-intensity truthful sentence.",
-                            "micro_action": "Say: I need to think about this and will reply later."
+                            "title": "Self-awareness × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 },
                 "ER_RM": {
                     "high_high": {
                         "zh-CN": {
-                            "title": "压力下仍能沟通和修复",
-                            "why_it_matters": "恢复能力和关系行动结合，是冲突后继续合作的关键。",
-                            "what_it_feels_like": "你能先稳住自己，再把对话拉回问题本身。",
-                            "strength": "冲突恢复和协作韧性强。",
-                            "cost": "可能成为默认救火者。",
-                            "development_lever": "把修复责任分给双方。",
-                            "micro_action": "问：我们各自下一步能做什么？"
+                            "title": "情绪调节 × 关系管理｜双高协同",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+                            "strength": "协同能力强，容易成为关系中的稳定点。",
+                            "cost": "别人可能过度依赖你的稳定。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You can communicate and repair under pressure",
-                            "why_it_matters": "Recovery plus relational action is key to collaboration after conflict.",
-                            "what_it_feels_like": "You can steady yourself and bring the conversation back to the issue.",
-                            "strength": "Strong conflict recovery and collaborative resilience.",
-                            "cost": "You may become the default fixer.",
-                            "development_lever": "Share repair responsibility.",
-                            "micro_action": "Ask: what can each of us do next?"
+                            "title": "Emotion regulation × Relationship management: both signals support each other",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+                            "strength": "Strong coordination can make you a stabilizing presence.",
+                            "cost": "Others may rely too much on your steadiness.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "high_low": {
                         "zh-CN": {
-                            "title": "自己能稳住，但关系未必修复",
-                            "why_it_matters": "你恢复了，不代表对话或关系已经恢复。",
-                            "what_it_feels_like": "你可能觉得事情过去了，但对方还停在情绪里。",
-                            "strength": "能减少个人失控。",
-                            "cost": "关系裂缝可能被低估。",
-                            "development_lever": "复位后做一次关系确认。",
-                            "micro_action": "说：刚才那段对话你现在感觉怎么样？"
+                            "title": "情绪调节 × 关系管理｜前者强，后者需要补位",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+                            "strength": "强项能成为练习入口。",
+                            "cost": "强项可能因为后续动作不足而变成消耗。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You stabilize yourself, but repair may not happen",
-                            "why_it_matters": "Your recovery does not mean the conversation or relationship has recovered.",
-                            "what_it_feels_like": "You may feel it has passed while the other person is still in it.",
-                            "strength": "Less personal escalation.",
-                            "cost": "Relationship cracks may be underestimated.",
-                            "development_lever": "Check the relationship after reset.",
-                            "micro_action": "Say: how are you feeling about that conversation now?"
+                            "title": "Emotion regulation × Relationship management: the first signal is stronger; the second needs support",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+                            "strength": "The stronger signal can become the practice entry point.",
+                            "cost": "The strength may become draining when follow-through is weak.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_high": {
                         "zh-CN": {
-                            "title": "想修复关系，但压力下难稳定",
-                            "why_it_matters": "关系意愿很重要，但压力未复位时动作容易变形。",
-                            "what_it_feels_like": "你想把事情讲好，却可能越讲越急。",
-                            "strength": "有合作和修复动机。",
-                            "cost": "调节不足会削弱修复效果。",
-                            "development_lever": "先复位，再修复。",
-                            "micro_action": "先暂停十分钟，再发出修复信息。"
+                            "title": "情绪调节 × 关系管理｜后者强，前者需要补位",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+                            "strength": "执行或稳定性较可用。",
+                            "cost": "缺少命名会让同类问题反复出现。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "You want repair, but pressure makes stability harder",
-                            "why_it_matters": "Repair motivation matters, but actions distort when you have not reset.",
-                            "what_it_feels_like": "You want to talk it through, but may become more urgent as you speak.",
-                            "strength": "Motivation for cooperation and repair.",
-                            "cost": "Weak regulation can reduce repair effectiveness.",
-                            "development_lever": "Reset before repair.",
-                            "micro_action": "Pause for ten minutes before sending the repair message."
+                            "title": "Emotion regulation × Relationship management: the second signal is stronger; the first needs support",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. Action is available, but unclear input can make you solve the wrong problem steadily.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+                            "strength": "Execution or steadiness is usable.",
+                            "cost": "Weak naming lets similar situations repeat.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     },
                     "low_low": {
                         "zh-CN": {
-                            "title": "压力和关系修复都需要最小闭环",
-                            "why_it_matters": "高压关系场景中，需要简单、可重复的停顿和回到问题的动作。",
-                            "what_it_feels_like": "冲突中你可能沉默、爆发或想尽快结束。",
-                            "strength": "小流程能显著降低失控概率。",
-                            "cost": "没有流程时关系容易积累未修复问题。",
-                            "development_lever": "建立冲突暂停协议。",
-                            "micro_action": "说：我需要十分钟冷静，然后我们只谈下一步。"
+                            "title": "情绪调节 × 关系管理｜两项都需要打底",
+                            "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+                            "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+                            "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+                            "strength": "从最小动作开始，反馈会更清楚。",
+                            "cost": "复杂场景里容易被动应对。",
+                            "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+                            "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+                            "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
                         },
                         "en": {
-                            "title": "Pressure and repair need a minimal loop",
-                            "why_it_matters": "High-pressure relational situations need simple repeatable pauses and return-to-issue moves.",
-                            "what_it_feels_like": "In conflict, you may go silent, escalate, or want to end quickly.",
-                            "strength": "A small process can reduce escalation risk.",
-                            "cost": "Without a process, unrepaired issues accumulate.",
-                            "development_lever": "Create a conflict pause protocol.",
-                            "micro_action": "Say: I need ten minutes to cool down, then let's discuss only the next step."
+                            "title": "Emotion regulation × Relationship management: both signals need foundations",
+                            "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. This is not a failure signal; it points to the need for a smallest repeatable process.",
+                            "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+                            "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+                            "strength": "Small actions can make the feedback clearer.",
+                            "cost": "Complex scenes may push you into reactive coping.",
+                            "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+                            "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+                            "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
                         }
                     }
                 }
@@ -890,98 +1506,1608 @@
             "scenes": {
                 "feedback": {
                     "zh-CN": {
-                        "title": "反馈场景",
-                        "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。",
-                        "strength": "能注意到反馈背后的真实意图和关系温度。",
-                        "cost": "如果恢复不足，容易把反馈体验成否定。",
-                        "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。"
+                        "title": "反馈",
+                        "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先问清反馈指向，再决定解释或调整。",
+                        "context": "别人指出问题、要求修改或评价你的表现时。",
+                        "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
                         "title": "Feedback",
-                        "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information.",
-                        "strength": "You can notice intent and relational temperature behind feedback.",
-                        "cost": "When recovery is weak, feedback may feel like rejection.",
-                        "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify."
+                        "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Clarify the target of the feedback before explaining or changing.",
+                        "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                        "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "conflict": {
                     "zh-CN": {
-                        "title": "冲突场景",
-                        "typical_response": "出现分歧时，你可能在维护关系和表达自己之间摇摆。",
-                        "strength": "有机会同时看见双方需求。",
-                        "cost": "如果没有暂停流程，容易过度解释、回避或急于修复。",
-                        "better_move": "先确认共同目标，再只讨论一个具体问题。"
+                        "title": "冲突",
+                        "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先把冲突缩小成一个可处理的问题。",
+                        "context": "意见分歧、语气升高或彼此防御时。",
+                        "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
                         "title": "Conflict",
-                        "typical_response": "During disagreement, you may move between preserving the relationship and expressing yourself.",
-                        "strength": "You can often see needs on both sides.",
-                        "cost": "Without a pause process, you may over-explain, avoid, or rush repair.",
-                        "better_move": "Name the shared goal first, then discuss one specific issue."
+                        "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Narrow the conflict to one workable issue first.",
+                        "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                        "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "relationship_boundary": {
                     "zh-CN": {
                         "title": "关系边界",
-                        "typical_response": "当别人需要你支持时，你可能很快进入理解或承担。",
-                        "strength": "容易让对方感到被接住。",
-                        "cost": "支持和代替之间的边界可能变模糊。",
-                        "better_move": "先问自己：我能支持到哪里，哪一部分仍然属于对方。"
+                        "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                        "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                        "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Relationship Boundaries",
-                        "typical_response": "When someone needs support, you may quickly move into understanding or taking responsibility.",
-                        "strength": "Others may feel received and understood.",
-                        "cost": "The line between supporting and replacing can blur.",
-                        "better_move": "Ask yourself: how far can I support, and which part remains theirs?"
+                        "title": "Relationship boundary",
+                        "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                        "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                        "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "team_collaboration": {
                     "zh-CN": {
                         "title": "团队协作",
-                        "typical_response": "在多人协作中，你可能同时追踪任务、关系和现场情绪。",
-                        "strength": "能发现协作中的隐性阻力。",
-                        "cost": "如果总是主动协调，容易承担过多情绪劳动。",
-                        "better_move": "把观察转成具体协作请求，而不是默默补位。"
+                        "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "把气氛问题转成角色、节奏和下一步。",
+                        "context": "多人协作、目标不清或责任交叉时。",
+                        "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Team Collaboration",
-                        "typical_response": "In group work, you may track task, relationship, and emotional climate at the same time.",
-                        "strength": "You can notice hidden friction in collaboration.",
-                        "cost": "If you always coordinate, you may carry too much emotional labor.",
-                        "better_move": "Turn observations into concrete collaboration requests instead of silently compensating."
+                        "title": "Team collaboration",
+                        "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                        "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                        "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "pressure_recovery": {
                     "zh-CN": {
                         "title": "压力恢复",
-                        "typical_response": "高压后你可能仍在脑内回放对话、评价或细节。",
-                        "strength": "复盘能力可以帮助你学习模式。",
-                        "cost": "没有恢复边界时，复盘会变成反刍。",
-                        "better_move": "给复盘设限：只写三个事实、一个感受、一个下次动作。"
+                        "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "离开场景后安排一个低输入恢复动作。",
+                        "context": "一段高压互动结束后，你需要重新回到自己。",
+                        "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Pressure Recovery",
-                        "typical_response": "After pressure, you may replay conversations, judgments, or details in your head.",
-                        "strength": "Review can help you learn patterns.",
-                        "cost": "Without recovery boundaries, review turns into rumination.",
-                        "better_move": "Limit review to three facts, one feeling, and one next action."
+                        "title": "Pressure recovery",
+                        "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "After the scene, schedule one low-input recovery move.",
+                        "context": "After a high-pressure interaction, when you need to return to yourself.",
+                        "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
                     }
                 },
                 "career_environment": {
                     "zh-CN": {
                         "title": "职业环境",
-                        "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。",
-                        "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
-                        "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
-                        "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。"
+                        "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                        "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                        "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+                        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
                     },
                     "en": {
-                        "title": "Career Environment",
-                        "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles.",
-                        "strength": "Understanding environmental variables helps you choose a better work rhythm.",
-                        "cost": "Job titles alone can hide the conditions that actually drain you.",
-                        "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space."
+                        "title": "Career environment",
+                        "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                        "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                        "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+                        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
+                    }
+                }
+            },
+            "formulation_scenes": {
+                "balanced_integrated": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能同时照顾自己的状态、他人的感受和关系目标。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You can hold your own state, other people, and the relationship goal in view at the same time. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能同时照顾自己的状态、他人的感受和关系目标。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You can hold your own state, other people, and the relationship goal in view at the same time. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。 你需要把理解和可承接范围分开。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能把情绪、关系和任务放在同一个画面里思考。 但如果规则不清，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can keep emotion, relationship, and task in the same frame. But when rules are unclear, others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我来稳住”改成“我们一起定规则”。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, move from “i will steady this” to “we need a shared rule.”",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can keep emotion, relationship, and task in the same frame.",
+                            "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "high_empathy_low_recovery": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你很快读到别人的状态，但恢复系统常常追不上共情速度。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You read the room quickly, but recovery can lag behind empathy. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你很快读到别人的状态，但恢复系统常常追不上共情速度。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You read the room quickly, but recovery can lag behind empathy. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能把别人的压力带回自己身上，离开场景后还在消化。 你需要把理解和可承接范围分开。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may carry other people’s pressure with you long after the moment ends. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你容易让别人感到被理解，尤其在情绪强烈的时刻。 但如果规则不清，你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can make people feel understood, especially when emotions run high. But when rules are unclear, you may carry other people’s pressure with you long after the moment ends.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，练习“理解但不接管”，让共情后面跟着边界。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, practice understanding without taking over, so empathy is followed by boundary.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can make people feel understood, especially when emotions run high.",
+                            "cost": "You may carry other people’s pressure with you long after the moment ends.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "aware_but_unregulated": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你常知道自己怎么了，但把自己带回来需要更长时间。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You often know what is happening inside, but the reset button is slower than the insight. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你常知道自己怎么了，但把自己带回来需要更长时间。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You often know what is happening inside, but the reset button is slower than the insight. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，越清楚自己被触发，越可能陷入反复分析或即时反应。 你需要把理解和可承接范围分开。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, The clearer the trigger feels, the easier it can be to over-analyze or react too soon. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能清楚识别触发点、感受和需要。 但如果规则不清，越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can identify triggers, feelings, and needs with unusual clarity. But when rules are unclear, the clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把觉察压缩成一个暂停动作，而不是继续解释。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn awareness into one pause action instead of another layer of explanation.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能清楚识别触发点、感受和需要。",
+                            "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "calm_but_distant": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能稳住事情，但别人不一定感到被情绪上接住。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You can steady the situation, but people may not always feel emotionally met. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能稳住事情，但别人不一定感到被情绪上接住。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You can steady the situation, but people may not always feel emotionally met. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，关系里的人可能觉得你有答案，但没有真正回应他们。 你需要把理解和可承接范围分开。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, People may feel that you have answers without feeling that you have responded to them. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你不容易被情绪推着走，能保留判断和节奏。 但如果规则不清，关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are less likely to be pushed around by emotion and can keep judgment and pace. But when rules are unclear, people may feel that you have answers without feeling that you have responded to them.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先回应一句感受，再给建议或方案。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, acknowledge one feeling before offering advice or a solution.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                            "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "cost": "People may feel that you have answers without feeling that you have responded to them.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "relationship_first_self_later": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你会先保护关系，再回头找自己的真实立场。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You protect the relationship first and find your own position later. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你会先保护关系，再回头找自己的真实立场。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You protect the relationship first and find your own position later. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能很晚才意识到自己其实不愿意、不同意或已经累了。 你需要把理解和可承接范围分开。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may notice too late that you disagreed, felt unwilling, or were already depleted. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你敏感于关系气氛，愿意让互动维持可进行。 但如果规则不清，你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are sensitive to relational tone and often keep interaction workable. But when rules are unclear, you may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，在照顾关系前，先给自己的感受一个位置。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, give your own feeling a place before you manage the relationship.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are sensitive to relational tone and often keep interaction workable.",
+                            "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "self_clear_repair_weak": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你知道自己的立场，但冲突后的修复需要更明确的工具。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You know your position, but repair after tension needs a clearer tool. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你知道自己的立场，但冲突后的修复需要更明确的工具。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You know your position, but repair after tension needs a clearer tool. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。 你需要把理解和可承接范围分开。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Without repair, others may remember the force of the moment more than your point. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你不容易在关系压力里丢掉自己的判断。 但如果规则不清，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are less likely to lose your judgment under relational pressure. But when rules are unclear, without repair, others may remember the force of the moment more than your point.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我说清楚了”补成“我们怎么重新对齐”。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, add “how do we realign?” after “i made my point.”",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你不容易在关系压力里丢掉自己的判断。",
+                            "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are less likely to lose your judgment under relational pressure.",
+                            "cost": "Without repair, others may remember the force of the moment more than your point.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "steady_collaborator": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能在压力下维持合作推进，但别让稳定只靠你一个人。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You keep collaboration moving under pressure, but steadiness should not depend only on you. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能在压力下维持合作推进，但别让稳定只靠你一个人。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You keep collaboration moving under pressure, but steadiness should not depend only on you. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，团队可能习惯让你来降温、翻译和收尾。 你需要把理解和可承接范围分开。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Teams may get used to you cooling things down, translating tension, and closing loops. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你能把紧张对话拉回事实、目标和下一步。 但如果规则不清，团队可能习惯让你来降温、翻译和收尾。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You can bring tense conversations back to facts, goals, and next steps. But when rules are unclear, teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把个人稳定能力变成团队流程。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn personal steadiness into team process.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你能把紧张对话拉回事实、目标和下一步。",
+                            "cost": "团队可能习惯让你来降温、翻译和收尾。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                            "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "sensitive_absorber": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你能捕捉细微变化，但敏感也容易变成情绪负重。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, You catch subtle shifts fast, and that sensitivity can become emotional load. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你能捕捉细微变化，但敏感也容易变成情绪负重。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, You catch subtle shifts fast, and that sensitivity can become emotional load. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，你可能回应了太多信号，最后分不清哪些真的需要你处理。 你需要把理解和可承接范围分开。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, You may respond to too many signals and lose track of which ones actually need your action. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你很快发现气氛、语气和关系位置的变化。 但如果规则不清，你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You quickly notice shifts in tone, mood, and relational position. But when rules are unclear, you may respond to too many signals and lose track of which ones actually need your action.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我感到了”区分成“我要不要回应”。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, separate “i noticed it” from “i need to respond.”",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你很快发现气氛、语气和关系位置的变化。",
+                            "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You quickly notice shifts in tone, mood, and relational position.",
+                            "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "developing_foundation": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果一次想改太多，容易很快放弃或自我否定。 你需要把理解和可承接范围分开。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Trying to change everything at once can lead to quick discouragement or self-criticism. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，你已经开始把情绪和关系当成可以观察、可以练习的对象。 但如果规则不清，如果一次想改太多，容易很快放弃或自我否定。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, You are beginning to treat emotion and relationships as observable and trainable. But when rules are unclear, trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先把一个情绪命名清楚，再谈复杂改变。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, name one feeling clearly before attempting a larger change.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    }
+                },
+                "low_confidence_result": {
+                    "feedback": {
+                        "zh-CN": {
+                            "scene_label": "反馈",
+                            "context": "别人指出问题、要求修改或评价你的表现时。",
+                            "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先问清反馈指向，再决定解释或调整。",
+                            "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Feedback",
+                            "context": "When someone points out a problem, requests changes, or evaluates your work.",
+                            "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Clarify the target of the feedback before explaining or changing.",
+                            "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "conflict": {
+                        "zh-CN": {
+                            "scene_label": "冲突",
+                            "context": "意见分歧、语气升高或彼此防御时。",
+                            "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先把冲突缩小成一个可处理的问题。",
+                            "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Conflict",
+                            "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+                            "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Narrow the conflict to one workable issue first.",
+                            "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "relationship_boundary": {
+                        "zh-CN": {
+                            "scene_label": "关系边界",
+                            "context": "别人期待你理解、帮忙、让步或继续承接时。",
+                            "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "先承认对方感受，再说明自己的可承接范围。",
+                            "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Relationship boundary",
+                            "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+                            "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+                            "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "team_collaboration": {
+                        "zh-CN": {
+                            "scene_label": "团队协作",
+                            "context": "多人协作、目标不清或责任交叉时。",
+                            "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "把气氛问题转成角色、节奏和下一步。",
+                            "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Team collaboration",
+                            "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+                            "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+                            "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "pressure_recovery": {
+                        "zh-CN": {
+                            "scene_label": "压力恢复",
+                            "context": "一段高压互动结束后，你需要重新回到自己。",
+                            "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "离开场景后安排一个低输入恢复动作。",
+                            "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Pressure recovery",
+                            "context": "After a high-pressure interaction, when you need to return to yourself.",
+                            "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "After the scene, schedule one low-input recovery move.",
+                            "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
+                    },
+                    "career_environment": {
+                        "zh-CN": {
+                            "scene_label": "职业环境",
+                            "context": "你判断一个工作环境会滋养你还是消耗你时。",
+                            "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+                            "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "cost": "如果强行套用画像，可能比不看结果更误导。",
+                            "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+                            "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+                            "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+                            "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+                        },
+                        "en": {
+                            "scene_label": "Career environment",
+                            "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+                            "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+                            "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "cost": "Forcing a profile onto this result could be more misleading than useful.",
+                            "better_move": "Verify environment variables instead of deriving a job from EQ.",
+                            "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+                            "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+                            "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+                        }
                     }
                 }
             }
@@ -993,300 +3119,660 @@
                 "interpersonal_density": {
                     "low": {
                         "zh-CN": {
-                            "label": "低人际密度",
-                            "meaning": "多数时间独立推进，互动频率较低。",
-                            "fit_signal": "适合需要恢复空间或深度专注的人。",
-                            "strain_signal": "可能减少练习关系动作的机会。",
-                            "what_to_verify": "确认岗位是否真的允许长时间独立工作。"
+                            "label": "人际密度：低",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Interpersonal Density",
-                            "meaning": "Most work is independent with fewer interactions.",
-                            "fit_signal": "Can fit people who need recovery space or deep focus.",
-                            "strain_signal": "May reduce practice opportunities for relational action.",
-                            "what_to_verify": "Check whether the role truly allows long independent work blocks."
+                            "label": "Interpersonal density: low",
+                            "meaning": "How many people you interact with, and how often. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等人际密度",
-                            "meaning": "日常有固定协作，但不是持续社交。",
-                            "fit_signal": "适合在协作和独立之间切换。",
-                            "strain_signal": "会议过多时仍会消耗。",
-                            "what_to_verify": "确认每周会议、同步和跨团队协作频率。"
+                            "label": "人际密度：中",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Interpersonal Density",
-                            "meaning": "Regular collaboration without constant social demand.",
-                            "fit_signal": "Fits switching between collaboration and independent work.",
-                            "strain_signal": "Too many meetings can still drain.",
-                            "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."
+                            "label": "Interpersonal density: medium",
+                            "meaning": "How many people you interact with, and how often. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高人际密度",
-                            "meaning": "大量沟通、协调和即时互动。",
-                            "fit_signal": "可发挥共情、协作和关系管理优势。",
-                            "strain_signal": "恢复不足时容易情绪过载。",
-                            "what_to_verify": "确认是否有可控的独处和恢复窗口。"
+                            "label": "人际密度：高",
+                            "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Interpersonal Density",
-                            "meaning": "Frequent communication, coordination, and real-time interaction.",
-                            "fit_signal": "Can use empathy, collaboration, and relationship-management strengths.",
-                            "strain_signal": "Weak recovery can lead to overload.",
-                            "what_to_verify": "Check whether protected solo recovery windows exist."
+                            "label": "Interpersonal density: high",
+                            "meaning": "How many people you interact with, and how often. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "emotional_labor": {
                     "low": {
                         "zh-CN": {
-                            "label": "低情绪劳动",
-                            "meaning": "较少承接他人情绪或安抚关系。",
-                            "fit_signal": "适合需要降低情绪消耗的人。",
-                            "strain_signal": "可能缺少运用共情优势的空间。",
-                            "what_to_verify": "确认用户、客户或团队情绪压力是否较低。"
+                            "label": "情绪劳动：低",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Emotional Labor",
-                            "meaning": "Less need to hold or soothe others' emotions.",
-                            "fit_signal": "Fits people who need lower emotional load.",
-                            "strain_signal": "May offer less space to use empathy strengths.",
-                            "what_to_verify": "Check whether user, client, or team emotional pressure is actually low."
+                            "label": "Emotional labor: low",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等情绪劳动",
-                            "meaning": "需要一定理解和安抚，但通常有边界。",
-                            "fit_signal": "适合练习共情与边界并存。",
-                            "strain_signal": "边界不清时会累积消耗。",
-                            "what_to_verify": "确认是否有升级、转介或交接机制。"
+                            "label": "情绪劳动：中",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Emotional Labor",
-                            "meaning": "Some understanding and soothing are needed, usually with boundaries.",
-                            "fit_signal": "Fits practicing empathy with boundaries.",
-                            "strain_signal": "Unclear boundaries accumulate cost.",
-                            "what_to_verify": "Check whether escalation, referral, or handoff mechanisms exist."
+                            "label": "Emotional labor: medium",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高情绪劳动",
-                            "meaning": "经常承接焦虑、投诉、冲突或脆弱情绪。",
-                            "fit_signal": "高共情者能建立信任。",
-                            "strain_signal": "低恢复者容易被情绪场拖走。",
-                            "what_to_verify": "确认督导、复盘和休息制度是否真实存在。"
+                            "label": "情绪劳动：高",
+                            "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Emotional Labor",
-                            "meaning": "Frequent exposure to anxiety, complaints, conflict, or vulnerability.",
-                            "fit_signal": "High-empathy people can build trust.",
-                            "strain_signal": "Low recovery can make the emotional field pull you in.",
-                            "what_to_verify": "Check whether supervision, review, and rest systems are real."
+                            "label": "Emotional labor: high",
+                            "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "conflict_frequency": {
                     "low": {
                         "zh-CN": {
-                            "label": "低冲突频率",
-                            "meaning": "较少谈判、投诉或强分歧。",
-                            "fit_signal": "降低情绪调节压力。",
-                            "strain_signal": "可能较少训练冲突修复。",
-                            "what_to_verify": "确认冲突是否只是被隐藏到异步沟通中。"
+                            "label": "冲突频率：低",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Conflict Frequency",
-                            "meaning": "Fewer negotiations, complaints, or strong disagreements.",
-                            "fit_signal": "Reduces regulation pressure.",
-                            "strain_signal": "May offer less practice in conflict repair.",
-                            "what_to_verify": "Check whether conflict is merely hidden in async communication."
+                            "label": "Conflict frequency: low",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等冲突频率",
-                            "meaning": "有周期性分歧，但通常有流程。",
-                            "fit_signal": "适合练习稳定沟通。",
-                            "strain_signal": "流程不清时会放大关系压力。",
-                            "what_to_verify": "确认冲突如何升级、记录和收口。"
+                            "label": "冲突频率：中",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Conflict Frequency",
-                            "meaning": "Periodic disagreement with some process.",
-                            "fit_signal": "Good for practicing steady communication.",
-                            "strain_signal": "Unclear process amplifies relational pressure.",
-                            "what_to_verify": "Check how conflict is escalated, recorded, and closed."
+                            "label": "Conflict frequency: medium",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高冲突频率",
-                            "meaning": "经常面对投诉、博弈、谈判或利益冲突。",
-                            "fit_signal": "高调节和高关系管理者可发挥优势。",
-                            "strain_signal": "ER 或 RM 低时消耗显著。",
-                            "what_to_verify": "确认是否有明确授权、边界和复盘支持。"
+                            "label": "冲突频率：高",
+                            "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Conflict Frequency",
-                            "meaning": "Frequent complaints, negotiation, bargaining, or interest conflict.",
-                            "fit_signal": "High ER and RM can become strengths.",
-                            "strain_signal": "Low ER or RM is costly here.",
-                            "what_to_verify": "Check whether authority, boundaries, and review support are clear."
+                            "label": "Conflict frequency: high",
+                            "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "feedback_intensity": {
                     "low": {
                         "zh-CN": {
-                            "label": "低反馈强度",
-                            "meaning": "评价和修改频率较低。",
-                            "fit_signal": "适合对评价敏感且需要稳定节奏的人。",
-                            "strain_signal": "成长反馈可能不足。",
-                            "what_to_verify": "确认是否仍有清晰目标和周期复盘。"
+                            "label": "反馈强度：低",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Feedback Intensity",
-                            "meaning": "Evaluation and revision are less frequent.",
-                            "fit_signal": "Fits people sensitive to evaluation who need a steadier rhythm.",
-                            "strain_signal": "Growth feedback may be insufficient.",
-                            "what_to_verify": "Check whether clear goals and periodic review still exist."
+                            "label": "Feedback intensity: low",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等反馈强度",
-                            "meaning": "定期复盘、修改和评价。",
-                            "fit_signal": "适合把反馈转成学习。",
-                            "strain_signal": "恢复不足时可能反复回想。",
-                            "what_to_verify": "确认反馈是否具体、可执行、不过度公开。"
+                            "label": "反馈强度：中",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Feedback Intensity",
-                            "meaning": "Regular review, revision, and evaluation.",
-                            "fit_signal": "Fits turning feedback into learning.",
-                            "strain_signal": "Weak recovery may lead to replaying feedback.",
-                            "what_to_verify": "Check whether feedback is specific, actionable, and not overly public."
+                            "label": "Feedback intensity: medium",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高反馈强度",
-                            "meaning": "频繁被评价、迭代或公开比较。",
-                            "fit_signal": "高觉察和高调节者可快速迭代。",
-                            "strain_signal": "低调节者容易把反馈体验成否定。",
-                            "what_to_verify": "确认是否有安全反馈文化和恢复空间。"
+                            "label": "反馈强度：高",
+                            "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Feedback Intensity",
-                            "meaning": "Frequent evaluation, iteration, or public comparison.",
-                            "fit_signal": "High SA and ER can support fast iteration.",
-                            "strain_signal": "Low ER may make feedback feel like rejection.",
-                            "what_to_verify": "Check for a safe feedback culture and recovery space."
+                            "label": "Feedback intensity: high",
+                            "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "autonomy_recovery": {
                     "low": {
                         "zh-CN": {
-                            "label": "低自主恢复空间",
-                            "meaning": "节奏常被外部打断，难以独处恢复。",
-                            "fit_signal": "适合恢复需求低且即时响应强的人。",
-                            "strain_signal": "高共情低恢复者风险较高。",
-                            "what_to_verify": "确认是否允许暂停、调班或离线恢复。"
+                            "label": "自主恢复空间：低",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Autonomy Recovery",
-                            "meaning": "Rhythm is often interrupted, with little solo recovery.",
-                            "fit_signal": "Fits people with low recovery needs and strong real-time response.",
-                            "strain_signal": "High empathy with low recovery is risky here.",
-                            "what_to_verify": "Check whether pauses, shift changes, or offline recovery are allowed."
+                            "label": "Autonomy and recovery: low",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等自主恢复空间",
-                            "meaning": "有一定独立安排，但仍受团队节奏影响。",
-                            "fit_signal": "适合多数人维持稳定表现。",
-                            "strain_signal": "忙季或危机期可能被压缩。",
-                            "what_to_verify": "确认高峰期的恢复安排。"
+                            "label": "自主恢复空间：中",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Autonomy Recovery",
-                            "meaning": "Some independent rhythm exists, though team rhythm still matters.",
-                            "fit_signal": "Helps most people sustain performance.",
-                            "strain_signal": "Busy or crisis periods may compress it.",
-                            "what_to_verify": "Check recovery arrangements during peak periods."
+                            "label": "Autonomy and recovery: medium",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高自主恢复空间",
-                            "meaning": "可以较多控制节奏、沟通窗口和深度工作时间。",
-                            "fit_signal": "有利于敏感、深度复盘或高恢复需求者。",
-                            "strain_signal": "也可能带来孤立或反馈不足。",
-                            "what_to_verify": "确认独立性不会变成缺少支持。"
+                            "label": "自主恢复空间：高",
+                            "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Autonomy Recovery",
-                            "meaning": "More control over rhythm, communication windows, and deep-work time.",
-                            "fit_signal": "Helpful for sensitive, reflective, or high-recovery-need people.",
-                            "strain_signal": "Can also create isolation or insufficient feedback.",
-                            "what_to_verify": "Check that autonomy does not mean lack of support."
+                            "label": "Autonomy and recovery: high",
+                            "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 },
                 "collaboration_complexity": {
                     "low": {
                         "zh-CN": {
-                            "label": "低协作复杂度",
-                            "meaning": "角色、接口和责任较清楚。",
-                            "fit_signal": "降低关系误解和协调成本。",
-                            "strain_signal": "可能较少发挥复杂协调优势。",
-                            "what_to_verify": "确认职责是否稳定且边界清楚。"
+                            "label": "协作复杂度：低",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示更少、更慢、更可控。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Low Collaboration Complexity",
-                            "meaning": "Roles, interfaces, and responsibilities are clear.",
-                            "fit_signal": "Lowers misunderstanding and coordination cost.",
-                            "strain_signal": "May offer less space for complex coordination strengths.",
-                            "what_to_verify": "Check whether responsibilities are stable and boundaries clear."
+                            "label": "Collaboration complexity: low",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is lower, slower, and more controlled.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "medium": {
                         "zh-CN": {
-                            "label": "中等协作复杂度",
-                            "meaning": "需要跨角色协作，但仍有明确流程。",
-                            "fit_signal": "适合练习关系管理和反馈沟通。",
-                            "strain_signal": "流程缺失时容易消耗。",
-                            "what_to_verify": "确认决策权、优先级和冲突处理方式。"
+                            "label": "协作复杂度：中",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示有一定强度，但仍可通过规则管理。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "Medium Collaboration Complexity",
-                            "meaning": "Cross-role collaboration is needed with some clear process.",
-                            "fit_signal": "Good for practicing relationship management and feedback communication.",
-                            "strain_signal": "Missing process can be draining.",
-                            "what_to_verify": "Check decision rights, priorities, and conflict-handling process."
+                            "label": "Collaboration complexity: medium",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is moderate, but manageable with rules.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     },
                     "high": {
                         "zh-CN": {
-                            "label": "高协作复杂度",
-                            "meaning": "多方目标、利益和节奏需要持续协调。",
-                            "fit_signal": "高 RM 与稳定 ER 能发挥明显优势。",
-                            "strain_signal": "边界不清时容易长期过载。",
-                            "what_to_verify": "确认是否有正式协调机制和优先级裁决。"
+                            "label": "协作复杂度：高",
+                            "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+                            "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+                            "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+                            "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+                            "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+                            "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+                            "role_observation_checklist": [
+                                "一天内高互动时段数量",
+                                "反馈是私下还是公开",
+                                "冲突由个人消化还是团队处理",
+                                "是否有低输入恢复窗口"
+                            ],
+                            "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+                            "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
                         },
                         "en": {
-                            "label": "High Collaboration Complexity",
-                            "meaning": "Multiple goals, interests, and rhythms require ongoing coordination.",
-                            "fit_signal": "High RM and stable ER can become clear strengths.",
-                            "strain_signal": "Unclear boundaries can cause chronic overload.",
-                            "what_to_verify": "Check formal coordination mechanisms and priority arbitration."
+                            "label": "Collaboration complexity: high",
+                            "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+                            "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+                            "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+                            "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+                            "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+                            "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+                            "role_observation_checklist": [
+                                "number of high-interaction periods in a day",
+                                "private vs public feedback",
+                                "whether conflict is handled individually or by the team",
+                                "availability of low-input recovery windows"
+                            ],
+                            "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+                            "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
                         }
                     }
                 }
@@ -1298,410 +3784,962 @@
             "prescriptions": {
                 "emotion_labeling": {
                     "zh-CN": {
-                        "title": "情绪命名处方",
-                        "why_this_matters": "先命名，才有可能选择回应。",
-                        "do_today": "今天选择一个具体情绪词，写下触发它的场景。",
-                        "script": "我现在感到的是 X，不代表我必须立刻做决定。",
+                        "title": "情绪命名",
+                        "why_this_matters": "当感受模糊、容易事后才明白时使用。",
+                        "do_today": "今天只做一件事：把一次情绪从“烦”改写成三个更具体的词。",
+                        "script": "我现在不是单纯不舒服，我可能是失望、紧张和需要确认。",
                         "seven_day_plan": [
-                            "第 1 天：记录一个情绪词。",
-                            "第 2 天：补充身体感受。",
-                            "第 3 天：写下触发场景。",
-                            "第 4 天：区分事实和解释。",
-                            "第 5 天：写一个可控动作。",
-                            "第 6 天：复盘一次沟通。",
-                            "第 7 天：选出最常见触发点。"
+                            {
+                                "day": 1,
+                                "practice": "记录一次情绪触发点。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下事实、感受、需要三栏。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "把“还好”改成三个具体情绪词。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "找一个低风险场景说出一个感受。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "复盘一次没说出口的需要。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "把一个情绪和身体感觉连接起来。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "选择一个下周继续练的情绪词。"
+                            }
                         ],
-                        "watch_out": "不要把情绪词变成自我评价。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当感受模糊、容易事后才明白时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Emotion Labeling",
-                        "why_this_matters": "Naming comes before choosing a response.",
-                        "do_today": "Choose one specific emotion word today and write the triggering context.",
-                        "script": "What I feel now is X; it does not mean I must decide immediately.",
+                        "title": "Emotion labeling",
+                        "why_this_matters": "Use when feelings are vague or only become clear afterward.",
+                        "do_today": "Today, turn one vague feeling into three more precise words.",
+                        "script": "I am not simply upset; I may be disappointed, tense, and needing clarity.",
                         "seven_day_plan": [
-                            "Day 1: record one emotion word.",
-                            "Day 2: add body sensations.",
-                            "Day 3: write the trigger.",
-                            "Day 4: separate fact and interpretation.",
-                            "Day 5: write one controllable action.",
-                            "Day 6: review one conversation.",
-                            "Day 7: identify the most common trigger."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not turn emotion words into self-judgment."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when feelings are vague or only become clear afterward.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "pause_recovery": {
                     "zh-CN": {
-                        "title": "暂停与恢复处方",
-                        "why_this_matters": "调节不是压住情绪，而是给选择回应争取空间。",
-                        "do_today": "遇到触发时暂停 60 秒，再回复。",
-                        "script": "我需要一分钟整理一下，再继续说。",
+                        "title": "暂停与恢复",
+                        "why_this_matters": "当你知道自己被触发，但很难立刻稳定时使用。",
+                        "do_today": "今天给自己设一个十秒暂停规则。",
+                        "script": "我需要先停十秒，等我能更清楚地回应。",
                         "seven_day_plan": [
-                            "第 1 天：练 60 秒暂停。",
-                            "第 2 天：加入一次深呼吸。",
-                            "第 3 天：离开屏幕一分钟。",
-                            "第 4 天：记录暂停前后的差异。",
-                            "第 5 天：在反馈场景使用。",
-                            "第 6 天：在冲突前使用。",
-                            "第 7 天：固定一个恢复动作。"
+                            {
+                                "day": 1,
+                                "practice": "选一个暂停信号。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "在一次小触发中练十秒呼吸。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "写下暂停前后的不同。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "给自己设一个延迟回复模板。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "练习离开屏幕两分钟。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘一次因为暂停而避免升级的场景。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "确定下周继续使用的暂停句。"
+                            }
                         ],
-                        "watch_out": "暂停不是逃避，暂停后要回到对话。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你知道自己被触发，但很难立刻稳定时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Pause and Recovery",
-                        "why_this_matters": "Regulation is not suppressing emotion; it creates room for choice.",
-                        "do_today": "When triggered, pause for 60 seconds before replying.",
-                        "script": "I need a minute to organize my thoughts before continuing.",
+                        "title": "Pause and recovery",
+                        "why_this_matters": "Use when you know you are triggered but cannot steady yourself immediately.",
+                        "do_today": "Set a ten-second pause rule today.",
+                        "script": "I need ten seconds so I can respond more clearly.",
                         "seven_day_plan": [
-                            "Day 1: practice a 60-second pause.",
-                            "Day 2: add one deep breath.",
-                            "Day 3: step away from the screen for one minute.",
-                            "Day 4: note the before-and-after difference.",
-                            "Day 5: use it in feedback.",
-                            "Day 6: use it before conflict.",
-                            "Day 7: fix one recovery action."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Pausing is not avoidance; return to the conversation."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you know you are triggered but cannot steady yourself immediately.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "feedback_decompression": {
                     "zh-CN": {
-                        "title": "反馈减压处方",
-                        "why_this_matters": "反馈容易混合事实、关系和自我评价，需要拆开处理。",
-                        "do_today": "把一次反馈拆成事实、感受、下一步三栏。",
-                        "script": "我先确认事实：你希望我调整的是 X，对吗？",
+                        "title": "反馈去压缩",
+                        "why_this_matters": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+                        "do_today": "今天把一次反馈拆成事实、评价和下一步。",
+                        "script": "我先确认一下，你希望我具体调整哪一部分？",
                         "seven_day_plan": [
-                            "第 1 天：拆一次反馈。",
-                            "第 2 天：只问一个澄清问题。",
-                            "第 3 天：延迟自我评价。",
-                            "第 4 天：记录可行动项。",
-                            "第 5 天：复盘语气触发。",
-                            "第 6 天：向对方确认优先级。",
-                            "第 7 天：总结一个反馈模板。"
+                            {
+                                "day": 1,
+                                "practice": "找一次近期反馈。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写出反馈里的事实。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "写出你脑中自动冒出的解释。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "问一个澄清问题。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "把反馈转成一个行动。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录反馈后的身体反应。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "总结一个下次先问的问题。"
+                            }
                         ],
-                        "watch_out": "不要把所有反馈都理解成人身否定。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Feedback Decompression",
-                        "why_this_matters": "Feedback mixes facts, relationship cues, and self-evaluation; separate them.",
-                        "do_today": "Split one feedback event into facts, feelings, and next step.",
-                        "script": "Let me confirm the fact: you want me to adjust X, correct?",
+                        "title": "Feedback decompression",
+                        "why_this_matters": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+                        "do_today": "Today, split one piece of feedback into facts, evaluation, and next step.",
+                        "script": "Can I clarify which part you want me to adjust?",
                         "seven_day_plan": [
-                            "Day 1: split one feedback event.",
-                            "Day 2: ask only one clarifying question.",
-                            "Day 3: delay self-judgment.",
-                            "Day 4: record the action item.",
-                            "Day 5: review tone triggers.",
-                            "Day 6: confirm priority.",
-                            "Day 7: summarize a feedback template."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not treat all feedback as personal rejection."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "empathy_boundary": {
                     "zh-CN": {
-                        "title": "共情边界处方",
-                        "why_this_matters": "高共情需要边界，才能长期有效。",
-                        "do_today": "支持别人前先确认自己能支持到哪里。",
-                        "script": "我愿意听你说十分钟，然后我们一起看下一步。",
+                        "title": "共情边界",
+                        "why_this_matters": "当你理解别人后容易承担过多时使用。",
+                        "do_today": "今天练习一句“理解但不接管”的话。",
+                        "script": "我理解这件事很难，我能帮你一起理清下一步，但不能替你承担全部。",
                         "seven_day_plan": [
-                            "第 1 天：识别一次我在承担什么。",
-                            "第 2 天：练习时间边界。",
-                            "第 3 天：练习责任边界。",
-                            "第 4 天：支持后做恢复。",
-                            "第 5 天：区分理解和代替。",
-                            "第 6 天：复盘一次求助场景。",
-                            "第 7 天：写下自己的支持边界。"
+                            {
+                                "day": 1,
+                                "practice": "识别一个你容易接管的场景。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下对方责任和你责任的边界。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练习一句支持但不接管的话。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "在一次对话中只提供一个具体帮助。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "对一个请求说出可承担范围。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘说边界后的真实后果。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "写下你的恢复动作。"
+                            }
                         ],
-                        "watch_out": "不要用冷漠来替代边界。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你理解别人后容易承担过多时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Empathy Boundary",
-                        "why_this_matters": "High empathy needs boundaries to remain sustainable.",
-                        "do_today": "Before supporting someone, decide how far you can support.",
-                        "script": "I can listen for ten minutes, then we can look at the next step together.",
+                        "title": "Empathy with boundary",
+                        "why_this_matters": "Use when understanding others turns into carrying too much.",
+                        "do_today": "Practice one sentence that understands without taking over.",
+                        "script": "I understand this is difficult. I can help you sort the next step, but I cannot carry all of it for you.",
                         "seven_day_plan": [
-                            "Day 1: identify what you are carrying.",
-                            "Day 2: practice a time boundary.",
-                            "Day 3: practice a responsibility boundary.",
-                            "Day 4: recover after support.",
-                            "Day 5: separate understanding from replacing.",
-                            "Day 6: review one help-seeking situation.",
-                            "Day 7: write your support boundary."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not replace boundaries with coldness."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when understanding others turns into carrying too much.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "repair_after_conflict": {
                     "zh-CN": {
-                        "title": "冲突后修复处方",
-                        "why_this_matters": "冲突后的修复决定关系能否继续合作。",
-                        "do_today": "选一个小冲突，发出一句修复确认。",
-                        "script": "刚才我语气急了，我想把重点重新说清楚。",
+                        "title": "冲突后修复",
+                        "why_this_matters": "当冲突后不知道如何重新开始时使用。",
+                        "do_today": "今天准备一句影响确认。",
+                        "script": "刚才我的表达可能让你感觉被否定了，我想重新说一次。",
                         "seven_day_plan": [
-                            "第 1 天：识别一次未完成冲突。",
-                            "第 2 天：写下自己的责任。",
-                            "第 3 天：写下对方可能在意的点。",
-                            "第 4 天：发出一句确认。",
-                            "第 5 天：只讨论下一步。",
-                            "第 6 天：复盘修复效果。",
-                            "第 7 天：形成自己的修复句式。"
+                            {
+                                "day": 1,
+                                "practice": "回忆一个小误解。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下你的意图和对方可能感受到的影响。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练一句影响确认。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "补一句你的真实意图。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "提出一个具体修复动作。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "在安全关系中尝试一次。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘对方是否更愿意继续对话。"
+                            }
                         ],
-                        "watch_out": "修复不是全盘认错，也不是要求对方立刻原谅。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当冲突后不知道如何重新开始时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Repair After Conflict",
-                        "why_this_matters": "Repair after conflict determines whether collaboration can continue.",
-                        "do_today": "Choose one small conflict and send one repair check.",
-                        "script": "My tone got sharp earlier; I want to restate the main point clearly.",
+                        "title": "Repair after conflict",
+                        "why_this_matters": "Use when you do not know how to restart after conflict.",
+                        "do_today": "Prepare one impact-checking sentence today.",
+                        "script": "My wording may have felt dismissive. I want to try saying it again.",
                         "seven_day_plan": [
-                            "Day 1: identify one unfinished conflict.",
-                            "Day 2: write your responsibility.",
-                            "Day 3: write what may matter to the other person.",
-                            "Day 4: send one confirmation.",
-                            "Day 5: discuss only the next step.",
-                            "Day 6: review repair effect.",
-                            "Day 7: build your repair sentence."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Repair is not total blame-taking or demanding immediate forgiveness."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you do not know how to restart after conflict.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "express_without_escalation": {
                     "zh-CN": {
-                        "title": "不升级表达处方",
-                        "why_this_matters": "清楚表达需要让对方听得进去。",
-                        "do_today": "用我感到、我需要、我建议三句表达一次需求。",
-                        "script": "我感到有点被打断，我需要先说完，之后我也会听你的看法。",
+                        "title": "表达但不升级",
+                        "why_this_matters": "当你很清楚自己的立场，但容易说得太硬时使用。",
+                        "do_today": "今天把一个强表达改成“事实 + 感受 + 请求”。",
+                        "script": "当这个决定突然改变时，我有点措手不及。我想先确认接下来怎么协作。",
                         "seven_day_plan": [
-                            "第 1 天：写一句我感到。",
-                            "第 2 天：写一句我需要。",
-                            "第 3 天：写一句我建议。",
-                            "第 4 天：合并三句。",
-                            "第 5 天：降低指责词。",
-                            "第 6 天：加入共同目标。",
-                            "第 7 天：在低风险场景练习。"
+                            {
+                                "day": 1,
+                                "practice": "写出一句原本想直接说的话。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "删掉评价词，只留事实。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "加上一个真实感受。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "加上一个可回应请求。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "读出来，检查语气。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "找一个低风险场景使用。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘它是否降低了防御。"
+                            }
                         ],
-                        "watch_out": "不要用永远、总是这类绝对词。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你很清楚自己的立场，但容易说得太硬时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Express Without Escalation",
-                        "why_this_matters": "Clear expression needs to be hearable.",
-                        "do_today": "Use I feel, I need, I suggest to express one need.",
-                        "script": "I feel a bit interrupted. I need to finish this point, and then I will listen to your view.",
+                        "title": "Express without escalation",
+                        "why_this_matters": "Use when your position is clear but may land too sharply.",
+                        "do_today": "Turn one strong statement into fact + feeling + request.",
+                        "script": "When this decision changed suddenly, I felt caught off guard. I want to clarify how we work together next.",
                         "seven_day_plan": [
-                            "Day 1: write one I feel sentence.",
-                            "Day 2: write one I need sentence.",
-                            "Day 3: write one I suggest sentence.",
-                            "Day 4: combine the three.",
-                            "Day 5: reduce blaming words.",
-                            "Day 6: add a shared goal.",
-                            "Day 7: practice in a low-risk context."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Avoid absolute words like always or never."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when your position is clear but may land too sharply.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "support_without_rescuing": {
                     "zh-CN": {
-                        "title": "支持但不拯救处方",
-                        "why_this_matters": "有效支持帮助对方恢复主体性，而不是替对方解决所有问题。",
-                        "do_today": "下次支持别人时，只问一个下一步问题。",
-                        "script": "我能陪你想，但这个决定需要你自己做。",
+                        "title": "支持但不拯救",
+                        "why_this_matters": "当你想帮人解决一切时使用。",
+                        "do_today": "今天先问对方需要倾听、建议还是行动帮助。",
+                        "script": "你现在更需要我听你说，还是一起想一个下一步？",
                         "seven_day_plan": [
-                            "第 1 天：识别一次想替别人解决的冲动。",
-                            "第 2 天：只提供倾听。",
-                            "第 3 天：只问一个问题。",
-                            "第 4 天：明确你能做的部分。",
-                            "第 5 天：明确你不能做的部分。",
-                            "第 6 天：支持后恢复。",
-                            "第 7 天：复盘对方是否更有主体性。"
+                            {
+                                "day": 1,
+                                "practice": "识别一次想立刻解决的冲动。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "暂停并问支持方式。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "只给一个帮助选项。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "避免替对方做决定。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "结束前确认对方自己的下一步。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录你的承担感变化。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复盘支持和接管的差别。"
+                            }
                         ],
-                        "watch_out": "不要把对方的不舒服全部变成你的责任。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你想帮人解决一切时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Support Without Rescuing",
-                        "why_this_matters": "Effective support restores agency instead of solving everything for the other person.",
-                        "do_today": "Next time you support someone, ask only one next-step question.",
-                        "script": "I can think with you, but this decision needs to be yours.",
+                        "title": "Support without rescuing",
+                        "why_this_matters": "Use when you feel pulled to solve everything for someone.",
+                        "do_today": "Ask whether the person wants listening, advice, or practical help.",
+                        "script": "Do you want me to listen, or would it help to think through one next step?",
                         "seven_day_plan": [
-                            "Day 1: notice one urge to solve for someone.",
-                            "Day 2: only listen.",
-                            "Day 3: ask only one question.",
-                            "Day 4: clarify what you can do.",
-                            "Day 5: clarify what you cannot do.",
-                            "Day 6: recover after support.",
-                            "Day 7: review whether their agency increased."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not make all of their discomfort your responsibility."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you feel pulled to solve everything for someone.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "cold_to_warm_response": {
                     "zh-CN": {
-                        "title": "从冷静到有温度处方",
-                        "why_this_matters": "稳定需要被他人感受到，才会变成关系中的安全感。",
-                        "do_today": "在给建议前先确认对方感受。",
-                        "script": "我能理解这件事让你不舒服，我们再一起看怎么处理。",
+                        "title": "从冷静到有温度",
+                        "why_this_matters": "当你能解决问题但别人感觉没被回应时使用。",
+                        "do_today": "今天在给方案前先回应一句感受。",
+                        "script": "我能理解这让你很挫败。我们可以一起看下一步怎么处理。",
                         "seven_day_plan": [
-                            "第 1 天：练一句情绪确认。",
-                            "第 2 天：先确认再建议。",
-                            "第 3 天：观察对方反应。",
-                            "第 4 天：减少过快解释。",
-                            "第 5 天：加入一句感谢。",
-                            "第 6 天：复盘一次低温回应。",
-                            "第 7 天：固定一个温暖开场。"
+                            {
+                                "day": 1,
+                                "practice": "听到问题后先不急着给方案。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "说出你听见的情绪。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "确认对方是否认可。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "再提出一个具体下一步。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "观察对方反应是否软化。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "复盘你是否少讲了道理。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "保留一个适合你的温度句。"
+                            }
                         ],
-                        "watch_out": "温暖不是放弃理性。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你能解决问题但别人感觉没被回应时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Cold to Warm Response",
-                        "why_this_matters": "Stability becomes relational safety only when others can feel it.",
-                        "do_today": "Acknowledge the feeling before giving advice.",
-                        "script": "I can see this was uncomfortable for you; let's look at what to do next.",
+                        "title": "From calm to warm response",
+                        "why_this_matters": "Use when you can solve the issue but others do not feel emotionally met.",
+                        "do_today": "Before offering a solution, acknowledge one feeling.",
+                        "script": "I can see how frustrating this is. We can look at the next step together.",
                         "seven_day_plan": [
-                            "Day 1: practice one emotional acknowledgment.",
-                            "Day 2: acknowledge before advising.",
-                            "Day 3: observe their response.",
-                            "Day 4: reduce fast explanation.",
-                            "Day 5: add one appreciation.",
-                            "Day 6: review one low-warmth response.",
-                            "Day 7: fix one warm opening."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Warmth does not mean giving up rationality."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you can solve the issue but others do not feel emotionally met.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "relationship_energy_management": {
                     "zh-CN": {
-                        "title": "关系能量管理处方",
-                        "why_this_matters": "关系投入需要节奏，否则优势会变成消耗。",
-                        "do_today": "给一个高消耗互动安排恢复窗口。",
-                        "script": "我现在可以聊二十分钟，之后需要休息一下。",
+                        "title": "关系能量管理",
+                        "why_this_matters": "当你在多人关系或强情绪场景后感到累时使用。",
+                        "do_today": "今天给一段高互动之后安排十分钟低输入时间。",
+                        "script": "我需要一点时间整理刚才的信息，之后我会回来回应。",
                         "seven_day_plan": [
-                            "第 1 天：列出高消耗互动。",
-                            "第 2 天：标出恢复方式。",
-                            "第 3 天：设置时间边界。",
-                            "第 4 天：减少即时回复。",
-                            "第 5 天：安排独处窗口。",
-                            "第 6 天：复盘能量变化。",
-                            "第 7 天：保留一个固定恢复段。"
+                            {
+                                "day": 1,
+                                "practice": "标记今天最耗能的一次互动。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "记录耗能来自人、情绪还是切换。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "安排十分钟低输入恢复。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "减少一个不必要回应。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "练习结束对话的句子。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "观察恢复前后差异。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "设定下周一个关系能量边界。"
+                            }
                         ],
-                        "watch_out": "不要等到耗尽才开始恢复。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你在多人关系或强情绪场景后感到累时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Relationship Energy Management",
-                        "why_this_matters": "Relational investment needs rhythm; otherwise strength becomes drain.",
-                        "do_today": "Schedule recovery after one high-cost interaction.",
-                        "script": "I can talk for twenty minutes now, and then I need a break.",
+                        "title": "Relationship energy management",
+                        "why_this_matters": "Use when you feel drained after relationally intense situations.",
+                        "do_today": "Schedule ten minutes of low input after one high-interaction moment.",
+                        "script": "I need a little time to process what just happened, and I will come back to it.",
                         "seven_day_plan": [
-                            "Day 1: list high-cost interactions.",
-                            "Day 2: mark recovery methods.",
-                            "Day 3: set a time boundary.",
-                            "Day 4: reduce instant replies.",
-                            "Day 5: schedule solo time.",
-                            "Day 6: review energy changes.",
-                            "Day 7: keep one fixed recovery block."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not wait until depletion to recover."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you feel drained after relationally intense situations.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "conflict_deescalation": {
                     "zh-CN": {
-                        "title": "冲突降温处方",
-                        "why_this_matters": "降温不是退让，而是让问题重新可谈。",
-                        "do_today": "下一次分歧时，只说共同目标和下一步。",
-                        "script": "我们先别扩大问题，我想先确认下一步怎么做。",
+                        "title": "冲突降温",
+                        "why_this_matters": "当对话开始升级时使用。",
+                        "do_today": "今天练习把争执缩小到一个具体问题。",
+                        "script": "我们先只谈一个点：现在最需要决定的是什么？",
                         "seven_day_plan": [
-                            "第 1 天：识别升级词。",
-                            "第 2 天：练习降温句。",
-                            "第 3 天：暂停十分钟。",
-                            "第 4 天：只谈一个问题。",
-                            "第 5 天：确认共同目标。",
-                            "第 6 天：复盘冲突过程。",
-                            "第 7 天：写下自己的降温协议。"
+                            {
+                                "day": 1,
+                                "practice": "识别一个容易升级的话题。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写出双方各自想保护什么。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "准备一句缩小问题的话。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "练习放慢语速。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "在对话中只问一个澄清问题。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "结束后复盘是否降温。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "保存一个下次可用的降温句。"
+                            }
                         ],
-                        "watch_out": "降温不等于压下真实问题。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当对话开始升级时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Conflict De-escalation",
-                        "why_this_matters": "De-escalation is not surrender; it makes the issue discussable again.",
-                        "do_today": "In the next disagreement, state only the shared goal and next step.",
-                        "script": "Let's not expand the issue. I want to confirm the next step first.",
+                        "title": "Conflict de-escalation",
+                        "why_this_matters": "Use when a conversation starts escalating.",
+                        "do_today": "Practice narrowing a disagreement to one concrete issue.",
+                        "script": "Let’s focus on one point: what needs to be decided right now?",
                         "seven_day_plan": [
-                            "Day 1: identify escalation words.",
-                            "Day 2: practice a cooling sentence.",
-                            "Day 3: pause ten minutes.",
-                            "Day 4: discuss one issue only.",
-                            "Day 5: confirm shared goal.",
-                            "Day 6: review the conflict process.",
-                            "Day 7: write your de-escalation protocol."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Cooling down does not mean suppressing the real issue."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when a conversation starts escalating.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "self_connection": {
                     "zh-CN": {
-                        "title": "自我连接处方",
-                        "why_this_matters": "关系顺畅不能替代对自己需求的确认。",
-                        "do_today": "答应别人前先写下我愿意和我不愿意。",
-                        "script": "我想先确认一下自己的安排，晚点回复你。",
+                        "title": "重新连接自己",
+                        "why_this_matters": "当你总先照顾关系而忽略自己时使用。",
+                        "do_today": "今天在答应前先问自己：我是真愿意，还是怕关系变差？",
+                        "script": "我想先想一下我真实能承担到哪里，再回复你。",
                         "seven_day_plan": [
-                            "第 1 天：记录一个自己的需求。",
-                            "第 2 天：记录一个不愿意。",
-                            "第 3 天：延迟答应。",
-                            "第 4 天：练习一个小拒绝。",
-                            "第 5 天：复盘拒绝后的关系。",
-                            "第 6 天：写下可接受条件。",
-                            "第 7 天：总结自己的边界句。"
+                            {
+                                "day": 1,
+                                "practice": "记录一次你想立刻答应的场景。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下真实愿意和勉强愿意的差别。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "练习延迟回应。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "说出一个较小的可承担范围。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "观察关系是否真的受损。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "记录一个被你忽略的感受。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "设定一个下周的自我连接问题。"
+                            }
                         ],
-                        "watch_out": "不要把照顾自己理解成破坏关系。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当你总先照顾关系而忽略自己时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Self-Connection",
-                        "why_this_matters": "A smooth relationship cannot replace checking your own needs.",
-                        "do_today": "Before agreeing, write what you are willing and not willing to do.",
-                        "script": "I want to check my own schedule first and reply later.",
+                        "title": "Reconnect with self",
+                        "why_this_matters": "Use when you care for the relationship before checking yourself.",
+                        "do_today": "Before agreeing today, ask: am I willing, or am I afraid the relationship will change?",
+                        "script": "I want to check what I can realistically take on before I answer.",
                         "seven_day_plan": [
-                            "Day 1: record one personal need.",
-                            "Day 2: record one not-willing item.",
-                            "Day 3: delay agreement.",
-                            "Day 4: practice a small no.",
-                            "Day 5: review the relationship after saying no.",
-                            "Day 6: write acceptable conditions.",
-                            "Day 7: summarize your boundary sentence."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not treat caring for yourself as damaging the relationship."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when you care for the relationship before checking yourself.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 },
                 "retest_reflection": {
                     "zh-CN": {
-                        "title": "复测与低风险反思处方",
-                        "why_this_matters": "低置信度结果不适合强解释，更适合作为复测提醒。",
-                        "do_today": "只记录一个你认可的线索，不做稳定结论。",
-                        "script": "这次结果我先当作提醒，等状态稳定后再复测。",
+                        "title": "复测前观察",
+                        "why_this_matters": "当本次结果置信度较低时使用。",
+                        "do_today": "今天不要急着定性，先记录作答时的状态。",
+                        "script": "这次结果我先轻一点看，等状态更稳定时再复测。",
                         "seven_day_plan": [
-                            "第 1 天：记录作答时状态。",
-                            "第 2 天：检查是否太快或太累。",
-                            "第 3 天：观察一个真实场景。",
-                            "第 4 天：不做标签化解释。",
-                            "第 5 天：选择复测时间。",
-                            "第 6 天：保证安静环境。",
-                            "第 7 天：重新完成测试。"
+                            {
+                                "day": 1,
+                                "practice": "记录作答时间和状态。"
+                            },
+                            {
+                                "day": 2,
+                                "practice": "写下是否太快、太累或太分心。"
+                            },
+                            {
+                                "day": 3,
+                                "practice": "挑三个最不确定的题目类型。"
+                            },
+                            {
+                                "day": 4,
+                                "practice": "观察一天真实情绪场景。"
+                            },
+                            {
+                                "day": 5,
+                                "practice": "不要做重大解释。"
+                            },
+                            {
+                                "day": 6,
+                                "practice": "选择一个更稳定的复测时间。"
+                            },
+                            {
+                                "day": 7,
+                                "practice": "复测后比较哪些部分稳定。"
+                            }
                         ],
-                        "watch_out": "不要用低置信度结果做重大决定。"
+                        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+                        "when_to_use": "当本次结果置信度较低时使用。",
+                        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
                     },
                     "en": {
-                        "title": "Retest and Low-Risk Reflection",
-                        "why_this_matters": "Low-confidence results should not drive strong interpretation; they are better used as a retest cue.",
-                        "do_today": "Record only one cue that feels useful; do not form a stable conclusion.",
-                        "script": "I will treat this result as a reminder and retake when I am more settled.",
+                        "title": "Reflection before retest",
+                        "why_this_matters": "Use when this result has lower interpretation confidence.",
+                        "do_today": "Do not label yourself today; first record the response context.",
+                        "script": "I will read this result lightly and retest when my context is steadier.",
                         "seven_day_plan": [
-                            "Day 1: record your state during response.",
-                            "Day 2: check if you were too fast or tired.",
-                            "Day 3: observe one real situation.",
-                            "Day 4: avoid labeling yourself.",
-                            "Day 5: choose a retest time.",
-                            "Day 6: ensure a quiet setting.",
-                            "Day 7: complete the test again."
+                            {
+                                "day": 1,
+                                "practice": "Notice one relevant real situation."
+                            },
+                            {
+                                "day": 2,
+                                "practice": "Write the fact, feeling, and need separately."
+                            },
+                            {
+                                "day": 3,
+                                "practice": "Practice the key sentence once out loud."
+                            },
+                            {
+                                "day": 4,
+                                "practice": "Use the practice in a low-risk interaction."
+                            },
+                            {
+                                "day": 5,
+                                "practice": "Record what changed before and after."
+                            },
+                            {
+                                "day": 6,
+                                "practice": "Adjust the wording to sound natural."
+                            },
+                            {
+                                "day": 7,
+                                "practice": "Choose one version to keep using next week."
+                            }
                         ],
-                        "watch_out": "Do not use a low-confidence result for major decisions."
+                        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+                        "when_to_use": "Use when this result has lower interpretation confidence.",
+                        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
                     }
                 }
             }
@@ -1786,37 +4824,37 @@
             "assets": {
                 "eq.seo_geo_authority.en_landing.default": {
                     "zh-CN": {
-                        "meta_title": "免费情商 EQ 测试 | 情绪与关系模式报告",
-                        "meta_description": "完成 60 道自我报告题，理解自我觉察、情绪调节、共情理解和关系管理。结果免费，边界清晰，不用于诊断、招聘或能力认证。",
-                        "h1": "情商 EQ 测试：情绪与关系模式报告",
-                        "dek": "一份 60 题 self-report 测评，用于解释你如何感知、调节和回应自己与他人的情绪。",
-                        "entity_summary": "费马 EQ-60 是情绪与关系信号模块，输出自我报告型情绪与关系模式报告，而不是临床、招聘或认证能力测验。",
+                        "meta_title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "h1": "情绪与关系模式测试",
+                        "dek": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "entity_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
                         "content_modules": [
                             {
-                                "heading": "测评测什么",
-                                "summary": "自我觉察、情绪调节、共情理解和关系管理四个维度。"
+                                "heading": "测试定义",
+                                "summary": "测试定义"
                             },
                             {
-                                "heading": "结果页给什么",
-                                "summary": "综合指数、四维矩阵、核心洞察、现实场景、行动处方和科学边界。"
+                                "heading": "测量内容",
+                                "summary": "测量内容"
                             },
                             {
-                                "heading": "不做什么",
-                                "summary": "不做临床诊断、招聘筛选、职业适配结论或客观能力认证。"
+                                "heading": "不适用边界",
+                                "summary": "不适用边界"
+                            },
+                            {
+                                "heading": "下一步行动",
+                                "summary": "下一步行动"
                             }
                         ],
                         "faq": [
                             {
-                                "question": "这是免费的情商测试吗？",
-                                "answer": "是。EQ-60 基础报告免费；报告深度由完成的数据决定，不由付费门槛决定。"
+                                "question": "分数代表什么？",
+                                "answer": ""
                             },
                             {
-                                "question": "它是能力测验吗？",
-                                "answer": "不是。它基于自我报告，适合自我理解、沟通反思和成长规划。"
-                            },
-                            {
-                                "question": "未来的情境判断模块是什么？",
-                                "answer": "EQ-SJT 16 目前仅为 planned 状态，未来会补充情境选择信息，但不会被表述为认证能力测验。"
+                                "question": "结果应该怎么使用？",
+                                "answer": ""
                             }
                         ],
                         "structured_data": {
@@ -1825,48 +4863,47 @@
                             "result_scope": "emotional_and_relational_pattern_report",
                             "is_free": true
                         },
-                        "llms_summary": "EQ-60 是费马测试的自我报告型情绪与关系模式测评。它用 60 道题解释自我觉察、情绪调节、共情理解和关系管理，并输出免费结果页。",
-                        "claim_boundary": "仅用于自我理解和成长规划；不用于临床诊断、招聘筛选、职业适配承诺、治疗建议或客观能力认证。",
-                        "source_authority": "页面标题、SEO 摘要、FAQ、结构化数据边界和 LLM 摘要以 backend content pack 为权威来源。",
+                        "llms_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。",
+                        "source_authority": "后端 content pack 是公开 EQ SEO/GEO 文案权威来源。",
                         "no_go_claims": [
-                            "不声称测量客观情绪能力",
-                            "不声称预测工作表现",
-                            "不用于招聘筛选",
-                            "不用于临床诊断"
+                            "不用于临床",
+                            "不用于招聘",
+                            "不用于认证"
                         ]
                     },
                     "en": {
-                        "meta_title": "Free EQ Test | Emotional & Relational Pattern Report",
-                        "meta_description": "Take a free 60-item self-report EQ test covering self-awareness, emotion regulation, empathy, and relationship management. Clear boundaries: not clinical, hiring, or certified ability assessment.",
-                        "h1": "EQ Test: Emotional & Relational Pattern Report",
-                        "dek": "A 60-item self-report assessment that explains how you notice, regulate, and respond to emotions in yourself and in relationships.",
-                        "entity_summary": "FermatMind EQ-60 is an emotional and relational signal module. It produces a self-report pattern report, not a clinical, hiring, or certified ability assessment.",
+                        "meta_title": "Free EQ Test | Emotional Intelligence Test",
+                        "meta_description": "Take a free self-report emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+                        "h1": "Free Emotional Intelligence Test",
+                        "dek": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "entity_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
                         "content_modules": [
                             {
-                                "heading": "What it measures",
-                                "summary": "Self-awareness, emotion regulation, empathic understanding, and relationship management."
+                                "heading": "definition",
+                                "summary": "definition"
                             },
                             {
-                                "heading": "What the report includes",
-                                "summary": "A global index, four-dimension matrix, core insight, real-world scenes, action prescription, and scientific boundary."
+                                "heading": "what it measures",
+                                "summary": "what it measures"
                             },
                             {
-                                "heading": "What it does not do",
-                                "summary": "It does not provide clinical diagnosis, hiring suitability, career-fit promises, or objective ability certification."
+                                "heading": "what it does not decide",
+                                "summary": "what it does not decide"
+                            },
+                            {
+                                "heading": "next useful action",
+                                "summary": "next useful action"
                             }
                         ],
                         "faq": [
                             {
-                                "question": "Is this EQ test free?",
-                                "answer": "Yes. The EQ-60 base report is free; report depth is based on completed data, not a paywall."
+                                "question": "What does the score mean?",
+                                "answer": "Your result summarizes a self-report emotional and relational pattern across self-awareness, emotion regulation, empathy, and relationship management."
                             },
                             {
-                                "question": "Is this an ability test?",
-                                "answer": "No. It is based on self-report and is intended for self-understanding, communication reflection, and growth planning."
-                            },
-                            {
-                                "question": "What is the future scenario module?",
-                                "answer": "EQ-SJT 16 is currently planned only. It will add scenario-choice information in the future, without being positioned as a certified ability assessment."
+                                "question": "How should I use the result?",
+                                "answer": "Use it to reflect on your patterns, choose a small next action, and decide whether a retest or related assessment would be useful."
                             }
                         ],
                         "structured_data": {
@@ -1875,15 +4912,1146 @@
                             "result_scope": "emotional_and_relational_pattern_report",
                             "is_free": true
                         },
-                        "llms_summary": "EQ-60 is FermatMind's self-report emotional and relational pattern assessment. It uses 60 items to explain self-awareness, emotion regulation, empathic understanding, and relationship management, then returns a free result page.",
-                        "claim_boundary": "For self-understanding and growth planning only; not for clinical diagnosis, hiring selection, career-fit promises, treatment advice, or objective ability certification.",
-                        "source_authority": "Page title, SEO summary, FAQ, structured-data boundary, and LLM summary are authoritative in the backend content pack.",
+                        "llms_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "claim_boundary": "Use for self-understanding, reflection, and growth planning; not for clinical diagnosis, hiring, credentialing, or job-performance prediction.",
+                        "source_authority": "Backend content pack is authoritative for public EQ SEO/GEO copy.",
                         "no_go_claims": [
-                            "Does not claim objective emotional ability measurement",
-                            "Does not predict job performance",
-                            "Not for hiring selection",
-                            "Not for clinical diagnosis"
+                            "not clinical",
+                            "not hiring",
+                            "not credentialing"
                         ]
+                    }
+                }
+            },
+            "faq_assets": [
+                {
+                    "zh-CN": {
+                        "question": "什么是 EQ？",
+                        "answer": "EQ 指情绪与关系相关的自我觉察、调节、共情和关系处理方式。费马 EQ-60 用自我报告方式帮助你理解这些模式。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What is EQ?",
+                        "answer": "EQ refers to emotional and relational patterns such as self-awareness, regulation, empathy, and relationship management. Fermat EQ-60 uses self-report to help you understand these patterns.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "这个 EQ 测试测什么？",
+                        "answer": "它测你如何看待自己的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does this EQ test measure?",
+                        "answer": "It measures how you perceive your emotional and relational tendencies across self-awareness, emotion regulation, empathy, and relationship management.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "它是不是现场表现测量？",
+                        "answer": "不是。EQ-60 是自我报告结果，解释你如何看待自己的情绪与关系模式，不等同于受控任务中的现场表现。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is this based on real-time performance?",
+                        "answer": "No. EQ-60 is a self-report result. It describes how you see your emotional and relational patterns, not how you would perform in a controlled task.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "和专业能力工具有什么区别？",
+                        "answer": "专业能力工具通常需要受控任务、专门评分和资格管理。EQ-60 更适合自我理解和成长规划。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is it different from professional ability instruments?",
+                        "answer": "Professional ability instruments use controlled tasks, specialized scoring, and qualification procedures. EQ-60 is for reflection and growth planning.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 IQ 有什么区别？",
+                        "answer": "IQ 更关注认知问题解决；EQ-60 关注你如何感知、调节和处理情绪与关系。两者不是互相替代。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from IQ?",
+                        "answer": "IQ focuses more on cognitive problem solving. EQ-60 focuses on how you perceive, regulate, and handle emotion and relationships. They are not substitutes for each other.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 MBTI 有什么区别？",
+                        "answer": "MBTI 更像偏好类型语言；EQ-60 解释情绪和关系功能。两者可互补，但不能互相替代。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from MBTI?",
+                        "answer": "MBTI is more of a preference-type language. EQ-60 explains emotional and relational functioning. They can complement each other but do not replace each other.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和 Big Five 有什么区别？",
+                        "answer": "Big Five 描述广泛人格特质；EQ-60 聚焦情绪与关系模式。它们可能有重叠，但报告用途不同。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from Big Five?",
+                        "answer": "Big Five describes broad personality traits. EQ-60 focuses on emotional and relational patterns. They may overlap, but their report use differs.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "EQ 和九型人格有什么区别？",
+                        "answer": "九型人格常用于动机和模式叙事；EQ-60 更关注情绪觉察、调节、共情和关系管理。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How is EQ different from Enneagram?",
+                        "answer": "Enneagram is often used for motivation and pattern narratives. EQ-60 focuses on awareness, regulation, empathy, and relationship management.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "结果准吗？",
+                        "answer": "结果的有用性取决于题目质量、作答状态、常模版本和你是否如实作答。它适合作为自我理解起点。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is the result accurate?",
+                        "answer": "Its usefulness depends on item quality, response context, norm version, and honest responding. It is best used as a starting point for self-understanding.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么用自我报告？",
+                        "answer": "自我感知会影响你如何回应反馈、冲突和关系压力。它不是全部证据，但非常适合作为入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why self-report?",
+                        "answer": "Self-perception affects how you respond to feedback, conflict, and relational pressure. It is not the whole picture, but it is a useful entry point.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以用于人事决定吗？",
+                        "answer": "不建议。单次自我报告结果不适合用于录用、淘汰、晋升或岗位分配。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can it be used for employment decisions?",
+                        "answer": "No. A single self-report result is not appropriate for selection, rejection, promotion, or role assignment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以用于健康判断吗？",
+                        "answer": "不适合。它可以帮助你描述体验，但不能替代专业支持或高风险判断。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can it be used for health decisions?",
+                        "answer": "No. It can help describe experience, but it does not replace qualified support or high-stakes judgment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "分数低怎么办？",
+                        "answer": "先看最低维度和行动处方。低分不是失败，而是指向更具体的练习入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What if my score is low?",
+                        "answer": "Start with the lowest dimension and the action prescription. A lower score is not failure; it points to a more specific practice entry point.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "低置信结果是什么意思？",
+                        "answer": "它表示这次作答状态让解释需要更谨慎。你仍可参考，但不宜做强结论。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does lower confidence mean?",
+                        "answer": "It means the response pattern calls for more cautious interpretation. You can still use it, but avoid strong conclusions.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以复测吗？",
+                        "answer": "可以。建议在状态更稳定、没有赶时间时复测，并比较哪些维度保持一致。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can I retest?",
+                        "answer": "Yes. Retest when you are not rushed and your context is steadier, then compare which dimensions remain stable.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么情境判断暂未开放？",
+                        "answer": "因为情境题需要评分规则、文化审校和验证。当前先保持 planned 状态，不开放入口。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why is the scenario module not available yet?",
+                        "answer": "Scenario items need scoring rubrics, cultural review, and validation. It remains planned and unavailable for now.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "未来情境判断会补充什么？",
+                        "answer": "它会观察你在反馈、冲突、边界和压力场景中倾向选择什么回应。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What will the future scenario module add?",
+                        "answer": "It will examine the responses you tend to choose in feedback, conflict, boundary, and pressure situations.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "情绪调节低是什么意思？",
+                        "answer": "它通常表示在压力或被触发时恢复较慢，不代表你无法改变。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What does lower emotion regulation mean?",
+                        "answer": "It often means recovery is slower under pressure or activation. It does not mean you cannot improve.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "共情高是不是一定好？",
+                        "answer": "不是绝对好坏。高共情能帮助理解别人，但如果恢复和边界不足，也可能带来消耗。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is high empathy always good?",
+                        "answer": "Not absolutely. High empathy helps you understand others, but without recovery and boundaries it can become draining.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "职业环境变量是什么意思？",
+                        "answer": "它不是推荐具体职业，而是帮助你观察一个工作环境的人际密度、反馈强度、冲突频率和恢复空间。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "What is a career environment variable?",
+                        "answer": "It is not a job recommendation. It helps you examine interpersonal density, feedback intensity, conflict frequency, and recovery space in a work environment.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "如何用结果处理反馈？",
+                        "answer": "先看 ER 和 SA，再用行动处方把反馈拆成事实、感受和下一步。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How can I use the result for feedback?",
+                        "answer": "Look at ER and SA, then use the action prescription to split feedback into facts, feelings, and next steps.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "如何用结果改善关系？",
+                        "answer": "选择一个关系场景，不要泛泛改自己。先练一句更清楚、更可被接住的话。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How can I use the result in relationships?",
+                        "answer": "Pick one relationship scene rather than trying to change everything. Practice one clearer, more receivable sentence.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "情商可以提升吗？",
+                        "answer": "可以练习其中的具体行为，例如情绪命名、暂停、共情回应、边界表达和关系修复。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can EQ improve?",
+                        "answer": "Specific behaviors can be practiced, such as emotion naming, pausing, empathic response, boundary expression, and repair.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "可以分享结果吗？",
+                        "answer": "可以分享模式摘要，但不建议公开详细分数或把结果当作固定标签。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Can I share my result?",
+                        "answer": "You can share a pattern summary, but avoid posting detailed scores or treating the result as a fixed label.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么要保存报告？",
+                        "answer": "保存后你可以复测、比较变化，并继续查看行动处方。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why save the report?",
+                        "answer": "Saving lets you retest, compare change, and keep the action plan continuous.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "这是给我贴标签吗？",
+                        "answer": "不是。formulation 是把本次结果组织成一个可理解的模式，不是永久身份。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Is this labeling me?",
+                        "answer": "No. A formulation organizes the current result into an understandable pattern; it is not a permanent identity.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "质量提示是不是说我答错了？",
+                        "answer": "不是。质量提示描述这次作答状态，不评价你这个人。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Do quality flags mean I answered wrong?",
+                        "answer": "No. Quality notes describe this response session; they do not judge you as a person.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "四个维度为什么是这四个？",
+                        "answer": "它们覆盖自己与他人、理解与行动两个轴，形成一个简洁的情绪与关系矩阵。",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "Why these four dimensions?",
+                        "answer": "They cover self vs others and understanding vs action, forming a concise emotional-relational matrix.",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "工作中怎么用？",
+                        "answer": "把结果转成场景问题：我如何接收反馈、处理冲突、设边界、恢复压力？",
+                        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+                    },
+                    "en": {
+                        "question": "How do I use it at work?",
+                        "answer": "Translate it into scene questions: how do I handle feedback, conflict, boundaries, and recovery?",
+                        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "为什么要保存报告？",
+                        "answer": "保存后，你可以回看本次核心模式、行动处方和复测变化。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "Why save the report?",
+                        "answer": "Saving lets you return to your pattern, action prescription, and future retest comparison.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "多久复测一次比较合适？",
+                        "answer": "如果你只是好奇，4–8 周后复测更有意义；如果本次置信度较低，可以在状态更稳定时更早复测。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "When should I retest?",
+                        "answer": "For normal reflection, 4–8 weeks gives change more room to appear. If confidence was low, retest when your state is steadier.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                },
+                {
+                    "zh-CN": {
+                        "question": "我可以问 Agent 什么？",
+                        "answer": "可以问一个具体场景，比如反馈、冲突、边界或压力恢复。Agent 应基于你的报告资产解释，不会改分数。",
+                        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+                    },
+                    "en": {
+                        "question": "What can I ask the Agent?",
+                        "answer": "Ask about one real scene: feedback, conflict, boundaries, or recovery. The Agent explains your report assets; it does not change your scores.",
+                        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+                    }
+                }
+            ],
+            "seo_geo_assets": {
+                "eq.seo.en.emotional_intelligence_test": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotional Intelligence Test",
+                        "meta_description": "Take a free emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+                        "short_answer": "Understand your emotional and relational pattern, not a live-performance credential.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Understand your emotional and relational pattern, not a live-performance credential."
+                    }
+                },
+                "eq.seo.en.free_eq_test": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Free EQ Test",
+                        "meta_description": "A free EQ test with a complete self-report result, confidence note, and action prescription.",
+                        "short_answer": "Designed for reflection, workstyle insight, and relationship growth.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Designed for reflection, workstyle insight, and relationship growth."
+                    }
+                },
+                "eq.seo.en.eq_score_meaning": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ Score Meaning",
+                        "meta_description": "Learn how EQ scores, bands, percentiles, and confidence notes should be read.",
+                        "short_answer": "A score is a starting point; dimensions and context carry the real interpretation.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "A score is a starting point; dimensions and context carry the real interpretation."
+                    }
+                },
+                "eq.seo.en.self_report_vs_ability_ei": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Self-Report vs Ability EI",
+                        "meta_description": "Understand the difference between self-report EQ and controlled ability-style instruments.",
+                        "short_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment."
+                    }
+                },
+                "eq.seo.en.eq_vs_iq": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ vs IQ",
+                        "meta_description": "EQ and IQ describe different domains: emotional-relational patterns and cognitive problem solving.",
+                        "short_answer": "The two are complementary and should not be collapsed into one score.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "The two are complementary and should not be collapsed into one score."
+                    }
+                },
+                "eq.seo.en.eq_in_workplace": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotional Intelligence at Work",
+                        "meta_description": "Use EQ results to examine feedback, conflict, collaboration, and recovery patterns.",
+                        "short_answer": "Focus on environment variables and communication habits.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Focus on environment variables and communication habits."
+                    }
+                },
+                "eq.seo.en.how_to_improve_eq": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "How to Improve EQ",
+                        "meta_description": "Practice emotion naming, pausing, empathic response, boundaries, and repair.",
+                        "short_answer": "Improvement begins with one repeatable behavior in a real situation.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Improvement begins with one repeatable behavior in a real situation."
+                    }
+                },
+                "eq.seo.en.eq_and_relationships": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "EQ in Relationships",
+                        "meta_description": "See how empathy, boundaries, expression, and repair shape relationship patterns.",
+                        "short_answer": "The goal is clearer conversation, not fixed labels.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "The goal is clearer conversation, not fixed labels."
+                    }
+                },
+                "eq.seo.en.emotion_regulation": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Emotion Regulation",
+                        "meta_description": "Understand recovery and response choice after emotional activation.",
+                        "short_answer": "Regulation is not suppression; it keeps enough choice to respond well.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Regulation is not suppression; it keeps enough choice to respond well."
+                    }
+                },
+                "eq.seo.en.empathy_context": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Empathy in EQ",
+                        "meta_description": "Empathy helps you read others, but needs boundaries and recovery.",
+                        "short_answer": "High empathy can be a strength and a load depending on context.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "High empathy can be a strength and a load depending on context."
+                    }
+                },
+                "eq.seo.en.eq_methodology": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Fermat EQ Methodology",
+                        "meta_description": "How EQ-60 uses self-report, four dimensions, quality checks, and versioned norms.",
+                        "short_answer": "Transparent boundaries make the result more useful, not weaker.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Transparent boundaries make the result more useful, not weaker."
+                    }
+                },
+                "eq.seo.en.eq_retest": {
+                    "zh-CN": {
+                        "title": "情绪与关系模式测试",
+                        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+                        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+                        "long_answer_outline": [
+                            "测试定义",
+                            "测量内容",
+                            "不适用边界",
+                            "下一步行动"
+                        ],
+                        "related_questions": [
+                            "分数代表什么？",
+                            "结果应该怎么使用？"
+                        ],
+                        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+                    },
+                    "en": {
+                        "title": "Retesting EQ",
+                        "meta_description": "Retesting can show which emotional-relational patterns remain stable over time.",
+                        "short_answer": "Compare dimensions and confidence notes, not just the total score.",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": "Compare dimensions and confidence notes, not just the total score."
+                    }
+                },
+                "eq.seo.zh.qingshang_ceshi": {
+                    "zh-CN": {
+                        "title": "情商测试",
+                        "meta_description": "免费查看你的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+                        "short_answer": "结果用于自我理解和成长规划，不用于高风险判断。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_ceshi": {
+                    "zh-CN": {
+                        "title": "EQ测试",
+                        "meta_description": "基于 60 道自我报告题，生成情绪与关系模式报告。",
+                        "short_answer": "重点不是给你贴标签，而是找到可执行的练习入口。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.qingxu_zhili": {
+                    "zh-CN": {
+                        "title": "情绪智力",
+                        "meta_description": "了解情绪觉察、调节、共情和关系处理如何影响沟通与压力恢复。",
+                        "short_answer": "情绪智力可以拆成具体行为来练习。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.qingxu_tiaojie": {
+                    "zh-CN": {
+                        "title": "情绪调节",
+                        "meta_description": "理解被触发后如何暂停、恢复和选择回应。",
+                        "short_answer": "情绪调节不是压抑情绪，而是保留回应选择。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.gongqing_nengli": {
+                    "zh-CN": {
+                        "title": "共情能力",
+                        "meta_description": "共情帮助你读懂别人，但也需要边界和恢复。",
+                        "short_answer": "高共情不是绝对好坏，要看它是否和调节协同。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_vs_iq": {
+                    "zh-CN": {
+                        "title": "EQ和IQ区别",
+                        "meta_description": "IQ偏认知问题解决，EQ-60偏情绪与关系模式。",
+                        "short_answer": "两者互补，不能互相替代。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.self_report_vs_ability": {
+                    "zh-CN": {
+                        "title": "自我报告和表现型测量区别",
+                        "meta_description": "自我报告解释你如何看待自己，能力工具需要受控任务和专门评分。",
+                        "short_answer": "费马 EQ-60 当前属于自我报告结果。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_score_meaning": {
+                    "zh-CN": {
+                        "title": "EQ分数怎么理解",
+                        "meta_description": "分数要和四维、百分位、置信度和行动建议一起读。",
+                        "short_answer": "不要只看一个总分。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_workplace": {
+                    "zh-CN": {
+                        "title": "职场情商",
+                        "meta_description": "用 EQ 结果观察反馈、冲突、协作和恢复方式。",
+                        "short_answer": "报告只解释环境变量和工作方式，不推荐具体岗位。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.improve_eq": {
+                    "zh-CN": {
+                        "title": "如何提高情商",
+                        "meta_description": "从情绪命名、暂停、共情回应、边界表达和修复脚本开始。",
+                        "short_answer": "选择一个场景练习，比泛泛努力更有效。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_relationship": {
+                    "zh-CN": {
+                        "title": "情商与关系",
+                        "meta_description": "理解你如何表达、共情、设边界和修复关系。",
+                        "short_answer": "结果不是关系定论，而是对话入口。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
+                    }
+                },
+                "eq.seo.zh.eq_methodology": {
+                    "zh-CN": {
+                        "title": "费马EQ方法论",
+                        "meta_description": "说明 EQ-60 的四维模型、计分、质量提示和科学边界。",
+                        "short_answer": "透明的方法边界能提升可信度。",
+                        "long_answer_outline": [
+                            "definition",
+                            "what it measures",
+                            "what it does not decide",
+                            "next useful action"
+                        ],
+                        "related_questions": [
+                            "What does the score mean?",
+                            "How should I use the result?"
+                        ],
+                        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+                    },
+                    "en": {
+                        "title": "",
+                        "meta_description": "",
+                        "short_answer": "",
+                        "long_answer_outline": [],
+                        "related_questions": [],
+                        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+                        "search_intent_answer": ""
                     }
                 }
             }
@@ -1894,22 +6062,1509 @@
             "assets": {
                 "eq.sjt_bridge.planned": {
                     "zh-CN": {
-                        "title": "未来将支持 16 道情境判断模块",
-                        "status": "planned",
-                        "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
-                        "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
-                        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。",
-                        "button_label": "情境判断模块规划中",
-                        "available": false
+                        "title": "未来情境判断模块",
+                        "status": "planned_unavailable",
+                        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
                     },
                     "en": {
-                        "title": "A 16-item scenario module is planned",
+                        "title": "Future scenario module",
+                        "status": "planned_unavailable",
+                        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.what_it_adds": {
+                    "zh-CN": {
+                        "title": "它会补充什么",
+                        "status": "planned_unavailable",
+                        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "What it will add",
+                        "status": "planned_unavailable",
+                        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.what_it_is_not": {
+                    "zh-CN": {
+                        "title": "它不是什么",
+                        "status": "planned_unavailable",
+                        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "What it is not",
+                        "status": "planned_unavailable",
+                        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.future_integrated_report": {
+                    "zh-CN": {
+                        "title": "未来综合报告",
+                        "status": "planned_unavailable",
+                        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "Future integrated report",
+                        "status": "planned_unavailable",
+                        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                },
+                "eq.sjt_bridge.unavailable_note": {
+                    "zh-CN": {
+                        "title": "暂未开放说明",
+                        "status": "planned_unavailable",
+                        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。",
+                        "what_it_adds": "未来补充情境选择信息。",
+                        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+                        "button_label": "暂未开放",
+                        "available": false,
+                        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+                    },
+                    "en": {
+                        "title": "Unavailable note",
+                        "status": "planned_unavailable",
+                        "description": "This module remains planned. The frontend should not provide a clickable start entry.",
+                        "what_it_adds": "It supplements self-report with future scenario choices.",
+                        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+                        "button_label": "Not available yet",
+                        "available": false,
+                        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+                    }
+                }
+            }
+        },
+        "result_snapshot": {
+            "schema": "eq60.report_assets.result_snapshot.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.snapshot.balanced_integrated": {
+                    "zh-CN": {
+                        "headline": "均衡整合型",
+                        "core_judgment": "你能同时照顾自己的状态、他人的感受和关系目标。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能同时照顾自己的状态、他人的感受和关系目标。",
+                            "你能把情绪、关系和任务放在同一个画面里思考。",
+                            "下一步：把“我来稳住”改成“我们一起定规则”。"
+                        ],
+                        "top_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+                        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+                        "minimal_action": "把“我来稳住”改成“我们一起定规则”。",
+                        "share_safe_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Balanced Integrator",
+                        "core_judgment": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You can hold your own state, other people, and the relationship goal in view at the same time.",
+                            "You can keep emotion, relationship, and task in the same frame.",
+                            "Next move: Move from “I will steady this” to “we need a shared rule.”"
+                        ],
+                        "top_strength": "You can keep emotion, relationship, and task in the same frame.",
+                        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+                        "minimal_action": "Move from “I will steady this” to “we need a shared rule.”",
+                        "share_safe_sentence": "I can steady a relationship without maintaining the whole system alone.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.balanced_integrated",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "balanced_integrated"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.high_empathy_low_recovery": {
+                    "zh-CN": {
+                        "headline": "高共情，低恢复",
+                        "core_judgment": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+                            "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                            "下一步：练习“理解但不接管”，让共情后面跟着边界。"
+                        ],
+                        "top_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+                        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+                        "minimal_action": "练习“理解但不接管”，让共情后面跟着边界。",
+                        "share_safe_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "High Empathy, Slow Recovery",
+                        "core_judgment": "You read the room quickly, but recovery can lag behind empathy.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You read the room quickly, but recovery can lag behind empathy.",
+                            "You can make people feel understood, especially when emotions run high.",
+                            "Next move: Practice understanding without taking over, so empathy is followed by boundary."
+                        ],
+                        "top_strength": "You can make people feel understood, especially when emotions run high.",
+                        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+                        "minimal_action": "Practice understanding without taking over, so empathy is followed by boundary.",
+                        "share_safe_sentence": "I can understand someone without carrying the whole emotional load.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.high_empathy_low_recovery",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "high_empathy_low_recovery"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.aware_but_unregulated": {
+                    "zh-CN": {
+                        "headline": "有觉察，调节不足",
+                        "core_judgment": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你常知道自己怎么了，但把自己带回来需要更长时间。",
+                            "你能清楚识别触发点、感受和需要。",
+                            "下一步：把觉察压缩成一个暂停动作，而不是继续解释。"
+                        ],
+                        "top_strength": "你能清楚识别触发点、感受和需要。",
+                        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+                        "minimal_action": "把觉察压缩成一个暂停动作，而不是继续解释。",
+                        "share_safe_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Aware, Still Reactive",
+                        "core_judgment": "You often know what is happening inside, but the reset button is slower than the insight.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You often know what is happening inside, but the reset button is slower than the insight.",
+                            "You can identify triggers, feelings, and needs with unusual clarity.",
+                            "Next move: Turn awareness into one pause action instead of another layer of explanation."
+                        ],
+                        "top_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+                        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+                        "minimal_action": "Turn awareness into one pause action instead of another layer of explanation.",
+                        "share_safe_sentence": "I know what is happening; the next skill is bringing myself back.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.aware_but_unregulated",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "aware_but_unregulated"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.calm_but_distant": {
+                    "zh-CN": {
+                        "headline": "冷静稳定，但距离感强",
+                        "core_judgment": "你能稳住事情，但别人不一定感到被情绪上接住。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能稳住事情，但别人不一定感到被情绪上接住。",
+                            "你不容易被情绪推着走，能保留判断和节奏。",
+                            "下一步：先回应一句感受，再给建议或方案。"
+                        ],
+                        "top_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+                        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+                        "minimal_action": "先回应一句感受，再给建议或方案。",
+                        "share_safe_sentence": "我能稳住事情，也要让人感到被看见。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Steady, Less Attuned",
+                        "core_judgment": "You can steady the situation, but people may not always feel emotionally met.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You can steady the situation, but people may not always feel emotionally met.",
+                            "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                            "Next move: Acknowledge one feeling before offering advice or a solution."
+                        ],
+                        "top_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+                        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+                        "minimal_action": "Acknowledge one feeling before offering advice or a solution.",
+                        "share_safe_sentence": "I can steady the situation and still help people feel seen.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.calm_but_distant",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "calm_but_distant"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.relationship_first_self_later": {
+                    "zh-CN": {
+                        "headline": "关系优先，自我后置",
+                        "core_judgment": "你会先保护关系，再回头找自己的真实立场。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你会先保护关系，再回头找自己的真实立场。",
+                            "你敏感于关系气氛，愿意让互动维持可进行。",
+                            "下一步：在照顾关系前，先给自己的感受一个位置。"
+                        ],
+                        "top_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+                        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+                        "minimal_action": "在照顾关系前，先给自己的感受一个位置。",
+                        "share_safe_sentence": "关系重要，我的感受也需要在场。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Relationship First, Self Later",
+                        "core_judgment": "You protect the relationship first and find your own position later.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You protect the relationship first and find your own position later.",
+                            "You are sensitive to relational tone and often keep interaction workable.",
+                            "Next move: Give your own feeling a place before you manage the relationship."
+                        ],
+                        "top_strength": "You are sensitive to relational tone and often keep interaction workable.",
+                        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+                        "minimal_action": "Give your own feeling a place before you manage the relationship.",
+                        "share_safe_sentence": "The relationship matters, and my own state belongs in the room too.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.relationship_first_self_later",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "relationship_first_self_later"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.self_clear_repair_weak": {
+                    "zh-CN": {
+                        "headline": "自我清楚，修复不足",
+                        "core_judgment": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+                            "你不容易在关系压力里丢掉自己的判断。",
+                            "下一步：把“我说清楚了”补成“我们怎么重新对齐”。"
+                        ],
+                        "top_strength": "你不容易在关系压力里丢掉自己的判断。",
+                        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+                        "minimal_action": "把“我说清楚了”补成“我们怎么重新对齐”。",
+                        "share_safe_sentence": "我可以清楚表达，也可以把关系重新接上。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Clear Self, Repair Gap",
+                        "core_judgment": "You know your position, but repair after tension needs a clearer tool.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You know your position, but repair after tension needs a clearer tool.",
+                            "You are less likely to lose your judgment under relational pressure.",
+                            "Next move: Add “how do we realign?” after “I made my point.”"
+                        ],
+                        "top_strength": "You are less likely to lose your judgment under relational pressure.",
+                        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+                        "minimal_action": "Add “how do we realign?” after “I made my point.”",
+                        "share_safe_sentence": "I can be clear and still reconnect the relationship.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.self_clear_repair_weak",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "self_clear_repair_weak"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.steady_collaborator": {
+                    "zh-CN": {
+                        "headline": "稳定协作型",
+                        "core_judgment": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+                            "你能把紧张对话拉回事实、目标和下一步。",
+                            "下一步：把个人稳定能力变成团队流程。"
+                        ],
+                        "top_strength": "你能把紧张对话拉回事实、目标和下一步。",
+                        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+                        "minimal_action": "把个人稳定能力变成团队流程。",
+                        "share_safe_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Steady Collaborator",
+                        "core_judgment": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+                            "You can bring tense conversations back to facts, goals, and next steps.",
+                            "Next move: Turn personal steadiness into team process."
+                        ],
+                        "top_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+                        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+                        "minimal_action": "Turn personal steadiness into team process.",
+                        "share_safe_sentence": "I can help collaboration, but the rules cannot live only in me.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.steady_collaborator",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "steady_collaborator"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.sensitive_absorber": {
+                    "zh-CN": {
+                        "headline": "高敏感，易吸收",
+                        "core_judgment": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+                            "你很快发现气氛、语气和关系位置的变化。",
+                            "下一步：把“我感到了”区分成“我要不要回应”。"
+                        ],
+                        "top_strength": "你很快发现气氛、语气和关系位置的变化。",
+                        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+                        "minimal_action": "把“我感到了”区分成“我要不要回应”。",
+                        "share_safe_sentence": "我能感到很多东西，但不需要回应所有东西。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Sensitive Absorber",
+                        "core_judgment": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+                            "You quickly notice shifts in tone, mood, and relational position.",
+                            "Next move: Separate “I noticed it” from “I need to respond.”"
+                        ],
+                        "top_strength": "You quickly notice shifts in tone, mood, and relational position.",
+                        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+                        "minimal_action": "Separate “I noticed it” from “I need to respond.”",
+                        "share_safe_sentence": "I can feel a lot without responding to everything.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.sensitive_absorber",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "sensitive_absorber"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.developing_foundation": {
+                    "zh-CN": {
+                        "headline": "基础发展中",
+                        "core_judgment": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+                        "three_sentence_summary": [
+                            "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+                            "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                            "下一步：先把一个情绪命名清楚，再谈复杂改变。"
+                        ],
+                        "top_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+                        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+                        "minimal_action": "先把一个情绪命名清楚，再谈复杂改变。",
+                        "share_safe_sentence": "先练一个小动作，就已经是在建立基础。",
+                        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Developing Foundation",
+                        "core_judgment": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+                        "three_sentence_summary": [
+                            "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+                            "You are beginning to treat emotion and relationships as observable and trainable.",
+                            "Next move: Name one feeling clearly before attempting a larger change."
+                        ],
+                        "top_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+                        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+                        "minimal_action": "Name one feeling clearly before attempting a larger change.",
+                        "share_safe_sentence": "One small practice is already foundation-building.",
+                        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+                        "conversion_actions": [
+                            "save_report",
+                            "email_revisit",
+                            "share_card",
+                            "talk_to_agent",
+                            "related_tests"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.developing_foundation",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "developing_foundation"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.snapshot.low_confidence_result": {
+                    "zh-CN": {
+                        "headline": "本次结果置信度较低",
+                        "core_judgment": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                        "evidence_point": "由于本次作答质量不足，系统不会输出强画像判断。",
+                        "three_sentence_summary": [
+                            "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+                            "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                            "下一步：先记录状态，之后在更稳定的时间复测。"
+                        ],
+                        "top_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+                        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+                        "minimal_action": "先记录状态，之后在更稳定的时间复测。",
+                        "share_safe_sentence": "这次结果不是不能看，而是要轻一点看。",
+                        "continue_path": "先记录本次作答状态，之后在更稳定的时间复测。",
+                        "conversion_actions": [
+                            "save_report",
+                            "retest_reminder",
+                            "talk_to_agent"
+                        ],
+                        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+                    },
+                    "en": {
+                        "headline": "Lower-Confidence Result",
+                        "core_judgment": "Read this result lightly; the most useful signal is the response context of this session.",
+                        "evidence_point": "Because response confidence is limited, the system avoids a strong profile statement.",
+                        "three_sentence_summary": [
+                            "Read this result lightly; the most useful signal is the response context of this session.",
+                            "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                            "Next move: Record the context first, then retest when conditions are steadier."
+                        ],
+                        "top_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+                        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+                        "minimal_action": "Record the context first, then retest when conditions are steadier.",
+                        "share_safe_sentence": "This result is not useless; it simply needs a lighter reading.",
+                        "continue_path": "Record the response context first, then retest when conditions are steadier.",
+                        "conversion_actions": [
+                            "save_report",
+                            "retest_reminder",
+                            "talk_to_agent"
+                        ],
+                        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+                    },
+                    "meta": {
+                        "id": "eq.snapshot.low_confidence_result",
+                        "asset_type": "result_snapshot",
+                        "purpose": "30-second first-screen commercial summary",
+                        "trigger_logic": {
+                            "formulation_id": "low_confidence_result"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "commercial_conversion_assets": {
+            "schema": "eq60.report_assets.commercial_conversion_assets.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.conversion.save_report": {
+                    "zh-CN": {
+                        "title": "保存报告",
+                        "body": "把这次核心模式、行动处方和复测入口留住。",
+                        "cta_label": "保存报告",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Save your report",
+                        "body": "Keep your pattern, action prescription, and retest path in one place.",
+                        "cta_label": "Save report",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.save_report",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "save_report"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.email_revisit": {
+                    "zh-CN": {
+                        "title": "邮件回看",
+                        "body": "把报告发送给自己，适合之后复盘或继续和 Agent 对话。",
+                        "cta_label": "发送到邮箱",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Email revisit",
+                        "body": "Send the report to yourself so you can revisit it or continue with the Agent later.",
+                        "cta_label": "Email me",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.email_revisit",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "email_revisit"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.pdf_export": {
+                    "zh-CN": {
+                        "title": "PDF 报告",
+                        "body": "生成可保存版本，适合个人复盘，不建议用于招聘或评估他人。",
+                        "cta_label": "生成 PDF",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "PDF report",
+                        "body": "Create a saved copy for personal reflection, not for hiring or evaluating another person.",
+                        "cta_label": "Create PDF",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.pdf_export",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "pdf_export"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.share_card": {
+                    "zh-CN": {
+                        "title": "分享卡",
+                        "body": "只分享模式句，不分享详细分数和敏感解释。",
+                        "cta_label": "生成分享卡",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Share card",
+                        "body": "Share the pattern sentence, not detailed scores or sensitive interpretation.",
+                        "cta_label": "Create share card",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.share_card",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "share_card"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.retest_reminder": {
+                    "zh-CN": {
+                        "title": "复测提醒",
+                        "body": "4–8 周后重新查看模式是否稳定，低置信结果可更早复测。",
+                        "cta_label": "设置复测提醒",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Retest reminder",
+                        "body": "Check whether the pattern is stable after 4–8 weeks; low-confidence results can be retested sooner.",
+                        "cta_label": "Set reminder",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.retest_reminder",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "retest_reminder"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.related_tests": {
+                    "zh-CN": {
+                        "title": "相关测试",
+                        "body": "用 Big Five、RIASEC、MBTI 作为补充视角，不把 EQ 当成唯一结论。",
+                        "cta_label": "继续探索",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Related tests",
+                        "body": "Use Big Five, RIASEC, or MBTI as complementary lenses, not as replacements for EQ.",
+                        "cta_label": "Explore related tests",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.related_tests",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "related_tests"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                },
+                "eq.conversion.agent_entry": {
+                    "zh-CN": {
+                        "title": "问问 Agent",
+                        "body": "带着一个真实场景提问，例如反馈、冲突、边界或压力恢复。",
+                        "cta_label": "问 Agent",
+                        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+                        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+                    },
+                    "en": {
+                        "title": "Ask the Agent",
+                        "body": "Ask about one real scene, such as feedback, conflict, boundaries, or recovery.",
+                        "cta_label": "Ask the Agent",
+                        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+                        "do_not_overread": "This is a free product action, it does not change report access."
+                    },
+                    "meta": {
+                        "id": "eq.conversion.agent_entry",
+                        "asset_type": "commercial_conversion",
+                        "purpose": "Commercial retention/conversion action",
+                        "trigger_logic": {
+                            "conversion_action": "agent_entry"
+                        },
+                        "claim_sensitivity": "low"
+                    }
+                }
+            }
+        },
+        "quality_confidence": {
+            "schema": "eq60.report_assets.quality_confidence.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.quality.level.A": {
+                    "zh-CN": {
+                        "label": "高置信",
+                        "body": "本次作答节奏和一致性支持较稳定解释。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "可在未来复测观察稳定变化。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "High confidence",
+                        "body": "The response pattern supports a relatively stable interpretation.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "Retest later to observe stable change.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.A",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "A"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.quality.level.B": {
+                    "zh-CN": {
+                        "label": "正常置信",
+                        "body": "本次结果可用于阅读主要模式，但仍建议结合现实场景理解。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "可在未来复测观察稳定变化。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Standard confidence",
+                        "body": "The result can be used for the main pattern, while still being read with real-life context.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "Retest later to observe stable change.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.B",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "B"
+                        },
+                        "claim_sensitivity": "medium"
+                    }
+                },
+                "eq.quality.level.C": {
+                    "zh-CN": {
+                        "label": "中等置信",
+                        "body": "本次结果适合作为初步参考，强结论需要减少。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Moderate confidence",
+                        "body": "The result is best treated as a preliminary reference; strong conclusions should be reduced.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.C",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "C"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.quality.level.D": {
+                    "zh-CN": {
+                        "label": "低置信",
+                        "body": "本次结果应轻读，优先看作答状态和复测建议。",
+                        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+                        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+                        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+                        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+                        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+                    },
+                    "en": {
+                        "label": "Lower confidence",
+                        "body": "Read this result lightly; focus on response context and retest guidance.",
+                        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+                        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+                        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+                        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+                        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+                    },
+                    "meta": {
+                        "id": "eq.quality.level.D",
+                        "asset_type": "quality_confidence",
+                        "purpose": "Explain report confidence",
+                        "trigger_logic": {
+                            "quality_level": "D"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "psychometric_evidence_status": {
+            "schema": "eq60.report_assets.psychometric_evidence_status.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.evidence.content_validity": {
+                    "zh-CN": {
+                        "status": "preliminary",
+                        "body": "题项和报告维度已有内容映射，但需要持续专家复核和用户反馈。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "preliminary",
+                        "body": "Items and report dimensions have content mapping, with ongoing need for expert review and user feedback.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.content_validity",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "content_validity"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.internal_consistency": {
+                    "zh-CN": {
                         "status": "planned",
-                        "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
-                        "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
-                        "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions.",
-                        "button_label": "Scenario module planned",
-                        "available": false
+                        "body": "后续应按语言、地区和维度计算内部一致性，并记录版本。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Future work should estimate internal consistency by language, region, and dimension with version tracking.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.internal_consistency",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "internal_consistency"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.test_retest": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "建议在 30–90 天窗口评估稳定性和可变性。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "A 30–90 day window should be used to evaluate stability and change.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.test_retest",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "test_retest"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.factor_structure": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "需要用 EFA/CFA 或其他合适方法验证四维结构。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "The four-dimension structure should be evaluated with EFA/CFA or suitable methods.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.factor_structure",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "factor_structure"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.criterion_validity": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "可探索与工作满意、关系满意、压力恢复等低风险外部指标的关联。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Associations with low-risk external indicators such as work satisfaction, relationship satisfaction, and recovery may be explored.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.criterion_validity",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "criterion_validity"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.measurement_invariance": {
+                    "zh-CN": {
+                        "status": "planned",
+                        "body": "中英文和主要人群组之间需要做等值或 DIF 检查。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "planned",
+                        "body": "Chinese/English and major user groups require invariance or DIF checks.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.measurement_invariance",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "measurement_invariance"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.evidence.norm_status": {
+                    "zh-CN": {
+                        "status": "provisional",
+                        "body": "当前常模解释为阶段性版本，不应被理解为最终全球常模。",
+                        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+                        "user_facing_status_label": "证据持续建设中",
+                        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+                        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+                    },
+                    "en": {
+                        "status": "provisional",
+                        "body": "Current norms are provisional and should not be read as final global norms.",
+                        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+                        "user_facing_status_label": "Evidence is still being built",
+                        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+                        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+                    },
+                    "meta": {
+                        "id": "eq.evidence.norm_status",
+                        "asset_type": "psychometric_evidence_status",
+                        "purpose": "State evidence maturity",
+                        "trigger_logic": {
+                            "evidence_area": "norm_status"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                }
+            }
+        },
+        "agent_dialogue_playbooks": {
+            "schema": "eq60.report_assets.agent_dialogue_playbooks.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.agent.playbook.understand_result": {
+                    "zh-CN": {
+                        "title": "理解我的结果",
+                        "response_policy": "先引用用户 formulation，再问一个现实场景。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Understand my result",
+                        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.understand_result",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "understand_result"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "understand_result"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.scene_advice": {
+                    "zh-CN": {
+                        "title": "某个场景怎么办",
+                        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "What should I do in this situation?",
+                        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.scene_advice",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "scene_advice"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "scene_advice"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.career_environment": {
+                    "zh-CN": {
+                        "title": "我适合什么工作环境",
+                        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "What work environment fits me?",
+                        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.career_environment",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "career_environment"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "career_environment"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.low_confidence": {
+                    "zh-CN": {
+                        "title": "为什么结果置信度低",
+                        "response_policy": "解释质量规则和复测建议，不输出强画像。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Why is confidence low?",
+                        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.low_confidence",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "low_confidence"
+                        },
+                        "claim_sensitivity": "medium",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "low_confidence"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                },
+                "eq.agent.playbook.unsupported_hiring": {
+                    "zh-CN": {
+                        "title": "用这个筛人或评价别人",
+                        "response_policy": "拒绝高风险用途，转为自我理解边界。",
+                        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+                        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+                        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+                        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+                    },
+                    "en": {
+                        "title": "Use this to screen someone",
+                        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
+                        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+                        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+                        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+                        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+                    },
+                    "meta": {
+                        "id": "eq.agent.playbook.unsupported_hiring",
+                        "asset_type": "agent_dialogue_playbook",
+                        "purpose": "Agent response policy and examples",
+                        "trigger_logic": {
+                            "user_intent": "unsupported_hiring"
+                        },
+                        "claim_sensitivity": "high",
+                        "retrieval_tags": [
+                            "eq60",
+                            "self_report",
+                            "result_explanation",
+                            "unsupported_hiring"
+                        ],
+                        "content_change_flow": [
+                            "draft suggestion",
+                            "lint against forbidden claims",
+                            "human review",
+                            "backend asset update",
+                            "fixture validation"
+                        ]
+                    }
+                }
+            }
+        },
+        "backend_integration_contract": {
+            "schema": "eq60.report_assets.backend_integration_contract.v1",
+            "pack_id": "EQ_60",
+            "assets": {
+                "eq.backend_contract.schema_mapping": {
+                    "zh-CN": {
+                        "title": "Schema 映射",
+                        "requirement": "将每个资产文件映射到后端 content-pack compiler 可识别的字段。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Map every asset file into backend content-pack compiler fields before production",
+                        "requirement": "Map every asset file into backend content-pack compiler fields before production.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.schema_mapping",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "schema_mapping"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.canonical_fixtures": {
+                    "zh-CN": {
+                        "title": "Canonical fixtures",
+                        "requirement": "为 balanced、high_empathy_low_recovery、low_confidence 三条路径生成 zh-CN / en canonical fixtures。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths",
+                        "requirement": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.canonical_fixtures",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "canonical_fixtures"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.contract_tests": {
+                    "zh-CN": {
+                        "title": "契约测试",
+                        "requirement": "断言 report payload 包含 v1.6 assets、免费转化动作、无权限门槛，且 SJT 保持 unavailable。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Assert report payload contains v1",
+                        "requirement": "Assert report payload contains v1.6 assets, conversion actions, no access wall, and SJT unavailable.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.contract_tests",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "contract_tests"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.frontend_consumption": {
+                    "zh-CN": {
+                        "title": "前端消费契约",
+                        "requirement": "前端必须渲染后端 resolved assets，不得硬编码正式报告解释文案。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Frontend must render resolved assets and must not hardcode official report explanation",
+                        "requirement": "Frontend must render resolved assets and must not hardcode official report explanation.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.frontend_consumption",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "frontend_consumption"
+                        },
+                        "claim_sensitivity": "high"
+                    }
+                },
+                "eq.backend_contract.agent_readiness": {
+                    "zh-CN": {
+                        "title": "Agent 就绪契约",
+                        "requirement": "Agent 在检索、拒答和边界评测通过前，只能解释已解析报告资产。",
+                        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+                        "do_not_overread": "这是导入契约，不是运行时代码。"
+                    },
+                    "en": {
+                        "title": "Agent can only explain resolved assets until retrieval and refusal evals pass",
+                        "requirement": "Agent can only explain resolved assets until retrieval and refusal evals pass.",
+                        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+                        "do_not_overread": "This is an import contract, not runtime code."
+                    },
+                    "meta": {
+                        "id": "eq.backend_contract.agent_readiness",
+                        "asset_type": "backend_integration_contract",
+                        "purpose": "Production import and contract requirement",
+                        "trigger_logic": {
+                            "contract_gate": "agent_readiness"
+                        },
+                        "claim_sensitivity": "high"
                     }
                 }
             }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/action_prescriptions.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/action_prescriptions.json
@@ -3,52 +3,964 @@
   "pack_id": "EQ_60",
   "prescriptions": {
     "emotion_labeling": {
-      "zh-CN": {"title": "情绪命名处方", "why_this_matters": "先命名，才有可能选择回应。", "do_today": "今天选择一个具体情绪词，写下触发它的场景。", "script": "我现在感到的是 X，不代表我必须立刻做决定。", "seven_day_plan": ["第 1 天：记录一个情绪词。", "第 2 天：补充身体感受。", "第 3 天：写下触发场景。", "第 4 天：区分事实和解释。", "第 5 天：写一个可控动作。", "第 6 天：复盘一次沟通。", "第 7 天：选出最常见触发点。"], "watch_out": "不要把情绪词变成自我评价。"},
-      "en": {"title": "Emotion Labeling", "why_this_matters": "Naming comes before choosing a response.", "do_today": "Choose one specific emotion word today and write the triggering context.", "script": "What I feel now is X; it does not mean I must decide immediately.", "seven_day_plan": ["Day 1: record one emotion word.", "Day 2: add body sensations.", "Day 3: write the trigger.", "Day 4: separate fact and interpretation.", "Day 5: write one controllable action.", "Day 6: review one conversation.", "Day 7: identify the most common trigger."], "watch_out": "Do not turn emotion words into self-judgment."}
+      "zh-CN": {
+        "title": "情绪命名",
+        "why_this_matters": "当感受模糊、容易事后才明白时使用。",
+        "do_today": "今天只做一件事：把一次情绪从“烦”改写成三个更具体的词。",
+        "script": "我现在不是单纯不舒服，我可能是失望、紧张和需要确认。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录一次情绪触发点。"
+          },
+          {
+            "day": 2,
+            "practice": "写下事实、感受、需要三栏。"
+          },
+          {
+            "day": 3,
+            "practice": "把“还好”改成三个具体情绪词。"
+          },
+          {
+            "day": 4,
+            "practice": "找一个低风险场景说出一个感受。"
+          },
+          {
+            "day": 5,
+            "practice": "复盘一次没说出口的需要。"
+          },
+          {
+            "day": 6,
+            "practice": "把一个情绪和身体感觉连接起来。"
+          },
+          {
+            "day": 7,
+            "practice": "选择一个下周继续练的情绪词。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当感受模糊、容易事后才明白时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Emotion labeling",
+        "why_this_matters": "Use when feelings are vague or only become clear afterward.",
+        "do_today": "Today, turn one vague feeling into three more precise words.",
+        "script": "I am not simply upset; I may be disappointed, tense, and needing clarity.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when feelings are vague or only become clear afterward.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "pause_recovery": {
-      "zh-CN": {"title": "暂停与恢复处方", "why_this_matters": "调节不是压住情绪，而是给选择回应争取空间。", "do_today": "遇到触发时暂停 60 秒，再回复。", "script": "我需要一分钟整理一下，再继续说。", "seven_day_plan": ["第 1 天：练 60 秒暂停。", "第 2 天：加入一次深呼吸。", "第 3 天：离开屏幕一分钟。", "第 4 天：记录暂停前后的差异。", "第 5 天：在反馈场景使用。", "第 6 天：在冲突前使用。", "第 7 天：固定一个恢复动作。"], "watch_out": "暂停不是逃避，暂停后要回到对话。"},
-      "en": {"title": "Pause and Recovery", "why_this_matters": "Regulation is not suppressing emotion; it creates room for choice.", "do_today": "When triggered, pause for 60 seconds before replying.", "script": "I need a minute to organize my thoughts before continuing.", "seven_day_plan": ["Day 1: practice a 60-second pause.", "Day 2: add one deep breath.", "Day 3: step away from the screen for one minute.", "Day 4: note the before-and-after difference.", "Day 5: use it in feedback.", "Day 6: use it before conflict.", "Day 7: fix one recovery action."], "watch_out": "Pausing is not avoidance; return to the conversation."}
+      "zh-CN": {
+        "title": "暂停与恢复",
+        "why_this_matters": "当你知道自己被触发，但很难立刻稳定时使用。",
+        "do_today": "今天给自己设一个十秒暂停规则。",
+        "script": "我需要先停十秒，等我能更清楚地回应。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "选一个暂停信号。"
+          },
+          {
+            "day": 2,
+            "practice": "在一次小触发中练十秒呼吸。"
+          },
+          {
+            "day": 3,
+            "practice": "写下暂停前后的不同。"
+          },
+          {
+            "day": 4,
+            "practice": "给自己设一个延迟回复模板。"
+          },
+          {
+            "day": 5,
+            "practice": "练习离开屏幕两分钟。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘一次因为暂停而避免升级的场景。"
+          },
+          {
+            "day": 7,
+            "practice": "确定下周继续使用的暂停句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你知道自己被触发，但很难立刻稳定时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Pause and recovery",
+        "why_this_matters": "Use when you know you are triggered but cannot steady yourself immediately.",
+        "do_today": "Set a ten-second pause rule today.",
+        "script": "I need ten seconds so I can respond more clearly.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you know you are triggered but cannot steady yourself immediately.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "feedback_decompression": {
-      "zh-CN": {"title": "反馈减压处方", "why_this_matters": "反馈容易混合事实、关系和自我评价，需要拆开处理。", "do_today": "把一次反馈拆成事实、感受、下一步三栏。", "script": "我先确认事实：你希望我调整的是 X，对吗？", "seven_day_plan": ["第 1 天：拆一次反馈。", "第 2 天：只问一个澄清问题。", "第 3 天：延迟自我评价。", "第 4 天：记录可行动项。", "第 5 天：复盘语气触发。", "第 6 天：向对方确认优先级。", "第 7 天：总结一个反馈模板。"], "watch_out": "不要把所有反馈都理解成人身否定。"},
-      "en": {"title": "Feedback Decompression", "why_this_matters": "Feedback mixes facts, relationship cues, and self-evaluation; separate them.", "do_today": "Split one feedback event into facts, feelings, and next step.", "script": "Let me confirm the fact: you want me to adjust X, correct?", "seven_day_plan": ["Day 1: split one feedback event.", "Day 2: ask only one clarifying question.", "Day 3: delay self-judgment.", "Day 4: record the action item.", "Day 5: review tone triggers.", "Day 6: confirm priority.", "Day 7: summarize a feedback template."], "watch_out": "Do not treat all feedback as personal rejection."}
+      "zh-CN": {
+        "title": "反馈去压缩",
+        "why_this_matters": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+        "do_today": "今天把一次反馈拆成事实、评价和下一步。",
+        "script": "我先确认一下，你希望我具体调整哪一部分？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "找一次近期反馈。"
+          },
+          {
+            "day": 2,
+            "practice": "写出反馈里的事实。"
+          },
+          {
+            "day": 3,
+            "practice": "写出你脑中自动冒出的解释。"
+          },
+          {
+            "day": 4,
+            "practice": "问一个澄清问题。"
+          },
+          {
+            "day": 5,
+            "practice": "把反馈转成一个行动。"
+          },
+          {
+            "day": 6,
+            "practice": "记录反馈后的身体反应。"
+          },
+          {
+            "day": 7,
+            "practice": "总结一个下次先问的问题。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当反馈让你立刻紧张、防御或自我怀疑时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Feedback decompression",
+        "why_this_matters": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+        "do_today": "Today, split one piece of feedback into facts, evaluation, and next step.",
+        "script": "Can I clarify which part you want me to adjust?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when feedback quickly creates tension, defensiveness, or self-doubt.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "empathy_boundary": {
-      "zh-CN": {"title": "共情边界处方", "why_this_matters": "高共情需要边界，才能长期有效。", "do_today": "支持别人前先确认自己能支持到哪里。", "script": "我愿意听你说十分钟，然后我们一起看下一步。", "seven_day_plan": ["第 1 天：识别一次我在承担什么。", "第 2 天：练习时间边界。", "第 3 天：练习责任边界。", "第 4 天：支持后做恢复。", "第 5 天：区分理解和代替。", "第 6 天：复盘一次求助场景。", "第 7 天：写下自己的支持边界。"], "watch_out": "不要用冷漠来替代边界。"},
-      "en": {"title": "Empathy Boundary", "why_this_matters": "High empathy needs boundaries to remain sustainable.", "do_today": "Before supporting someone, decide how far you can support.", "script": "I can listen for ten minutes, then we can look at the next step together.", "seven_day_plan": ["Day 1: identify what you are carrying.", "Day 2: practice a time boundary.", "Day 3: practice a responsibility boundary.", "Day 4: recover after support.", "Day 5: separate understanding from replacing.", "Day 6: review one help-seeking situation.", "Day 7: write your support boundary."], "watch_out": "Do not replace boundaries with coldness."}
+      "zh-CN": {
+        "title": "共情边界",
+        "why_this_matters": "当你理解别人后容易承担过多时使用。",
+        "do_today": "今天练习一句“理解但不接管”的话。",
+        "script": "我理解这件事很难，我能帮你一起理清下一步，但不能替你承担全部。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一个你容易接管的场景。"
+          },
+          {
+            "day": 2,
+            "practice": "写下对方责任和你责任的边界。"
+          },
+          {
+            "day": 3,
+            "practice": "练习一句支持但不接管的话。"
+          },
+          {
+            "day": 4,
+            "practice": "在一次对话中只提供一个具体帮助。"
+          },
+          {
+            "day": 5,
+            "practice": "对一个请求说出可承担范围。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘说边界后的真实后果。"
+          },
+          {
+            "day": 7,
+            "practice": "写下你的恢复动作。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你理解别人后容易承担过多时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Empathy with boundary",
+        "why_this_matters": "Use when understanding others turns into carrying too much.",
+        "do_today": "Practice one sentence that understands without taking over.",
+        "script": "I understand this is difficult. I can help you sort the next step, but I cannot carry all of it for you.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when understanding others turns into carrying too much.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "repair_after_conflict": {
-      "zh-CN": {"title": "冲突后修复处方", "why_this_matters": "冲突后的修复决定关系能否继续合作。", "do_today": "选一个小冲突，发出一句修复确认。", "script": "刚才我语气急了，我想把重点重新说清楚。", "seven_day_plan": ["第 1 天：识别一次未完成冲突。", "第 2 天：写下自己的责任。", "第 3 天：写下对方可能在意的点。", "第 4 天：发出一句确认。", "第 5 天：只讨论下一步。", "第 6 天：复盘修复效果。", "第 7 天：形成自己的修复句式。"], "watch_out": "修复不是全盘认错，也不是要求对方立刻原谅。"},
-      "en": {"title": "Repair After Conflict", "why_this_matters": "Repair after conflict determines whether collaboration can continue.", "do_today": "Choose one small conflict and send one repair check.", "script": "My tone got sharp earlier; I want to restate the main point clearly.", "seven_day_plan": ["Day 1: identify one unfinished conflict.", "Day 2: write your responsibility.", "Day 3: write what may matter to the other person.", "Day 4: send one confirmation.", "Day 5: discuss only the next step.", "Day 6: review repair effect.", "Day 7: build your repair sentence."], "watch_out": "Repair is not total blame-taking or demanding immediate forgiveness."}
+      "zh-CN": {
+        "title": "冲突后修复",
+        "why_this_matters": "当冲突后不知道如何重新开始时使用。",
+        "do_today": "今天准备一句影响确认。",
+        "script": "刚才我的表达可能让你感觉被否定了，我想重新说一次。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "回忆一个小误解。"
+          },
+          {
+            "day": 2,
+            "practice": "写下你的意图和对方可能感受到的影响。"
+          },
+          {
+            "day": 3,
+            "practice": "练一句影响确认。"
+          },
+          {
+            "day": 4,
+            "practice": "补一句你的真实意图。"
+          },
+          {
+            "day": 5,
+            "practice": "提出一个具体修复动作。"
+          },
+          {
+            "day": 6,
+            "practice": "在安全关系中尝试一次。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘对方是否更愿意继续对话。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当冲突后不知道如何重新开始时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Repair after conflict",
+        "why_this_matters": "Use when you do not know how to restart after conflict.",
+        "do_today": "Prepare one impact-checking sentence today.",
+        "script": "My wording may have felt dismissive. I want to try saying it again.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you do not know how to restart after conflict.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "express_without_escalation": {
-      "zh-CN": {"title": "不升级表达处方", "why_this_matters": "清楚表达需要让对方听得进去。", "do_today": "用我感到、我需要、我建议三句表达一次需求。", "script": "我感到有点被打断，我需要先说完，之后我也会听你的看法。", "seven_day_plan": ["第 1 天：写一句我感到。", "第 2 天：写一句我需要。", "第 3 天：写一句我建议。", "第 4 天：合并三句。", "第 5 天：降低指责词。", "第 6 天：加入共同目标。", "第 7 天：在低风险场景练习。"], "watch_out": "不要用永远、总是这类绝对词。"},
-      "en": {"title": "Express Without Escalation", "why_this_matters": "Clear expression needs to be hearable.", "do_today": "Use I feel, I need, I suggest to express one need.", "script": "I feel a bit interrupted. I need to finish this point, and then I will listen to your view.", "seven_day_plan": ["Day 1: write one I feel sentence.", "Day 2: write one I need sentence.", "Day 3: write one I suggest sentence.", "Day 4: combine the three.", "Day 5: reduce blaming words.", "Day 6: add a shared goal.", "Day 7: practice in a low-risk context."], "watch_out": "Avoid absolute words like always or never."}
+      "zh-CN": {
+        "title": "表达但不升级",
+        "why_this_matters": "当你很清楚自己的立场，但容易说得太硬时使用。",
+        "do_today": "今天把一个强表达改成“事实 + 感受 + 请求”。",
+        "script": "当这个决定突然改变时，我有点措手不及。我想先确认接下来怎么协作。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "写出一句原本想直接说的话。"
+          },
+          {
+            "day": 2,
+            "practice": "删掉评价词，只留事实。"
+          },
+          {
+            "day": 3,
+            "practice": "加上一个真实感受。"
+          },
+          {
+            "day": 4,
+            "practice": "加上一个可回应请求。"
+          },
+          {
+            "day": 5,
+            "practice": "读出来，检查语气。"
+          },
+          {
+            "day": 6,
+            "practice": "找一个低风险场景使用。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘它是否降低了防御。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你很清楚自己的立场，但容易说得太硬时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Express without escalation",
+        "why_this_matters": "Use when your position is clear but may land too sharply.",
+        "do_today": "Turn one strong statement into fact + feeling + request.",
+        "script": "When this decision changed suddenly, I felt caught off guard. I want to clarify how we work together next.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when your position is clear but may land too sharply.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "support_without_rescuing": {
-      "zh-CN": {"title": "支持但不拯救处方", "why_this_matters": "有效支持帮助对方恢复主体性，而不是替对方解决所有问题。", "do_today": "下次支持别人时，只问一个下一步问题。", "script": "我能陪你想，但这个决定需要你自己做。", "seven_day_plan": ["第 1 天：识别一次想替别人解决的冲动。", "第 2 天：只提供倾听。", "第 3 天：只问一个问题。", "第 4 天：明确你能做的部分。", "第 5 天：明确你不能做的部分。", "第 6 天：支持后恢复。", "第 7 天：复盘对方是否更有主体性。"], "watch_out": "不要把对方的不舒服全部变成你的责任。"},
-      "en": {"title": "Support Without Rescuing", "why_this_matters": "Effective support restores agency instead of solving everything for the other person.", "do_today": "Next time you support someone, ask only one next-step question.", "script": "I can think with you, but this decision needs to be yours.", "seven_day_plan": ["Day 1: notice one urge to solve for someone.", "Day 2: only listen.", "Day 3: ask only one question.", "Day 4: clarify what you can do.", "Day 5: clarify what you cannot do.", "Day 6: recover after support.", "Day 7: review whether their agency increased."], "watch_out": "Do not make all of their discomfort your responsibility."}
+      "zh-CN": {
+        "title": "支持但不拯救",
+        "why_this_matters": "当你想帮人解决一切时使用。",
+        "do_today": "今天先问对方需要倾听、建议还是行动帮助。",
+        "script": "你现在更需要我听你说，还是一起想一个下一步？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一次想立刻解决的冲动。"
+          },
+          {
+            "day": 2,
+            "practice": "暂停并问支持方式。"
+          },
+          {
+            "day": 3,
+            "practice": "只给一个帮助选项。"
+          },
+          {
+            "day": 4,
+            "practice": "避免替对方做决定。"
+          },
+          {
+            "day": 5,
+            "practice": "结束前确认对方自己的下一步。"
+          },
+          {
+            "day": 6,
+            "practice": "记录你的承担感变化。"
+          },
+          {
+            "day": 7,
+            "practice": "复盘支持和接管的差别。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你想帮人解决一切时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Support without rescuing",
+        "why_this_matters": "Use when you feel pulled to solve everything for someone.",
+        "do_today": "Ask whether the person wants listening, advice, or practical help.",
+        "script": "Do you want me to listen, or would it help to think through one next step?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you feel pulled to solve everything for someone.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "cold_to_warm_response": {
-      "zh-CN": {"title": "从冷静到有温度处方", "why_this_matters": "稳定需要被他人感受到，才会变成关系中的安全感。", "do_today": "在给建议前先确认对方感受。", "script": "我能理解这件事让你不舒服，我们再一起看怎么处理。", "seven_day_plan": ["第 1 天：练一句情绪确认。", "第 2 天：先确认再建议。", "第 3 天：观察对方反应。", "第 4 天：减少过快解释。", "第 5 天：加入一句感谢。", "第 6 天：复盘一次低温回应。", "第 7 天：固定一个温暖开场。"], "watch_out": "温暖不是放弃理性。"},
-      "en": {"title": "Cold to Warm Response", "why_this_matters": "Stability becomes relational safety only when others can feel it.", "do_today": "Acknowledge the feeling before giving advice.", "script": "I can see this was uncomfortable for you; let's look at what to do next.", "seven_day_plan": ["Day 1: practice one emotional acknowledgment.", "Day 2: acknowledge before advising.", "Day 3: observe their response.", "Day 4: reduce fast explanation.", "Day 5: add one appreciation.", "Day 6: review one low-warmth response.", "Day 7: fix one warm opening."], "watch_out": "Warmth does not mean giving up rationality."}
+      "zh-CN": {
+        "title": "从冷静到有温度",
+        "why_this_matters": "当你能解决问题但别人感觉没被回应时使用。",
+        "do_today": "今天在给方案前先回应一句感受。",
+        "script": "我能理解这让你很挫败。我们可以一起看下一步怎么处理。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "听到问题后先不急着给方案。"
+          },
+          {
+            "day": 2,
+            "practice": "说出你听见的情绪。"
+          },
+          {
+            "day": 3,
+            "practice": "确认对方是否认可。"
+          },
+          {
+            "day": 4,
+            "practice": "再提出一个具体下一步。"
+          },
+          {
+            "day": 5,
+            "practice": "观察对方反应是否软化。"
+          },
+          {
+            "day": 6,
+            "practice": "复盘你是否少讲了道理。"
+          },
+          {
+            "day": 7,
+            "practice": "保留一个适合你的温度句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你能解决问题但别人感觉没被回应时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "From calm to warm response",
+        "why_this_matters": "Use when you can solve the issue but others do not feel emotionally met.",
+        "do_today": "Before offering a solution, acknowledge one feeling.",
+        "script": "I can see how frustrating this is. We can look at the next step together.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you can solve the issue but others do not feel emotionally met.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "relationship_energy_management": {
-      "zh-CN": {"title": "关系能量管理处方", "why_this_matters": "关系投入需要节奏，否则优势会变成消耗。", "do_today": "给一个高消耗互动安排恢复窗口。", "script": "我现在可以聊二十分钟，之后需要休息一下。", "seven_day_plan": ["第 1 天：列出高消耗互动。", "第 2 天：标出恢复方式。", "第 3 天：设置时间边界。", "第 4 天：减少即时回复。", "第 5 天：安排独处窗口。", "第 6 天：复盘能量变化。", "第 7 天：保留一个固定恢复段。"], "watch_out": "不要等到耗尽才开始恢复。"},
-      "en": {"title": "Relationship Energy Management", "why_this_matters": "Relational investment needs rhythm; otherwise strength becomes drain.", "do_today": "Schedule recovery after one high-cost interaction.", "script": "I can talk for twenty minutes now, and then I need a break.", "seven_day_plan": ["Day 1: list high-cost interactions.", "Day 2: mark recovery methods.", "Day 3: set a time boundary.", "Day 4: reduce instant replies.", "Day 5: schedule solo time.", "Day 6: review energy changes.", "Day 7: keep one fixed recovery block."], "watch_out": "Do not wait until depletion to recover."}
+      "zh-CN": {
+        "title": "关系能量管理",
+        "why_this_matters": "当你在多人关系或强情绪场景后感到累时使用。",
+        "do_today": "今天给一段高互动之后安排十分钟低输入时间。",
+        "script": "我需要一点时间整理刚才的信息，之后我会回来回应。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "标记今天最耗能的一次互动。"
+          },
+          {
+            "day": 2,
+            "practice": "记录耗能来自人、情绪还是切换。"
+          },
+          {
+            "day": 3,
+            "practice": "安排十分钟低输入恢复。"
+          },
+          {
+            "day": 4,
+            "practice": "减少一个不必要回应。"
+          },
+          {
+            "day": 5,
+            "practice": "练习结束对话的句子。"
+          },
+          {
+            "day": 6,
+            "practice": "观察恢复前后差异。"
+          },
+          {
+            "day": 7,
+            "practice": "设定下周一个关系能量边界。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你在多人关系或强情绪场景后感到累时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Relationship energy management",
+        "why_this_matters": "Use when you feel drained after relationally intense situations.",
+        "do_today": "Schedule ten minutes of low input after one high-interaction moment.",
+        "script": "I need a little time to process what just happened, and I will come back to it.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you feel drained after relationally intense situations.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "conflict_deescalation": {
-      "zh-CN": {"title": "冲突降温处方", "why_this_matters": "降温不是退让，而是让问题重新可谈。", "do_today": "下一次分歧时，只说共同目标和下一步。", "script": "我们先别扩大问题，我想先确认下一步怎么做。", "seven_day_plan": ["第 1 天：识别升级词。", "第 2 天：练习降温句。", "第 3 天：暂停十分钟。", "第 4 天：只谈一个问题。", "第 5 天：确认共同目标。", "第 6 天：复盘冲突过程。", "第 7 天：写下自己的降温协议。"], "watch_out": "降温不等于压下真实问题。"},
-      "en": {"title": "Conflict De-escalation", "why_this_matters": "De-escalation is not surrender; it makes the issue discussable again.", "do_today": "In the next disagreement, state only the shared goal and next step.", "script": "Let's not expand the issue. I want to confirm the next step first.", "seven_day_plan": ["Day 1: identify escalation words.", "Day 2: practice a cooling sentence.", "Day 3: pause ten minutes.", "Day 4: discuss one issue only.", "Day 5: confirm shared goal.", "Day 6: review the conflict process.", "Day 7: write your de-escalation protocol."], "watch_out": "Cooling down does not mean suppressing the real issue."}
+      "zh-CN": {
+        "title": "冲突降温",
+        "why_this_matters": "当对话开始升级时使用。",
+        "do_today": "今天练习把争执缩小到一个具体问题。",
+        "script": "我们先只谈一个点：现在最需要决定的是什么？",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "识别一个容易升级的话题。"
+          },
+          {
+            "day": 2,
+            "practice": "写出双方各自想保护什么。"
+          },
+          {
+            "day": 3,
+            "practice": "准备一句缩小问题的话。"
+          },
+          {
+            "day": 4,
+            "practice": "练习放慢语速。"
+          },
+          {
+            "day": 5,
+            "practice": "在对话中只问一个澄清问题。"
+          },
+          {
+            "day": 6,
+            "practice": "结束后复盘是否降温。"
+          },
+          {
+            "day": 7,
+            "practice": "保存一个下次可用的降温句。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当对话开始升级时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Conflict de-escalation",
+        "why_this_matters": "Use when a conversation starts escalating.",
+        "do_today": "Practice narrowing a disagreement to one concrete issue.",
+        "script": "Let’s focus on one point: what needs to be decided right now?",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when a conversation starts escalating.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "self_connection": {
-      "zh-CN": {"title": "自我连接处方", "why_this_matters": "关系顺畅不能替代对自己需求的确认。", "do_today": "答应别人前先写下我愿意和我不愿意。", "script": "我想先确认一下自己的安排，晚点回复你。", "seven_day_plan": ["第 1 天：记录一个自己的需求。", "第 2 天：记录一个不愿意。", "第 3 天：延迟答应。", "第 4 天：练习一个小拒绝。", "第 5 天：复盘拒绝后的关系。", "第 6 天：写下可接受条件。", "第 7 天：总结自己的边界句。"], "watch_out": "不要把照顾自己理解成破坏关系。"},
-      "en": {"title": "Self-Connection", "why_this_matters": "A smooth relationship cannot replace checking your own needs.", "do_today": "Before agreeing, write what you are willing and not willing to do.", "script": "I want to check my own schedule first and reply later.", "seven_day_plan": ["Day 1: record one personal need.", "Day 2: record one not-willing item.", "Day 3: delay agreement.", "Day 4: practice a small no.", "Day 5: review the relationship after saying no.", "Day 6: write acceptable conditions.", "Day 7: summarize your boundary sentence."], "watch_out": "Do not treat caring for yourself as damaging the relationship."}
+      "zh-CN": {
+        "title": "重新连接自己",
+        "why_this_matters": "当你总先照顾关系而忽略自己时使用。",
+        "do_today": "今天在答应前先问自己：我是真愿意，还是怕关系变差？",
+        "script": "我想先想一下我真实能承担到哪里，再回复你。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录一次你想立刻答应的场景。"
+          },
+          {
+            "day": 2,
+            "practice": "写下真实愿意和勉强愿意的差别。"
+          },
+          {
+            "day": 3,
+            "practice": "练习延迟回应。"
+          },
+          {
+            "day": 4,
+            "practice": "说出一个较小的可承担范围。"
+          },
+          {
+            "day": 5,
+            "practice": "观察关系是否真的受损。"
+          },
+          {
+            "day": 6,
+            "practice": "记录一个被你忽略的感受。"
+          },
+          {
+            "day": 7,
+            "practice": "设定一个下周的自我连接问题。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当你总先照顾关系而忽略自己时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Reconnect with self",
+        "why_this_matters": "Use when you care for the relationship before checking yourself.",
+        "do_today": "Before agreeing today, ask: am I willing, or am I afraid the relationship will change?",
+        "script": "I want to check what I can realistically take on before I answer.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when you care for the relationship before checking yourself.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     },
     "retest_reflection": {
-      "zh-CN": {"title": "复测与低风险反思处方", "why_this_matters": "低置信度结果不适合强解释，更适合作为复测提醒。", "do_today": "只记录一个你认可的线索，不做稳定结论。", "script": "这次结果我先当作提醒，等状态稳定后再复测。", "seven_day_plan": ["第 1 天：记录作答时状态。", "第 2 天：检查是否太快或太累。", "第 3 天：观察一个真实场景。", "第 4 天：不做标签化解释。", "第 5 天：选择复测时间。", "第 6 天：保证安静环境。", "第 7 天：重新完成测试。"], "watch_out": "不要用低置信度结果做重大决定。"},
-      "en": {"title": "Retest and Low-Risk Reflection", "why_this_matters": "Low-confidence results should not drive strong interpretation; they are better used as a retest cue.", "do_today": "Record only one cue that feels useful; do not form a stable conclusion.", "script": "I will treat this result as a reminder and retake when I am more settled.", "seven_day_plan": ["Day 1: record your state during response.", "Day 2: check if you were too fast or tired.", "Day 3: observe one real situation.", "Day 4: avoid labeling yourself.", "Day 5: choose a retest time.", "Day 6: ensure a quiet setting.", "Day 7: complete the test again."], "watch_out": "Do not use a low-confidence result for major decisions."}
+      "zh-CN": {
+        "title": "复测前观察",
+        "why_this_matters": "当本次结果置信度较低时使用。",
+        "do_today": "今天不要急着定性，先记录作答时的状态。",
+        "script": "这次结果我先轻一点看，等状态更稳定时再复测。",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "记录作答时间和状态。"
+          },
+          {
+            "day": 2,
+            "practice": "写下是否太快、太累或太分心。"
+          },
+          {
+            "day": 3,
+            "practice": "挑三个最不确定的题目类型。"
+          },
+          {
+            "day": 4,
+            "practice": "观察一天真实情绪场景。"
+          },
+          {
+            "day": 5,
+            "practice": "不要做重大解释。"
+          },
+          {
+            "day": 6,
+            "practice": "选择一个更稳定的复测时间。"
+          },
+          {
+            "day": 7,
+            "practice": "复测后比较哪些部分稳定。"
+          }
+        ],
+        "watch_out": "不要把练习做成自我批评；只观察一个小动作是否变得更清楚。",
+        "when_to_use": "当本次结果置信度较低时使用。",
+        "do_not_overread": "行动处方是练习建议，不承诺改变结果或替代专业支持。"
+      },
+      "en": {
+        "title": "Reflection before retest",
+        "why_this_matters": "Use when this result has lower interpretation confidence.",
+        "do_today": "Do not label yourself today; first record the response context.",
+        "script": "I will read this result lightly and retest when my context is steadier.",
+        "seven_day_plan": [
+          {
+            "day": 1,
+            "practice": "Notice one relevant real situation."
+          },
+          {
+            "day": 2,
+            "practice": "Write the fact, feeling, and need separately."
+          },
+          {
+            "day": 3,
+            "practice": "Practice the key sentence once out loud."
+          },
+          {
+            "day": 4,
+            "practice": "Use the practice in a low-risk interaction."
+          },
+          {
+            "day": 5,
+            "practice": "Record what changed before and after."
+          },
+          {
+            "day": 6,
+            "practice": "Adjust the wording to sound natural."
+          },
+          {
+            "day": 7,
+            "practice": "Choose one version to keep using next week."
+          }
+        ],
+        "watch_out": "Do not turn the practice into self-criticism; observe one small behavior becoming clearer.",
+        "when_to_use": "Use when this result has lower interpretation confidence.",
+        "do_not_overread": "An action prescription is a practice suggestion, not a promised outcome or substitute for qualified support."
+      }
     }
   }
 }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_dialogue_playbooks.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/agent_dialogue_playbooks.json
@@ -1,0 +1,206 @@
+{
+  "schema": "eq60.report_assets.agent_dialogue_playbooks.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.agent.playbook.understand_result": {
+      "zh-CN": {
+        "title": "理解我的结果",
+        "response_policy": "先引用用户 formulation，再问一个现实场景。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Understand my result",
+        "response_policy": "Use the user’s formulation first, then ask for one real scene.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.understand_result",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "understand_result"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "understand_result"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.scene_advice": {
+      "zh-CN": {
+        "title": "某个场景怎么办",
+        "response_policy": "只处理一个场景，调用 reality_translation 和 action_prescription。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "What should I do in this situation?",
+        "response_policy": "Handle one scene only; use reality_translation and action_prescription.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.scene_advice",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "scene_advice"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "scene_advice"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.career_environment": {
+      "zh-CN": {
+        "title": "我适合什么工作环境",
+        "response_policy": "只讨论环境变量，不给具体职业适配结论。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "What work environment fits me?",
+        "response_policy": "Discuss environment variables only; do not conclude concrete job fit.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.career_environment",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "career_environment"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "career_environment"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.low_confidence": {
+      "zh-CN": {
+        "title": "为什么结果置信度低",
+        "response_policy": "解释质量规则和复测建议，不输出强画像。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Why is confidence low?",
+        "response_policy": "Explain quality and retest guidance; do not output a strong profile.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.low_confidence",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "low_confidence"
+        },
+        "claim_sensitivity": "medium",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "low_confidence"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    },
+    "eq.agent.playbook.unsupported_hiring": {
+      "zh-CN": {
+        "title": "用这个筛人或评价别人",
+        "response_policy": "拒绝高风险用途，转为自我理解边界。",
+        "clarifying_question": "你想讨论哪个具体场景？反馈、冲突、边界、协作还是压力恢复？",
+        "safe_response_example": "我会基于你的报告资产解释这个场景，不会重新打分或替你做高风险判断。",
+        "refusal_example": "我不能用 EQ 结果来筛选、诊断或评价他人，但可以帮你理解自己的沟通和恢复模式。",
+        "escalation_rule": "涉及伤害风险、临床困扰、招聘筛选或要求改分时转人工/边界说明。"
+      },
+      "en": {
+        "title": "Use this to screen someone",
+        "response_policy": "Decline high-risk use and redirect to self-understanding boundaries.",
+        "clarifying_question": "Which scene do you want to discuss: feedback, conflict, boundary, collaboration, or recovery?",
+        "safe_response_example": "I will explain this scene using your report assets; I will not rescore you or make high-risk judgments.",
+        "refusal_example": "I cannot use EQ results to screen, diagnose, or evaluate another person, but I can help you understand your communication and recovery pattern.",
+        "escalation_rule": "Escalate or set boundaries for safety risk, clinical distress, hiring use, or requests to change scores."
+      },
+      "meta": {
+        "id": "eq.agent.playbook.unsupported_hiring",
+        "asset_type": "agent_dialogue_playbook",
+        "purpose": "Agent response policy and examples",
+        "trigger_logic": {
+          "user_intent": "unsupported_hiring"
+        },
+        "claim_sensitivity": "high",
+        "retrieval_tags": [
+          "eq60",
+          "self_report",
+          "result_explanation",
+          "unsupported_hiring"
+        ],
+        "content_change_flow": [
+          "draft suggestion",
+          "lint against forbidden claims",
+          "human review",
+          "backend asset update",
+          "fixture validation"
+        ]
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/backend_integration_contract.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/backend_integration_contract.json
@@ -1,0 +1,121 @@
+{
+  "schema": "eq60.report_assets.backend_integration_contract.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.backend_contract.schema_mapping": {
+      "zh-CN": {
+        "title": "Schema 映射",
+        "requirement": "将每个资产文件映射到后端 content-pack compiler 可识别的字段。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Map every asset file into backend content-pack compiler fields before production",
+        "requirement": "Map every asset file into backend content-pack compiler fields before production.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.schema_mapping",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "schema_mapping"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.canonical_fixtures": {
+      "zh-CN": {
+        "title": "Canonical fixtures",
+        "requirement": "为 balanced、high_empathy_low_recovery、low_confidence 三条路径生成 zh-CN / en canonical fixtures。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths",
+        "requirement": "Generate zh-CN/en fixtures for balanced, high empathy low recovery, and low confidence paths.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.canonical_fixtures",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "canonical_fixtures"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.contract_tests": {
+      "zh-CN": {
+        "title": "契约测试",
+        "requirement": "断言 report payload 包含 v1.6 assets、免费转化动作、无权限门槛，且 SJT 保持 unavailable。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Assert report payload contains v1",
+        "requirement": "Assert report payload contains v1.6 assets, conversion actions, no access wall, and SJT unavailable.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.contract_tests",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "contract_tests"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.frontend_consumption": {
+      "zh-CN": {
+        "title": "前端消费契约",
+        "requirement": "前端必须渲染后端 resolved assets，不得硬编码正式报告解释文案。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Frontend must render resolved assets and must not hardcode official report explanation",
+        "requirement": "Frontend must render resolved assets and must not hardcode official report explanation.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.frontend_consumption",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "frontend_consumption"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.backend_contract.agent_readiness": {
+      "zh-CN": {
+        "title": "Agent 就绪契约",
+        "requirement": "Agent 在检索、拒答和边界评测通过前，只能解释已解析报告资产。",
+        "acceptance": "后端 schema、compiler、fixture、contract test 通过后才可生产使用。",
+        "do_not_overread": "这是导入契约，不是运行时代码。"
+      },
+      "en": {
+        "title": "Agent can only explain resolved assets until retrieval and refusal evals pass",
+        "requirement": "Agent can only explain resolved assets until retrieval and refusal evals pass.",
+        "acceptance": "Backend schema, compiler, fixtures, and contract tests must pass before production use.",
+        "do_not_overread": "This is an import contract, not runtime code."
+      },
+      "meta": {
+        "id": "eq.backend_contract.agent_readiness",
+        "asset_type": "backend_integration_contract",
+        "purpose": "Production import and contract requirement",
+        "trigger_logic": {
+          "contract_gate": "agent_readiness"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/career_environment.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/career_environment.json
@@ -4,86 +4,662 @@
   "variables": {
     "interpersonal_density": {
       "low": {
-        "zh-CN": {"label": "低人际密度", "meaning": "多数时间独立推进，互动频率较低。", "fit_signal": "适合需要恢复空间或深度专注的人。", "strain_signal": "可能减少练习关系动作的机会。", "what_to_verify": "确认岗位是否真的允许长时间独立工作。"},
-        "en": {"label": "Low Interpersonal Density", "meaning": "Most work is independent with fewer interactions.", "fit_signal": "Can fit people who need recovery space or deep focus.", "strain_signal": "May reduce practice opportunities for relational action.", "what_to_verify": "Check whether the role truly allows long independent work blocks."}
+        "zh-CN": {
+          "label": "人际密度：低",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: low",
+          "meaning": "How many people you interact with, and how often. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等人际密度", "meaning": "日常有固定协作，但不是持续社交。", "fit_signal": "适合在协作和独立之间切换。", "strain_signal": "会议过多时仍会消耗。", "what_to_verify": "确认每周会议、同步和跨团队协作频率。"},
-        "en": {"label": "Medium Interpersonal Density", "meaning": "Regular collaboration without constant social demand.", "fit_signal": "Fits switching between collaboration and independent work.", "strain_signal": "Too many meetings can still drain.", "what_to_verify": "Check weekly meetings, syncs, and cross-team collaboration frequency."}
+        "zh-CN": {
+          "label": "人际密度：中",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: medium",
+          "meaning": "How many people you interact with, and how often. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高人际密度", "meaning": "大量沟通、协调和即时互动。", "fit_signal": "可发挥共情、协作和关系管理优势。", "strain_signal": "恢复不足时容易情绪过载。", "what_to_verify": "确认是否有可控的独处和恢复窗口。"},
-        "en": {"label": "High Interpersonal Density", "meaning": "Frequent communication, coordination, and real-time interaction.", "fit_signal": "Can use empathy, collaboration, and relationship-management strengths.", "strain_signal": "Weak recovery can lead to overload.", "what_to_verify": "Check whether protected solo recovery windows exist."}
+        "zh-CN": {
+          "label": "人际密度：高",
+          "meaning": "工作中需要和多少人、以多高频率互动。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，人际密度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当人际密度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的人际密度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的人际密度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Interpersonal density: high",
+          "meaning": "How many people you interact with, and how often. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high interpersonal density may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when interpersonal density does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of interpersonal density: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of interpersonal density in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "emotional_labor": {
       "low": {
-        "zh-CN": {"label": "低情绪劳动", "meaning": "较少承接他人情绪或安抚关系。", "fit_signal": "适合需要降低情绪消耗的人。", "strain_signal": "可能缺少运用共情优势的空间。", "what_to_verify": "确认用户、客户或团队情绪压力是否较低。"},
-        "en": {"label": "Low Emotional Labor", "meaning": "Less need to hold or soothe others' emotions.", "fit_signal": "Fits people who need lower emotional load.", "strain_signal": "May offer less space to use empathy strengths.", "what_to_verify": "Check whether user, client, or team emotional pressure is actually low."}
+        "zh-CN": {
+          "label": "情绪劳动：低",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: low",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等情绪劳动", "meaning": "需要一定理解和安抚，但通常有边界。", "fit_signal": "适合练习共情与边界并存。", "strain_signal": "边界不清时会累积消耗。", "what_to_verify": "确认是否有升级、转介或交接机制。"},
-        "en": {"label": "Medium Emotional Labor", "meaning": "Some understanding and soothing are needed, usually with boundaries.", "fit_signal": "Fits practicing empathy with boundaries.", "strain_signal": "Unclear boundaries accumulate cost.", "what_to_verify": "Check whether escalation, referral, or handoff mechanisms exist."}
+        "zh-CN": {
+          "label": "情绪劳动：中",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: medium",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高情绪劳动", "meaning": "经常承接焦虑、投诉、冲突或脆弱情绪。", "fit_signal": "高共情者能建立信任。", "strain_signal": "低恢复者容易被情绪场拖走。", "what_to_verify": "确认督导、复盘和休息制度是否真实存在。"},
-        "en": {"label": "High Emotional Labor", "meaning": "Frequent exposure to anxiety, complaints, conflict, or vulnerability.", "fit_signal": "High-empathy people can build trust.", "strain_signal": "Low recovery can make the emotional field pull you in.", "what_to_verify": "Check whether supervision, review, and rest systems are real."}
+        "zh-CN": {
+          "label": "情绪劳动：高",
+          "meaning": "你是否需要长期承接、安抚或调节他人情绪。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，情绪劳动高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当情绪劳动与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的情绪劳动真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的情绪劳动大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Emotional labor: high",
+          "meaning": "How often you must absorb, soothe, or regulate others’ emotions. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high emotional labor may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when emotional labor does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of emotional labor: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of emotional labor in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "conflict_frequency": {
       "low": {
-        "zh-CN": {"label": "低冲突频率", "meaning": "较少谈判、投诉或强分歧。", "fit_signal": "降低情绪调节压力。", "strain_signal": "可能较少训练冲突修复。", "what_to_verify": "确认冲突是否只是被隐藏到异步沟通中。"},
-        "en": {"label": "Low Conflict Frequency", "meaning": "Fewer negotiations, complaints, or strong disagreements.", "fit_signal": "Reduces regulation pressure.", "strain_signal": "May offer less practice in conflict repair.", "what_to_verify": "Check whether conflict is merely hidden in async communication."}
+        "zh-CN": {
+          "label": "冲突频率：低",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: low",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等冲突频率", "meaning": "有周期性分歧，但通常有流程。", "fit_signal": "适合练习稳定沟通。", "strain_signal": "流程不清时会放大关系压力。", "what_to_verify": "确认冲突如何升级、记录和收口。"},
-        "en": {"label": "Medium Conflict Frequency", "meaning": "Periodic disagreement with some process.", "fit_signal": "Good for practicing steady communication.", "strain_signal": "Unclear process amplifies relational pressure.", "what_to_verify": "Check how conflict is escalated, recorded, and closed."}
+        "zh-CN": {
+          "label": "冲突频率：中",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: medium",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高冲突频率", "meaning": "经常面对投诉、博弈、谈判或利益冲突。", "fit_signal": "高调节和高关系管理者可发挥优势。", "strain_signal": "ER 或 RM 低时消耗显著。", "what_to_verify": "确认是否有明确授权、边界和复盘支持。"},
-        "en": {"label": "High Conflict Frequency", "meaning": "Frequent complaints, negotiation, bargaining, or interest conflict.", "fit_signal": "High ER and RM can become strengths.", "strain_signal": "Low ER or RM is costly here.", "what_to_verify": "Check whether authority, boundaries, and review support are clear."}
+        "zh-CN": {
+          "label": "冲突频率：高",
+          "meaning": "分歧、投诉、谈判、博弈出现的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，冲突频率高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当冲突频率与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的冲突频率真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的冲突频率大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Conflict frequency: high",
+          "meaning": "How often disagreement, complaints, negotiation, or tension appear. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high conflict frequency may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when conflict frequency does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of conflict frequency: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of conflict frequency in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "feedback_intensity": {
       "low": {
-        "zh-CN": {"label": "低反馈强度", "meaning": "评价和修改频率较低。", "fit_signal": "适合对评价敏感且需要稳定节奏的人。", "strain_signal": "成长反馈可能不足。", "what_to_verify": "确认是否仍有清晰目标和周期复盘。"},
-        "en": {"label": "Low Feedback Intensity", "meaning": "Evaluation and revision are less frequent.", "fit_signal": "Fits people sensitive to evaluation who need a steadier rhythm.", "strain_signal": "Growth feedback may be insufficient.", "what_to_verify": "Check whether clear goals and periodic review still exist."}
+        "zh-CN": {
+          "label": "反馈强度：低",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: low",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等反馈强度", "meaning": "定期复盘、修改和评价。", "fit_signal": "适合把反馈转成学习。", "strain_signal": "恢复不足时可能反复回想。", "what_to_verify": "确认反馈是否具体、可执行、不过度公开。"},
-        "en": {"label": "Medium Feedback Intensity", "meaning": "Regular review, revision, and evaluation.", "fit_signal": "Fits turning feedback into learning.", "strain_signal": "Weak recovery may lead to replaying feedback.", "what_to_verify": "Check whether feedback is specific, actionable, and not overly public."}
+        "zh-CN": {
+          "label": "反馈强度：中",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: medium",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高反馈强度", "meaning": "频繁被评价、迭代或公开比较。", "fit_signal": "高觉察和高调节者可快速迭代。", "strain_signal": "低调节者容易把反馈体验成否定。", "what_to_verify": "确认是否有安全反馈文化和恢复空间。"},
-        "en": {"label": "High Feedback Intensity", "meaning": "Frequent evaluation, iteration, or public comparison.", "fit_signal": "High SA and ER can support fast iteration.", "strain_signal": "Low ER may make feedback feel like rejection.", "what_to_verify": "Check for a safe feedback culture and recovery space."}
+        "zh-CN": {
+          "label": "反馈强度：高",
+          "meaning": "你被评价、修改、复盘或公开比较的频率。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，反馈强度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当反馈强度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的反馈强度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的反馈强度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Feedback intensity: high",
+          "meaning": "How often your work is evaluated, revised, reviewed, or compared. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high feedback intensity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when feedback intensity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of feedback intensity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of feedback intensity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "autonomy_recovery": {
       "low": {
-        "zh-CN": {"label": "低自主恢复空间", "meaning": "节奏常被外部打断，难以独处恢复。", "fit_signal": "适合恢复需求低且即时响应强的人。", "strain_signal": "高共情低恢复者风险较高。", "what_to_verify": "确认是否允许暂停、调班或离线恢复。"},
-        "en": {"label": "Low Autonomy Recovery", "meaning": "Rhythm is often interrupted, with little solo recovery.", "fit_signal": "Fits people with low recovery needs and strong real-time response.", "strain_signal": "High empathy with low recovery is risky here.", "what_to_verify": "Check whether pauses, shift changes, or offline recovery are allowed."}
+        "zh-CN": {
+          "label": "自主恢复空间：低",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: low",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等自主恢复空间", "meaning": "有一定独立安排，但仍受团队节奏影响。", "fit_signal": "适合多数人维持稳定表现。", "strain_signal": "忙季或危机期可能被压缩。", "what_to_verify": "确认高峰期的恢复安排。"},
-        "en": {"label": "Medium Autonomy Recovery", "meaning": "Some independent rhythm exists, though team rhythm still matters.", "fit_signal": "Helps most people sustain performance.", "strain_signal": "Busy or crisis periods may compress it.", "what_to_verify": "Check recovery arrangements during peak periods."}
+        "zh-CN": {
+          "label": "自主恢复空间：中",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: medium",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高自主恢复空间", "meaning": "可以较多控制节奏、沟通窗口和深度工作时间。", "fit_signal": "有利于敏感、深度复盘或高恢复需求者。", "strain_signal": "也可能带来孤立或反馈不足。", "what_to_verify": "确认独立性不会变成缺少支持。"},
-        "en": {"label": "High Autonomy Recovery", "meaning": "More control over rhythm, communication windows, and deep-work time.", "fit_signal": "Helpful for sensitive, reflective, or high-recovery-need people.", "strain_signal": "Can also create isolation or insufficient feedback.", "what_to_verify": "Check that autonomy does not mean lack of support."}
+        "zh-CN": {
+          "label": "自主恢复空间：高",
+          "meaning": "你是否能安排独处、节奏和低输入恢复时间。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，自主恢复空间高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当自主恢复空间与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的自主恢复空间真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的自主恢复空间大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Autonomy and recovery: high",
+          "meaning": "How much control you have over solitude, rhythm, and low-input recovery. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high autonomy and recovery may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when autonomy and recovery does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of autonomy and recovery: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of autonomy and recovery in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     },
     "collaboration_complexity": {
       "low": {
-        "zh-CN": {"label": "低协作复杂度", "meaning": "角色、接口和责任较清楚。", "fit_signal": "降低关系误解和协调成本。", "strain_signal": "可能较少发挥复杂协调优势。", "what_to_verify": "确认职责是否稳定且边界清楚。"},
-        "en": {"label": "Low Collaboration Complexity", "meaning": "Roles, interfaces, and responsibilities are clear.", "fit_signal": "Lowers misunderstanding and coordination cost.", "strain_signal": "May offer less space for complex coordination strengths.", "what_to_verify": "Check whether responsibilities are stable and boundaries clear."}
+        "zh-CN": {
+          "label": "协作复杂度：低",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示更少、更慢、更可控。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度低档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: low",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is lower, slower, and more controlled.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, low collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "medium": {
-        "zh-CN": {"label": "中等协作复杂度", "meaning": "需要跨角色协作，但仍有明确流程。", "fit_signal": "适合练习关系管理和反馈沟通。", "strain_signal": "流程缺失时容易消耗。", "what_to_verify": "确认决策权、优先级和冲突处理方式。"},
-        "en": {"label": "Medium Collaboration Complexity", "meaning": "Cross-role collaboration is needed with some clear process.", "fit_signal": "Good for practicing relationship management and feedback communication.", "strain_signal": "Missing process can be draining.", "what_to_verify": "Check decision rights, priorities, and conflict-handling process."}
+        "zh-CN": {
+          "label": "协作复杂度：中",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示有一定强度，但仍可通过规则管理。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度中档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: medium",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is moderate, but manageable with rules.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, medium collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       },
       "high": {
-        "zh-CN": {"label": "高协作复杂度", "meaning": "多方目标、利益和节奏需要持续协调。", "fit_signal": "高 RM 与稳定 ER 能发挥明显优势。", "strain_signal": "边界不清时容易长期过载。", "what_to_verify": "确认是否有正式协调机制和优先级裁决。"},
-        "en": {"label": "High Collaboration Complexity", "meaning": "Multiple goals, interests, and rhythms require ongoing coordination.", "fit_signal": "High RM and stable ER can become clear strengths.", "strain_signal": "Unclear boundaries can cause chronic overload.", "what_to_verify": "Check formal coordination mechanisms and priority arbitration."}
+        "zh-CN": {
+          "label": "协作复杂度：高",
+          "meaning": "你需要协调多少角色、目标和隐性关系规则。 当前档位表示强度高、频率高，对恢复和边界要求更高。",
+          "fit_signal": "如果你的报告优势需要稳定节奏或清晰边界，协作复杂度高档可能更容易发挥；如果你的优势来自高互动，也要确认机会是否足够。",
+          "strain_signal": "当协作复杂度与恢复空间、反馈方式或责任边界不匹配时，容易放大消耗。",
+          "what_to_verify": "面试或试岗时验证：这里的协作复杂度真实强度是多少？谁负责调节关系和处理冲突？",
+          "do_not_overread": "这是职业环境变量，不是具体职业推荐，也不用于招聘筛选。",
+          "interview_question": "我想了解这个岗位日常的协作复杂度大概是什么水平？高压时通常如何分工和复盘？",
+          "role_observation_checklist": [
+            "一天内高互动时段数量",
+            "反馈是私下还是公开",
+            "冲突由个人消化还是团队处理",
+            "是否有低输入恢复窗口"
+          ],
+          "team_risk": "如果团队默认由高 EQ 的人承担关系维护，这个环境会把优势变成隐形负担。",
+          "safe_experiment": "先用一周观察互动节奏和恢复空间，不要仅凭岗位名称判断适配。"
+        },
+        "en": {
+          "label": "Collaboration complexity: high",
+          "meaning": "How many roles, goals, and unstated relational rules you must coordinate. This level is high intensity and frequency, requiring stronger recovery and boundaries.",
+          "fit_signal": "If your EQ pattern works best with clear rhythm and boundaries, high collaboration complexity may support it; if your strengths need high interaction, verify that the environment provides enough of it.",
+          "strain_signal": "Strain increases when collaboration complexity does not match recovery space, feedback style, or responsibility boundaries.",
+          "what_to_verify": "In interviews or trials, verify the real level of collaboration complexity: who handles relationship tension and how conflict is reviewed.",
+          "do_not_overread": "This is a career-environment variable, not a job recommendation or hiring screen.",
+          "interview_question": "What is the usual level of collaboration complexity in this role, and how does the team divide responsibility under pressure?",
+          "role_observation_checklist": [
+            "number of high-interaction periods in a day",
+            "private vs public feedback",
+            "whether conflict is handled individually or by the team",
+            "availability of low-input recovery windows"
+          ],
+          "team_risk": "If the team expects emotionally skilled people to maintain the relationship system, this environment can turn strength into invisible labor.",
+          "safe_experiment": "Observe rhythm and recovery space for one week before judging fit from a job title."
+        }
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/commercial_conversion_assets.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/commercial_conversion_assets.json
@@ -1,0 +1,181 @@
+{
+  "schema": "eq60.report_assets.commercial_conversion_assets.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.conversion.save_report": {
+      "zh-CN": {
+        "title": "保存报告",
+        "body": "把这次核心模式、行动处方和复测入口留住。",
+        "cta_label": "保存报告",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Save your report",
+        "body": "Keep your pattern, action prescription, and retest path in one place.",
+        "cta_label": "Save report",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.save_report",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "save_report"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.email_revisit": {
+      "zh-CN": {
+        "title": "邮件回看",
+        "body": "把报告发送给自己，适合之后复盘或继续和 Agent 对话。",
+        "cta_label": "发送到邮箱",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Email revisit",
+        "body": "Send the report to yourself so you can revisit it or continue with the Agent later.",
+        "cta_label": "Email me",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.email_revisit",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "email_revisit"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.pdf_export": {
+      "zh-CN": {
+        "title": "PDF 报告",
+        "body": "生成可保存版本，适合个人复盘，不建议用于招聘或评估他人。",
+        "cta_label": "生成 PDF",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "PDF report",
+        "body": "Create a saved copy for personal reflection, not for hiring or evaluating another person.",
+        "cta_label": "Create PDF",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.pdf_export",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "pdf_export"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.share_card": {
+      "zh-CN": {
+        "title": "分享卡",
+        "body": "只分享模式句，不分享详细分数和敏感解释。",
+        "cta_label": "生成分享卡",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Share card",
+        "body": "Share the pattern sentence, not detailed scores or sensitive interpretation.",
+        "cta_label": "Create share card",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.share_card",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "share_card"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.retest_reminder": {
+      "zh-CN": {
+        "title": "复测提醒",
+        "body": "4–8 周后重新查看模式是否稳定，低置信结果可更早复测。",
+        "cta_label": "设置复测提醒",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Retest reminder",
+        "body": "Check whether the pattern is stable after 4–8 weeks; low-confidence results can be retested sooner.",
+        "cta_label": "Set reminder",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.retest_reminder",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "retest_reminder"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.related_tests": {
+      "zh-CN": {
+        "title": "相关测试",
+        "body": "用 Big Five、RIASEC、MBTI 作为补充视角，不把 EQ 当成唯一结论。",
+        "cta_label": "继续探索",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Related tests",
+        "body": "Use Big Five, RIASEC, or MBTI as complementary lenses, not as replacements for EQ.",
+        "cta_label": "Explore related tests",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.related_tests",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "related_tests"
+        },
+        "claim_sensitivity": "low"
+      }
+    },
+    "eq.conversion.agent_entry": {
+      "zh-CN": {
+        "title": "问问 Agent",
+        "body": "带着一个真实场景提问，例如反馈、冲突、边界或压力恢复。",
+        "cta_label": "问 Agent",
+        "placement": "结果页底部、首屏次级动作或报告保存区域。",
+        "do_not_overread": "这是免费产品动作，不改变报告权限。"
+      },
+      "en": {
+        "title": "Ask the Agent",
+        "body": "Ask about one real scene, such as feedback, conflict, boundaries, or recovery.",
+        "cta_label": "Ask the Agent",
+        "placement": "Use in result-page footer, secondary hero action, or saved-report area.",
+        "do_not_overread": "This is a free product action, it does not change report access."
+      },
+      "meta": {
+        "id": "eq.conversion.agent_entry",
+        "asset_type": "commercial_conversion",
+        "purpose": "Commercial retention/conversion action",
+        "trigger_logic": {
+          "conversion_action": "agent_entry"
+        },
+        "claim_sensitivity": "low"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/core_formulations.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/core_formulations.json
@@ -5,221 +5,321 @@
     "balanced_integrated": {
       "zh-CN": {
         "title": "均衡整合型",
-        "one_liner": "你的情绪与关系信号比较均衡，优势在于稳定和可迁移。",
-        "core_claim": "你通常能同时看见自己、理解他人，并在多数情境中维持可用的回应方式。",
-        "evidence_basis": ["四维分数相对均衡", "无明显单一短板"],
-        "primary_strength": "稳定性和多场景适应能力。",
-        "likely_cost": "容易低估特定高压情境对自己的消耗。",
-        "development_lever": "选择一个真实场景做精细化复盘，而不是泛泛提升。",
-        "do_not_overread": "这不代表你在任何情境中都不会被触发。"
+        "one_liner": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "hero_summary": "你能同时照顾自己的状态、他人的感受和关系目标。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+        "development_lever": "把“我来稳住”改成“我们一起定规则”。",
+        "user_memory_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Balanced Integration",
-        "one_liner": "Your emotional and relational signals are relatively balanced; stability is the main strength.",
-        "core_claim": "You usually notice yourself, understand others, and maintain usable responses across many contexts.",
-        "evidence_basis": ["Four dimensions are relatively balanced", "No single severe gap stands out"],
-        "primary_strength": "Stability and transfer across contexts.",
-        "likely_cost": "You may underestimate how specific high-pressure contexts drain you.",
-        "development_lever": "Choose one real situation for precise review rather than trying to improve everything.",
-        "do_not_overread": "This does not mean you will never be triggered."
+        "title": "Balanced Integrator",
+        "one_liner": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "hero_summary": "You can hold your own state, other people, and the relationship goal in view at the same time. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can keep emotion, relationship, and task in the same frame.",
+        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+        "development_lever": "Move from “I will steady this” to “we need a shared rule.”",
+        "user_memory_sentence": "I can steady a relationship without maintaining the whole system alone.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "high_empathy_low_recovery": {
       "zh-CN": {
         "title": "高共情，低恢复",
-        "one_liner": "你容易理解他人感受，但恢复和边界是当前杠杆。",
-        "core_claim": "你可能很快接住别人的情绪，却不一定能及时把对方状态和自己的状态分开。",
-        "evidence_basis": ["EM 明显高于 ER", "共情信号强于恢复信号"],
-        "primary_strength": "对他人状态敏感，容易建立信任。",
-        "likely_cost": "在冲突、求助或高情绪劳动场景中容易被卷入。",
-        "development_lever": "共情之后建立边界和恢复动作。",
-        "do_not_overread": "发展方向不是减少共情，而是让共情更有边界。"
+        "one_liner": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "hero_summary": "你很快读到别人的状态，但恢复系统常常追不上共情速度。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+        "development_lever": "练习“理解但不接管”，让共情后面跟着边界。",
+        "user_memory_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "High Empathy, Low Recovery",
-        "one_liner": "You tend to understand others quickly, while recovery and boundaries are the current lever.",
-        "core_claim": "You may absorb other people's emotions quickly without separating their state from your own soon enough.",
-        "evidence_basis": ["EM is meaningfully higher than ER", "Empathy signal is stronger than recovery signal"],
-        "primary_strength": "Sensitivity to others and trust building.",
-        "likely_cost": "Conflict, support, and high emotional-labor settings may pull you in too deeply.",
-        "development_lever": "Build boundaries and recovery after empathy.",
-        "do_not_overread": "The goal is not less empathy; it is empathy with clearer boundaries."
+        "title": "High Empathy, Slow Recovery",
+        "one_liner": "You read the room quickly, but recovery can lag behind empathy.",
+        "hero_summary": "You read the room quickly, but recovery can lag behind empathy. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You read the room quickly, but recovery can lag behind empathy.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can make people feel understood, especially when emotions run high.",
+        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+        "development_lever": "Practice understanding without taking over, so empathy is followed by boundary.",
+        "user_memory_sentence": "I can understand someone without carrying the whole emotional load.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "aware_but_unregulated": {
       "zh-CN": {
-        "title": "高觉察，调节不足",
-        "one_liner": "你能知道自己怎么了，但不一定能很快恢复。",
-        "core_claim": "你可能很快觉察到被触发，却需要更稳定的暂停、命名和复位动作。",
-        "evidence_basis": ["SA 高于 ER", "自我识别强于调节行动"],
-        "primary_strength": "能捕捉自己的情绪变化。",
-        "likely_cost": "知道问题但仍被情绪带着走。",
-        "development_lever": "把觉察转成具体调节步骤。",
-        "do_not_overread": "觉察本身不是问题，问题在于缺少后续动作。"
+        "title": "有觉察，调节不足",
+        "one_liner": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "hero_summary": "你常知道自己怎么了，但把自己带回来需要更长时间。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能清楚识别触发点、感受和需要。",
+        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+        "development_lever": "把觉察压缩成一个暂停动作，而不是继续解释。",
+        "user_memory_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Aware but Under-Regulated",
-        "one_liner": "You may know what is happening inside, but recovery may lag.",
-        "core_claim": "You may notice triggers quickly and still need steadier pause, labeling, and reset actions.",
-        "evidence_basis": ["SA is higher than ER", "Self-recognition is stronger than regulation action"],
-        "primary_strength": "You can catch emotional shifts in yourself.",
-        "likely_cost": "You may know the issue while still being carried by the emotion.",
-        "development_lever": "Turn awareness into concrete regulation steps.",
-        "do_not_overread": "Awareness is not the problem; the missing step is what follows."
+        "title": "Aware, Still Reactive",
+        "one_liner": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "hero_summary": "You often know what is happening inside, but the reset button is slower than the insight. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+        "development_lever": "Turn awareness into one pause action instead of another layer of explanation.",
+        "user_memory_sentence": "I know what is happening; the next skill is bringing myself back.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "calm_but_distant": {
       "zh-CN": {
-        "title": "冷静稳定，但回应偏远",
-        "one_liner": "你较能维持稳定，但可能不够读懂或回应他人情绪。",
-        "core_claim": "你在压力下可能保持冷静，但关系中的温度和回应需要更多主动性。",
-        "evidence_basis": ["ER 高于 EM", "稳定信号强于共情信号"],
-        "primary_strength": "不容易被情绪场带乱。",
-        "likely_cost": "他人可能感到你不够理解或靠近。",
-        "development_lever": "在稳定之外增加情绪确认。",
-        "do_not_overread": "冷静不等于冷漠，但需要被他人感受到。"
+        "title": "冷静稳定，但距离感强",
+        "one_liner": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "hero_summary": "你能稳住事情，但别人不一定感到被情绪上接住。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+        "development_lever": "先回应一句感受，再给建议或方案。",
+        "user_memory_sentence": "我能稳住事情，也要让人感到被看见。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Calm but Distant",
-        "one_liner": "You may stay steady while reading or responding to others less actively.",
-        "core_claim": "You may remain calm under pressure, but warmth and relational response need more intentional action.",
-        "evidence_basis": ["ER is higher than EM", "Stability signal is stronger than empathy signal"],
-        "primary_strength": "You are less likely to be disrupted by the emotional field.",
-        "likely_cost": "Others may feel less understood or less met.",
-        "development_lever": "Add emotional acknowledgment to stability.",
-        "do_not_overread": "Calm is not coldness, but it needs to be felt by others."
+        "title": "Steady, Less Attuned",
+        "one_liner": "You can steady the situation, but people may not always feel emotionally met.",
+        "hero_summary": "You can steady the situation, but people may not always feel emotionally met. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You can steady the situation, but people may not always feel emotionally met.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+        "development_lever": "Acknowledge one feeling before offering advice or a solution.",
+        "user_memory_sentence": "I can steady the situation and still help people feel seen.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "relationship_first_self_later": {
       "zh-CN": {
         "title": "关系优先，自我后置",
-        "one_liner": "你能维护关系，但可能晚一步看见自己的真实感受。",
-        "core_claim": "你倾向先让关系顺畅，再处理自己的边界、需求和消耗。",
-        "evidence_basis": ["RM 高于 SA", "关系行动强于自我连接"],
-        "primary_strength": "能维持合作和关系稳定。",
-        "likely_cost": "长期忽略自己的感受和界限。",
-        "development_lever": "在回应别人前先确认自己的底线。",
-        "do_not_overread": "重视关系不是问题，自我后置过久才是风险。"
+        "one_liner": "你会先保护关系，再回头找自己的真实立场。",
+        "hero_summary": "你会先保护关系，再回头找自己的真实立场。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你会先保护关系，再回头找自己的真实立场。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+        "development_lever": "在照顾关系前，先给自己的感受一个位置。",
+        "user_memory_sentence": "关系重要，我的感受也需要在场。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Relationship First, Self Later",
-        "one_liner": "You can maintain relationships, but may notice your own feelings too late.",
-        "core_claim": "You tend to keep the relationship smooth before checking your own boundaries, needs, and cost.",
-        "evidence_basis": ["RM is higher than SA", "Relational action is stronger than self-connection"],
-        "primary_strength": "You can preserve cooperation and relational stability.",
-        "likely_cost": "You may overlook your feelings and limits over time.",
-        "development_lever": "Check your bottom line before responding to others.",
-        "do_not_overread": "Valuing relationships is not the issue; staying self-later for too long is the risk."
+        "one_liner": "You protect the relationship first and find your own position later.",
+        "hero_summary": "You protect the relationship first and find your own position later. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You protect the relationship first and find your own position later.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are sensitive to relational tone and often keep interaction workable.",
+        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+        "development_lever": "Give your own feeling a place before you manage the relationship.",
+        "user_memory_sentence": "The relationship matters, and my own state belongs in the room too.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "self_clear_repair_weak": {
       "zh-CN": {
         "title": "自我清楚，修复不足",
-        "one_liner": "你知道自己的感受，但关系修复动作需要更清晰。",
-        "core_claim": "你可能能表达立场，却不一定能把表达转成可继续合作的关系动作。",
-        "evidence_basis": ["SA 高于 RM", "自我清楚强于关系修复"],
-        "primary_strength": "有清楚的自我感受和判断。",
-        "likely_cost": "表达后关系可能停在紧张或防御状态。",
-        "development_lever": "把表达、确认和修复连成一组动作。",
-        "do_not_overread": "清楚表达不是攻击，关键是加上修复。"
+        "one_liner": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "hero_summary": "你知道自己的立场，但冲突后的修复需要更明确的工具。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你不容易在关系压力里丢掉自己的判断。",
+        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+        "development_lever": "把“我说清楚了”补成“我们怎么重新对齐”。",
+        "user_memory_sentence": "我可以清楚表达，也可以把关系重新接上。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Self-Clear, Repair Weaker",
-        "one_liner": "You may know your feelings while needing clearer relational repair moves.",
-        "core_claim": "You may state your position without always turning it into actions that keep collaboration possible.",
-        "evidence_basis": ["SA is higher than RM", "Self-clarity is stronger than repair"],
-        "primary_strength": "Clear self-feeling and judgment.",
-        "likely_cost": "After expression, the relationship may remain tense or defensive.",
-        "development_lever": "Connect expression, acknowledgment, and repair as one sequence.",
-        "do_not_overread": "Clear expression is not attack; the key is adding repair."
+        "title": "Clear Self, Repair Gap",
+        "one_liner": "You know your position, but repair after tension needs a clearer tool.",
+        "hero_summary": "You know your position, but repair after tension needs a clearer tool. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You know your position, but repair after tension needs a clearer tool.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are less likely to lose your judgment under relational pressure.",
+        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+        "development_lever": "Add “how do we realign?” after “I made my point.”",
+        "user_memory_sentence": "I can be clear and still reconnect the relationship.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "steady_collaborator": {
       "zh-CN": {
         "title": "稳定协作型",
-        "one_liner": "你在压力下较能维持合作和修复。",
-        "core_claim": "你通常能在情绪波动中保持可沟通，并把关系拉回可协作状态。",
-        "evidence_basis": ["ER 与 RM 都较高", "压力恢复和关系行动同向"],
-        "primary_strength": "压力下仍能保持建设性。",
-        "likely_cost": "可能承担过多协调责任。",
-        "development_lever": "区分需要你修复的事和不该由你承担的事。",
-        "do_not_overread": "稳定协作不意味着你必须负责所有人的情绪。"
+        "one_liner": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "hero_summary": "你能在压力下维持合作推进，但别让稳定只靠你一个人。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你能把紧张对话拉回事实、目标和下一步。",
+        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+        "development_lever": "把个人稳定能力变成团队流程。",
+        "user_memory_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Steady Collaborator",
-        "one_liner": "You tend to maintain collaboration and repair under pressure.",
-        "core_claim": "You can often stay communicative during emotional shifts and bring the relationship back to workable ground.",
-        "evidence_basis": ["ER and RM are both relatively high", "Recovery and relational action move together"],
-        "primary_strength": "Constructive response under pressure.",
-        "likely_cost": "You may take on too much coordination responsibility.",
-        "development_lever": "Separate what is yours to repair from what is not yours to carry.",
-        "do_not_overread": "Being steady does not make you responsible for everyone else's emotions."
+        "one_liner": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "hero_summary": "You keep collaboration moving under pressure, but steadiness should not depend only on you. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+        "development_lever": "Turn personal steadiness into team process.",
+        "user_memory_sentence": "I can help collaboration, but the rules cannot live only in me.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "sensitive_absorber": {
       "zh-CN": {
         "title": "高敏感，易吸收",
-        "one_liner": "你很能感知自己和他人，但也更容易被情绪环境影响。",
-        "core_claim": "你可能同时捕捉自己的细微信号和他人情绪，因此需要更强的区分与恢复。",
-        "evidence_basis": ["SA 与 EM 较高", "ER 相对较低"],
-        "primary_strength": "情绪线索捕捉能力强。",
-        "likely_cost": "容易过度加工或吸收环境情绪。",
-        "development_lever": "区分我的感受、他人的感受和现场压力。",
-        "do_not_overread": "敏感不是脆弱，它需要更好的过滤系统。"
+        "one_liner": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "hero_summary": "你能捕捉细微变化，但敏感也容易变成情绪负重。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你很快发现气氛、语气和关系位置的变化。",
+        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+        "development_lever": "把“我感到了”区分成“我要不要回应”。",
+        "user_memory_sentence": "我能感到很多东西，但不需要回应所有东西。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Sensitive Absorber",
-        "one_liner": "You notice yourself and others strongly, and may be more affected by the emotional field.",
-        "core_claim": "You may catch subtle self-signals and other people's emotions at the same time, requiring stronger separation and recovery.",
-        "evidence_basis": ["SA and EM are relatively high", "ER is relatively lower"],
-        "primary_strength": "Strong emotional cue detection.",
-        "likely_cost": "You may over-process or absorb environmental emotion.",
-        "development_lever": "Separate my feeling, their feeling, and situational pressure.",
-        "do_not_overread": "Sensitivity is not weakness; it needs a better filtering system."
+        "one_liner": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "hero_summary": "You catch subtle shifts fast, and that sensitivity can become emotional load. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You quickly notice shifts in tone, mood, and relational position.",
+        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+        "development_lever": "Separate “I noticed it” from “I need to respond.”",
+        "user_memory_sentence": "I can feel a lot without responding to everything.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "developing_foundation": {
       "zh-CN": {
         "title": "基础发展中",
-        "one_liner": "多个情绪与关系信号仍在打基础，适合从一个小场景开始练。",
-        "core_claim": "你的结果提示当前不宜追求复杂技巧，先建立命名、暂停和复盘的基础动作更重要。",
-        "evidence_basis": ["多个维度处于基础或发展区间", "没有稳定优势维度足以独立支撑"],
-        "primary_strength": "可塑性强，适合从低风险场景开始。",
-        "likely_cost": "同时处理太多关系任务会增加压力。",
-        "development_lever": "先练一个最小闭环：识别、暂停、选择下一句。",
-        "do_not_overread": "这不是能力定论，而是当前自我报告信号。"
+        "one_liner": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "hero_summary": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+        "development_lever": "先把一个情绪命名清楚，再谈复杂改变。",
+        "user_memory_sentence": "先练一个小动作，就已经是在建立基础。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
         "title": "Developing Foundation",
-        "one_liner": "Several emotional and relational signals are still foundational; start with one small context.",
-        "core_claim": "The result suggests starting with basic labeling, pausing, and review before complex techniques.",
-        "evidence_basis": ["Multiple dimensions are foundational or developing", "No stable strength is strong enough to carry the pattern alone"],
-        "primary_strength": "High room for growth through low-risk practice.",
-        "likely_cost": "Handling too many relational tasks at once can increase pressure.",
-        "development_lever": "Practice one small loop: notice, pause, choose the next sentence.",
-        "do_not_overread": "This is not a fixed ability judgment; it is the current self-report signal."
+        "one_liner": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "hero_summary": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+        "development_lever": "Name one feeling clearly before attempting a larger change.",
+        "user_memory_sentence": "One small practice is already foundation-building.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     },
     "low_confidence_result": {
       "zh-CN": {
-        "title": "本次结果置信度不足",
-        "one_liner": "本次作答质量信号降低了解释置信度，建议先谨慎阅读。",
-        "core_claim": "系统检测到会影响解释稳定性的作答模式，因此不应输出强人格判断。",
-        "evidence_basis": ["质量等级为 C 或 D", "存在速度、长串、极端、中立或不一致信号"],
-        "primary_strength": "仍可作为反思线索。",
-        "likely_cost": "具体维度和画像容易被误读。",
-        "development_lever": "在状态稳定时复测，或只使用低风险建议。",
-        "do_not_overread": "不要把这次结果作为稳定结论。"
+        "title": "本次结果置信度较低",
+        "one_liner": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "hero_summary": "这次结果应轻一点读，最有价值的是理解本次作答状态。 最值得看的不是一个高低标签，而是它在哪个场景反复出现，以及今天能练哪一个动作。",
+        "core_claim": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "evidence_basis": [
+          "由四维分数、维度差距、质量等级和组合机制共同触发。"
+        ],
+        "primary_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+        "development_lever": "先记录状态，之后在更稳定的时间复测。",
+        "user_memory_sentence": "这次结果不是不能看，而是要轻一点看。",
+        "do_not_overread": "这是本次结果的组织方式，不是永久人格标签，也不适合用于临床、招聘或高风险判断。",
+        "conversion_hook": "保存报告后，可在复测时比较这个模式是否稳定。"
       },
       "en": {
-        "title": "Lower Confidence Result",
-        "one_liner": "Response-quality signals reduce interpretation confidence; read this result cautiously.",
-        "core_claim": "The system detected response patterns that can reduce interpretive stability, so strong personality claims should not be made.",
-        "evidence_basis": ["Quality level is C or D", "Speed, long-string, extreme, neutral, or inconsistency signals are present"],
-        "primary_strength": "It can still serve as a reflection cue.",
-        "likely_cost": "Specific dimensions and patterns may be overread.",
-        "development_lever": "Retake when stable, or use only low-risk suggestions.",
-        "do_not_overread": "Do not treat this result as a stable conclusion."
+        "title": "Lower-Confidence Result",
+        "one_liner": "Read this result lightly; the most useful signal is the response context of this session.",
+        "hero_summary": "Read this result lightly; the most useful signal is the response context of this session. The useful part is not a high-or-low label; it is the scene where the pattern shows up and the one move to practice next.",
+        "core_claim": "Read this result lightly; the most useful signal is the response context of this session.",
+        "evidence_basis": [
+          "Triggered by dimension scores, score gaps, quality level, and mechanism pattern."
+        ],
+        "primary_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "development_lever": "Record the context first, then retest when conditions are steadier.",
+        "user_memory_sentence": "This result is not useless; it simply needs a lighter reading.",
+        "do_not_overread": "This is how the current result is organized; it is not a permanent personality label or a basis for clinical, hiring, or high-risk decisions.",
+        "conversion_hook": "Save this report so a future retest can show whether the pattern is stable or changing."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/mechanism_map.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/mechanism_map.json
@@ -1,415 +1,500 @@
 {
   "schema": "eq60.report_assets.mechanism_map.v1",
   "pack_id": "EQ_60",
-  "states": ["high_high", "high_low", "low_high", "low_low"],
+  "states": [
+    "high_high",
+    "high_low",
+    "low_high",
+    "low_low"
+  ],
   "pairs": {
     "SA_ER": {
       "high_high": {
         "zh-CN": {
-          "title": "知道自己，也能复位",
-          "why_it_matters": "自我觉察只有接上调节动作，才会变成现实中的稳定回应。",
-          "what_it_feels_like": "你通常能说清自己怎么了，并较快找到下一步。",
-          "strength": "减少反复内耗，把情绪信息转成行动。",
-          "cost": "可能过度依赖自我控制，忽略休息需求。",
-          "development_lever": "让复位动作更轻量。",
-          "micro_action": "用一句话命名情绪，再决定下一句怎么说。"
+          "title": "自我觉察 × 情绪调节｜双高协同",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You notice yourself and can reset",
-          "why_it_matters": "Self-awareness becomes real-world stability only when it connects to regulation.",
-          "what_it_feels_like": "You can usually name what is happening and find the next step.",
-          "strength": "Less rumination; more action from emotional information.",
-          "cost": "You may over-rely on self-control and miss rest needs.",
-          "development_lever": "Make reset actions lighter.",
-          "micro_action": "Name the emotion in one sentence, then choose the next sentence."
+          "title": "Self-awareness × Emotion regulation: both signals support each other",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "知道自己，但恢复跟不上",
-          "why_it_matters": "觉察会放大感受，如果没有调节动作，反而更容易卡住。",
-          "what_it_feels_like": "你知道自己被触发了，但身体和语气不一定跟得上。",
-          "strength": "能早期识别风险信号。",
-          "cost": "容易陷入反复解释或自责。",
-          "development_lever": "把觉察后 30 秒变成固定流程。",
-          "micro_action": "暂停、命名、喝水或离开屏幕 60 秒。"
+          "title": "自我觉察 × 情绪调节｜前者强，后者需要补位",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You notice yourself, but recovery lags",
-          "why_it_matters": "Awareness can intensify feelings when no regulation step follows.",
-          "what_it_feels_like": "You know you are triggered, but your body or tone may not catch up.",
-          "strength": "Early detection of risk signals.",
-          "cost": "You may loop in explanation or self-blame.",
-          "development_lever": "Turn the first 30 seconds after awareness into a routine.",
-          "micro_action": "Pause, label, drink water, or step away from the screen for 60 seconds."
+          "title": "Self-awareness × Emotion regulation: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "能稳定，但不总知道原因",
-          "why_it_matters": "调节有效，但如果不理解触发点，模式会重复出现。",
-          "what_it_feels_like": "你能忍住或恢复，但事后未必知道自己为何被影响。",
-          "strength": "压力下不易失控。",
-          "cost": "复盘不足会让同类问题反复。",
-          "development_lever": "补上事后命名。",
-          "micro_action": "事后写下：刚才我真正介意的是什么。"
+          "title": "自我觉察 × 情绪调节｜后者强，前者需要补位",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You can stabilize without always knowing why",
-          "why_it_matters": "Regulation helps, but without understanding triggers the pattern repeats.",
-          "what_it_feels_like": "You can hold or recover, but may not know what affected you.",
-          "strength": "Less likely to lose control under pressure.",
-          "cost": "Weak review lets similar problems recur.",
-          "development_lever": "Add after-action labeling.",
-          "micro_action": "Afterward, write: what did I actually care about?"
+          "title": "Self-awareness × Emotion regulation: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "识别和恢复都需要打底",
-          "why_it_matters": "如果既难识别也难复位，复杂场景会迅速耗尽资源。",
-          "what_it_feels_like": "你可能到事后才发现自己已经很累或很烦。",
-          "strength": "适合从最小动作建立可预测性。",
-          "cost": "高压沟通中容易被动应对。",
-          "development_lever": "先练一个简单情绪词表。",
-          "micro_action": "每天一次选择一个情绪词，并写下触发场景。"
+          "title": "自我觉察 × 情绪调节｜两项都需要打底",
+          "mechanism": "这个机制解释知道自己怎么了，与能不能把自己带回来之间的关系。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Both recognition and recovery need foundations",
-          "why_it_matters": "When both noticing and resetting are hard, complex situations drain resources quickly.",
-          "what_it_feels_like": "You may realize only afterward that you were tired or irritated.",
-          "strength": "Small actions can build predictability.",
-          "cost": "High-pressure communication may become reactive.",
-          "development_lever": "Start with a simple emotion vocabulary.",
-          "micro_action": "Once a day, choose one emotion word and write the trigger."
+          "title": "Self-awareness × Emotion regulation: both signals need foundations",
+          "mechanism": "This mechanism explains how knowing what is happening inside connects with bringing yourself back. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "EM_ER": {
       "high_high": {
         "zh-CN": {
-          "title": "能理解别人，也能保留自己",
-          "why_it_matters": "共情和恢复并存时，理解他人不必以自我消耗为代价。",
-          "what_it_feels_like": "你能靠近他人情绪，也能及时回到自己的节奏。",
-          "strength": "支持他人而不容易被吞没。",
-          "cost": "可能被期待持续承担情绪支持。",
-          "development_lever": "明确支持边界。",
-          "micro_action": "先确认对方需要倾听、建议还是具体帮助。"
+          "title": "共情理解 × 情绪调节｜双高协同",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You understand others and keep yourself",
-          "why_it_matters": "When empathy and recovery coexist, understanding others does not require self-drain.",
-          "what_it_feels_like": "You can approach others' emotions and return to your own rhythm.",
-          "strength": "Support without being swallowed by the situation.",
-          "cost": "Others may expect constant emotional support.",
-          "development_lever": "Make support boundaries explicit.",
-          "micro_action": "Ask whether they need listening, advice, or concrete help."
+          "title": "Empathy × Emotion regulation: both signals support each other",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "共情强，边界和恢复偏弱",
-          "why_it_matters": "你越能理解别人，越需要知道哪些情绪不是你要承担的。",
-          "what_it_feels_like": "别人难受时，你可能很快进入帮助或自责状态。",
-          "strength": "容易让人感到被看见。",
-          "cost": "容易吸收过多情绪劳动。",
-          "development_lever": "共情后加一句边界确认。",
-          "micro_action": "在心里说：这是对方的感受，我可以支持，但不需要代替。"
+          "title": "共情理解 × 情绪调节｜前者强，后者需要补位",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Strong empathy, weaker boundaries and recovery",
-          "why_it_matters": "The more you understand others, the more you need to know what is not yours to carry.",
-          "what_it_feels_like": "When someone is distressed, you may quickly move into helping or self-blame.",
-          "strength": "People often feel seen by you.",
-          "cost": "You may absorb too much emotional labor.",
-          "development_lever": "Add one boundary check after empathy.",
-          "micro_action": "Say internally: this is their feeling; I can support without replacing them."
+          "title": "Empathy × Emotion regulation: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "稳定有余，情绪读人不足",
-          "why_it_matters": "稳定能保护你，但关系需要对他人情绪的基本回应。",
-          "what_it_feels_like": "你能保持冷静，却可能错过对方真正介意的点。",
-          "strength": "不容易被外部情绪带乱。",
-          "cost": "他人可能觉得你太理性或太远。",
-          "development_lever": "先回应感受，再处理事实。",
-          "micro_action": "说一句：我听到这件事让你很不舒服。"
+          "title": "共情理解 × 情绪调节｜后者强，前者需要补位",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Steady, but less emotionally attuned",
-          "why_it_matters": "Stability protects you, but relationships need basic emotional acknowledgment.",
-          "what_it_feels_like": "You stay calm but may miss what the other person really cares about.",
-          "strength": "External emotion disrupts you less.",
-          "cost": "Others may experience you as too rational or distant.",
-          "development_lever": "Respond to feeling before facts.",
-          "micro_action": "Say: I hear that this felt uncomfortable for you."
+          "title": "Empathy × Emotion regulation: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "理解他人与恢复都需降低难度",
-          "why_it_matters": "当共情和恢复都弱时，先降低情境复杂度比追求技巧更有效。",
-          "what_it_feels_like": "强情绪场景可能让你想躲开或快速结束。",
-          "strength": "可从低风险互动开始建立经验。",
-          "cost": "高情绪劳动场景消耗明显。",
-          "development_lever": "用固定句式承接基础情绪。",
-          "micro_action": "先说：我需要一点时间理解你说的。"
+          "title": "共情理解 × 情绪调节｜两项都需要打底",
+          "mechanism": "这个机制解释理解别人之后，能不能保留自己的节奏和恢复空间。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Lower complexity for empathy and recovery",
-          "why_it_matters": "When both empathy and recovery are weaker, reducing complexity helps more than chasing advanced technique.",
-          "what_it_feels_like": "High-emotion situations may make you want to avoid or end quickly.",
-          "strength": "Low-risk interactions can build experience.",
-          "cost": "High emotional-labor settings are draining.",
-          "development_lever": "Use a stable sentence to receive basic emotion.",
-          "micro_action": "Say: I need a little time to understand what you mean."
+          "title": "Empathy × Emotion regulation: both signals need foundations",
+          "mechanism": "This mechanism explains whether understanding others still leaves room for your own rhythm and recovery. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "EM_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "读懂别人，也能处理关系",
-          "why_it_matters": "理解和行动结合时，共情更容易变成有效协作。",
-          "what_it_feels_like": "你能读懂现场气氛，并推动关系回到可沟通状态。",
-          "strength": "适合复杂协作和关系修复。",
-          "cost": "可能过度承担协调者角色。",
-          "development_lever": "把责任边界说清楚。",
-          "micro_action": "问：这件事我能负责哪一部分？"
+          "title": "共情理解 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You read others and manage the relationship",
-          "why_it_matters": "When understanding and action combine, empathy becomes workable collaboration.",
-          "what_it_feels_like": "You can read the room and move the relationship back to communication.",
-          "strength": "Useful for complex collaboration and repair.",
-          "cost": "You may overtake the coordinator role.",
-          "development_lever": "Clarify responsibility boundaries.",
-          "micro_action": "Ask: which part of this is mine to own?"
+          "title": "Empathy × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "读懂别人，但关系动作不足",
-          "why_it_matters": "看见对方感受后，还需要把理解转成一句话或一个动作。",
-          "what_it_feels_like": "你知道对方在意什么，却不一定知道怎么回应。",
-          "strength": "关系判断较细腻。",
-          "cost": "理解停在心里，别人感受不到。",
-          "development_lever": "把理解外化成确认句。",
-          "micro_action": "说：我理解你在意的是 X，而不是只是在反对。"
+          "title": "共情理解 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You read others, but action is weaker",
-          "why_it_matters": "After seeing someone's feeling, understanding needs to become a sentence or action.",
-          "what_it_feels_like": "You know what matters to them but may not know how to respond.",
-          "strength": "Nuanced relational judgment.",
-          "cost": "Understanding stays inside and may not be felt.",
-          "development_lever": "Externalize understanding as confirmation.",
-          "micro_action": "Say: I understand that X matters to you, not just that you disagree."
+          "title": "Empathy × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "会行动，但可能没读准情绪",
-          "why_it_matters": "关系动作如果没有情绪理解，容易变成流程化处理。",
-          "what_it_feels_like": "你会推进解决，但对方可能觉得重点没被接住。",
-          "strength": "能快速进入处理模式。",
-          "cost": "修复动作可能不够贴合。",
-          "development_lever": "行动前先做一次情绪校准。",
-          "micro_action": "问：这件事里你最难受的是哪一部分？"
+          "title": "共情理解 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You act, but may miss the emotion",
-          "why_it_matters": "Relational action without emotional understanding can become procedural.",
-          "what_it_feels_like": "You move into solving while the other person may feel the point was missed.",
-          "strength": "Fast entry into action mode.",
-          "cost": "Repair may not fit the real concern.",
-          "development_lever": "Calibrate emotion before action.",
-          "micro_action": "Ask: which part of this felt hardest for you?"
+          "title": "Empathy × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "关系理解和行动都需要脚手架",
-          "why_it_matters": "复杂关系不能只靠临场反应，需要可复用脚本。",
-          "what_it_feels_like": "你可能不知道对方为何反应强，也不知道下一句怎么说。",
-          "strength": "固定脚本能快速提升可用性。",
-          "cost": "临场压力下容易沉默或回避。",
-          "development_lever": "先学低风险确认句。",
-          "micro_action": "说：我可能没完全理解，你能再说一次你的重点吗？"
+          "title": "共情理解 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释读懂别人之后，能不能把关系推进到清楚和可修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Relational understanding and action need scaffolding",
-          "why_it_matters": "Complex relationships need reusable scripts, not only improvisation.",
-          "what_it_feels_like": "You may not know why they reacted strongly or what to say next.",
-          "strength": "Stable scripts can improve usability quickly.",
-          "cost": "Under pressure, silence or avoidance may appear.",
-          "development_lever": "Start with low-risk confirmation lines.",
-          "micro_action": "Say: I may not fully understand; can you restate your main point?"
+          "title": "Empathy × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains whether reading others can become clear and repairable relational action. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "SA_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "能表达自己，也能维护关系",
-          "why_it_matters": "自我清楚和关系行动结合时，边界更容易被听见。",
-          "what_it_feels_like": "你能说出自己的感受，同时照顾沟通继续。",
-          "strength": "适合边界、反馈和修复场景。",
-          "cost": "可能被期待承担沟通示范。",
-          "development_lever": "让表达更简洁。",
-          "micro_action": "用我感到、我需要、我建议三句完成表达。"
+          "title": "自我觉察 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You express yourself and maintain the relationship",
-          "why_it_matters": "When self-clarity and relational action combine, boundaries are easier to hear.",
-          "what_it_feels_like": "You can state your feeling while keeping communication possible.",
-          "strength": "Useful in boundaries, feedback, and repair.",
-          "cost": "You may be expected to model communication for others.",
-          "development_lever": "Make expression more concise.",
-          "micro_action": "Use: I feel, I need, I suggest."
+          "title": "Self-awareness × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "自我清楚，但关系承接不足",
-          "why_it_matters": "表达自己之后，需要给关系一个继续对话的入口。",
-          "what_it_feels_like": "你能说清立场，但对方可能进入防御。",
-          "strength": "不容易丢失自我。",
-          "cost": "表达可能被听成指责。",
-          "development_lever": "表达后加一句共同目标。",
-          "micro_action": "说：我讲这个是希望我们下次更好配合。"
+          "title": "自我觉察 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Self-clear, but relational holding is weaker",
-          "why_it_matters": "After expressing yourself, the relationship needs an entry point to continue.",
-          "what_it_feels_like": "You can state your position, but the other person may become defensive.",
-          "strength": "You are less likely to lose yourself.",
-          "cost": "Expression may be heard as blame.",
-          "development_lever": "Add a shared goal after expression.",
-          "micro_action": "Say: I am raising this so we can work better next time."
+          "title": "Self-awareness × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "会维护关系，但自我容易后置",
-          "why_it_matters": "如果只维护关系，不表达自我，长期会积累消耗。",
-          "what_it_feels_like": "你能把场面圆回来，但之后才发现自己不舒服。",
-          "strength": "关系稳定和协作维持能力强。",
-          "cost": "自己的需求容易被延后。",
-          "development_lever": "回应前先问自己底线。",
-          "micro_action": "在答应前停三秒，确认我是否真的可以。"
+          "title": "自我觉察 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You maintain relationships, but self may come later",
-          "why_it_matters": "If you only preserve the relationship and do not express yourself, cost accumulates.",
-          "what_it_feels_like": "You smooth the moment, then later notice discomfort.",
-          "strength": "Strong relational stability and collaboration maintenance.",
-          "cost": "Your needs may be delayed.",
-          "development_lever": "Check your boundary before responding.",
-          "micro_action": "Pause three seconds before agreeing and ask whether you truly can."
+          "title": "Self-awareness × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "自我表达和关系修复都需要练习",
-          "why_it_matters": "当自我和关系动作都弱时，先从低风险表达开始。",
-          "what_it_feels_like": "你可能既不想说破，也不知道怎么收场。",
-          "strength": "可用结构化脚本降低难度。",
-          "cost": "问题容易拖延或变成误会。",
-          "development_lever": "练习一句低强度真实表达。",
-          "micro_action": "说：这件事我还需要想一下，晚点回复你。"
+          "title": "自我觉察 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释表达真实自己，同时让关系还能继续对话。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Self-expression and repair both need practice",
-          "why_it_matters": "When self and relational moves are both weaker, start with low-risk expression.",
-          "what_it_feels_like": "You may not want to say it directly and may not know how to close the loop.",
-          "strength": "Structured scripts can lower difficulty.",
-          "cost": "Issues may be delayed or become misunderstandings.",
-          "development_lever": "Practice one low-intensity truthful sentence.",
-          "micro_action": "Say: I need to think about this and will reply later."
+          "title": "Self-awareness × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains expressing yourself honestly while keeping the relationship open. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     },
     "ER_RM": {
       "high_high": {
         "zh-CN": {
-          "title": "压力下仍能沟通和修复",
-          "why_it_matters": "恢复能力和关系行动结合，是冲突后继续合作的关键。",
-          "what_it_feels_like": "你能先稳住自己，再把对话拉回问题本身。",
-          "strength": "冲突恢复和协作韧性强。",
-          "cost": "可能成为默认救火者。",
-          "development_lever": "把修复责任分给双方。",
-          "micro_action": "问：我们各自下一步能做什么？"
+          "title": "情绪调节 × 关系管理｜双高协同",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这两项信号可以互相支持，重点是不要把稳定变成默认责任。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你通常既能看见线索，也能采取较可用的行动。",
+          "strength": "协同能力强，容易成为关系中的稳定点。",
+          "cost": "别人可能过度依赖你的稳定。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You can communicate and repair under pressure",
-          "why_it_matters": "Recovery plus relational action is key to collaboration after conflict.",
-          "what_it_feels_like": "You can steady yourself and bring the conversation back to the issue.",
-          "strength": "Strong conflict recovery and collaborative resilience.",
-          "cost": "You may become the default fixer.",
-          "development_lever": "Share repair responsibility.",
-          "micro_action": "Ask: what can each of us do next?"
+          "title": "Emotion regulation × Relationship management: both signals support each other",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The two signals can reinforce each other; the key is not turning stability into default responsibility.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can usually notice the signal and take a usable action.",
+          "strength": "Strong coordination can make you a stabilizing presence.",
+          "cost": "Others may rely too much on your steadiness.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "high_low": {
         "zh-CN": {
-          "title": "自己能稳住，但关系未必修复",
-          "why_it_matters": "你恢复了，不代表对话或关系已经恢复。",
-          "what_it_feels_like": "你可能觉得事情过去了，但对方还停在情绪里。",
-          "strength": "能减少个人失控。",
-          "cost": "关系裂缝可能被低估。",
-          "development_lever": "复位后做一次关系确认。",
-          "micro_action": "说：刚才那段对话你现在感觉怎么样？"
+          "title": "情绪调节 × 关系管理｜前者强，后者需要补位",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。强项会让你更早发现问题，但弱项决定你能否把它落地。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你知道很多或感到很多，但后一步不够稳。",
+          "strength": "强项能成为练习入口。",
+          "cost": "强项可能因为后续动作不足而变成消耗。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You stabilize yourself, but repair may not happen",
-          "why_it_matters": "Your recovery does not mean the conversation or relationship has recovered.",
-          "what_it_feels_like": "You may feel it has passed while the other person is still in it.",
-          "strength": "Less personal escalation.",
-          "cost": "Relationship cracks may be underestimated.",
-          "development_lever": "Check the relationship after reset.",
-          "micro_action": "Say: how are you feeling about that conversation now?"
+          "title": "Emotion regulation × Relationship management: the first signal is stronger; the second needs support",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. The strength helps you notice earlier, but the weaker signal determines whether it becomes usable action.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You notice or feel a lot, but the next step is less stable.",
+          "strength": "The stronger signal can become the practice entry point.",
+          "cost": "The strength may become draining when follow-through is weak.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_high": {
         "zh-CN": {
-          "title": "想修复关系，但压力下难稳定",
-          "why_it_matters": "关系意愿很重要，但压力未复位时动作容易变形。",
-          "what_it_feels_like": "你想把事情讲好，却可能越讲越急。",
-          "strength": "有合作和修复动机。",
-          "cost": "调节不足会削弱修复效果。",
-          "development_lever": "先复位，再修复。",
-          "micro_action": "先暂停十分钟，再发出修复信息。"
+          "title": "情绪调节 × 关系管理｜后者强，前者需要补位",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。行动能力存在，但如果前置信号不清，容易稳定地处理了错误问题。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你能做出反应，但未必说得清真正触发点。",
+          "strength": "执行或稳定性较可用。",
+          "cost": "缺少命名会让同类问题反复出现。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "You want repair, but pressure makes stability harder",
-          "why_it_matters": "Repair motivation matters, but actions distort when you have not reset.",
-          "what_it_feels_like": "You want to talk it through, but may become more urgent as you speak.",
-          "strength": "Motivation for cooperation and repair.",
-          "cost": "Weak regulation can reduce repair effectiveness.",
-          "development_lever": "Reset before repair.",
-          "micro_action": "Pause for ten minutes before sending the repair message."
+          "title": "Emotion regulation × Relationship management: the second signal is stronger; the first needs support",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. Action is available, but unclear input can make you solve the wrong problem steadily.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You can respond, but may not know what actually triggered the situation.",
+          "strength": "Execution or steadiness is usable.",
+          "cost": "Weak naming lets similar situations repeat.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       },
       "low_low": {
         "zh-CN": {
-          "title": "压力和关系修复都需要最小闭环",
-          "why_it_matters": "高压关系场景中，需要简单、可重复的停顿和回到问题的动作。",
-          "what_it_feels_like": "冲突中你可能沉默、爆发或想尽快结束。",
-          "strength": "小流程能显著降低失控概率。",
-          "cost": "没有流程时关系容易积累未修复问题。",
-          "development_lever": "建立冲突暂停协议。",
-          "micro_action": "说：我需要十分钟冷静，然后我们只谈下一步。"
+          "title": "情绪调节 × 关系管理｜两项都需要打底",
+          "mechanism": "这个机制解释压力下能不能沟通、降温和修复。这不是失败信号，而是说明要先建立最小可重复流程。",
+          "why_it_matters": "单个维度告诉你哪里强弱，组合机制解释为什么同一个分数会在现实关系里变成优势、代价或练习入口。",
+          "what_it_feels_like": "你可能事后才发现自己已经很累或关系已经卡住。",
+          "strength": "从最小动作开始，反馈会更清楚。",
+          "cost": "复杂场景里容易被动应对。",
+          "development_lever": "把机制放回一个具体场景，只练一个最小动作。",
+          "micro_action": "下次类似场景出现时，先说一句准备好的降温或澄清句。",
+          "do_not_overread": "机制解释不是人格标签，也不是对每段关系的固定判断。"
         },
         "en": {
-          "title": "Pressure and repair need a minimal loop",
-          "why_it_matters": "High-pressure relational situations need simple repeatable pauses and return-to-issue moves.",
-          "what_it_feels_like": "In conflict, you may go silent, escalate, or want to end quickly.",
-          "strength": "A small process can reduce escalation risk.",
-          "cost": "Without a process, unrepaired issues accumulate.",
-          "development_lever": "Create a conflict pause protocol.",
-          "micro_action": "Say: I need ten minutes to cool down, then let's discuss only the next step."
+          "title": "Emotion regulation × Relationship management: both signals need foundations",
+          "mechanism": "This mechanism explains communicating, cooling down, and repairing under pressure. This is not a failure signal; it points to the need for a smallest repeatable process.",
+          "why_it_matters": "A single dimension shows strength or gap; a mechanism explains how the same score becomes strength, cost, or practice entry in real relationships.",
+          "what_it_feels_like": "You may notice only afterward that you were drained or that the relationship was stuck.",
+          "strength": "Small actions can make the feedback clearer.",
+          "cost": "Complex scenes may push you into reactive coping.",
+          "development_lever": "Put the mechanism back into one concrete scene and practice one smallest action.",
+          "micro_action": "In the next similar scene, use one prepared cooling or clarifying sentence first.",
+          "do_not_overread": "A mechanism is not a personality label or a fixed judgment about every relationship."
         }
       }
     }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/psychometric_evidence_status.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/psychometric_evidence_status.json
@@ -1,0 +1,195 @@
+{
+  "schema": "eq60.report_assets.psychometric_evidence_status.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.evidence.content_validity": {
+      "zh-CN": {
+        "status": "preliminary",
+        "body": "题项和报告维度已有内容映射，但需要持续专家复核和用户反馈。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "preliminary",
+        "body": "Items and report dimensions have content mapping, with ongoing need for expert review and user feedback.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.content_validity",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "content_validity"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.internal_consistency": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "后续应按语言、地区和维度计算内部一致性，并记录版本。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Future work should estimate internal consistency by language, region, and dimension with version tracking.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.internal_consistency",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "internal_consistency"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.test_retest": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "建议在 30–90 天窗口评估稳定性和可变性。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "A 30–90 day window should be used to evaluate stability and change.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.test_retest",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "test_retest"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.factor_structure": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "需要用 EFA/CFA 或其他合适方法验证四维结构。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "The four-dimension structure should be evaluated with EFA/CFA or suitable methods.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.factor_structure",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "factor_structure"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.criterion_validity": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "可探索与工作满意、关系满意、压力恢复等低风险外部指标的关联。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Associations with low-risk external indicators such as work satisfaction, relationship satisfaction, and recovery may be explored.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.criterion_validity",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "criterion_validity"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.measurement_invariance": {
+      "zh-CN": {
+        "status": "planned",
+        "body": "中英文和主要人群组之间需要做等值或 DIF 检查。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "planned",
+        "body": "Chinese/English and major user groups require invariance or DIF checks.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.measurement_invariance",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "measurement_invariance"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.evidence.norm_status": {
+      "zh-CN": {
+        "status": "provisional",
+        "body": "当前常模解释为阶段性版本，不应被理解为最终全球常模。",
+        "do_not_overread": "证据状态透明不是削弱产品，而是防止过度解释。",
+        "user_facing_status_label": "证据持续建设中",
+        "what_this_means_for_user": "你可以把结果用于自我理解、沟通反思和成长计划，但不应用于高风险决策。",
+        "next_validation_step": "后续应通过样本扩展、复测稳定性、用户反馈和专家复核持续验证。"
+      },
+      "en": {
+        "status": "provisional",
+        "body": "Current norms are provisional and should not be read as final global norms.",
+        "do_not_overread": "Transparent evidence status strengthens proper interpretation.",
+        "user_facing_status_label": "Evidence is still being built",
+        "what_this_means_for_user": "Use the result for self-understanding, communication reflection, and growth planning, not high-risk decisions.",
+        "next_validation_step": "Next validation should include larger samples, retest stability, user feedback, and expert review."
+      },
+      "meta": {
+        "id": "eq.evidence.norm_status",
+        "asset_type": "psychometric_evidence_status",
+        "purpose": "State evidence maturity",
+        "trigger_logic": {
+          "evidence_area": "norm_status"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/quality_confidence.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/quality_confidence.json
@@ -1,0 +1,122 @@
+{
+  "schema": "eq60.report_assets.quality_confidence.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.quality.level.A": {
+      "zh-CN": {
+        "label": "高置信",
+        "body": "本次作答节奏和一致性支持较稳定解释。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "可在未来复测观察稳定变化。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "High confidence",
+        "body": "The response pattern supports a relatively stable interpretation.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "Retest later to observe stable change.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.A",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "A"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.quality.level.B": {
+      "zh-CN": {
+        "label": "正常置信",
+        "body": "本次结果可用于阅读主要模式，但仍建议结合现实场景理解。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "可在未来复测观察稳定变化。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Standard confidence",
+        "body": "The result can be used for the main pattern, while still being read with real-life context.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "Retest later to observe stable change.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.B",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "B"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.quality.level.C": {
+      "zh-CN": {
+        "label": "中等置信",
+        "body": "本次结果适合作为初步参考，强结论需要减少。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Moderate confidence",
+        "body": "The result is best treated as a preliminary reference; strong conclusions should be reduced.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.C",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "C"
+        },
+        "claim_sensitivity": "high"
+      }
+    },
+    "eq.quality.level.D": {
+      "zh-CN": {
+        "label": "低置信",
+        "body": "本次结果应轻读，优先看作答状态和复测建议。",
+        "user_guidance": "根据置信度调整阅读力度，不要用它评价自己。",
+        "retest_note": "如果你作答很快、很累或分心，建议稍后复测。",
+        "why_this_level": "根据作答完整度、节奏、一致性、极端/中立倾向和反应模式综合判断。",
+        "how_to_read": "置信度决定阅读力度：高置信可看模式与行动，低置信先看作答状态和复测建议。",
+        "commercial_display": "建议在结果页用质量 Banner 明示，不隐藏在页脚。"
+      },
+      "en": {
+        "label": "Lower confidence",
+        "body": "Read this result lightly; focus on response context and retest guidance.",
+        "user_guidance": "Adjust how strongly you read the report; do not use it to judge yourself.",
+        "retest_note": "If you answered quickly, tiredly, or while distracted, retest later.",
+        "why_this_level": "Based on completion, response pace, consistency, extreme or neutral tendency, and response pattern.",
+        "how_to_read": "Confidence controls reading strength: high confidence supports pattern and action; low confidence points first to response context and retest guidance.",
+        "commercial_display": "Show this in the result-page quality banner, not only in a footer."
+      },
+      "meta": {
+        "id": "eq.quality.level.D",
+        "asset_type": "quality_confidence",
+        "purpose": "Explain report confidence",
+        "trigger_logic": {
+          "quality_level": "D"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/reality_translation.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/reality_translation.json
@@ -4,98 +4,1608 @@
   "scenes": {
     "feedback": {
       "zh-CN": {
-        "title": "反馈场景",
-        "typical_response": "收到评价或修改意见时，你可能先捕捉语气和关系信号，再处理信息本身。",
-        "strength": "能注意到反馈背后的真实意图和关系温度。",
-        "cost": "如果恢复不足，容易把反馈体验成否定。",
-        "better_move": "先拆分事实、情绪和下一步：对方说了什么，我有什么感受，我要确认什么。"
+        "title": "反馈",
+        "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先问清反馈指向，再决定解释或调整。",
+        "context": "别人指出问题、要求修改或评价你的表现时。",
+        "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
         "title": "Feedback",
-        "typical_response": "When receiving critique or edits, you may notice tone and relational cues before processing the information.",
-        "strength": "You can notice intent and relational temperature behind feedback.",
-        "cost": "When recovery is weak, feedback may feel like rejection.",
-        "better_move": "Separate facts, feeling, and next step: what was said, what I feel, what I need to clarify."
+        "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Clarify the target of the feedback before explaining or changing.",
+        "context": "When someone points out a problem, requests changes, or evaluates your work.",
+        "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "conflict": {
       "zh-CN": {
-        "title": "冲突场景",
-        "typical_response": "出现分歧时，你可能在维护关系和表达自己之间摇摆。",
-        "strength": "有机会同时看见双方需求。",
-        "cost": "如果没有暂停流程，容易过度解释、回避或急于修复。",
-        "better_move": "先确认共同目标，再只讨论一个具体问题。"
+        "title": "冲突",
+        "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先把冲突缩小成一个可处理的问题。",
+        "context": "意见分歧、语气升高或彼此防御时。",
+        "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
         "title": "Conflict",
-        "typical_response": "During disagreement, you may move between preserving the relationship and expressing yourself.",
-        "strength": "You can often see needs on both sides.",
-        "cost": "Without a pause process, you may over-explain, avoid, or rush repair.",
-        "better_move": "Name the shared goal first, then discuss one specific issue."
+        "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Narrow the conflict to one workable issue first.",
+        "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+        "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "relationship_boundary": {
       "zh-CN": {
         "title": "关系边界",
-        "typical_response": "当别人需要你支持时，你可能很快进入理解或承担。",
-        "strength": "容易让对方感到被接住。",
-        "cost": "支持和代替之间的边界可能变模糊。",
-        "better_move": "先问自己：我能支持到哪里，哪一部分仍然属于对方。"
+        "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "先承认对方感受，再说明自己的可承接范围。",
+        "context": "别人期待你理解、帮忙、让步或继续承接时。",
+        "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Relationship Boundaries",
-        "typical_response": "When someone needs support, you may quickly move into understanding or taking responsibility.",
-        "strength": "Others may feel received and understood.",
-        "cost": "The line between supporting and replacing can blur.",
-        "better_move": "Ask yourself: how far can I support, and which part remains theirs?"
+        "title": "Relationship boundary",
+        "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+        "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+        "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "team_collaboration": {
       "zh-CN": {
         "title": "团队协作",
-        "typical_response": "在多人协作中，你可能同时追踪任务、关系和现场情绪。",
-        "strength": "能发现协作中的隐性阻力。",
-        "cost": "如果总是主动协调，容易承担过多情绪劳动。",
-        "better_move": "把观察转成具体协作请求，而不是默默补位。"
+        "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "把气氛问题转成角色、节奏和下一步。",
+        "context": "多人协作、目标不清或责任交叉时。",
+        "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Team Collaboration",
-        "typical_response": "In group work, you may track task, relationship, and emotional climate at the same time.",
-        "strength": "You can notice hidden friction in collaboration.",
-        "cost": "If you always coordinate, you may carry too much emotional labor.",
-        "better_move": "Turn observations into concrete collaboration requests instead of silently compensating."
+        "title": "Team collaboration",
+        "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+        "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+        "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "pressure_recovery": {
       "zh-CN": {
         "title": "压力恢复",
-        "typical_response": "高压后你可能仍在脑内回放对话、评价或细节。",
-        "strength": "复盘能力可以帮助你学习模式。",
-        "cost": "没有恢复边界时，复盘会变成反刍。",
-        "better_move": "给复盘设限：只写三个事实、一个感受、一个下次动作。"
+        "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "离开场景后安排一个低输入恢复动作。",
+        "context": "一段高压互动结束后，你需要重新回到自己。",
+        "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Pressure Recovery",
-        "typical_response": "After pressure, you may replay conversations, judgments, or details in your head.",
-        "strength": "Review can help you learn patterns.",
-        "cost": "Without recovery boundaries, review turns into rumination.",
-        "better_move": "Limit review to three facts, one feeling, and one next action."
+        "title": "Pressure recovery",
+        "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "After the scene, schedule one low-input recovery move.",
+        "context": "After a high-pressure interaction, when you need to return to yourself.",
+        "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
       }
     },
     "career_environment": {
       "zh-CN": {
         "title": "职业环境",
-        "typical_response": "你对岗位中的人际密度、情绪劳动和反馈强度会有不同消耗。",
-        "strength": "理解环境变量后，更容易选择适合自己的工作节奏。",
-        "cost": "只看职位名称，容易忽略真正消耗你的工作条件。",
-        "better_move": "评估岗位时优先询问互动频率、冲突频率和恢复空间。"
+        "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+        "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "cost": "如果强行套用画像，可能比不看结果更误导。",
+        "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+        "context": "你判断一个工作环境会滋养你还是消耗你时。",
+        "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+        "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。",
+        "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。"
       },
       "en": {
-        "title": "Career Environment",
-        "typical_response": "Interpersonal density, emotional labor, and feedback intensity can drain you differently across roles.",
-        "strength": "Understanding environmental variables helps you choose a better work rhythm.",
-        "cost": "Job titles alone can hide the conditions that actually drain you.",
-        "better_move": "When evaluating roles, ask about interaction frequency, conflict frequency, and recovery space."
+        "title": "Career environment",
+        "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+        "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "better_move": "Verify environment variables instead of deriving a job from EQ.",
+        "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+        "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+        "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison.",
+        "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction."
+      }
+    }
+  },
+  "formulation_scenes": {
+    "balanced_integrated": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能同时照顾自己的状态、他人的感受和关系目标。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You can hold your own state, other people, and the relationship goal in view at the same time. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能同时照顾自己的状态、他人的感受和关系目标。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You can hold your own state, other people, and the relationship goal in view at the same time. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。 你需要把理解和可承接范围分开。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能把情绪、关系和任务放在同一个画面里思考。 但如果规则不清，别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can keep emotion, relationship, and task in the same frame. But when rules are unclear, others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我来稳住”改成“我们一起定规则”。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, move from “i will steady this” to “we need a shared rule.”",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+          "cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can keep emotion, relationship, and task in the same frame.",
+          "cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "high_empathy_low_recovery": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你很快读到别人的状态，但恢复系统常常追不上共情速度。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You read the room quickly, but recovery can lag behind empathy. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你很快读到别人的状态，但恢复系统常常追不上共情速度。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You read the room quickly, but recovery can lag behind empathy. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能把别人的压力带回自己身上，离开场景后还在消化。 你需要把理解和可承接范围分开。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may carry other people’s pressure with you long after the moment ends. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你容易让别人感到被理解，尤其在情绪强烈的时刻。 但如果规则不清，你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can make people feel understood, especially when emotions run high. But when rules are unclear, you may carry other people’s pressure with you long after the moment ends.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，练习“理解但不接管”，让共情后面跟着边界。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, practice understanding without taking over, so empathy is followed by boundary.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can make people feel understood, especially when emotions run high.",
+          "cost": "You may carry other people’s pressure with you long after the moment ends.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "aware_but_unregulated": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你常知道自己怎么了，但把自己带回来需要更长时间。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You often know what is happening inside, but the reset button is slower than the insight. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你常知道自己怎么了，但把自己带回来需要更长时间。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You often know what is happening inside, but the reset button is slower than the insight. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，越清楚自己被触发，越可能陷入反复分析或即时反应。 你需要把理解和可承接范围分开。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, The clearer the trigger feels, the easier it can be to over-analyze or react too soon. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能清楚识别触发点、感受和需要。 但如果规则不清，越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can identify triggers, feelings, and needs with unusual clarity. But when rules are unclear, the clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把觉察压缩成一个暂停动作，而不是继续解释。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn awareness into one pause action instead of another layer of explanation.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能清楚识别触发点、感受和需要。",
+          "cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+          "cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "calm_but_distant": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能稳住事情，但别人不一定感到被情绪上接住。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You can steady the situation, but people may not always feel emotionally met. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能稳住事情，但别人不一定感到被情绪上接住。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You can steady the situation, but people may not always feel emotionally met. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，关系里的人可能觉得你有答案，但没有真正回应他们。 你需要把理解和可承接范围分开。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, People may feel that you have answers without feeling that you have responded to them. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你不容易被情绪推着走，能保留判断和节奏。 但如果规则不清，关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are less likely to be pushed around by emotion and can keep judgment and pace. But when rules are unclear, people may feel that you have answers without feeling that you have responded to them.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先回应一句感受，再给建议或方案。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, acknowledge one feeling before offering advice or a solution.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你不容易被情绪推着走，能保留判断和节奏。",
+          "cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "cost": "People may feel that you have answers without feeling that you have responded to them.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "relationship_first_self_later": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你会先保护关系，再回头找自己的真实立场。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You protect the relationship first and find your own position later. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你会先保护关系，再回头找自己的真实立场。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You protect the relationship first and find your own position later. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能很晚才意识到自己其实不愿意、不同意或已经累了。 你需要把理解和可承接范围分开。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may notice too late that you disagreed, felt unwilling, or were already depleted. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你敏感于关系气氛，愿意让互动维持可进行。 但如果规则不清，你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are sensitive to relational tone and often keep interaction workable. But when rules are unclear, you may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，在照顾关系前，先给自己的感受一个位置。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, give your own feeling a place before you manage the relationship.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+          "cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are sensitive to relational tone and often keep interaction workable.",
+          "cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "self_clear_repair_weak": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你知道自己的立场，但冲突后的修复需要更明确的工具。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You know your position, but repair after tension needs a clearer tool. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你知道自己的立场，但冲突后的修复需要更明确的工具。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You know your position, but repair after tension needs a clearer tool. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。 你需要把理解和可承接范围分开。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Without repair, others may remember the force of the moment more than your point. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你不容易在关系压力里丢掉自己的判断。 但如果规则不清，如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are less likely to lose your judgment under relational pressure. But when rules are unclear, without repair, others may remember the force of the moment more than your point.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我说清楚了”补成“我们怎么重新对齐”。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, add “how do we realign?” after “i made my point.”",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你不容易在关系压力里丢掉自己的判断。",
+          "cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are less likely to lose your judgment under relational pressure.",
+          "cost": "Without repair, others may remember the force of the moment more than your point.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "steady_collaborator": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能在压力下维持合作推进，但别让稳定只靠你一个人。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You keep collaboration moving under pressure, but steadiness should not depend only on you. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能在压力下维持合作推进，但别让稳定只靠你一个人。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You keep collaboration moving under pressure, but steadiness should not depend only on you. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，团队可能习惯让你来降温、翻译和收尾。 你需要把理解和可承接范围分开。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Teams may get used to you cooling things down, translating tension, and closing loops. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你能把紧张对话拉回事实、目标和下一步。 但如果规则不清，团队可能习惯让你来降温、翻译和收尾。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You can bring tense conversations back to facts, goals, and next steps. But when rules are unclear, teams may get used to you cooling things down, translating tension, and closing loops.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把个人稳定能力变成团队流程。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, turn personal steadiness into team process.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你能把紧张对话拉回事实、目标和下一步。",
+          "cost": "团队可能习惯让你来降温、翻译和收尾。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You can bring tense conversations back to facts, goals, and next steps.",
+          "cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "sensitive_absorber": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你能捕捉细微变化，但敏感也容易变成情绪负重。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, You catch subtle shifts fast, and that sensitivity can become emotional load. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你能捕捉细微变化，但敏感也容易变成情绪负重。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, You catch subtle shifts fast, and that sensitivity can become emotional load. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，你可能回应了太多信号，最后分不清哪些真的需要你处理。 你需要把理解和可承接范围分开。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, You may respond to too many signals and lose track of which ones actually need your action. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你很快发现气氛、语气和关系位置的变化。 但如果规则不清，你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You quickly notice shifts in tone, mood, and relational position. But when rules are unclear, you may respond to too many signals and lose track of which ones actually need your action.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，把“我感到了”区分成“我要不要回应”。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, separate “i noticed it” from “i need to respond.”",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你很快发现气氛、语气和关系位置的变化。",
+          "cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You quickly notice shifts in tone, mood, and relational position.",
+          "cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "developing_foundation": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果一次想改太多，容易很快放弃或自我否定。 你需要把理解和可承接范围分开。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Trying to change everything at once can lead to quick discouragement or self-criticism. The skill is separating understanding from what you can realistically take on.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，你已经开始把情绪和关系当成可以观察、可以练习的对象。 但如果规则不清，如果一次想改太多，容易很快放弃或自我否定。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, You are beginning to treat emotion and relationships as observable and trainable. But when rules are unclear, trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先把一个情绪命名清楚，再谈复杂改变。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, name one feeling clearly before attempting a larger change.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "cost": "如果一次想改太多，容易很快放弃或自我否定。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+          "cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      }
+    },
+    "low_confidence_result": {
+      "feedback": {
+        "zh-CN": {
+          "scene_label": "反馈",
+          "context": "别人指出问题、要求修改或评价你的表现时。",
+          "typical_response": "收到反馈时，这次结果应轻一点读，最有价值的是理解本次作答状态。 你最容易受影响的不是分数本身，而是反馈背后的关系信号。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先问清反馈指向，再决定解释或调整。",
+          "one_sentence_script": "我想先确认一下，你最希望我调整的是结果、过程，还是沟通方式？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Feedback",
+          "context": "When someone points out a problem, requests changes, or evaluates your work.",
+          "typical_response": "In feedback, Read this result lightly; the most useful signal is the response context of this session. The sensitive point is often not the score itself, but the relationship signal behind the feedback.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Clarify the target of the feedback before explaining or changing.",
+          "one_sentence_script": "Can I clarify whether you want me to change the outcome, the process, or the way I communicated?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "conflict": {
+        "zh-CN": {
+          "scene_label": "冲突",
+          "context": "意见分歧、语气升高或彼此防御时。",
+          "typical_response": "冲突中，这次结果应轻一点读，最有价值的是理解本次作答状态。 这个模式会决定你是先稳住、先解释、先承接，还是先退出。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先把冲突缩小成一个可处理的问题。",
+          "one_sentence_script": "我们先把问题缩小到一个点：现在最需要解决的是什么？",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Conflict",
+          "context": "When disagreement, sharper tone, or mutual defensiveness appears.",
+          "typical_response": "In conflict, Read this result lightly; the most useful signal is the response context of this session. This pattern shapes whether you stabilize, explain, absorb, or exit first.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Narrow the conflict to one workable issue first.",
+          "one_sentence_script": "Let’s narrow this to one issue: what needs to be solved first?",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "relationship_boundary": {
+        "zh-CN": {
+          "scene_label": "关系边界",
+          "context": "别人期待你理解、帮忙、让步或继续承接时。",
+          "typical_response": "边界场景里，如果强行套用画像，可能比不看结果更误导。 你需要把理解和可承接范围分开。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "先承认对方感受，再说明自己的可承接范围。",
+          "one_sentence_script": "我理解这对你很重要，我现在能承接的是这一部分。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Relationship boundary",
+          "context": "When someone expects understanding, help, concession, or continued emotional availability.",
+          "typical_response": "In boundary moments, Forcing a profile onto this result could be more misleading than useful. The skill is separating understanding from what you can realistically take on.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Acknowledge the feeling, then state what you can realistically take on.",
+          "one_sentence_script": "I understand this matters to you. What I can take on right now is this part.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "team_collaboration": {
+        "zh-CN": {
+          "scene_label": "团队协作",
+          "context": "多人协作、目标不清或责任交叉时。",
+          "typical_response": "协作中，即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。 但如果规则不清，如果强行套用画像，可能比不看结果更误导。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "把气氛问题转成角色、节奏和下一步。",
+          "one_sentence_script": "我们先确认角色、截止时间和下一步，不让情绪替我们做决定。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Team collaboration",
+          "context": "When several people collaborate with unclear goals or overlapping responsibility.",
+          "typical_response": "In collaboration, Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe. But when rules are unclear, forcing a profile onto this result could be more misleading than useful.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Turn emotional friction into roles, rhythm, and next steps.",
+          "one_sentence_script": "Let’s clarify roles, timing, and the next step so emotion does not make the decision for us.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "pressure_recovery": {
+        "zh-CN": {
+          "scene_label": "压力恢复",
+          "context": "一段高压互动结束后，你需要重新回到自己。",
+          "typical_response": "高压互动结束后，真正的信号是你多久能回到自己。对你来说，先记录状态，之后在更稳定的时间复测。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "离开场景后安排一个低输入恢复动作。",
+          "one_sentence_script": "我需要十分钟低输入时间，之后再回来处理下一步。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Pressure recovery",
+          "context": "After a high-pressure interaction, when you need to return to yourself.",
+          "typical_response": "After pressure, the real signal is how long it takes to return to yourself. For this pattern, record the context first, then retest when conditions are steadier.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "After the scene, schedule one low-input recovery move.",
+          "one_sentence_script": "I need ten minutes of low input, then I can come back to the next step.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
+      },
+      "career_environment": {
+        "zh-CN": {
+          "scene_label": "职业环境",
+          "context": "你判断一个工作环境会滋养你还是消耗你时。",
+          "typical_response": "选择环境时，重点不是哪个职业适合你，而是哪类互动密度、反馈强度和恢复空间会放大这个模式。",
+          "strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "cost": "如果强行套用画像，可能比不看结果更误导。",
+          "better_move": "验证环境变量，不用 EQ 直接推导职业。",
+          "one_sentence_script": "我想验证这个环境的互动频率、反馈方式和恢复空间。",
+          "do_not_overread": "这是场景化解释，不是对每次互动的固定预测。",
+          "commercial_use": "可用于结果页场景卡、Agent 场景追问和复测对比。"
+        },
+        "en": {
+          "scene_label": "Career environment",
+          "context": "When you judge whether a work setting will support or drain your emotional pattern.",
+          "typical_response": "When choosing a work setting, the question is not which job fits you; it is which interaction density, feedback intensity, and recovery space amplify this pattern.",
+          "strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "cost": "Forcing a profile onto this result could be more misleading than useful.",
+          "better_move": "Verify environment variables instead of deriving a job from EQ.",
+          "one_sentence_script": "I want to verify the interaction pace, feedback style, and recovery space in this environment.",
+          "do_not_overread": "This is a scene translation, not a fixed prediction for every interaction.",
+          "commercial_use": "Use in result scene cards, Agent scene follow-ups, and retest comparison."
+        }
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/result_snapshot.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/result_snapshot.json
@@ -1,0 +1,572 @@
+{
+  "schema": "eq60.report_assets.result_snapshot.v1",
+  "pack_id": "EQ_60",
+  "assets": {
+    "eq.snapshot.balanced_integrated": {
+      "zh-CN": {
+        "headline": "均衡整合型",
+        "core_judgment": "你能同时照顾自己的状态、他人的感受和关系目标。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能同时照顾自己的状态、他人的感受和关系目标。",
+          "你能把情绪、关系和任务放在同一个画面里思考。",
+          "下一步：把“我来稳住”改成“我们一起定规则”。"
+        ],
+        "top_strength": "你能把情绪、关系和任务放在同一个画面里思考。",
+        "likely_cost": "别人可能默认你来稳定局面，久了会变成隐形情绪劳动。",
+        "minimal_action": "把“我来稳住”改成“我们一起定规则”。",
+        "share_safe_sentence": "我能稳定关系，但不必独自维护整个关系系统。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Balanced Integrator",
+        "core_judgment": "You can hold your own state, other people, and the relationship goal in view at the same time.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You can hold your own state, other people, and the relationship goal in view at the same time.",
+          "You can keep emotion, relationship, and task in the same frame.",
+          "Next move: Move from “I will steady this” to “we need a shared rule.”"
+        ],
+        "top_strength": "You can keep emotion, relationship, and task in the same frame.",
+        "likely_cost": "Others may quietly expect you to stabilize the room, turning your steadiness into hidden labor.",
+        "minimal_action": "Move from “I will steady this” to “we need a shared rule.”",
+        "share_safe_sentence": "I can steady a relationship without maintaining the whole system alone.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.balanced_integrated",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "balanced_integrated"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.high_empathy_low_recovery": {
+      "zh-CN": {
+        "headline": "高共情，低恢复",
+        "core_judgment": "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你很快读到别人的状态，但恢复系统常常追不上共情速度。",
+          "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+          "下一步：练习“理解但不接管”，让共情后面跟着边界。"
+        ],
+        "top_strength": "你容易让别人感到被理解，尤其在情绪强烈的时刻。",
+        "likely_cost": "你可能把别人的压力带回自己身上，离开场景后还在消化。",
+        "minimal_action": "练习“理解但不接管”，让共情后面跟着边界。",
+        "share_safe_sentence": "我可以理解别人，但不必替别人承受全部情绪。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "High Empathy, Slow Recovery",
+        "core_judgment": "You read the room quickly, but recovery can lag behind empathy.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You read the room quickly, but recovery can lag behind empathy.",
+          "You can make people feel understood, especially when emotions run high.",
+          "Next move: Practice understanding without taking over, so empathy is followed by boundary."
+        ],
+        "top_strength": "You can make people feel understood, especially when emotions run high.",
+        "likely_cost": "You may carry other people’s pressure with you long after the moment ends.",
+        "minimal_action": "Practice understanding without taking over, so empathy is followed by boundary.",
+        "share_safe_sentence": "I can understand someone without carrying the whole emotional load.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.high_empathy_low_recovery",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "high_empathy_low_recovery"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.aware_but_unregulated": {
+      "zh-CN": {
+        "headline": "有觉察，调节不足",
+        "core_judgment": "你常知道自己怎么了，但把自己带回来需要更长时间。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你常知道自己怎么了，但把自己带回来需要更长时间。",
+          "你能清楚识别触发点、感受和需要。",
+          "下一步：把觉察压缩成一个暂停动作，而不是继续解释。"
+        ],
+        "top_strength": "你能清楚识别触发点、感受和需要。",
+        "likely_cost": "越清楚自己被触发，越可能陷入反复分析或即时反应。",
+        "minimal_action": "把觉察压缩成一个暂停动作，而不是继续解释。",
+        "share_safe_sentence": "我知道自己怎么了，下一步是把自己带回来。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Aware, Still Reactive",
+        "core_judgment": "You often know what is happening inside, but the reset button is slower than the insight.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You often know what is happening inside, but the reset button is slower than the insight.",
+          "You can identify triggers, feelings, and needs with unusual clarity.",
+          "Next move: Turn awareness into one pause action instead of another layer of explanation."
+        ],
+        "top_strength": "You can identify triggers, feelings, and needs with unusual clarity.",
+        "likely_cost": "The clearer the trigger feels, the easier it can be to over-analyze or react too soon.",
+        "minimal_action": "Turn awareness into one pause action instead of another layer of explanation.",
+        "share_safe_sentence": "I know what is happening; the next skill is bringing myself back.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.aware_but_unregulated",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "aware_but_unregulated"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.calm_but_distant": {
+      "zh-CN": {
+        "headline": "冷静稳定，但距离感强",
+        "core_judgment": "你能稳住事情，但别人不一定感到被情绪上接住。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能稳住事情，但别人不一定感到被情绪上接住。",
+          "你不容易被情绪推着走，能保留判断和节奏。",
+          "下一步：先回应一句感受，再给建议或方案。"
+        ],
+        "top_strength": "你不容易被情绪推着走，能保留判断和节奏。",
+        "likely_cost": "关系里的人可能觉得你有答案，但没有真正回应他们。",
+        "minimal_action": "先回应一句感受，再给建议或方案。",
+        "share_safe_sentence": "我能稳住事情，也要让人感到被看见。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Steady, Less Attuned",
+        "core_judgment": "You can steady the situation, but people may not always feel emotionally met.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You can steady the situation, but people may not always feel emotionally met.",
+          "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+          "Next move: Acknowledge one feeling before offering advice or a solution."
+        ],
+        "top_strength": "You are less likely to be pushed around by emotion and can keep judgment and pace.",
+        "likely_cost": "People may feel that you have answers without feeling that you have responded to them.",
+        "minimal_action": "Acknowledge one feeling before offering advice or a solution.",
+        "share_safe_sentence": "I can steady the situation and still help people feel seen.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.calm_but_distant",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "calm_but_distant"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.relationship_first_self_later": {
+      "zh-CN": {
+        "headline": "关系优先，自我后置",
+        "core_judgment": "你会先保护关系，再回头找自己的真实立场。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你会先保护关系，再回头找自己的真实立场。",
+          "你敏感于关系气氛，愿意让互动维持可进行。",
+          "下一步：在照顾关系前，先给自己的感受一个位置。"
+        ],
+        "top_strength": "你敏感于关系气氛，愿意让互动维持可进行。",
+        "likely_cost": "你可能很晚才意识到自己其实不愿意、不同意或已经累了。",
+        "minimal_action": "在照顾关系前，先给自己的感受一个位置。",
+        "share_safe_sentence": "关系重要，我的感受也需要在场。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Relationship First, Self Later",
+        "core_judgment": "You protect the relationship first and find your own position later.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You protect the relationship first and find your own position later.",
+          "You are sensitive to relational tone and often keep interaction workable.",
+          "Next move: Give your own feeling a place before you manage the relationship."
+        ],
+        "top_strength": "You are sensitive to relational tone and often keep interaction workable.",
+        "likely_cost": "You may notice too late that you disagreed, felt unwilling, or were already depleted.",
+        "minimal_action": "Give your own feeling a place before you manage the relationship.",
+        "share_safe_sentence": "The relationship matters, and my own state belongs in the room too.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.relationship_first_self_later",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "relationship_first_self_later"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.self_clear_repair_weak": {
+      "zh-CN": {
+        "headline": "自我清楚，修复不足",
+        "core_judgment": "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你知道自己的立场，但冲突后的修复需要更明确的工具。",
+          "你不容易在关系压力里丢掉自己的判断。",
+          "下一步：把“我说清楚了”补成“我们怎么重新对齐”。"
+        ],
+        "top_strength": "你不容易在关系压力里丢掉自己的判断。",
+        "likely_cost": "如果表达后缺少修复，对方可能只记得强度，而不是你的重点。",
+        "minimal_action": "把“我说清楚了”补成“我们怎么重新对齐”。",
+        "share_safe_sentence": "我可以清楚表达，也可以把关系重新接上。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Clear Self, Repair Gap",
+        "core_judgment": "You know your position, but repair after tension needs a clearer tool.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You know your position, but repair after tension needs a clearer tool.",
+          "You are less likely to lose your judgment under relational pressure.",
+          "Next move: Add “how do we realign?” after “I made my point.”"
+        ],
+        "top_strength": "You are less likely to lose your judgment under relational pressure.",
+        "likely_cost": "Without repair, others may remember the force of the moment more than your point.",
+        "minimal_action": "Add “how do we realign?” after “I made my point.”",
+        "share_safe_sentence": "I can be clear and still reconnect the relationship.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.self_clear_repair_weak",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "self_clear_repair_weak"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.steady_collaborator": {
+      "zh-CN": {
+        "headline": "稳定协作型",
+        "core_judgment": "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能在压力下维持合作推进，但别让稳定只靠你一个人。",
+          "你能把紧张对话拉回事实、目标和下一步。",
+          "下一步：把个人稳定能力变成团队流程。"
+        ],
+        "top_strength": "你能把紧张对话拉回事实、目标和下一步。",
+        "likely_cost": "团队可能习惯让你来降温、翻译和收尾。",
+        "minimal_action": "把个人稳定能力变成团队流程。",
+        "share_safe_sentence": "我能帮助协作，但协作规则不能只靠我承担。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Steady Collaborator",
+        "core_judgment": "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You keep collaboration moving under pressure, but steadiness should not depend only on you.",
+          "You can bring tense conversations back to facts, goals, and next steps.",
+          "Next move: Turn personal steadiness into team process."
+        ],
+        "top_strength": "You can bring tense conversations back to facts, goals, and next steps.",
+        "likely_cost": "Teams may get used to you cooling things down, translating tension, and closing loops.",
+        "minimal_action": "Turn personal steadiness into team process.",
+        "share_safe_sentence": "I can help collaboration, but the rules cannot live only in me.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.steady_collaborator",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "steady_collaborator"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.sensitive_absorber": {
+      "zh-CN": {
+        "headline": "高敏感，易吸收",
+        "core_judgment": "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你能捕捉细微变化，但敏感也容易变成情绪负重。",
+          "你很快发现气氛、语气和关系位置的变化。",
+          "下一步：把“我感到了”区分成“我要不要回应”。"
+        ],
+        "top_strength": "你很快发现气氛、语气和关系位置的变化。",
+        "likely_cost": "你可能回应了太多信号，最后分不清哪些真的需要你处理。",
+        "minimal_action": "把“我感到了”区分成“我要不要回应”。",
+        "share_safe_sentence": "我能感到很多东西，但不需要回应所有东西。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Sensitive Absorber",
+        "core_judgment": "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "You catch subtle shifts fast, and that sensitivity can become emotional load.",
+          "You quickly notice shifts in tone, mood, and relational position.",
+          "Next move: Separate “I noticed it” from “I need to respond.”"
+        ],
+        "top_strength": "You quickly notice shifts in tone, mood, and relational position.",
+        "likely_cost": "You may respond to too many signals and lose track of which ones actually need your action.",
+        "minimal_action": "Separate “I noticed it” from “I need to respond.”",
+        "share_safe_sentence": "I can feel a lot without responding to everything.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.sensitive_absorber",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "sensitive_absorber"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.developing_foundation": {
+      "zh-CN": {
+        "headline": "基础发展中",
+        "core_judgment": "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+        "evidence_point": "依据四维分数、维度差距、答题质量和机制组合生成。",
+        "three_sentence_summary": [
+          "你的情绪与关系模式还在建立，最有效的是先练一个稳定小动作。",
+          "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+          "下一步：先把一个情绪命名清楚，再谈复杂改变。"
+        ],
+        "top_strength": "你已经开始把情绪和关系当成可以观察、可以练习的对象。",
+        "likely_cost": "如果一次想改太多，容易很快放弃或自我否定。",
+        "minimal_action": "先把一个情绪命名清楚，再谈复杂改变。",
+        "share_safe_sentence": "先练一个小动作，就已经是在建立基础。",
+        "continue_path": "保存报告，7 天后复测；也可以用 Agent 追问一个具体场景。",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Developing Foundation",
+        "core_judgment": "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+        "evidence_point": "Based on the four dimension scores, score gaps, response quality, and mechanism pattern.",
+        "three_sentence_summary": [
+          "Your emotional and relational pattern is still forming; one reliable practice matters more than a full reset.",
+          "You are beginning to treat emotion and relationships as observable and trainable.",
+          "Next move: Name one feeling clearly before attempting a larger change."
+        ],
+        "top_strength": "You are beginning to treat emotion and relationships as observable and trainable.",
+        "likely_cost": "Trying to change everything at once can lead to quick discouragement or self-criticism.",
+        "minimal_action": "Name one feeling clearly before attempting a larger change.",
+        "share_safe_sentence": "One small practice is already foundation-building.",
+        "continue_path": "Save the report, retest later, or ask the Agent about one real scene.",
+        "conversion_actions": [
+          "save_report",
+          "email_revisit",
+          "share_card",
+          "talk_to_agent",
+          "related_tests"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.developing_foundation",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "developing_foundation"
+        },
+        "claim_sensitivity": "medium"
+      }
+    },
+    "eq.snapshot.low_confidence_result": {
+      "zh-CN": {
+        "headline": "本次结果置信度较低",
+        "core_judgment": "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+        "evidence_point": "由于本次作答质量不足，系统不会输出强画像判断。",
+        "three_sentence_summary": [
+          "这次结果应轻一点读，最有价值的是理解本次作答状态。",
+          "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+          "下一步：先记录状态，之后在更稳定的时间复测。"
+        ],
+        "top_strength": "即使不适合强结论，也能提醒你观察最近的压力、疲劳或作答方式。",
+        "likely_cost": "如果强行套用画像，可能比不看结果更误导。",
+        "minimal_action": "先记录状态，之后在更稳定的时间复测。",
+        "share_safe_sentence": "这次结果不是不能看，而是要轻一点看。",
+        "continue_path": "先记录本次作答状态，之后在更稳定的时间复测。",
+        "conversion_actions": [
+          "save_report",
+          "retest_reminder",
+          "talk_to_agent"
+        ],
+        "do_not_overread": "首屏只给核心阅读路径，不替代完整报告。"
+      },
+      "en": {
+        "headline": "Lower-Confidence Result",
+        "core_judgment": "Read this result lightly; the most useful signal is the response context of this session.",
+        "evidence_point": "Because response confidence is limited, the system avoids a strong profile statement.",
+        "three_sentence_summary": [
+          "Read this result lightly; the most useful signal is the response context of this session.",
+          "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+          "Next move: Record the context first, then retest when conditions are steadier."
+        ],
+        "top_strength": "Even without a strong conclusion, it can point you toward stress, fatigue, or response style to observe.",
+        "likely_cost": "Forcing a profile onto this result could be more misleading than useful.",
+        "minimal_action": "Record the context first, then retest when conditions are steadier.",
+        "share_safe_sentence": "This result is not useless; it simply needs a lighter reading.",
+        "continue_path": "Record the response context first, then retest when conditions are steadier.",
+        "conversion_actions": [
+          "save_report",
+          "retest_reminder",
+          "talk_to_agent"
+        ],
+        "do_not_overread": "The first screen is a reading path, not a replacement for the full report."
+      },
+      "meta": {
+        "id": "eq.snapshot.low_confidence_result",
+        "asset_type": "result_snapshot",
+        "purpose": "30-second first-screen commercial summary",
+        "trigger_logic": {
+          "formulation_id": "low_confidence_result"
+        },
+        "claim_sensitivity": "high"
+      }
+    }
+  }
+}

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/scientific_contract.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/scientific_contract.json
@@ -4,24 +4,28 @@
   "assets": {
     "eq.scientific_contract.default": {
       "zh-CN": {
-        "test_definition": "这是一份基于 60 道自我报告题的情绪与关系模式报告，用于解释你如何感知、调节、回应和管理自己与他人的情绪。",
-        "self_report_statement": "本报告反映你对自身情绪与关系模式的主观感知，不等同于客观能力测验。",
-        "non_clinical_statement": "本报告不用于临床诊断、治疗建议或危机评估。",
-        "non_hiring_statement": "本报告不用于招聘筛选、录用、晋升或其他高风险人事决策。",
-        "non_ability_statement": "本报告不是认证能力测验，也不声称测量真实情商能力。",
-        "norm_status_statement": "当前常模为阶段性常模，百分位和标准分用于解释相对位置，后续会随样本增长持续校准。",
-        "quality_rules_statement": "系统会参考作答时长、长串作答、极端反应、中立反应和一致性信号，给出解释置信度。",
-        "version_statement": "报告版本 eq_report_v5_assets，计分版本 v1.0_normed_validity，内容版本 EQ_60/v1。"
+        "test_definition": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+        "self_report_statement": "这份报告基于你对 60 道题的作答，解释你如何理解、调节和回应自己与他人的情绪。它的价值在于把自我感知转化为可复盘的关系线索、行动入口和职业环境变量；它不是对所有现场行为的直接观察。",
+        "non_clinical_statement": "本报告不用于医疗、治疗或风险处置决定。如果困扰持续影响睡眠、工作、人际安全或日常功能，应寻求合格专业人士支持。",
+        "non_hiring_statement": "本结果不应用于录用、淘汰、晋升或岗位分配。它更适合个人发展、团队沟通和自我反思。",
+        "non_ability_statement": "EQ-60 解释的是自我感知中的情绪与关系模式，不等同于认证能力评估，也不应作为高风险决策依据。未来的情境判断模块也只会补充情境选择数据，而不是把结果变成能力认证。",
+        "norm_status_statement": "当前分数使用阶段性常模和版本化解释。百分位用于提供相对位置感，而不是精确排名。随着样本和版本更新，报告会保留当时版本以便复测对比。",
+        "quality_rules_statement": "报告会参考作答速度、连续相同选择、极端选择、中立选择和一致性线索来判断解释置信度。低置信不等于结果无用，而是需要更谨慎地读。",
+        "version_statement": "报告由题库版本、计分版本、常模版本和内容资产版本共同决定。版本记录让复测、客服和内容审校能追踪同一结果如何生成。",
+        "user_safe_summary": "适合用于自我理解、关系复盘和成长规划。",
+        "do_not_overread": "不要把自我报告结果当作他人观察或现场行为记录。"
       },
       "en": {
-        "test_definition": "This is an emotional and relational pattern report based on 60 self-report items. It explains how you notice, regulate, respond to, and manage emotions in yourself and others.",
-        "self_report_statement": "This report reflects your subjective self-perception of emotional and relational patterns. It is not an objective ability test.",
-        "non_clinical_statement": "This report is not for clinical diagnosis, treatment advice, or crisis evaluation.",
-        "non_hiring_statement": "This report is not for hiring, selection, promotion, or other high-stakes employment decisions.",
-        "non_ability_statement": "This report is not a certified ability assessment and does not claim to measure true emotional intelligence ability.",
-        "norm_status_statement": "Current norms are provisional. Percentiles and standard scores explain relative position and will be recalibrated as samples grow.",
-        "quality_rules_statement": "The system considers response time, long-string patterns, extreme responding, neutral responding, and consistency signals to estimate interpretation confidence.",
-        "version_statement": "Report version eq_report_v5_assets, scoring version v1.0_normed_validity, content version EQ_60/v1."
+        "test_definition": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+        "self_report_statement": "This report is based on your responses to 60 items. It explains how you tend to understand, regulate, and respond to emotions in yourself and others. Its value is turning self-perception into reviewable relational signals, action entries, and career-environment variables; it is not direct observation of every live behavior.",
+        "non_clinical_statement": "This report is not intended for healthcare, treatment, or safety decisions. If distress affects sleep, work, safety, or daily functioning, consult a qualified professional.",
+        "non_hiring_statement": "This result should not be used for selection, promotion, rejection, or role assignment. It is better suited for development, communication, and reflection.",
+        "non_ability_statement": "EQ-60 explains emotional and relational patterns in self-perception. It is not a certified capability evaluation and should not be used as a high-stakes decision tool. A future scenario module may add judgment data, but it would still not turn the result into a credential.",
+        "norm_status_statement": "Scores currently use provisional norms and versioned interpretation. Percentiles provide a sense of relative standing, not an exact rank. As samples and versions improve, reports retain the version used for comparison over time.",
+        "quality_rules_statement": "The report considers response speed, repeated identical choices, extreme choices, neutral choices, and consistency signals to estimate interpretation confidence. Lower confidence does not make the result useless; it means read it more cautiously.",
+        "version_statement": "The report is shaped by item version, scoring version, norm version, and content asset version. Versioning lets retests, support, and editorial review trace how a result was produced.",
+        "user_safe_summary": "Use it for self-understanding, relational reflection, and growth planning.",
+        "do_not_overread": "Do not treat self-report results as external observation or a live behavior record."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/score_system.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/score_system.json
@@ -4,140 +4,632 @@
   "global_index": {
     "zh-CN": {
       "label": "情绪与关系综合指数",
-      "meaning": "综合四个维度的自我报告信号，描述当前情绪与关系功能的整体稳定度。"
+      "definition": "综合指数把四个维度合并成一个整体视角，用来帮助你快速理解当前情绪与关系模式。",
+      "not_a_capability_score": "它不是现场表现的能力凭证，也不应单独决定任何重要选择。",
+      "how_to_use": "先看总览，再回到四维、质量提示和行动处方。"
     },
     "en": {
       "label": "Emotional & Relational Functioning Index",
-      "meaning": "A combined self-report signal across four dimensions, describing the current stability of emotional and relational functioning."
-    }
-  },
-  "score_notes": {
-    "zh-CN": {
-      "standard_score": "标准分以阶段性常模为参照，平均附近代表稳定可用。",
-      "percentile": "百分位表示在当前参考样本中的相对位置，不代表能力认证。"
-    },
-    "en": {
-      "standard_score": "Standard scores are interpreted against provisional norms. Scores near the mean indicate a stable usable range.",
-      "percentile": "Percentiles indicate relative position in the current reference sample and are not ability certification."
+      "definition": "The index combines the four dimensions into one overall view of your current emotional and relational pattern.",
+      "not_a_capability_score": "It is not a credential of live performance and should not be used alone for important decisions.",
+      "how_to_use": "Start with the overview, then read dimensions, confidence, and action prescription."
     }
   },
   "bands": {
     "foundational": {
-      "zh-CN": "基础发展中：当前信号提示该能力更需要外部结构、练习和复盘支持。",
-      "en": "Foundational: the current signal suggests this area benefits from more structure, practice, and review."
+      "zh-CN": "基础发展中",
+      "en": "Foundational"
     },
     "developing": {
-      "zh-CN": "发展中：已经有可用基础，但在压力或复杂关系中可能不够稳定。",
-      "en": "Developing: usable foundations are present, but the pattern may be less stable under pressure or relational complexity."
+      "zh-CN": "发展中",
+      "en": "Developing"
     },
     "stable": {
-      "zh-CN": "稳定可用：多数日常场景中可以发挥作用，但仍需要看和其他维度的组合。",
-      "en": "Stable: generally usable in everyday contexts, while interpretation still depends on how it combines with other dimensions."
+      "zh-CN": "稳定可用",
+      "en": "Stable"
     },
     "proficient": {
-      "zh-CN": "熟练成熟：该维度通常是可依赖的优势信号，也可能带来相应消耗。",
-      "en": "Proficient: this dimension is usually a reliable strength signal and may also carry related costs."
+      "zh-CN": "熟练成熟",
+      "en": "Proficient"
     },
     "integrated": {
-      "zh-CN": "高度整合：该维度表现突出，重点是避免过度使用并保持情境灵活性。",
-      "en": "Integrated: this dimension is prominent; the key is avoiding overuse and staying contextually flexible."
+      "zh-CN": "高度整合",
+      "en": "Integrated"
     }
   },
   "dimensions": {
     "SA": {
       "zh-CN": {
         "label": "自我觉察",
-        "definition": "识别、命名和理解自身情绪线索的倾向。",
-        "band_explanations": {
-          "foundational": "自我觉察处于基础发展中，建议先练习用具体词语命名情绪。",
-          "developing": "自我觉察已有基础，但在压力下可能较晚发现真实触发点。",
-          "stable": "自我觉察稳定可用，通常能理解自己的主要情绪线索。",
-          "proficient": "自我觉察较成熟，能较快捕捉情绪变化和背后需求。",
-          "integrated": "自我觉察高度整合，重点是避免过度分析并转向行动。"
-        }
+        "short_label": "自我觉察",
+        "definition": "识别、命名和理解自己情绪的倾向。",
+        "what_high_can_look_like": "你能较快识别自己的感受和触发点，但仍需把觉察转化为行动。",
+        "what_low_can_look_like": "情绪常在事后才变清楚，容易先反应后理解。",
+        "development_question": "我此刻真正的感受和需要是什么？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Self-Awareness",
-        "definition": "The tendency to notice, name, and understand emotional cues in yourself.",
-        "band_explanations": {
-          "foundational": "Self-awareness is foundational; start by naming emotions with specific words.",
-          "developing": "Self-awareness has a base, but real triggers may be noticed late under pressure.",
-          "stable": "Self-awareness is stable and usually helps you understand key emotional cues.",
-          "proficient": "Self-awareness is mature enough to catch shifts and underlying needs quickly.",
-          "integrated": "Self-awareness is highly integrated; the focus is avoiding over-analysis and moving to action."
-        }
+        "short_label": "Self-Awareness",
+        "definition": "The tendency to notice, name, and make sense of your own emotions.",
+        "what_high_can_look_like": "You can often identify feelings and triggers quickly, while still needing to turn awareness into action.",
+        "what_low_can_look_like": "Feelings may become clear only afterward, making it easier to react before understanding.",
+        "development_question": "What am I actually feeling and needing right now?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "ER": {
       "zh-CN": {
         "label": "情绪调节",
-        "definition": "在压力、反馈或冲突中恢复、暂停和选择回应方式的倾向。",
-        "band_explanations": {
-          "foundational": "情绪调节处于基础发展中，建议先建立暂停和恢复流程。",
-          "developing": "情绪调节已有基础，但强反馈或冲突中仍可能不稳定。",
-          "stable": "情绪调节稳定可用，多数日常压力下能找到恢复方式。",
-          "proficient": "情绪调节较成熟，能在触发后较快回到可沟通状态。",
-          "integrated": "情绪调节高度整合，重点是避免过度控制并保留真实感受。"
-        }
+        "short_label": "情绪调节",
+        "definition": "在压力、反馈、挫败或冲突中稳定和恢复自己的倾向。",
+        "what_high_can_look_like": "你在压力中较能暂停、恢复和选择回应，但不代表没有情绪。",
+        "what_low_can_look_like": "被触发后恢复较慢，容易用回避、解释或压抑处理。",
+        "development_question": "我能不能先让自己降一点温，再决定怎么回应？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Emotion Regulation",
-        "definition": "The tendency to recover, pause, and choose responses during pressure, feedback, or conflict.",
-        "band_explanations": {
-          "foundational": "Emotion regulation is foundational; build a pause and recovery process first.",
-          "developing": "Emotion regulation has a base, but strong feedback or conflict may still destabilize it.",
-          "stable": "Emotion regulation is stable and usually supports recovery in everyday pressure.",
-          "proficient": "Emotion regulation is mature enough to return to communication after being triggered.",
-          "integrated": "Emotion regulation is highly integrated; avoid over-control and keep authentic feeling available."
-        }
+        "short_label": "Emotion Regulation",
+        "definition": "The tendency to steady and recover yourself under pressure, feedback, frustration, or conflict.",
+        "what_high_can_look_like": "You can often pause, recover, and choose a response under pressure, without being emotionless.",
+        "what_low_can_look_like": "Recovery may take longer after being triggered, with avoidance, over-explaining, or suppression becoming common.",
+        "development_question": "Can I lower the heat first before choosing my response?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "EM": {
       "zh-CN": {
         "label": "共情理解",
-        "definition": "理解他人情绪、立场和关系线索的倾向。",
-        "band_explanations": {
-          "foundational": "共情理解处于基础发展中，建议先练习确认对方感受。",
-          "developing": "共情理解已有基础，但可能错过隐性情绪或真实需求。",
-          "stable": "共情理解稳定可用，多数场景能把握他人基本感受。",
-          "proficient": "共情理解较成熟，能较细腻地捕捉关系和情绪线索。",
-          "integrated": "共情理解高度整合，重点是避免过度承接他人情绪。"
-        }
+        "short_label": "共情理解",
+        "definition": "理解他人情绪、立场和未说出口感受的倾向。",
+        "what_high_can_look_like": "你能敏锐捕捉他人的状态，但需要避免过度吸收。",
+        "what_low_can_look_like": "可能更关注任务或事实，较容易漏过对方的情绪线索。",
+        "development_question": "对方真正担心或在意的是什么？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Empathy",
-        "definition": "The tendency to understand other people's emotions, perspectives, and relational cues.",
-        "band_explanations": {
-          "foundational": "Empathy is foundational; start by confirming the other person's feeling.",
-          "developing": "Empathy has a base, but hidden emotion or real needs may be missed.",
-          "stable": "Empathy is stable and usually helps you grasp basic feelings in others.",
-          "proficient": "Empathy is mature enough to notice relational and emotional cues with nuance.",
-          "integrated": "Empathy is highly integrated; avoid over-carrying other people's emotions."
-        }
+        "short_label": "Empathy",
+        "definition": "The tendency to understand others’ feelings, perspectives, and unspoken emotional cues.",
+        "what_high_can_look_like": "You can notice others’ emotional states, while still needing boundaries against over-absorbing.",
+        "what_low_can_look_like": "You may focus on tasks or facts and miss some emotional cues.",
+        "development_question": "What is the other person really concerned about?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
       }
     },
     "RM": {
       "zh-CN": {
         "label": "关系管理",
-        "definition": "在沟通、协作、修复和边界中采取建设性行动的倾向。",
-        "band_explanations": {
-          "foundational": "关系管理处于基础发展中，建议先学习低风险沟通脚本。",
-          "developing": "关系管理已有基础，但在冲突、边界或修复中可能不稳定。",
-          "stable": "关系管理稳定可用，多数协作场景中能采取建设性行动。",
-          "proficient": "关系管理较成熟，能主动推进沟通、协调和修复。",
-          "integrated": "关系管理高度整合，重点是避免承担过多协调责任。"
-        }
+        "short_label": "关系管理",
+        "definition": "通过表达、协作、边界和修复维持关系质量的倾向。",
+        "what_high_can_look_like": "你能维护沟通和关系质量，但仍需留意真实表达和边界。",
+        "what_low_can_look_like": "知道自己或对方感受后，不一定能把对话修复或推进。",
+        "development_question": "这句话怎样说，既真实又能让关系继续对话？",
+        "do_not_overread": "高低分都不是固定标签，它们描述的是当前自我报告倾向。"
       },
       "en": {
         "label": "Relationship Management",
-        "definition": "The tendency to act constructively in communication, collaboration, repair, and boundaries.",
-        "band_explanations": {
-          "foundational": "Relationship management is foundational; start with low-risk communication scripts.",
-          "developing": "Relationship management has a base, but conflict, boundaries, or repair may be unstable.",
-          "stable": "Relationship management is stable and usually supports constructive action in collaboration.",
-          "proficient": "Relationship management is mature enough to actively support communication, coordination, and repair.",
-          "integrated": "Relationship management is highly integrated; avoid taking too much coordination responsibility."
+        "short_label": "Relationship Management",
+        "definition": "The tendency to maintain relationship quality through expression, collaboration, boundaries, and repair.",
+        "what_high_can_look_like": "You can maintain communication and relationship quality, while still watching for honest expression and boundaries.",
+        "what_low_can_look_like": "Even when feelings are clear, repairing or moving the conversation forward may be harder.",
+        "development_question": "How can I say this honestly while keeping the conversation open?",
+        "do_not_overread": "High or low scores are not fixed labels; they describe current self-reported tendencies."
+      }
+    }
+  },
+  "dimension_bands": {
+    "SA": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "你可能常在事情过去后，才慢慢明白自己真正的感受。当前重点不是马上控制情绪，而是先把情绪命名清楚。",
+          "strength": "愿意回头复盘时，能够逐步看见真实感受。",
+          "risk": "现场容易先解释、压住或转移，之后才发现自己被触发。",
+          "typical_scene": "别人问“你怎么了”时，你可能需要一段时间才说得清。",
+          "practice_focus": "每天记录一个情绪词、一个触发点和一个身体反应。",
+          "do_not_overread": "这不代表你不懂自己，只说明当下觉察信号还需要更稳定的捕捉方式。",
+          "label": "自我觉察 · 基础发展中"
+        },
+        "en": {
+          "meaning": "Your feelings may become clear only after the moment has passed. The first task is not to control emotion faster, but to name it more reliably.",
+          "strength": "When you review an event afterward, you can gradually identify what was actually happening inside.",
+          "risk": "In the moment, you may explain, suppress, or move on before noticing that you were triggered.",
+          "typical_scene": "When someone asks what is wrong, you may need time before you can answer clearly.",
+          "practice_focus": "Track one emotion word, one trigger, and one body signal each day.",
+          "do_not_overread": "This does not mean you lack self-understanding; it means your emotional signals need a more stable capture method.",
+          "label": "Self-awareness · Foundational"
         }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你已经能捕捉到部分情绪线索，但在反馈、冲突或压力场景里，还不总能及时分辨“事实”和“感受”。",
+          "strength": "你开始能把情绪从混乱体验里拆出来。",
+          "risk": "觉察到情绪后，可能仍会被它带着走。",
+          "typical_scene": "收到批评时，你能意识到不舒服，但需要时间判断这份不舒服来自哪里。",
+          "practice_focus": "用“我感到…因为我在意…”练习把感受说具体。",
+          "do_not_overread": "发展中不是不稳定人格，而是觉察速度和表达精度仍在形成。",
+          "label": "自我觉察 · 发展中"
+        },
+        "en": {
+          "meaning": "You can notice some emotional signals, but in feedback, conflict, or stress you may not always separate facts from feelings quickly.",
+          "strength": "You are beginning to separate emotion from the overall sense of confusion.",
+          "risk": "After noticing a feeling, you may still be carried by it before choosing a response.",
+          "typical_scene": "When criticized, you know something feels uncomfortable but need time to identify the source.",
+          "practice_focus": "Practice the sentence: “I feel... because I care about...”",
+          "do_not_overread": "Developing does not mean an unstable personality; it means speed and precision of awareness are still forming.",
+          "label": "Self-awareness · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常场景中，你能识别自己的情绪、触发点和基本需要。真正的提升点在于高压下更快把觉察转成选择。",
+          "strength": "你通常能说清楚自己为什么被影响。",
+          "risk": "压力升高时，觉察可能变成反复分析，而不是行动。",
+          "typical_scene": "复盘一次对话时，你能指出哪个细节让自己紧张或防御。",
+          "practice_focus": "每次觉察后补一句：“我现在可以选择的下一步是…”。",
+          "do_not_overread": "稳定可用不等于任何场景都冷静，只表示多数日常场景有可靠基础。",
+          "label": "自我觉察 · 稳定可用"
+        },
+        "en": {
+          "meaning": "In most everyday situations, you can identify your feelings, triggers, and basic needs. The next gain is turning awareness into choice under pressure.",
+          "strength": "You can usually explain why something affected you.",
+          "risk": "Under higher pressure, awareness may turn into repeated analysis rather than action.",
+          "typical_scene": "When reviewing a conversation, you can point to the detail that made you tense or defensive.",
+          "practice_focus": "After naming the feeling, add: “The next step I can choose is...”",
+          "do_not_overread": "Stable does not mean calm in every situation; it means you have a reliable base in most everyday settings.",
+          "label": "Self-awareness · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能较快命名情绪、理解触发点，并知道自己在意什么。下一步是减少过度解读，让觉察服务行动。",
+          "strength": "你能把复杂感受组织成比较清楚的表达。",
+          "risk": "容易把每个反应都分析得很细，反而延迟沟通或恢复。",
+          "typical_scene": "在重要对话前，你能预判自己可能被哪些点触发。",
+          "practice_focus": "给觉察设时间盒：命名、确认需要、选择一个小行动。",
+          "do_not_overread": "熟练成熟不代表你必须解释所有感受，也不代表别人一定会立即理解。",
+          "label": "自我觉察 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually name feelings quickly, understand triggers, and identify what matters to you. The next step is using awareness to support action, not over-analysis.",
+          "strength": "You can organize complex feelings into relatively clear expression.",
+          "risk": "You may analyze every reaction in detail and delay communication or recovery.",
+          "typical_scene": "Before an important conversation, you can anticipate which points may trigger you.",
+          "practice_focus": "Time-box awareness: name the feeling, identify the need, then choose one small action.",
+          "do_not_overread": "Proficient does not mean you must explain every feeling, or that others will immediately understand it.",
+          "label": "Self-awareness · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把自我觉察和行动选择连接起来：知道自己怎么了，也较能判断此刻该表达、等待还是恢复。",
+          "strength": "你能在真实场景中使用觉察，而不只是事后理解。",
+          "risk": "可能默认自己必须一直清楚、一直成熟，从而忽略疲劳。",
+          "typical_scene": "冲突中，你能觉察自己的防御反应，并调整说话方式。",
+          "practice_focus": "保留轻量复盘，重点观察“我是否也给了自己恢复空间”。",
+          "do_not_overread": "高度整合不是永远理性，而是更常能在觉察和行动之间保持连接。",
+          "label": "自我觉察 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can connect self-awareness with action: you know what is happening inside and can often choose whether to speak, pause, or recover.",
+          "strength": "You can use awareness in real time, not only in later reflection.",
+          "risk": "You may expect yourself to stay clear and mature all the time, which can hide fatigue.",
+          "typical_scene": "In conflict, you can notice defensiveness and adjust how you speak.",
+          "practice_focus": "Keep a light review habit and ask: “Did I also give myself room to recover?”",
+          "do_not_overread": "Integrated does not mean permanently rational; it means awareness and action stay connected more often.",
+          "label": "Self-awareness · Integrated"
+        }
+      }
+    },
+    "ER": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "情绪被触发后，恢复可能需要比较久。当前重点是建立最小暂停，而不是要求自己马上平静。",
+          "strength": "你能从明显的情绪反应中发现需要练习的场景。",
+          "risk": "压力下容易直接回应、回避或进入长时间内耗。",
+          "typical_scene": "冲突结束后，你可能还会在脑中反复回放很久。",
+          "practice_focus": "先练 30 秒暂停：停下、呼吸、说“我需要一点时间”。",
+          "do_not_overread": "这不等于情绪失控，只说明恢复策略还没有稳定自动化。",
+          "label": "情绪调节 · 基础发展中"
+        },
+        "en": {
+          "meaning": "After being triggered, recovery may take longer. The priority is building a small pause, not forcing yourself to become calm immediately.",
+          "strength": "Clear emotional reactions can show you exactly which situations need practice.",
+          "risk": "Under stress, you may respond too quickly, avoid the issue, or stay mentally stuck afterward.",
+          "typical_scene": "After a conflict, you may replay the conversation for a long time.",
+          "practice_focus": "Practice a 30-second pause: stop, breathe, and say, “I need a little time.”",
+          "do_not_overread": "This does not mean you are out of control; it means recovery strategies are not yet automatic.",
+          "label": "Emotion regulation · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你有时能把情绪降下来，但方法还不够稳定。关键是把偶尔有效的恢复动作变成可重复流程。",
+          "strength": "你已经知道某些做法能帮自己缓下来。",
+          "risk": "情绪强度一高，原本有效的方法可能想不起来。",
+          "typical_scene": "你知道先不要回消息更好，但仍可能忍不住马上解释。",
+          "practice_focus": "准备一个固定恢复菜单：离开现场、写三句话、延迟回复。",
+          "do_not_overread": "发展中不代表无法调节，而是需要把策略从偶发变成默认选项。",
+          "label": "情绪调节 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sometimes cool down, but the method is not yet consistent. The key is turning occasional recovery moves into a repeatable process.",
+          "strength": "You already know that some actions help you settle.",
+          "risk": "When intensity rises, strategies that usually work may be hard to remember.",
+          "typical_scene": "You know it would be better not to reply immediately, but still feel pulled to explain.",
+          "practice_focus": "Prepare a recovery menu: step away, write three sentences, delay the reply.",
+          "do_not_overread": "Developing does not mean you cannot regulate; it means strategy needs to become a default option.",
+          "label": "Emotion regulation · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常压力下，你能让情绪回到可沟通、可行动的范围。更大的挑战通常出现在高冲突或长期消耗中。",
+          "strength": "你能把情绪从“主导全局”降到“可以被管理”。",
+          "risk": "如果持续压着自己保持稳定，后续可能出现疲劳或延迟爆发。",
+          "typical_scene": "紧张会议后，你能逐渐恢复工作节奏。",
+          "practice_focus": "给恢复安排边界：什么时候暂停、什么时候回来处理。",
+          "do_not_overread": "稳定可用不是没有波动，而是多数时候能回到可选择状态。",
+          "label": "情绪调节 · 稳定可用"
+        },
+        "en": {
+          "meaning": "Under most everyday stress, you can bring emotion back into a range where communication and action are possible. Higher conflict or long-term strain remains harder.",
+          "strength": "You can reduce emotion from “running the situation” to “something manageable.”",
+          "risk": "If you keep forcing yourself to stay stable, fatigue or delayed escalation may follow.",
+          "typical_scene": "After a tense meeting, you can gradually return to your work rhythm.",
+          "practice_focus": "Set recovery boundaries: when to pause and when to return to the issue.",
+          "do_not_overread": "Stable does not mean no fluctuation; it means you can usually return to a state of choice.",
+          "label": "Emotion regulation · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能在压力下先降温，再选择回应方式。下一步是避免把调节变成过度控制或情绪隔离。",
+          "strength": "你能为沟通争取到更好的时机和语气。",
+          "risk": "有时会显得太冷静，让别人感受不到你的真实立场。",
+          "typical_scene": "被挑战时，你能先稳住语气，再回应重点。",
+          "practice_focus": "调节后补充真实表达：“我需要想清楚，但这件事对我重要。”",
+          "do_not_overread": "熟练调节不等于必须压住情绪，真实表达仍然是关系信息。",
+          "label": "情绪调节 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually cool down before choosing a response under pressure. The next step is avoiding over-control or emotional distance.",
+          "strength": "You can create better timing and tone for communication.",
+          "risk": "At times, you may appear so calm that others cannot read your real position.",
+          "typical_scene": "When challenged, you can steady your tone before addressing the point.",
+          "practice_focus": "After regulating, add authentic expression: “I need to think, but this matters to me.”",
+          "do_not_overread": "Proficient regulation does not mean suppressing emotion; honest expression is still relational information.",
+          "label": "Emotion regulation · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能在情绪强度较高时仍保留选择空间，并把恢复、表达和行动结合起来。重点是保护长期能量。",
+          "strength": "你能让情绪成为信息，而不是让它接管关系或判断。",
+          "risk": "别人可能过度依赖你的稳定，你也可能承担过多调停责任。",
+          "typical_scene": "冲突中，你能暂停升级，同时保留清晰边界。",
+          "practice_focus": "定期检查：我是在稳定局面，还是在替所有人承担情绪成本？",
+          "do_not_overread": "高度整合不是永远平静，而是更能在高压中保留恢复和选择。",
+          "label": "情绪调节 · 高度整合"
+        },
+        "en": {
+          "meaning": "Even when emotion is intense, you can often keep room for choice and connect recovery, expression, and action. The priority is protecting long-term energy.",
+          "strength": "You can use emotion as information instead of letting it take over relationships or judgment.",
+          "risk": "Others may rely too heavily on your stability, and you may take on too much mediation.",
+          "typical_scene": "In conflict, you can slow escalation while keeping a clear boundary.",
+          "practice_focus": "Check regularly: “Am I stabilizing the situation, or carrying everyone’s emotional cost?”",
+          "do_not_overread": "Integrated does not mean permanently calm; it means more room for recovery and choice under pressure.",
+          "label": "Emotion regulation · Integrated"
+        }
+      }
+    },
+    "EM": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "你可能不总能及时读到他人的情绪线索，尤其在线索很含蓄或关系压力较高时。当前重点是减少猜测，增加确认。",
+          "strength": "你可以通过直接提问建立更清楚的信息。",
+          "risk": "容易把沉默、语气或表情理解得过少或过多。",
+          "typical_scene": "对方说“没事”时，你不确定该继续问还是停下。",
+          "practice_focus": "使用确认句：“我不确定我理解得对不对，你现在更需要空间还是回应？”",
+          "do_not_overread": "这不代表你冷漠，只说明读取线索时需要更明确的信息支持。",
+          "label": "共情理解 · 基础发展中"
+        },
+        "en": {
+          "meaning": "You may not always read others’ emotional cues quickly, especially when signals are subtle or relational pressure is high. The priority is reducing guesswork and increasing checking.",
+          "strength": "Direct questions can give you clearer information.",
+          "risk": "You may read too little or too much into silence, tone, or facial expression.",
+          "typical_scene": "When someone says “I’m fine,” you are not sure whether to ask again or step back.",
+          "practice_focus": "Use a checking sentence: “I may be wrong; do you need space or a response right now?”",
+          "do_not_overread": "This does not mean you are uncaring; it means cue reading needs clearer information support.",
+          "label": "Empathic understanding · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你能感到别人状态有变化，但有时会把自己的担心投射进去。提升点是区分“我观察到的”和“我猜测的”。",
+          "strength": "你开始关注关系中的情绪温度。",
+          "risk": "可能过早判断别人不高兴、失望或疏远。",
+          "typical_scene": "朋友回复变短时，你会察觉异常，但不确定原因。",
+          "practice_focus": "把判断拆成两句：我观察到什么？我还不知道什么？",
+          "do_not_overread": "发展中不代表共情差，而是需要让共情建立在证据上。",
+          "label": "共情理解 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sense when someone’s state changes, but may sometimes project your own concern into it. The next step is separating observation from interpretation.",
+          "strength": "You are starting to track the emotional temperature in relationships.",
+          "risk": "You may too quickly assume someone is upset, disappointed, or distant.",
+          "typical_scene": "When a friend’s replies become shorter, you notice a shift but do not know the reason.",
+          "practice_focus": "Split the judgment into two questions: What did I observe? What do I not know yet?",
+          "do_not_overread": "Developing does not mean weak empathy; it means empathy needs to be grounded in evidence.",
+          "label": "Empathic understanding · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "你通常能理解他人的情绪线索和基本需要。关键是保持边界：理解别人，不等于必须替别人承受。",
+          "strength": "你能让对方感到被看见和被认真对待。",
+          "risk": "在关系压力中，可能为了照顾别人而忽略自己的容量。",
+          "typical_scene": "同事语气紧张时，你能意识到对方可能在承压。",
+          "practice_focus": "共情后加一句边界：“我理解你现在很难，我能帮的是…”",
+          "do_not_overread": "稳定共情不是读心，也不是无限承担别人的情绪。",
+          "label": "共情理解 · 稳定可用"
+        },
+        "en": {
+          "meaning": "You can usually understand others’ emotional cues and basic needs. The key is boundary: understanding someone does not mean carrying the emotion for them.",
+          "strength": "You can help others feel seen and taken seriously.",
+          "risk": "Under relational pressure, you may ignore your own capacity while caring for others.",
+          "typical_scene": "When a colleague sounds tense, you can recognize that they may be under pressure.",
+          "practice_focus": "After empathy, add a boundary: “I understand this is hard; what I can help with is...”",
+          "do_not_overread": "Stable empathy is not mind-reading, and it is not unlimited responsibility for another person’s emotion.",
+          "label": "Empathic understanding · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你能读到较细微的情绪变化，并理解别人话语背后的需要。下一步是避免过度承接，把共情和边界一起使用。",
+          "strength": "你能在复杂关系中捕捉未说出口的信息。",
+          "risk": "容易把别人的紧张、失望或期待变成自己的责任。",
+          "typical_scene": "会议里气氛变了，你能很快察觉谁在退缩或不安。",
+          "practice_focus": "先验证再承担：“我感觉你可能有顾虑，我理解对吗？”",
+          "do_not_overread": "熟练共情不等于你必须解决所有人的感受。",
+          "label": "共情理解 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can read subtle emotional shifts and understand needs behind words. The next step is using empathy together with boundaries.",
+          "strength": "You can notice unspoken information in complex relationships.",
+          "risk": "You may turn others’ tension, disappointment, or expectations into your responsibility.",
+          "typical_scene": "When the mood changes in a meeting, you quickly notice who is withdrawing or uneasy.",
+          "practice_focus": "Validate before carrying: “I sense you may have a concern; am I reading that correctly?”",
+          "do_not_overread": "Proficient empathy does not mean you must solve everyone’s feelings.",
+          "label": "Empathic understanding · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把共情、判断和边界结合起来：既看见他人，也不轻易丢失自己。重点是让共情服务关系质量，而不是变成过度负责。",
+          "strength": "你能在理解别人时仍保持清晰位置。",
+          "risk": "别人可能习惯向你倾倒情绪，你也可能被期待持续照顾场面。",
+          "typical_scene": "对方情绪很强时，你能回应感受，同时不接下不属于你的责任。",
+          "practice_focus": "练习“理解 + 边界 + 下一步”三段回应。",
+          "do_not_overread": "高度整合的共情不是永远温柔，而是能同时保留理解和判断。",
+          "label": "共情理解 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can combine empathy, judgment, and boundary: seeing the other person without losing yourself. The focus is making empathy serve relationship quality, not over-responsibility.",
+          "strength": "You can understand others while keeping a clear position.",
+          "risk": "Others may become used to unloading emotion onto you, and you may be expected to manage the room.",
+          "typical_scene": "When someone is highly emotional, you can respond to the feeling without taking responsibility that is not yours.",
+          "practice_focus": "Practice a three-part response: understanding, boundary, next step.",
+          "do_not_overread": "Integrated empathy is not endless softness; it is the ability to hold understanding and judgment together.",
+          "label": "Empathic understanding · Integrated"
+        }
+      }
+    },
+    "RM": {
+      "foundational": {
+        "zh-CN": {
+          "meaning": "在紧张关系里，表达、修复和推进对话可能还缺少稳定结构。当前重点是用简单脚本让沟通重新可进行。",
+          "strength": "只要有清楚步骤，你可以逐步提升关系处理能力。",
+          "risk": "容易在不舒服时沉默、解释过多或直接退出。",
+          "typical_scene": "争执后，你知道需要修复，但不知道第一句话怎么说。",
+          "practice_focus": "准备一句开场：“刚才那段对话有点卡住了，我想重新说一次。”",
+          "do_not_overread": "这不代表你不重视关系，只说明修复工具还不够熟。",
+          "label": "关系管理 · 基础发展中"
+        },
+        "en": {
+          "meaning": "In tense relationships, expression, repair, and moving the conversation forward may still need more structure. The priority is using simple scripts to make communication workable again.",
+          "strength": "With clear steps, your relationship skills can improve steadily.",
+          "risk": "When uncomfortable, you may go silent, over-explain, or exit the conversation.",
+          "typical_scene": "After an argument, you know repair is needed but do not know the first sentence.",
+          "practice_focus": "Prepare an opener: “That conversation got stuck. I’d like to try saying it again.”",
+          "do_not_overread": "This does not mean you do not value relationships; it means repair tools are not yet familiar.",
+          "label": "Relationship management · Foundational"
+        }
+      },
+      "developing": {
+        "zh-CN": {
+          "meaning": "你有时能重启对话或表达立场，但在对方情绪强、关系重要时仍容易失去节奏。关键是把修复动作提前准备好。",
+          "strength": "你已经能意识到关系需要被处理，而不是只等它过去。",
+          "risk": "可能一边想维护关系，一边又把真实想法说得不够清楚。",
+          "typical_scene": "你想缓和气氛，但担心一开口又引发冲突。",
+          "practice_focus": "使用“事实 + 感受 + 请求”三句结构。",
+          "do_not_overread": "发展中不代表关系能力差，而是现场压力下需要更可依赖的表达框架。",
+          "label": "关系管理 · 发展中"
+        },
+        "en": {
+          "meaning": "You can sometimes restart a conversation or state your position, but strong emotion or important relationships can still disrupt your rhythm. The key is preparing repair moves in advance.",
+          "strength": "You already recognize that relationships need to be addressed, not simply waited out.",
+          "risk": "You may try to preserve the relationship while leaving your real position unclear.",
+          "typical_scene": "You want to ease the atmosphere but worry that speaking will restart the conflict.",
+          "practice_focus": "Use a three-sentence structure: fact, feeling, request.",
+          "do_not_overread": "Developing does not mean weak relationship ability; it means pressure requires a more reliable expression frame.",
+          "label": "Relationship management · Developing"
+        }
+      },
+      "stable": {
+        "zh-CN": {
+          "meaning": "多数日常关系里，你能维持基本沟通、合作和修复。下一步是提升高压对话中的清晰度和边界。",
+          "strength": "你能让关系在小摩擦后回到可合作状态。",
+          "risk": "为了维持顺畅，可能回避更难但必要的话题。",
+          "typical_scene": "误会出现后，你通常愿意解释并重新对齐。",
+          "practice_focus": "在修复之外补充边界：“下次我们可以用这个方式处理。”",
+          "do_not_overread": "稳定可用不等于没有冲突，而是多数冲突后还能回到工作关系。",
+          "label": "关系管理 · 稳定可用"
+        },
+        "en": {
+          "meaning": "In most everyday relationships, you can maintain communication, collaboration, and repair. The next step is more clarity and boundary in high-pressure conversations.",
+          "strength": "You can help a relationship return to cooperation after small friction.",
+          "risk": "To keep things smooth, you may avoid harder but necessary topics.",
+          "typical_scene": "After a misunderstanding, you are usually willing to explain and realign.",
+          "practice_focus": "Add a boundary after repair: “Next time, we can handle it this way.”",
+          "do_not_overread": "Stable does not mean no conflict; it means most conflicts can return to a workable relationship.",
+          "label": "Relationship management · Stable"
+        }
+      },
+      "proficient": {
+        "zh-CN": {
+          "meaning": "你通常能在紧张对话中兼顾表达、倾听和推进。下一步是避免总是承担调停者角色。",
+          "strength": "你能把冲突转化为更清楚的协作规则。",
+          "risk": "别人可能默认你来收拾关系残局。",
+          "typical_scene": "团队意见不合时，你能帮助大家回到事实和下一步。",
+          "practice_focus": "在协调前先确认职责：“这件事需要谁来决定，谁来执行？”",
+          "do_not_overread": "熟练关系管理不是永远做中间人，也不是牺牲自己的边界。",
+          "label": "关系管理 · 熟练成熟"
+        },
+        "en": {
+          "meaning": "You can usually balance expression, listening, and forward movement in tense conversations. The next step is avoiding the default mediator role.",
+          "strength": "You can turn conflict into clearer rules for collaboration.",
+          "risk": "Others may assume you will clean up the relational aftermath.",
+          "typical_scene": "When a team disagrees, you can help people return to facts and next steps.",
+          "practice_focus": "Before coordinating, clarify roles: “Who decides this, and who executes it?”",
+          "do_not_overread": "Proficient relationship management is not permanent mediation, and it does not require sacrificing your boundary.",
+          "label": "Relationship management · Proficient"
+        }
+      },
+      "integrated": {
+        "zh-CN": {
+          "meaning": "你能把关系修复、清晰表达、边界和协作推进结合起来。重点是让关系系统更健康，而不是靠你一个人维持。",
+          "strength": "你能在复杂关系中创造清晰、可持续的合作方式。",
+          "risk": "因为你能处理关系，系统可能把过多情绪劳动交给你。",
+          "typical_scene": "冲突升级时，你能帮助各方降温、对齐目标，并明确责任。",
+          "practice_focus": "把个人调停转成系统规则：节奏、边界、责任和复盘。",
+          "do_not_overread": "高度整合不代表你必须承担所有关系维护工作。",
+          "label": "关系管理 · 高度整合"
+        },
+        "en": {
+          "meaning": "You can combine repair, clear expression, boundary, and collaborative movement. The focus is building a healthier relationship system, not maintaining it alone.",
+          "strength": "You can create clear and sustainable collaboration in complex relationships.",
+          "risk": "Because you can handle relationships, the system may hand you too much emotional labor.",
+          "typical_scene": "When conflict escalates, you can help people cool down, align goals, and clarify responsibility.",
+          "practice_focus": "Turn personal mediation into system rules: rhythm, boundary, responsibility, and review.",
+          "do_not_overread": "Integrated does not mean you must carry all relationship maintenance.",
+          "label": "Relationship management · Integrated"
+        }
+      }
+    }
+  },
+  "score_notes": {
+    "zh-CN": {
+      "percentile": "百分位用于说明相对位置，不代表固定能力标签。",
+      "standard_score": "标准分用于稳定展示和维度比较。",
+      "commercial_boundary": "总分用于定位阅读入口，最终解释以四维、质量和场景为准。"
+    },
+    "en": {
+      "percentile": "Percentile explains relative position; it is not a fixed ability label.",
+      "standard_score": "Standard score supports stable display and dimension comparison.",
+      "commercial_boundary": "The total score is a reading entry; interpretation depends on dimensions, confidence, and scenes."
+    }
+  },
+  "band_details": {
+    "foundational": {
+      "zh-CN": {
+        "label": "基础发展中",
+        "meaning": "当前信号提示你需要先建立更清晰的识别、命名和复位习惯。",
+        "strength": "从一个小而重复的动作开始，进步会更稳定。",
+        "risk": "如果直接追求复杂沟通技巧，容易因为基础信号不清而挫败。",
+        "practice_focus": "每天一次情绪命名，配合一个低成本复位动作。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Foundational",
+        "meaning": "The current signal suggests starting with clearer recognition, naming, and reset habits.",
+        "strength": "Small repeatable actions can create more stable progress.",
+        "risk": "Jumping into complex communication tactics may frustrate you if the base signal is unclear.",
+        "practice_focus": "Name one emotion daily and pair it with one low-cost reset action.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "developing": {
+      "zh-CN": {
+        "label": "发展中",
+        "meaning": "你已有可用基础，但在反馈、压力或关系拉扯中稳定性还会下降。",
+        "strength": "你已经能抓住一部分线索，适合把它们转成固定流程。",
+        "risk": "最容易卡在“知道一点，但现场用不上”。",
+        "practice_focus": "选择一个高频场景，提前准备一句回应。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Developing",
+        "meaning": "You have a usable base, but consistency may drop during feedback, pressure, or relational tension.",
+        "strength": "You already catch part of the signal and can turn it into a routine.",
+        "risk": "The common trap is knowing something but not using it in the moment.",
+        "practice_focus": "Pick one frequent scene and prepare one response sentence.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "stable": {
+      "zh-CN": {
+        "label": "稳定可用",
+        "meaning": "多数日常场景中，你能使用这些情绪与关系能力，但仍有明确触发点。",
+        "strength": "你的结果已经能支持更精细的场景训练。",
+        "risk": "稳定不等于没有代价，尤其在高强度关系环境中。",
+        "practice_focus": "找出最容易失稳的一个场景，做事后复盘。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Stable",
+        "meaning": "In many everyday settings, these emotional and relational skills are usable, with specific triggers still visible.",
+        "strength": "Your result can support more precise scene-based practice.",
+        "risk": "Stability does not mean no cost, especially in high-intensity relational environments.",
+        "practice_focus": "Identify one scene where stability drops and review it afterward.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "proficient": {
+      "zh-CN": {
+        "label": "熟练成熟",
+        "meaning": "你通常能较稳定地识别、调节和处理关系信号。",
+        "strength": "你可以把个人优势转成可复制的沟通习惯。",
+        "risk": "他人可能默认你应该一直承担稳定局面的角色。",
+        "practice_focus": "把“我能处理”升级为“我选择如何处理”。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Proficient",
+        "meaning": "You can usually recognize, regulate, and handle relational signals with good consistency.",
+        "strength": "You can turn personal strengths into repeatable communication habits.",
+        "risk": "Others may assume you should always be the stabilizing person.",
+        "practice_focus": "Move from “I can handle this” to “I choose how to handle this.”",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
+      }
+    },
+    "integrated": {
+      "zh-CN": {
+        "label": "高度整合",
+        "meaning": "四维信号通常能协同工作，帮助你兼顾自己、他人和关系目标。",
+        "strength": "你适合把优势系统化，形成边界、修复和恢复节奏。",
+        "risk": "高整合也可能带来过度承担和高标准疲劳。",
+        "practice_focus": "建立恢复边界，避免把稳定别人变成默认责任。",
+        "do_not_overread": "总分用于定位阅读入口，不能替代四维、质量和场景解释。"
+      },
+      "en": {
+        "label": "Integrated",
+        "meaning": "The four signals often work together, helping you hold self, others, and the relationship goal in view.",
+        "strength": "You can systematize strengths into boundaries, repair, and recovery rhythm.",
+        "risk": "High integration may still create over-responsibility and high-standard fatigue.",
+        "practice_focus": "Build recovery boundaries so stabilizing others does not become your default duty.",
+        "do_not_overread": "The total score locates the reading entry; it does not replace dimensions, confidence, and scene interpretation."
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/seo_geo_authority.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/seo_geo_authority.json
@@ -16,37 +16,37 @@
   "assets": {
     "eq.seo_geo_authority.en_landing.default": {
       "zh-CN": {
-        "meta_title": "免费情商 EQ 测试 | 情绪与关系模式报告",
-        "meta_description": "完成 60 道自我报告题，理解自我觉察、情绪调节、共情理解和关系管理。结果免费，边界清晰，不用于诊断、招聘或能力认证。",
-        "h1": "情商 EQ 测试：情绪与关系模式报告",
-        "dek": "一份 60 题 self-report 测评，用于解释你如何感知、调节和回应自己与他人的情绪。",
-        "entity_summary": "费马 EQ-60 是情绪与关系信号模块，输出自我报告型情绪与关系模式报告，而不是临床、招聘或认证能力测验。",
+        "meta_title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "h1": "情绪与关系模式测试",
+        "dek": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "entity_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
         "content_modules": [
           {
-            "heading": "测评测什么",
-            "summary": "自我觉察、情绪调节、共情理解和关系管理四个维度。"
+            "heading": "测试定义",
+            "summary": "测试定义"
           },
           {
-            "heading": "结果页给什么",
-            "summary": "综合指数、四维矩阵、核心洞察、现实场景、行动处方和科学边界。"
+            "heading": "测量内容",
+            "summary": "测量内容"
           },
           {
-            "heading": "不做什么",
-            "summary": "不做临床诊断、招聘筛选、职业适配结论或客观能力认证。"
+            "heading": "不适用边界",
+            "summary": "不适用边界"
+          },
+          {
+            "heading": "下一步行动",
+            "summary": "下一步行动"
           }
         ],
         "faq": [
           {
-            "question": "这是免费的情商测试吗？",
-            "answer": "是。EQ-60 基础报告免费；报告深度由完成的数据决定，不由付费门槛决定。"
+            "question": "分数代表什么？",
+            "answer": ""
           },
           {
-            "question": "它是能力测验吗？",
-            "answer": "不是。它基于自我报告，适合自我理解、沟通反思和成长规划。"
-          },
-          {
-            "question": "未来的情境判断模块是什么？",
-            "answer": "EQ-SJT 16 目前仅为 planned 状态，未来会补充情境选择信息，但不会被表述为认证能力测验。"
+            "question": "结果应该怎么使用？",
+            "answer": ""
           }
         ],
         "structured_data": {
@@ -55,48 +55,47 @@
           "result_scope": "emotional_and_relational_pattern_report",
           "is_free": true
         },
-        "llms_summary": "EQ-60 是费马测试的自我报告型情绪与关系模式测评。它用 60 道题解释自我觉察、情绪调节、共情理解和关系管理，并输出免费结果页。",
-        "claim_boundary": "仅用于自我理解和成长规划；不用于临床诊断、招聘筛选、职业适配承诺、治疗建议或客观能力认证。",
-        "source_authority": "页面标题、SEO 摘要、FAQ、结构化数据边界和 LLM 摘要以 backend content pack 为权威来源。",
+        "llms_summary": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。",
+        "source_authority": "后端 content pack 是公开 EQ SEO/GEO 文案权威来源。",
         "no_go_claims": [
-          "不声称测量客观情绪能力",
-          "不声称预测工作表现",
-          "不用于招聘筛选",
-          "不用于临床诊断"
+          "不用于临床",
+          "不用于招聘",
+          "不用于认证"
         ]
       },
       "en": {
-        "meta_title": "Free EQ Test | Emotional & Relational Pattern Report",
-        "meta_description": "Take a free 60-item self-report EQ test covering self-awareness, emotion regulation, empathy, and relationship management. Clear boundaries: not clinical, hiring, or certified ability assessment.",
-        "h1": "EQ Test: Emotional & Relational Pattern Report",
-        "dek": "A 60-item self-report assessment that explains how you notice, regulate, and respond to emotions in yourself and in relationships.",
-        "entity_summary": "FermatMind EQ-60 is an emotional and relational signal module. It produces a self-report pattern report, not a clinical, hiring, or certified ability assessment.",
+        "meta_title": "Free EQ Test | Emotional Intelligence Test",
+        "meta_description": "Take a free self-report emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+        "h1": "Free Emotional Intelligence Test",
+        "dek": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "entity_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
         "content_modules": [
           {
-            "heading": "What it measures",
-            "summary": "Self-awareness, emotion regulation, empathic understanding, and relationship management."
+            "heading": "definition",
+            "summary": "definition"
           },
           {
-            "heading": "What the report includes",
-            "summary": "A global index, four-dimension matrix, core insight, real-world scenes, action prescription, and scientific boundary."
+            "heading": "what it measures",
+            "summary": "what it measures"
           },
           {
-            "heading": "What it does not do",
-            "summary": "It does not provide clinical diagnosis, hiring suitability, career-fit promises, or objective ability certification."
+            "heading": "what it does not decide",
+            "summary": "what it does not decide"
+          },
+          {
+            "heading": "next useful action",
+            "summary": "next useful action"
           }
         ],
         "faq": [
           {
-            "question": "Is this EQ test free?",
-            "answer": "Yes. The EQ-60 base report is free; report depth is based on completed data, not a paywall."
+            "question": "What does the score mean?",
+            "answer": "Your result summarizes a self-report emotional and relational pattern across self-awareness, emotion regulation, empathy, and relationship management."
           },
           {
-            "question": "Is this an ability test?",
-            "answer": "No. It is based on self-report and is intended for self-understanding, communication reflection, and growth planning."
-          },
-          {
-            "question": "What is the future scenario module?",
-            "answer": "EQ-SJT 16 is currently planned only. It will add scenario-choice information in the future, without being positioned as a certified ability assessment."
+            "question": "How should I use the result?",
+            "answer": "Use it to reflect on your patterns, choose a small next action, and decide whether a retest or related assessment would be useful."
           }
         ],
         "structured_data": {
@@ -105,15 +104,1146 @@
           "result_scope": "emotional_and_relational_pattern_report",
           "is_free": true
         },
-        "llms_summary": "EQ-60 is FermatMind's self-report emotional and relational pattern assessment. It uses 60 items to explain self-awareness, emotion regulation, empathic understanding, and relationship management, then returns a free result page.",
-        "claim_boundary": "For self-understanding and growth planning only; not for clinical diagnosis, hiring selection, career-fit promises, treatment advice, or objective ability certification.",
-        "source_authority": "Page title, SEO summary, FAQ, structured-data boundary, and LLM summary are authoritative in the backend content pack.",
+        "llms_summary": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "claim_boundary": "Use for self-understanding, reflection, and growth planning; not for clinical diagnosis, hiring, credentialing, or job-performance prediction.",
+        "source_authority": "Backend content pack is authoritative for public EQ SEO/GEO copy.",
         "no_go_claims": [
-          "Does not claim objective emotional ability measurement",
-          "Does not predict job performance",
-          "Not for hiring selection",
-          "Not for clinical diagnosis"
+          "not clinical",
+          "not hiring",
+          "not credentialing"
         ]
+      }
+    }
+  },
+  "faq_assets": [
+    {
+      "zh-CN": {
+        "question": "什么是 EQ？",
+        "answer": "EQ 指情绪与关系相关的自我觉察、调节、共情和关系处理方式。费马 EQ-60 用自我报告方式帮助你理解这些模式。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What is EQ?",
+        "answer": "EQ refers to emotional and relational patterns such as self-awareness, regulation, empathy, and relationship management. Fermat EQ-60 uses self-report to help you understand these patterns.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "这个 EQ 测试测什么？",
+        "answer": "它测你如何看待自己的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does this EQ test measure?",
+        "answer": "It measures how you perceive your emotional and relational tendencies across self-awareness, emotion regulation, empathy, and relationship management.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "它是不是现场表现测量？",
+        "answer": "不是。EQ-60 是自我报告结果，解释你如何看待自己的情绪与关系模式，不等同于受控任务中的现场表现。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is this based on real-time performance?",
+        "answer": "No. EQ-60 is a self-report result. It describes how you see your emotional and relational patterns, not how you would perform in a controlled task.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "和专业能力工具有什么区别？",
+        "answer": "专业能力工具通常需要受控任务、专门评分和资格管理。EQ-60 更适合自我理解和成长规划。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is it different from professional ability instruments?",
+        "answer": "Professional ability instruments use controlled tasks, specialized scoring, and qualification procedures. EQ-60 is for reflection and growth planning.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 IQ 有什么区别？",
+        "answer": "IQ 更关注认知问题解决；EQ-60 关注你如何感知、调节和处理情绪与关系。两者不是互相替代。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from IQ?",
+        "answer": "IQ focuses more on cognitive problem solving. EQ-60 focuses on how you perceive, regulate, and handle emotion and relationships. They are not substitutes for each other.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 MBTI 有什么区别？",
+        "answer": "MBTI 更像偏好类型语言；EQ-60 解释情绪和关系功能。两者可互补，但不能互相替代。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from MBTI?",
+        "answer": "MBTI is more of a preference-type language. EQ-60 explains emotional and relational functioning. They can complement each other but do not replace each other.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和 Big Five 有什么区别？",
+        "answer": "Big Five 描述广泛人格特质；EQ-60 聚焦情绪与关系模式。它们可能有重叠，但报告用途不同。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from Big Five?",
+        "answer": "Big Five describes broad personality traits. EQ-60 focuses on emotional and relational patterns. They may overlap, but their report use differs.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "EQ 和九型人格有什么区别？",
+        "answer": "九型人格常用于动机和模式叙事；EQ-60 更关注情绪觉察、调节、共情和关系管理。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How is EQ different from Enneagram?",
+        "answer": "Enneagram is often used for motivation and pattern narratives. EQ-60 focuses on awareness, regulation, empathy, and relationship management.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "结果准吗？",
+        "answer": "结果的有用性取决于题目质量、作答状态、常模版本和你是否如实作答。它适合作为自我理解起点。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is the result accurate?",
+        "answer": "Its usefulness depends on item quality, response context, norm version, and honest responding. It is best used as a starting point for self-understanding.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么用自我报告？",
+        "answer": "自我感知会影响你如何回应反馈、冲突和关系压力。它不是全部证据，但非常适合作为入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why self-report?",
+        "answer": "Self-perception affects how you respond to feedback, conflict, and relational pressure. It is not the whole picture, but it is a useful entry point.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以用于人事决定吗？",
+        "answer": "不建议。单次自我报告结果不适合用于录用、淘汰、晋升或岗位分配。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can it be used for employment decisions?",
+        "answer": "No. A single self-report result is not appropriate for selection, rejection, promotion, or role assignment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以用于健康判断吗？",
+        "answer": "不适合。它可以帮助你描述体验，但不能替代专业支持或高风险判断。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can it be used for health decisions?",
+        "answer": "No. It can help describe experience, but it does not replace qualified support or high-stakes judgment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "分数低怎么办？",
+        "answer": "先看最低维度和行动处方。低分不是失败，而是指向更具体的练习入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What if my score is low?",
+        "answer": "Start with the lowest dimension and the action prescription. A lower score is not failure; it points to a more specific practice entry point.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "低置信结果是什么意思？",
+        "answer": "它表示这次作答状态让解释需要更谨慎。你仍可参考，但不宜做强结论。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does lower confidence mean?",
+        "answer": "It means the response pattern calls for more cautious interpretation. You can still use it, but avoid strong conclusions.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以复测吗？",
+        "answer": "可以。建议在状态更稳定、没有赶时间时复测，并比较哪些维度保持一致。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can I retest?",
+        "answer": "Yes. Retest when you are not rushed and your context is steadier, then compare which dimensions remain stable.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么情境判断暂未开放？",
+        "answer": "因为情境题需要评分规则、文化审校和验证。当前先保持 planned 状态，不开放入口。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why is the scenario module not available yet?",
+        "answer": "Scenario items need scoring rubrics, cultural review, and validation. It remains planned and unavailable for now.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "未来情境判断会补充什么？",
+        "answer": "它会观察你在反馈、冲突、边界和压力场景中倾向选择什么回应。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What will the future scenario module add?",
+        "answer": "It will examine the responses you tend to choose in feedback, conflict, boundary, and pressure situations.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "情绪调节低是什么意思？",
+        "answer": "它通常表示在压力或被触发时恢复较慢，不代表你无法改变。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What does lower emotion regulation mean?",
+        "answer": "It often means recovery is slower under pressure or activation. It does not mean you cannot improve.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "共情高是不是一定好？",
+        "answer": "不是绝对好坏。高共情能帮助理解别人，但如果恢复和边界不足，也可能带来消耗。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is high empathy always good?",
+        "answer": "Not absolutely. High empathy helps you understand others, but without recovery and boundaries it can become draining.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "职业环境变量是什么意思？",
+        "answer": "它不是推荐具体职业，而是帮助你观察一个工作环境的人际密度、反馈强度、冲突频率和恢复空间。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "What is a career environment variable?",
+        "answer": "It is not a job recommendation. It helps you examine interpersonal density, feedback intensity, conflict frequency, and recovery space in a work environment.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "如何用结果处理反馈？",
+        "answer": "先看 ER 和 SA，再用行动处方把反馈拆成事实、感受和下一步。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How can I use the result for feedback?",
+        "answer": "Look at ER and SA, then use the action prescription to split feedback into facts, feelings, and next steps.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "如何用结果改善关系？",
+        "answer": "选择一个关系场景，不要泛泛改自己。先练一句更清楚、更可被接住的话。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How can I use the result in relationships?",
+        "answer": "Pick one relationship scene rather than trying to change everything. Practice one clearer, more receivable sentence.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "情商可以提升吗？",
+        "answer": "可以练习其中的具体行为，例如情绪命名、暂停、共情回应、边界表达和关系修复。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can EQ improve?",
+        "answer": "Specific behaviors can be practiced, such as emotion naming, pausing, empathic response, boundary expression, and repair.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "可以分享结果吗？",
+        "answer": "可以分享模式摘要，但不建议公开详细分数或把结果当作固定标签。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Can I share my result?",
+        "answer": "You can share a pattern summary, but avoid posting detailed scores or treating the result as a fixed label.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么要保存报告？",
+        "answer": "保存后你可以复测、比较变化，并继续查看行动处方。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why save the report?",
+        "answer": "Saving lets you retest, compare change, and keep the action plan continuous.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "这是给我贴标签吗？",
+        "answer": "不是。formulation 是把本次结果组织成一个可理解的模式，不是永久身份。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Is this labeling me?",
+        "answer": "No. A formulation organizes the current result into an understandable pattern; it is not a permanent identity.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "质量提示是不是说我答错了？",
+        "answer": "不是。质量提示描述这次作答状态，不评价你这个人。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Do quality flags mean I answered wrong?",
+        "answer": "No. Quality notes describe this response session; they do not judge you as a person.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "四个维度为什么是这四个？",
+        "answer": "它们覆盖自己与他人、理解与行动两个轴，形成一个简洁的情绪与关系矩阵。",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "Why these four dimensions?",
+        "answer": "They cover self vs others and understanding vs action, forming a concise emotional-relational matrix.",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "工作中怎么用？",
+        "answer": "把结果转成场景问题：我如何接收反馈、处理冲突、设边界、恢复压力？",
+        "do_not_overread": "FAQ 是教育性说明，不是个人结论。"
+      },
+      "en": {
+        "question": "How do I use it at work?",
+        "answer": "Translate it into scene questions: how do I handle feedback, conflict, boundaries, and recovery?",
+        "do_not_overread": "FAQ answers are educational, not personal conclusions."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "为什么要保存报告？",
+        "answer": "保存后，你可以回看本次核心模式、行动处方和复测变化。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "Why save the report?",
+        "answer": "Saving lets you return to your pattern, action prescription, and future retest comparison.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "多久复测一次比较合适？",
+        "answer": "如果你只是好奇，4–8 周后复测更有意义；如果本次置信度较低，可以在状态更稳定时更早复测。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "When should I retest?",
+        "answer": "For normal reflection, 4–8 weeks gives change more room to appear. If confidence was low, retest when your state is steadier.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    },
+    {
+      "zh-CN": {
+        "question": "我可以问 Agent 什么？",
+        "answer": "可以问一个具体场景，比如反馈、冲突、边界或压力恢复。Agent 应基于你的报告资产解释，不会改分数。",
+        "do_not_overread": "FAQ 是导航和教育说明，不是个人诊断。"
+      },
+      "en": {
+        "question": "What can I ask the Agent?",
+        "answer": "Ask about one real scene: feedback, conflict, boundaries, or recovery. The Agent explains your report assets; it does not change your scores.",
+        "do_not_overread": "FAQ is navigation and education, not a personal diagnosis."
+      }
+    }
+  ],
+  "seo_geo_assets": {
+    "eq.seo.en.emotional_intelligence_test": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotional Intelligence Test",
+        "meta_description": "Take a free emotional intelligence test focused on self-awareness, emotion regulation, empathy, and relationship management.",
+        "short_answer": "Understand your emotional and relational pattern, not a live-performance credential.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Understand your emotional and relational pattern, not a live-performance credential."
+      }
+    },
+    "eq.seo.en.free_eq_test": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Free EQ Test",
+        "meta_description": "A free EQ test with a complete self-report result, confidence note, and action prescription.",
+        "short_answer": "Designed for reflection, workstyle insight, and relationship growth.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Designed for reflection, workstyle insight, and relationship growth."
+      }
+    },
+    "eq.seo.en.eq_score_meaning": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ Score Meaning",
+        "meta_description": "Learn how EQ scores, bands, percentiles, and confidence notes should be read.",
+        "short_answer": "A score is a starting point; dimensions and context carry the real interpretation.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "A score is a starting point; dimensions and context carry the real interpretation."
+      }
+    },
+    "eq.seo.en.self_report_vs_ability_ei": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Self-Report vs Ability EI",
+        "meta_description": "Understand the difference between self-report EQ and controlled ability-style instruments.",
+        "short_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Fermat EQ-60 is self-report; the future scenario module will add applied judgment."
+      }
+    },
+    "eq.seo.en.eq_vs_iq": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ vs IQ",
+        "meta_description": "EQ and IQ describe different domains: emotional-relational patterns and cognitive problem solving.",
+        "short_answer": "The two are complementary and should not be collapsed into one score.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "The two are complementary and should not be collapsed into one score."
+      }
+    },
+    "eq.seo.en.eq_in_workplace": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotional Intelligence at Work",
+        "meta_description": "Use EQ results to examine feedback, conflict, collaboration, and recovery patterns.",
+        "short_answer": "Focus on environment variables and communication habits.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Focus on environment variables and communication habits."
+      }
+    },
+    "eq.seo.en.how_to_improve_eq": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "How to Improve EQ",
+        "meta_description": "Practice emotion naming, pausing, empathic response, boundaries, and repair.",
+        "short_answer": "Improvement begins with one repeatable behavior in a real situation.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Improvement begins with one repeatable behavior in a real situation."
+      }
+    },
+    "eq.seo.en.eq_and_relationships": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "EQ in Relationships",
+        "meta_description": "See how empathy, boundaries, expression, and repair shape relationship patterns.",
+        "short_answer": "The goal is clearer conversation, not fixed labels.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "The goal is clearer conversation, not fixed labels."
+      }
+    },
+    "eq.seo.en.emotion_regulation": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Emotion Regulation",
+        "meta_description": "Understand recovery and response choice after emotional activation.",
+        "short_answer": "Regulation is not suppression; it keeps enough choice to respond well.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Regulation is not suppression; it keeps enough choice to respond well."
+      }
+    },
+    "eq.seo.en.empathy_context": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Empathy in EQ",
+        "meta_description": "Empathy helps you read others, but needs boundaries and recovery.",
+        "short_answer": "High empathy can be a strength and a load depending on context.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "High empathy can be a strength and a load depending on context."
+      }
+    },
+    "eq.seo.en.eq_methodology": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Fermat EQ Methodology",
+        "meta_description": "How EQ-60 uses self-report, four dimensions, quality checks, and versioned norms.",
+        "short_answer": "Transparent boundaries make the result more useful, not weaker.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Transparent boundaries make the result more useful, not weaker."
+      }
+    },
+    "eq.seo.en.eq_retest": {
+      "zh-CN": {
+        "title": "情绪与关系模式测试",
+        "meta_description": "免费查看你的自我觉察、情绪调节、共情理解和关系管理模式。",
+        "short_answer": "理解你的情绪与关系模式，而不是给出高风险能力结论。",
+        "long_answer_outline": [
+          "测试定义",
+          "测量内容",
+          "不适用边界",
+          "下一步行动"
+        ],
+        "related_questions": [
+          "分数代表什么？",
+          "结果应该怎么使用？"
+        ],
+        "safe_claim_boundary": "用于自我理解和成长规划，不用于临床、招聘或认证判断。"
+      },
+      "en": {
+        "title": "Retesting EQ",
+        "meta_description": "Retesting can show which emotional-relational patterns remain stable over time.",
+        "short_answer": "Compare dimensions and confidence notes, not just the total score.",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": "Compare dimensions and confidence notes, not just the total score."
+      }
+    },
+    "eq.seo.zh.qingshang_ceshi": {
+      "zh-CN": {
+        "title": "情商测试",
+        "meta_description": "免费查看你的情绪与关系模式，包括自我觉察、情绪调节、共情理解和关系管理。",
+        "short_answer": "结果用于自我理解和成长规划，不用于高风险判断。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_ceshi": {
+      "zh-CN": {
+        "title": "EQ测试",
+        "meta_description": "基于 60 道自我报告题，生成情绪与关系模式报告。",
+        "short_answer": "重点不是给你贴标签，而是找到可执行的练习入口。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.qingxu_zhili": {
+      "zh-CN": {
+        "title": "情绪智力",
+        "meta_description": "了解情绪觉察、调节、共情和关系处理如何影响沟通与压力恢复。",
+        "short_answer": "情绪智力可以拆成具体行为来练习。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.qingxu_tiaojie": {
+      "zh-CN": {
+        "title": "情绪调节",
+        "meta_description": "理解被触发后如何暂停、恢复和选择回应。",
+        "short_answer": "情绪调节不是压抑情绪，而是保留回应选择。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.gongqing_nengli": {
+      "zh-CN": {
+        "title": "共情能力",
+        "meta_description": "共情帮助你读懂别人，但也需要边界和恢复。",
+        "short_answer": "高共情不是绝对好坏，要看它是否和调节协同。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_vs_iq": {
+      "zh-CN": {
+        "title": "EQ和IQ区别",
+        "meta_description": "IQ偏认知问题解决，EQ-60偏情绪与关系模式。",
+        "short_answer": "两者互补，不能互相替代。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.self_report_vs_ability": {
+      "zh-CN": {
+        "title": "自我报告和表现型测量区别",
+        "meta_description": "自我报告解释你如何看待自己，能力工具需要受控任务和专门评分。",
+        "short_answer": "费马 EQ-60 当前属于自我报告结果。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_score_meaning": {
+      "zh-CN": {
+        "title": "EQ分数怎么理解",
+        "meta_description": "分数要和四维、百分位、置信度和行动建议一起读。",
+        "short_answer": "不要只看一个总分。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_workplace": {
+      "zh-CN": {
+        "title": "职场情商",
+        "meta_description": "用 EQ 结果观察反馈、冲突、协作和恢复方式。",
+        "short_answer": "报告只解释环境变量和工作方式，不推荐具体岗位。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.improve_eq": {
+      "zh-CN": {
+        "title": "如何提高情商",
+        "meta_description": "从情绪命名、暂停、共情回应、边界表达和修复脚本开始。",
+        "short_answer": "选择一个场景练习，比泛泛努力更有效。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_relationship": {
+      "zh-CN": {
+        "title": "情商与关系",
+        "meta_description": "理解你如何表达、共情、设边界和修复关系。",
+        "short_answer": "结果不是关系定论，而是对话入口。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
+      }
+    },
+    "eq.seo.zh.eq_methodology": {
+      "zh-CN": {
+        "title": "费马EQ方法论",
+        "meta_description": "说明 EQ-60 的四维模型、计分、质量提示和科学边界。",
+        "short_answer": "透明的方法边界能提升可信度。",
+        "long_answer_outline": [
+          "definition",
+          "what it measures",
+          "what it does not decide",
+          "next useful action"
+        ],
+        "related_questions": [
+          "What does the score mean?",
+          "How should I use the result?"
+        ],
+        "safe_claim_boundary": "Use for reflection and growth planning; avoid high-stakes conclusions."
+      },
+      "en": {
+        "title": "",
+        "meta_description": "",
+        "short_answer": "",
+        "long_answer_outline": [],
+        "related_questions": [],
+        "safe_claim_boundary": "Use for self-understanding, reflection, and growth planning; do not use for clinical, hiring, or credentialing decisions.",
+        "search_intent_answer": ""
       }
     }
   }

--- a/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/sjt_bridge.json
+++ b/backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/sjt_bridge.json
@@ -4,22 +4,112 @@
   "assets": {
     "eq.sjt_bridge.planned": {
       "zh-CN": {
-        "title": "未来将支持 16 道情境判断模块",
-        "status": "planned",
-        "description": "当前报告基于 EQ-60 自我报告。未来 EQ-SJT 16 会补充你在反馈、冲突、边界和压力情境中的选择方式。",
-        "what_it_adds": "它用于补充 self-report，帮助比较自我感知与情境选择之间的一致和差距。",
-        "what_it_is_not": "它不是 MSCEIT，不是认证能力测验，也不用于招聘筛选或临床判断。",
-        "button_label": "情境判断模块规划中",
-        "available": false
+        "title": "未来情境判断模块",
+        "status": "planned_unavailable",
+        "description": "你现在看到的是自我报告结果。未来的情境判断模块会补充你在反馈、冲突、边界和压力场景中倾向选择的回应。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
       },
       "en": {
-        "title": "A 16-item scenario module is planned",
-        "status": "planned",
-        "description": "The current report is based on EQ-60 self-report. A future EQ-SJT 16 module will add how you choose responses in feedback, conflict, boundary, and pressure situations.",
-        "what_it_adds": "It supplements self-report by comparing self-perception with scenario choices.",
-        "what_it_is_not": "It is not MSCEIT, not a certified ability assessment, and not for hiring or clinical decisions.",
-        "button_label": "Scenario module planned",
-        "available": false
+        "title": "Future scenario module",
+        "status": "planned_unavailable",
+        "description": "You are seeing a self-report result. A future scenario module will add how you tend to choose responses in feedback, conflict, boundary, and pressure situations.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.what_it_adds": {
+      "zh-CN": {
+        "title": "它会补充什么",
+        "status": "planned_unavailable",
+        "description": "它会补充情境选择、压力下回应、边界和修复策略等信息，帮助形成自我感知 × 情境选择的综合报告。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "What it will add",
+        "status": "planned_unavailable",
+        "description": "It will add response choices, pressure reactions, boundary patterns, and repair strategies, supporting an integrated self-perception × scenario-choice report.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.what_it_is_not": {
+      "zh-CN": {
+        "title": "它不是什么",
+        "status": "planned_unavailable",
+        "description": "它不是受控专业能力工具，不提供资格凭证，不用于高风险判断。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "What it is not",
+        "status": "planned_unavailable",
+        "description": "It is not a controlled professional ability instrument, does not provide a credential, and is not for high-stakes decisions.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.future_integrated_report": {
+      "zh-CN": {
+        "title": "未来综合报告",
+        "status": "planned_unavailable",
+        "description": "未来综合报告会比较你如何看待自己，以及你在情境中倾向如何选择，从而显示一致处和差距。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "Future integrated report",
+        "status": "planned_unavailable",
+        "description": "The future integrated report will compare how you see yourself with how you tend to choose in scenarios, showing alignment and gaps.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
+      }
+    },
+    "eq.sjt_bridge.unavailable_note": {
+      "zh-CN": {
+        "title": "暂未开放说明",
+        "status": "planned_unavailable",
+        "description": "该模块仍在 planned 状态。前端不应提供可点击开始入口。",
+        "what_it_adds": "未来补充情境选择信息。",
+        "what_it_is_not": "当前未开放，不是 MSCEIT，也不是认证测评。",
+        "button_label": "暂未开放",
+        "available": false,
+        "do_not_overread": "当前没有开放题库、入口或综合报告。"
+      },
+      "en": {
+        "title": "Unavailable note",
+        "status": "planned_unavailable",
+        "description": "This module remains planned. The frontend should not provide a clickable start entry.",
+        "what_it_adds": "It supplements self-report with future scenario choices.",
+        "what_it_is_not": "It is not live, not MSCEIT, and not a certified assessment.",
+        "button_label": "Not available yet",
+        "available": false,
+        "do_not_overread": "There is no public item bank, entry point, or integrated report yet."
       }
     }
   }

--- a/backend/tests/Feature/Content/Eq60ContentGateTest.php
+++ b/backend/tests/Feature/Content/Eq60ContentGateTest.php
@@ -69,6 +69,12 @@ final class Eq60ContentGateTest extends TestCase
             'cross_assessment_context',
             'seo_geo_authority',
             'sjt_bridge',
+            'result_snapshot',
+            'commercial_conversion_assets',
+            'quality_confidence',
+            'psychometric_evidence_status',
+            'agent_dialogue_playbooks',
+            'backend_integration_contract',
             'personalization_routes',
         ], array_keys((array) data_get($assets, 'assets', [])));
 
@@ -152,6 +158,52 @@ final class Eq60ContentGateTest extends TestCase
         $plannedSjt = is_array($sjtAssets['eq.sjt_bridge.planned'] ?? null) ? $sjtAssets['eq.sjt_bridge.planned'] : [];
         $this->assertFalse((bool) data_get($plannedSjt, 'zh-CN.available', true));
         $this->assertStringContainsString('not MSCEIT', (string) data_get($plannedSjt, 'en.what_it_is_not'));
+
+        $resultSnapshotAssets = (array) data_get($assets, 'assets.result_snapshot.assets', []);
+        $highEmpathySnapshot = is_array($resultSnapshotAssets['eq.snapshot.high_empathy_low_recovery'] ?? null)
+            ? (array) $resultSnapshotAssets['eq.snapshot.high_empathy_low_recovery']
+            : [];
+        $this->assertStringContainsString('恢复系统', (string) data_get($highEmpathySnapshot, 'zh-CN.core_judgment'));
+        $this->assertStringContainsString('recovery can lag', (string) data_get($highEmpathySnapshot, 'en.core_judgment'));
+        $this->assertNotEmpty((array) data_get($highEmpathySnapshot, 'en.conversion_actions'));
+
+        $conversionAssets = (array) data_get($assets, 'assets.commercial_conversion_assets.assets', []);
+        foreach ([
+            'eq.conversion.save_report',
+            'eq.conversion.email_revisit',
+            'eq.conversion.pdf_export',
+            'eq.conversion.share_card',
+            'eq.conversion.retest_reminder',
+            'eq.conversion.related_tests',
+            'eq.conversion.agent_entry',
+        ] as $assetId) {
+            $asset = is_array($conversionAssets[$assetId] ?? null) ? (array) $conversionAssets[$assetId] : [];
+            $this->assertNotSame('', (string) data_get($asset, 'zh-CN.cta_label'));
+            $this->assertNotSame('', (string) data_get($asset, 'en.cta_label'));
+        }
+        $this->assertStringNotContainsString('SKU_EQ_60_FULL_299', json_encode($conversionAssets, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+        $this->assertStringNotContainsString('购买', json_encode($conversionAssets, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+        $this->assertStringNotContainsString('解锁', json_encode($conversionAssets, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        $qualityAssets = (array) data_get($assets, 'assets.quality_confidence.assets', []);
+        $qualityA = is_array($qualityAssets['eq.quality.level.A'] ?? null) ? (array) $qualityAssets['eq.quality.level.A'] : [];
+        $this->assertNotSame('', (string) data_get($qualityA, 'zh-CN.why_this_level'));
+        $this->assertNotSame('', (string) data_get($qualityA, 'en.how_to_read'));
+
+        $evidenceAssets = (array) data_get($assets, 'assets.psychometric_evidence_status.assets', []);
+        $contentValidity = is_array($evidenceAssets['eq.evidence.content_validity'] ?? null) ? (array) $evidenceAssets['eq.evidence.content_validity'] : [];
+        $this->assertNotSame('', (string) data_get($contentValidity, 'zh-CN.user_facing_status_label'));
+        $this->assertNotSame('', (string) data_get($contentValidity, 'en.next_validation_step'));
+
+        $agentPlaybooks = (array) data_get($assets, 'assets.agent_dialogue_playbooks.assets', []);
+        $understandResult = is_array($agentPlaybooks['eq.agent.playbook.understand_result'] ?? null) ? (array) $agentPlaybooks['eq.agent.playbook.understand_result'] : [];
+        $this->assertNotSame('', (string) data_get($understandResult, 'zh-CN.clarifying_question'));
+        $this->assertNotSame('', (string) data_get($understandResult, 'en.refusal_example'));
+
+        $backendContractAssets = (array) data_get($assets, 'assets.backend_integration_contract.assets', []);
+        $schemaMapping = is_array($backendContractAssets['eq.backend_contract.schema_mapping'] ?? null) ? (array) $backendContractAssets['eq.backend_contract.schema_mapping'] : [];
+        $this->assertNotSame('', (string) data_get($schemaMapping, 'zh-CN.requirement'));
+        $this->assertStringContainsString('compiler', (string) data_get($schemaMapping, 'en.requirement'));
 
         $seoGeoAssets = (array) data_get($assets, 'assets.seo_geo_authority.assets', []);
         $seoGeoAsset = is_array($seoGeoAssets['eq.seo_geo_authority.en_landing.default'] ?? null)

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5,7 +5,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-01 Backend EQ v1.6 content-pack import and compile lint",
     "checks": {
@@ -32,11 +32,15 @@
           "git diff --check"
         ],
         "notes": "Focused PR-EQ-ASSET-01 content lint, compile, content gate, metadata parse, and diff checks passed. Non-report-assets compile timestamp side effects were restored before staging."
+      },
+      "github_initial": {
+        "status": "pending",
+        "evidence": "PR #2384 opened; GitHub checks pending."
       }
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2384",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -58,6 +62,12 @@
         "from": "local_checks_passed",
         "to": "committed",
         "notes": "Committed PR-EQ-ASSET-01 scoped content-pack import changes; branch head will be recorded after PR open or merge."
+      },
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "committed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2384."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,136 @@
 {
   "train_id": "email-first-result-access",
   "updated_at": "2026-06-23T16:40:00Z",
+  "PR-EQ-ASSET-01": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-asset-01-content-pack-v16",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "eq_v16_content_asset_productization",
+    "title": "PR-EQ-ASSET-01 Backend EQ v1.6 content-pack import and compile lint",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-ASSET-01, PR-EQ-ASSET-02, and PR-EQ-ASSET-03 manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR-EQ-ASSET-01 is the first item in the EQ v1.6 content asset productization train."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to EQ content compile/lint services, EQ_60 and EQ_EMOTIONAL_INTELLIGENCE report assets, EQ report_assets compiled outputs, Eq60ContentGateTest, and authorized PR train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check"
+        ],
+        "notes": "Focused PR-EQ-ASSET-01 content lint, compile, content gate, metadata parse, and diff checks passed. Non-report-assets compile timestamp side effects were restored before staging."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit EQ v1.6 content asset productization authorization."
+      },
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "EQ_60 content lint, content compile, Eq60ContentGateTest, YAML parse, state JSON parse, and diff check passed."
+      },
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "committed",
+        "notes": "Committed PR-EQ-ASSET-01 scoped content-pack import changes; branch head will be recorded after PR open or merge."
+      }
+    ]
+  },
+  "PR-EQ-ASSET-02": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-asset-02-report-payload-fixtures-v16",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_v16_content_asset_productization",
+    "title": "PR-EQ-ASSET-02 Backend EQ v1.6 report payload and canonical fixtures",
+    "depends_on": [
+      "PR-EQ-ASSET-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-ASSET-01, PR-EQ-ASSET-02, and PR-EQ-ASSET-03 manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-ASSET-01 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit EQ v1.6 content asset productization authorization."
+      }
+    ]
+  },
+  "PR-EQ-ASSET-03": {
+    "repo": "fap-web",
+    "branch": "codex/pr-eq-asset-03-frontend-v16-fixtures",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_v16_content_asset_productization",
+    "title": "PR-EQ-ASSET-03 Frontend EQ v1.6 contract fixture consumption",
+    "depends_on": [
+      "PR-EQ-ASSET-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-ASSET-01, PR-EQ-ASSET-02, and PR-EQ-ASSET-03 manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-ASSET-02 to merge into main."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit EQ v1.6 content asset productization authorization."
+      }
+    ]
+  },
   "SEO-AGENT-ARTICLE41-DRAFT-CLAIM-RISK-QA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-agent-article41-draft-claim-risk-qa-01",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -11,6 +11,131 @@ continuation_protocol:
     do_not_stop_train_when_external_and_required_checks_green: true
 prs:
 
+  - id: PR-EQ-ASSET-01
+    repo: fap-api
+    branch: codex/pr-eq-asset-01-content-pack-v16
+    title: "PR-EQ-ASSET-01 Backend EQ v1.6 content-pack import and compile lint"
+    train_scope: eq_v16_content_asset_productization
+    scope:
+      - Adapt the desktop EQ v1.6 commercial-ready content package into existing EQ_60/v1 raw report asset structures.
+      - Add the v1.6 result snapshot, commercial conversion, quality confidence, psychometric evidence, agent playbook, and backend integration asset layers.
+      - Extend EQ content compile and lint coverage for the new asset layers.
+      - Keep EQ_EMOTIONAL_INTELLIGENCE/v1 raw and compiled report assets mirrored with EQ_60/v1.
+    allowed_paths:
+      - backend/app/Services/Content/Eq60ContentCompileService.php
+      - backend/app/Services/Content/Eq60ContentLintService.php
+      - backend/content_packs/EQ_60/v1/raw/report_assets/**
+      - backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+      - backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/raw/report_assets/**
+      - backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/compiled/report_assets.compiled.json
+      - backend/tests/Feature/Content/Eq60ContentGateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change EQ-60 questions, options, reverse keys, scoring semantics, or norm algorithms.
+      - Change report composer payload behavior.
+      - Modify fap-web.
+      - Implement EQ-SJT runtime, scorer, routes, or take flow.
+      - Add paid, locked, blur, SKU, or access-wall semantics.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-ASSET-02
+    repo: fap-api
+    depends_on: [PR-EQ-ASSET-01]
+    branch: codex/pr-eq-asset-02-report-payload-fixtures-v16
+    title: "PR-EQ-ASSET-02 Backend EQ v1.6 report payload and canonical fixtures"
+    train_scope: eq_v16_content_asset_productization
+    scope:
+      - Resolve v1.6 assets in Eq60ReportComposer while preserving the EQ v5 all-free contract.
+      - Upgrade methodology.report_version to eq_report_v5_assets_commercial_ready_v1_6.
+      - Regenerate backend canonical fixtures for balanced, high-empathy-low-recovery, and low-confidence cases in zh-CN and en.
+      - Keep next_module.available=false and no paid, locked, blur, SKU, or access-wall semantics.
+    allowed_paths:
+      - backend/app/Services/Report/Eq60ReportComposer.php
+      - backend/tests/Fixtures/eq/v5/**
+      - backend/tests/Feature/Report/*Eq60*
+      - backend/tests/Feature/Content/Eq60*
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify raw EQ content assets except for fixture-required metadata fixes.
+      - Change EQ-60 questions, options, reverse keys, scoring semantics, or norm algorithms.
+      - Modify fap-web.
+      - Implement EQ-SJT runtime, scorer, routes, or take flow.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-ASSET-03
+    repo: fap-web
+    depends_on: [PR-EQ-ASSET-02]
+    branch: codex/pr-eq-asset-03-frontend-v16-fixtures
+    title: "PR-EQ-ASSET-03 Frontend EQ v1.6 contract fixture consumption"
+    train_scope: eq_v16_content_asset_productization
+    scope:
+      - Sync frontend EQ fixtures with backend v1.6 canonical payloads.
+      - Extend EQResultV5 contract and e2e assertions for snapshot, conversion actions, career decision support, quality evidence, and Agent entry copy.
+      - Keep the page structure stable and consume backend resolved assets without hardcoded report prose.
+      - Preserve no paid CTA, no locked, no blur, no access wall, no SKU, and no raw technical tags.
+    allowed_paths:
+      - components/result/eq/**
+      - lib/api/v0_3.ts
+      - tests/contracts/eq-result-v5-renderer.contract.test.tsx
+      - tests/e2e/iq-eq-result-regression.spec.ts
+      - tests/fixtures/eq/v5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-api.
+      - Add frontend-owned official EQ report copy.
+      - Add SJT take entry before EQ-SJT frontend route is implemented in a later PR.
+      - Add paid, locked, blur, SKU, or access-wall semantics.
+    validation:
+      - pnpm typecheck
+      - pnpm test:contract
+      - pnpm exec playwright test tests/e2e/iq-eq-result-regression.spec.ts
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-PER-01
     repo: fap-api
     branch: codex/pr-eq-per-01-all-free-copy-contract-cleanup


### PR DESCRIPTION
## What changed
- Adapted the desktop EQ v1.6 commercial-ready content package into existing EQ_60/v1 raw report asset structures.
- Added v1.6 report asset layers: result snapshot, commercial conversion actions, quality confidence, psychometric evidence status, agent dialogue playbooks, and backend integration contract.
- Extended EQ content compile/lint coverage for the new asset files and risk-boundary checks.
- Mirrored raw and compiled report assets into EQ_EMOTIONAL_INTELLIGENCE/v1 to avoid alias drift.
- Initialized PR-EQ-ASSET-01/02/03 manifest/state entries from explicit user authorization.

## Why
EQ v1.6 content assets need to enter the backend-authoritative content pack pipeline before report payload and frontend fixture work can consume them deterministically.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No Eq60ReportComposer payload changes; PR-EQ-ASSET-02 will resolve v1.6 assets in report payloads and canonical fixtures.
- No frontend fixture or renderer changes; PR-EQ-ASSET-03 will consume backend canonical payloads.
- No EQ-SJT implementation, scorer, route, take flow, or visible take entry.
- No EQ-60 question, reverse-key, scoring, or norm algorithm changes.
- No paid, locked, blur, SKU, or access-wall semantics.

## Repository rule impact
Backend content pack remains the authority for EQ report content. This PR adds new backend-authoritative report asset layers and does not introduce frontend-owned editorial content.