### PR TITLE
Sanitize career detail source lineage payload

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -16,6 +16,21 @@ final class CareerJobDetailController extends Controller
 {
     use RespondsWithNotFound;
 
+    private const INTERNAL_READER_PAYLOAD_KEYS = [
+        'source_id',
+        'source_ids',
+        'source_trace_id',
+        'evidence_id',
+        'row_hash',
+        'search_projection',
+        'audit_fields',
+        'compile_refs',
+        'crosswalk_ids',
+        'import_run_id',
+        'compile_run_id',
+        'index_state_id',
+    ];
+
     public function __construct(
         private readonly PublicCareerAuthorityResponseCache $responseCache,
         private readonly CareerCnProxyPublicOwnerSurfaceBuilder $cnProxySurfaceBuilder,
@@ -50,22 +65,24 @@ final class CareerJobDetailController extends Controller
      */
     private function projectReaderSafePayload(array $payload): array
     {
-        if (! is_array($payload['truth_layer']['source_refs'] ?? null)) {
-            return $payload;
+        return $this->stripInternalReaderPayloadKeys($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function stripInternalReaderPayloadKeys(array $payload): array
+    {
+        foreach (self::INTERNAL_READER_PAYLOAD_KEYS as $key) {
+            unset($payload[$key]);
         }
 
-        $payload['truth_layer']['source_refs'] = array_values(array_map(
-            static function (mixed $sourceRef): mixed {
-                if (! is_array($sourceRef)) {
-                    return $sourceRef;
-                }
-
-                unset($sourceRef['source_id'], $sourceRef['source_trace_id']);
-
-                return $sourceRef;
-            },
-            $payload['truth_layer']['source_refs'],
-        ));
+        foreach ($payload as $key => $value) {
+            if (is_array($value)) {
+                $payload[$key] = $this->stripInternalReaderPayloadKeys($value);
+            }
+        }
 
         return $payload;
     }

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -175,11 +175,31 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors')
             ->assertJsonMissingPath('truth_layer.source_refs.0.source_id')
-            ->assertJsonMissingPath('truth_layer.source_refs.0.source_trace_id');
+            ->assertJsonMissingPath('truth_layer.source_refs.0.source_trace_id')
+            ->assertJsonMissingPath('provenance_meta.source_trace_id')
+            ->assertJsonMissingPath('provenance_meta.compile_refs')
+            ->assertJsonMissingPath('provenance_meta.import_run_id')
+            ->assertJsonMissingPath('provenance_meta.compile_run_id')
+            ->assertJsonMissingPath('provenance_meta.index_state_id');
 
-        $encoded = json_encode($response->json('truth_layer.source_refs'), JSON_THROW_ON_ERROR);
-        $this->assertStringNotContainsString('source_id', $encoded);
-        $this->assertStringNotContainsString('source_trace_id', $encoded);
+        $encoded = json_encode($response->json(), JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'source_id',
+            'source_ids',
+            'source_trace_id',
+            'evidence_id',
+            'row_hash',
+            'search_projection',
+            'audit_fields',
+            'compile_refs',
+            'crosswalk_ids',
+            'import_run_id',
+            'compile_run_id',
+            'index_state_id',
+        ] as $internalKey) {
+            $this->assertStringNotContainsString($internalKey, $encoded);
+        }
     }
 
     public function test_it_adds_display_surface_for_selected_d5_assets(): void


### PR DESCRIPTION
## Summary
- Add recursive reader-safe sanitization for public career detail payloads.
- Strip source lineage and audit/internal keys anywhere in the response tree, including provenance metadata.
- Extend the career detail feature test to assert the full JSON payload does not expose internal lineage keys.

## Validation
- php artisan test --filter=CareerJobDisplaySurfaceApiTest
- php artisan route:list --path=api/v0.5/career/jobs --no-ansi
- git diff --check

## Intentionally deferred
- No content asset edits.
- No career asset re-import.
- No route readiness changes.
- No runtime/SEO/CMS changes.
- No staging or production import.

## Repository rule impact
Public career detail APIs remain backend-authoritative; this PR only tightens reader-safe projection and does not introduce frontend fallback content or SEO/runtime enumeration changes.