### PR TITLE
PERSONALITY-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-APPROVAL-INTEGRATION-01

### DIFF
--- a/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
+++ b/backend/app/Services/Cms/Mbti64CmsProjectionDraftWriter.php
@@ -134,6 +134,7 @@ final class Mbti64CmsProjectionDraftWriter
                 ? $this->nextRevisionNo($pageType, $targetField, $targetId)
                 : null;
             $qaResult = $qaResultsByUrl[(string) $recommendation['target_url']] ?? [];
+            $recommendationSha256 = hash('sha256', $this->jsonString($recommendation));
 
             $preparedRows[] = [
                 'position' => $position + 1,
@@ -149,6 +150,7 @@ final class Mbti64CmsProjectionDraftWriter
                 'snapshot_key' => self::SNAPSHOT_KEY,
                 'source_sha256' => $sourceSha256,
                 'qa_source_sha256' => $qaSha256,
+                'recommendation_sha256' => $recommendationSha256,
                 'existing_revision_id' => $existingRevision?->id !== null ? (int) $existingRevision->id : null,
                 'existing_revision_no' => $existingRevision?->revision_no !== null ? (int) $existingRevision->revision_no : null,
                 'next_revision_no' => $nextRevisionNo,
@@ -156,6 +158,18 @@ final class Mbti64CmsProjectionDraftWriter
                 'action' => 'pending',
                 'snapshot_preview' => $this->snapshotPayload($package, $qa, $recommendation, $identity, $sourceSha256, $qaSha256, $qaResult),
             ];
+        }
+
+        $approvalGate = $this->agentBatchApprovalGate($preparedRows, $sourceSha256, $qaSha256, $options);
+        if ((bool) ($approvalGate['required_for_write'] ?? false)) {
+            $approvalRowsByUrl = is_array($approvalGate['rows_by_url'] ?? null) ? $approvalGate['rows_by_url'] : [];
+            foreach ($preparedRows as &$preparedRow) {
+                $preparedRow['approval_queue'] = $approvalRowsByUrl[(string) ($preparedRow['url'] ?? '')] ?? [
+                    'ready' => false,
+                    'blocker' => 'approval_row_missing',
+                ];
+            }
+            unset($preparedRow);
         }
 
         if ($errors !== []) {
@@ -166,8 +180,32 @@ final class Mbti64CmsProjectionDraftWriter
                 'variant_row_count' => $this->countRows($preparedRows, 'variant'),
                 'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
                 'subset' => $this->subsetSummary($options, $preparedRows),
+                'approval_queue' => $this->approvalGateForOutput($approvalGate),
                 'rows' => $preparedRows,
                 'errors' => $errors,
+                'warnings' => $warnings,
+            ]);
+        }
+
+        if ($write && (bool) ($approvalGate['required_for_write'] ?? false) && ! (bool) ($approvalGate['ready_for_write'] ?? false)) {
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write, $options), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($preparedRows),
+                'variant_row_count' => $this->countRows($preparedRows, 'variant'),
+                'comparison_row_count' => $this->countRows($preparedRows, 'comparison'),
+                'created_revision_count' => 0,
+                'skipped_existing_count' => 0,
+                'would_create_revision_count' => 0,
+                'writes_committed' => false,
+                'subset' => $this->subsetSummary($options, $preparedRows),
+                'approval_queue' => $this->approvalGateForOutput($approvalGate),
+                'rows' => $preparedRows,
+                'errors' => [[
+                    'field' => 'approval_queue',
+                    'code' => 'agent_batch_approval_required',
+                    'message' => 'Agent batch writes require every selected recommendation to have a matching approved personality agent approval queue item.',
+                ]],
                 'warnings' => $warnings,
             ]);
         }
@@ -215,6 +253,7 @@ final class Mbti64CmsProjectionDraftWriter
             'would_create_revision_count' => $write ? 0 : count($preparedRows) - $skippedExisting,
             'writes_committed' => $write && $created > 0,
             'subset' => $this->subsetSummary($options, $preparedRows),
+            'approval_queue' => $this->approvalGateForOutput($approvalGate),
             'rows' => $preparedRows,
             'errors' => [],
             'warnings' => $warnings,
