### PR TITLE
ENNEAGRAM-AGENT-APPROVAL-QUEUE-INTEGRATION-01

### DIFF
--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -284,6 +284,14 @@ final class PersonalityAgentApprovalQueueWriter
             ];
         }
 
+        if ($this->isEnneagramPublicContentAssetPath($path, $matches)) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'page_type' => 'personality_public_content_asset',
+            ];
+        }
+
         if (preg_match('#^/(?<prefix>en|zh)/personality/[a-z0-9-]+$#i', $path, $matches) === 1) {
             return [
                 'path' => $path,
@@ -293,6 +301,26 @@ final class PersonalityAgentApprovalQueueWriter
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string,string>  $matches
+     */
+    private function isEnneagramPublicContentAssetPath(string $path, ?array &$matches = null): bool
+    {
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram$#i', $path, $matches) === 1) {
+            return true;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/centers/(?:gut|heart|head)$#i', $path, $matches) === 1) {
+            return true;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/type-[1-9]$#i', $path, $matches) === 1) {
+            return true;
+        }
+
+        return false;
     }
 
     private function localeFromPrefix(string $prefix): string
@@ -306,6 +334,7 @@ final class PersonalityAgentApprovalQueueWriter
             'pass',
             'PASS',
             'PASS_READY_FOR_CMS_DRAFT',
+            'PASS_READY_FOR_APPROVAL_QUEUE',
             'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
         ], true);
     }

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -147,6 +147,127 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         );
     }
 
+    public function test_enneagram_dry_run_accepts_hub_centers_and_core_type_public_asset_paths(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validEnneagramPackage(), $this->validEnneagramQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('enneagram', $payload['framework']);
+        $this->assertSame(3, $payload['planned_item_count']);
+        $this->assertSame(0, $payload['blocked_item_count']);
+        $this->assertSame(0, $payload['created_item_count']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertEquals(
+            ['personality_public_content_asset'],
+            array_values(array_unique(array_map(
+                static fn (array $item): string => (string) $item['page_type'],
+                $payload['items']
+            )))
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
+    public function test_enneagram_write_creates_pending_items_without_cms_or_search_side_effects(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validEnneagramPackage(), $this->validEnneagramQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('enneagram', $payload['framework']);
+        $this->assertSame(3, $payload['planned_item_count']);
+        $this->assertSame(3, $payload['created_item_count']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertFalse($payload['external_calls_attempted']);
+
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->where('framework', 'enneagram')->count());
+        $this->assertSame(3, DB::table('personality_agent_approval_items')->where('framework', 'enneagram')->count());
+        $this->assertSame(
+            ['pending'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('approval_state')->all()
+        );
+        $this->assertSame(
+            ['personality_public_content_asset'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('page_type')->all()
+        );
+    }
+
+    public function test_enneagram_wing_instinct_and_tritype_urls_fail_closed(): void
+    {
+        $package = [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'enneagram.agent_pilot.v1',
+            'status' => 'pass_ready_for_qa_gates',
+            'recommendations' => [
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/en/personality/enneagram/type-1-wing-9',
+                    'https://fermatmind.com/en/personality/enneagram/type-1-wing-9',
+                    'en',
+                    'wing'
+                ),
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/en/personality/enneagram/instinctual-subtypes',
+                    'https://fermatmind.com/en/personality/enneagram/instinctual-subtypes',
+                    'en',
+                    'instinctual_subtype'
+                ),
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/zh/personality/enneagram/tritype',
+                    'https://fermatmind.com/zh/personality/enneagram/tritype',
+                    'zh-CN',
+                    'tritype'
+                ),
+            ],
+        ];
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram/type-1-wing-9', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram/instinctual-subtypes', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+                $this->qaRow('https://fermatmind.com/zh/personality/enneagram/tritype', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+            ],
+        ]);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(0, $payload['planned_item_count']);
+        $this->assertSame(3, $payload['blocked_item_count']);
+        $this->assertContains('no_queueable_qa_passed_items', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -174,6 +295,54 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
     /**
      * @return array<string,mixed>
      */
+    private function validEnneagramPackage(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'enneagram.agent_pilot.v1',
+            'status' => 'pass_ready_for_qa_gates',
+            'recommendations' => [
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/en/personality/enneagram',
+                    'https://fermatmind.com/en/personality/enneagram',
+                    'en',
+                    'hub'
+                ),
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/zh/personality/enneagram/centers/gut',
+                    'https://fermatmind.com/zh/personality/enneagram/centers/gut',
+                    'zh-CN',
+                    'center'
+                ),
+                $this->enneagramRecommendation(
+                    'enneagram-agent:/en/personality/enneagram/type-1',
+                    'https://fermatmind.com/en/personality/enneagram/type-1',
+                    'en',
+                    'core_type'
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validEnneagramQa(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+                $this->qaRow('https://fermatmind.com/zh/personality/enneagram/centers/gut', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram/type-1', 'PASS_READY_FOR_APPROVAL_QUEUE'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     private function validQa(): array
     {
         return [
@@ -182,6 +351,29 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
             'page_results' => [
                 $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CMS_DRAFT'),
                 $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_CMS_DRAFT'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function enneagramRecommendation(string $id, string $targetUrl, string $locale, string $entityType): array
+    {
+        return [
+            'recommendation_id' => $id,
+            'target_url' => $targetUrl,
+            'framework' => 'enneagram',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => 'Enneagram title',
+                'description' => 'Enneagram description',
+                'h1' => 'Enneagram H1',
+                'quick_answer' => 'Reflective Enneagram quick answer.',
+                'faq' => [],
+                'internal_links' => [],
+                'differentiation_notes' => [],
             ],
         ];
     }


### PR DESCRIPTION
## What changed
- Extended the personality agent approval queue identity contract to accept Enneagram public content asset URLs for hub, center, and core type pages.
- Allowed the Enneagram QA closeout decision `PASS_READY_FOR_APPROVAL_QUEUE` to enter approval queue planning.
- Added focused tests proving Enneagram hub/center/core recommendations can enter pending approval queue state, while wing, instinctual subtype, and Tritype URLs fail closed.

## Why
This completes the Enneagram approval queue integration scope: QA-passed Enneagram recommendations can be staged for human review without writing CMS drafts or touching live content.

## Validation
- `php -l app/Services/Cms/PersonalityAgentApprovalQueueWriter.php`
- `php -l tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only `backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php` and `backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php` changed.

## Intentionally deferred
- No CMS draft writes.
- No live content promotion.
- No publish, index/search, sitemap/llms, queue enqueue/approve/submit, frontend, or production deploy changes.
- Enneagram CMS draft writer contract remains a separate follow-up PR.