@@ -576,6 +615,145 @@ final class Mbti64CmsProjectionDraftWriter
     }
 
     /**
+     * @param  list<array<string,mixed>>  $preparedRows
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function agentBatchApprovalGate(array $preparedRows, string $sourceSha256, string $qaSha256, array $options): array
+    {
+        if (! $this->agentBatchRequested($options)) {
+            return [
+                'required_for_write' => false,
+                'ready_for_write' => true,
+                'write_blocked_until_approved' => false,
+            ];
+        }
+
+        $batch = DB::table('personality_agent_approval_batches')
+            ->where('framework', 'mbti64')
+            ->where('source_package_sha256', $sourceSha256)
+            ->where('qa_sha256', $qaSha256)
+            ->first();
+
+        $rowsByUrl = [];
+        $counts = [
+            'approved_count' => 0,
+            'missing_count' => 0,
+            'pending_count' => 0,
+            'rejected_count' => 0,
+            'blocked_count' => 0,
+            'recommendation_hash_mismatch_count' => 0,
+            'qa_not_pass_count' => 0,
+            'approved_without_timestamp_count' => 0,
+        ];
+
+        foreach ($preparedRows as $row) {
+            $url = (string) ($row['url'] ?? '');
+            $expectedRecommendationSha = (string) ($row['recommendation_sha256'] ?? '');
+            $item = $batch === null
+                ? null
+                : DB::table('personality_agent_approval_items')
+                    ->where('batch_id', (int) $batch->id)
+                    ->where('target_url', $url)
+                    ->first();
+            $decision = $this->approvalDecisionForItem($item, $expectedRecommendationSha);
+            $blocker = (string) ($decision['blocker'] ?? '');
+
+            if ($blocker === '') {
+                $counts['approved_count']++;
+            } elseif (array_key_exists($blocker.'_count', $counts)) {
+                $counts[$blocker.'_count']++;
+            } else {
+                $counts['blocked_count']++;
+            }
+
+            $rowsByUrl[$url] = [
+                'ready' => (bool) $decision['ready'],
+                'blocker' => $blocker !== '' ? $blocker : null,
+                'approval_batch_id' => $batch?->id !== null ? (int) $batch->id : null,
+                'approval_item_id' => $item?->id !== null ? (int) $item->id : null,
+                'approval_state' => $item?->approval_state !== null ? (string) $item->approval_state : null,
+                'approved_at_present' => $item?->approved_at !== null,
+                'qa_decision' => $item?->qa_decision !== null ? (string) $item->qa_decision : null,
+                'expected_recommendation_sha256' => $expectedRecommendationSha,
+                'actual_recommendation_sha256' => $item?->recommendation_sha256 !== null ? (string) $item->recommendation_sha256 : null,
+            ];
+        }
+
+        $readyForWrite = count($preparedRows) > 0 && $counts['approved_count'] === count($preparedRows);
+
+        return array_merge([
+            'required_for_write' => true,
+            'ready_for_write' => $readyForWrite,
+            'write_blocked_until_approved' => ! $readyForWrite,
+            'approval_batch_id' => $batch?->id !== null ? (int) $batch->id : null,
+            'expected_source_package_sha256' => $sourceSha256,
+            'expected_qa_sha256' => $qaSha256,
+            'required_item_count' => count($preparedRows),
+            'rows_by_url' => $rowsByUrl,
+        ], $counts);
+    }
+
+    /**
+     * @return array{ready:bool,blocker:string|null}
+     */
+    private function approvalDecisionForItem(?object $item, string $expectedRecommendationSha): array
+    {
+        if ($item === null) {
+            return ['ready' => false, 'blocker' => 'missing'];
+        }
+
+        $blockedReason = $item->blocked_reason !== null ? trim((string) $item->blocked_reason) : '';
+        if ($blockedReason !== '') {
+            return ['ready' => false, 'blocker' => 'blocked'];
+        }
+
+        $state = (string) ($item->approval_state ?? '');
+        if ($state === 'rejected') {
+            return ['ready' => false, 'blocker' => 'rejected'];
+        }
+        if ($state !== 'approved') {
+            return ['ready' => false, 'blocker' => 'pending'];
+        }
+
+        if ($item->approved_at === null) {
+            return ['ready' => false, 'blocker' => 'approved_without_timestamp'];
+        }
+
+        if ((string) ($item->recommendation_sha256 ?? '') !== $expectedRecommendationSha) {
+            return ['ready' => false, 'blocker' => 'recommendation_hash_mismatch'];
+        }
+
+        if (! $this->approvalQaDecisionPasses((string) ($item->qa_decision ?? ''))) {
+            return ['ready' => false, 'blocker' => 'qa_not_pass'];
+        }
+
+        return ['ready' => true, 'blocker' => null];
+    }
+
+    private function approvalQaDecisionPasses(string $decision): bool
+    {
+        return in_array($decision, [
+            'pass',
+            'PASS',
+            'PASS_READY_FOR_CMS_DRAFT',
+            'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
+        ], true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $approvalGate
+     * @return array<string,mixed>
+     */
+    private function approvalGateForOutput(array $approvalGate): array
+    {
+        $output = $approvalGate;
+        unset($output['rows_by_url']);
+
+        return $output;
+    }
+
+    /**
      * @param  array<string,mixed>  $preparedRow
      */
     private function createRevision(array $preparedRow): PersonalityProfileRevision|PersonalityProfileVariantRevision
@@ -797,5 +975,16 @@ final class Mbti64CmsProjectionDraftWriter
         }
 
         return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
     }
 }

--- a/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php
@@ -14,6 +14,7 @@ use App\Models\PersonalityProfileVariantSection;
 use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -555,6 +556,11 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertFalse($payload['subset']['arbitrary_url_subset_allowed']);
         $this->assertSame([5, 10], $payload['subset']['allowed_batch_sizes']);
         $this->assertSame($expectedUrls, $payload['subset']['selected_urls']);
+        $this->assertTrue($payload['approval_queue']['required_for_write']);
+        $this->assertFalse($payload['approval_queue']['ready_for_write']);
+        $this->assertTrue($payload['approval_queue']['write_blocked_until_approved']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(5, $payload['approval_queue']['missing_count']);
         $this->assertSame($expectedUrls, array_map(
             static fn (array $row): string => (string) ($row['url'] ?? ''),
             $payload['rows'] ?? []
@@ -611,10 +617,40 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
 
+    public function test_agent_batch_safe_write_without_approved_queue_rows_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(5, $payload['row_count']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(5, $payload['approval_queue']['missing_count']);
+        $this->assertTrue($payload['approval_queue']['write_blocked_until_approved']);
+        $this->assertContains('agent_batch_approval_required', array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
     public function test_agent_batch_safe_write_creates_only_selected_draft_revisions(): void
     {
         $targets = $this->seedAllTargets();
-        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0);
         $profileBefore = $this->profileLiveState($targets['en|ENFJ']);
         $variantBefore = $this->variantLiveState($targets['en|ENFJ-A']);
         $surfaceCountsBefore = $this->liveSurfaceCounts();
@@ -634,6 +670,8 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(5, $payload['created_revision_count']);
         $this->assertSame(0, $payload['skipped_existing_count']);
         $this->assertSame('agent_batch_safe', $payload['subset']['mode']);
+        $this->assertTrue($payload['approval_queue']['ready_for_write']);
+        $this->assertSame(5, $payload['approval_queue']['approved_count']);
         $this->assertSame($this->expectedBatchUrls(5, 0), $payload['subset']['selected_urls']);
         $this->assertSame($payload['comparison_row_count'], PersonalityProfileRevision::query()->count());
         $this->assertSame($payload['variant_row_count'], PersonalityProfileVariantRevision::query()->count());
@@ -652,7 +690,10 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
     public function test_agent_batch_safe_second_write_is_idempotent_for_same_source_hash(): void
     {
         $this->seedAllTargets();
-        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0);
         $options = $this->writeOptions($packagePath, $qaPath);
         $options['--agent-batch-size'] = '5';
         $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
@@ -669,6 +710,127 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         $this->assertSame(0, $payload['created_revision_count']);
         $this->assertSame(5, $payload['skipped_existing_count']);
         $this->assertSame(5, PersonalityProfileRevision::query()->count() + PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_with_partial_approval_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 4, 0);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(4, $payload['approval_queue']['approved_count']);
+        $this->assertSame(1, $payload['approval_queue']['missing_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_with_rejected_item_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0, [
+            $this->expectedBatchUrls(5, 0)[0] => [
+                'approval_state' => 'rejected',
+                'approved_at' => null,
+                'rejected_at' => now(),
+            ],
+        ]);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(4, $payload['approval_queue']['approved_count']);
+        $this->assertSame(1, $payload['approval_queue']['rejected_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_with_stale_package_hash_approval_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0, [], 'stale-package-sha');
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(5, $payload['approval_queue']['missing_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_with_stale_qa_hash_approval_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0, [], null, 'stale-qa-sha');
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(0, $payload['approval_queue']['approved_count']);
+        $this->assertSame(5, $payload['approval_queue']['missing_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
+    }
+
+    public function test_agent_batch_safe_write_with_recommendation_hash_mismatch_fails_closed_without_revisions(): void
+    {
+        $this->seedAllTargets();
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->seedApprovedAgentApprovalRows($package, $qa, $packagePath, $qaPath, 5, 0, [
+            $this->expectedBatchUrls(5, 0)[0] => [
+                'recommendation_sha256' => str_repeat('a', 64),
+            ],
+        ]);
+        $options = $this->writeOptions($packagePath, $qaPath);
+        $options['--agent-batch-size'] = '5';
+        $options['--operator-approved'] = 'MBTI64-AGENT-CMS-DRAFT-BATCH-SAFE-WRITER-01';
+
+        $exitCode = Artisan::call('personality:mbti64-cms-projection-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(4, $payload['approval_queue']['approved_count']);
+        $this->assertSame(1, $payload['approval_queue']['recommendation_hash_mismatch_count']);
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
 
     public function test_agent_batch_safe_rejects_invalid_batch_size_without_writes(): void
@@ -1291,6 +1453,89 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
     }
 
     /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @param  array<string,array<string,mixed>>  $overridesByUrl
+     */
+    private function seedApprovedAgentApprovalRows(
+        array $package,
+        array $qa,
+        string $packagePath,
+        string $qaPath,
+        int $size,
+        int $offset,
+        array $overridesByUrl = [],
+        ?string $sourceSha256 = null,
+        ?string $qaSha256 = null,
+    ): void {
+        $sourceSha256 ??= hash_file('sha256', $packagePath);
+        $qaSha256 ??= hash_file('sha256', $qaPath);
+        $recommendations = array_slice((array) $package['recommendations'], $offset, $size);
+        $qaResultsByUrl = [];
+        foreach ((array) $qa['page_results'] as $qaResult) {
+            if (is_array($qaResult)) {
+                $qaResultsByUrl[(string) ($qaResult['target_url'] ?? '')] = $qaResult;
+            }
+        }
+
+        $batchId = (int) DB::table('personality_agent_approval_batches')->insertGetId([
+            'framework' => 'mbti64',
+            'source_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_artifact_path' => $packagePath,
+            'source_package_sha256' => $sourceSha256,
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'qa_artifact_path' => $qaPath,
+            'qa_sha256' => $qaSha256,
+            'status' => 'pending_review',
+            'planned_item_count' => count($recommendations),
+            'queued_item_count' => count($recommendations),
+            'blocked_item_count' => 0,
+            'safety_holds_json' => $this->jsonString([
+                'cms_write_attempted' => false,
+                'publish_attempted' => false,
+                'search_release_attempted' => false,
+            ]),
+            'summary_json' => $this->jsonString(['fixture' => true]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        foreach ($recommendations as $recommendation) {
+            $this->assertIsArray($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $path = (string) (parse_url($targetUrl, PHP_URL_PATH) ?: '');
+            $override = $overridesByUrl[$targetUrl] ?? [];
+            $qaResult = $qaResultsByUrl[$targetUrl] ?? [];
+            $row = array_merge([
+                'batch_id' => $batchId,
+                'framework' => 'mbti64',
+                'target_url' => $targetUrl,
+                'path' => $path,
+                'locale' => str_starts_with($path, '/zh/') ? 'zh-CN' : 'en',
+                'page_type' => str_contains($path, '-a-vs-') ? 'personality_profile_comparison' : 'personality_profile_variant',
+                'recommendation_id' => (string) ($recommendation['recommendation_id'] ?? ''),
+                'recommendation_sha256' => hash('sha256', $this->jsonString($recommendation)),
+                'qa_decision' => 'PASS_READY_FOR_CMS_DRAFT',
+                'approval_state' => 'approved',
+                'approved_at' => now(),
+                'rejected_at' => null,
+                'blocked_reason' => null,
+                'safety_holds_json' => $this->jsonString([
+                    'cms_write_attempted' => false,
+                    'publish_attempted' => false,
+                    'search_release_attempted' => false,
+                ]),
+                'recommendation_json' => $this->jsonString($recommendation),
+                'qa_json' => $this->jsonString(is_array($qaResult) ? $qaResult : []),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], $override);
+
+            DB::table('personality_agent_approval_items')->insert($row);
+        }
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function jsonOutput(): array
@@ -1311,5 +1556,16 @@ final class PersonalityMbti64CmsProjectionDraftCommandTest extends TestCase
         sort($values);
 
         return $values;
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
     }
 }


### PR DESCRIPTION
## What changed
- Added approval-queue enforcement for `personality:mbti64-cms-projection-draft` agent-batch writes.
- Agent-batch rows now carry deterministic `recommendation_sha256` values and write mode requires matching approved `personality_agent_approval_items` evidence by source package hash, QA hash, target URL, and recommendation hash.
- Dry-run remains non-mutating and reports approval readiness counts plus `write_blocked_until_approved` when approvals are missing or pending.
- Write mode fails closed with zero draft revisions when any selected row is missing approval, pending, rejected, blocked, stale, hash-mismatched, or not QA-pass.
- Existing full-88, visible-3, fresh-3, and fresh-5 fixed flows remain unchanged.

## Why
This connects the existing approval queue to the batch-safe CMS draft writer so only QA PASS + human-approved agent recommendations can create draft revisions.

## Validation
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityMbti64CmsProjectionDraftCommandTest.php --display-warnings`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`

Note: the first two PHPUnit commands passed with local temp-worktree `.env` file warnings before the CI script generated its temp env.

## Intentionally deferred
- No approval UI or approve command changes.
- No CMS live content promotion.
- No publish/index/search, sitemap/llms, queue enqueue/approve/submit, or external API behavior.

## Repository rule impact
Backend CMS remains the authority. This PR adds an approval-gating layer before draft-only revision creation for agent-batch writes; it does not introduce frontend content authority or runtime publishing behavior.