### PR TITLE
ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php
+++ b/backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\EnneagramCmsDraftWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityEnneagramCmsDraft extends Command
+{
+    private const OPERATOR_APPROVAL = 'ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'draft-only',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:enneagram-cms-draft
+        {--package= : Path to the Enneagram agent recommendation JSON package}
+        {--qa= : Path to the Enneagram agent QA JSON artifact}
+        {--dry-run : Validate and plan without database writes}
+        {--write : Create Enneagram public content asset draft rows}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--draft-only : Required for --write; confirms draft-only content asset write}
+        {--no-publish : Required for --write; confirms no publish action}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Create Enneagram public profile CMS draft assets with explicit no-publish/no-index guards.';
+
+    public function handle(EnneagramCmsDraftWriter $writer): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(EnneagramCmsDraftWriter $writer): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = $this->resolvePath(trim((string) $this->option('package')), 'Package');
+        $qaPath = $this->resolvePath(trim((string) $this->option('qa')), 'QA artifact');
+        $packageRaw = (string) File::get($packagePath);
+        $qaRaw = (string) File::get($qaPath);
+        $package = json_decode($packageRaw, true);
+        $qa = json_decode($qaRaw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+        if (! is_array($qa)) {
+            throw new RuntimeException('QA artifact must be a JSON object.');
+        }
+
+        $summary = $write
+            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw))
+            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw));
+
+        return array_merge($summary, [
+            'package_path' => $packagePath,
+            'qa_path' => $qaPath,
+            'command' => 'personality:enneagram-cms-draft',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path, string $label): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('--'.strtolower(str_replace(' artifact', '', $label)).' is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException($label.' file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
+        $this->line('created_asset_count='.(string) ($summary['created_asset_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -175,6 +175,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityAgentApprovalQueueCommand;
+use App\Console\Commands\PersonalityEnneagramCmsDraft;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
 use App\Console\Commands\PersonalityMbti64BackendImportContract;
@@ -247,6 +248,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityAgentApprovalQueueCommand::class,
+        PersonalityEnneagramCmsDraft::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64GscQueryReadonlyExport::class,
         PersonalityMbti64CmsInternalLinkDraft::class,

--- a/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
+++ b/backend/app/Services/Cms/EnneagramCmsDraftWriter.php
@@ -1,0 +1,464 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Support\Facades\DB;
+
+final class EnneagramCmsDraftWriter
+{
+    private const SNAPSHOT_SOURCE = 'enneagram_agent_projection_draft_v1';
+
+    private const ALLOWED_ENTITY_TYPES = [
+        PersonalityPublicContentAsset::ENTITY_HUB,
+        PersonalityPublicContentAsset::ENTITY_CENTER,
+        PersonalityPublicContentAsset::ENTITY_CORE_TYPE,
+    ];
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    {
+        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    {
+        $qaRows = $this->qaRowsByUrl($qa);
+        $errors = [];
+        $rows = [];
+
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $qaRow = $qaRows[$targetUrl] ?? [];
+            $recommendationJson = $this->jsonString($recommendation);
+
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'unsupported_enneagram_target_url',
+                    'message' => 'Only Enneagram hub, center, and core type public URLs are supported.',
+                ];
+
+                continue;
+            }
+
+            if ($this->containsForbiddenRoutePattern($targetUrl) || $this->containsForbiddenRoutePattern($recommendationJson)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position),
+                    'code' => 'forbidden_private_route_pattern_present',
+                    'message' => 'Recommendation contains a private/result/order/payment/account/share route or sensitive query key.',
+                ];
+            }
+
+            if ($qaRow === [] || ! $this->qaDecisionPasses((string) ($qaRow['decision'] ?? $qaRow['status'] ?? $qaRow['qa_status'] ?? ''))) {
+                $errors[] = [
+                    'field' => 'qa.'.((string) $targetUrl),
+                    'code' => 'qa_pass_required',
+                    'message' => 'Every Enneagram draft row requires a matching PASS QA row.',
+                ];
+            }
+
+            if ((array) ($qaRow['blockers'] ?? []) !== []) {
+                $errors[] = [
+                    'field' => 'qa.'.((string) $targetUrl).'.blockers',
+                    'code' => 'qa_blockers_present',
+                    'message' => 'QA blockers prevent CMS draft planning.',
+                ];
+            }
+
+            $existing = $this->existingAsset($identity);
+            if ($existing instanceof PersonalityPublicContentAsset && ! $this->existingAssetIsWritableDraft($existing, $sourceSha256)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'existing_live_or_foreign_asset_blocks_draft_write',
+                    'message' => 'Existing public/content-ready/published/indexable or foreign-source asset blocks draft-only writes.',
+                ];
+            }
+
+            $rows[] = [
+                'position' => $position + 1,
+                'url' => $targetUrl,
+                'path' => $identity['path'],
+                'locale' => $identity['locale'],
+                'entity_type' => $identity['entity_type'],
+                'entity_key' => $identity['entity_key'],
+                'slug' => $identity['slug'],
+                'source_sha256' => $sourceSha256,
+                'qa_source_sha256' => $qaSha256,
+                'recommendation_sha256' => hash('sha256', $recommendationJson),
+                'existing_asset_id' => $existing?->id !== null ? (int) $existing->id : null,
+                'action' => $existing instanceof PersonalityPublicContentAsset ? 'skip_existing_same_source_draft' : 'create_draft_asset',
+                'asset_preview' => $this->assetPayload($recommendation, $identity, $sourceSha256, $qaSha256),
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($rows),
+                'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+                'center_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CENTER),
+                'core_type_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CORE_TYPE),
+                'would_create_asset_count' => 0,
+                'created_asset_count' => 0,
+                'skipped_existing_count' => 0,
+                'rows' => $rows,
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $created = 0;
+        $skipped = 0;
+        if ($write) {
+            foreach ($rows as &$row) {
+                if (($row['existing_asset_id'] ?? null) !== null) {
+                    $row['action'] = 'skipped_existing';
+                    $skipped++;
+
+                    continue;
+                }
+
+                PersonalityPublicContentAsset::query()->create((array) $row['asset_preview']);
+                $row['action'] = 'created_draft_asset';
+                $created++;
+            }
+            unset($row);
+        }
+
+        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'row_count' => count($rows),
+            'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+            'center_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CENTER),
+            'core_type_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CORE_TYPE),
+            'would_create_asset_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['existing_asset_id'] ?? null) === null)),
+            'created_asset_count' => $created,
+            'skipped_existing_count' => $skipped,
+            'writes_committed' => $write && $created > 0,
+            'rows' => $rows,
+            'errors' => [],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $qa
+     * @return array<string,array<string,mixed>>
+     */
+    private function qaRowsByUrl(array $qa): array
+    {
+        $rows = [];
+        foreach ([$qa['page_results'] ?? null, $qa['results'] ?? null, $qa['items'] ?? null] as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            foreach ($source as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $url = (string) ($item['target_url'] ?? $item['url'] ?? '');
+                if ($url !== '') {
+                    $rows[$url] = $item;
+                }
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        $framework = (string) ($recommendation['framework'] ?? '');
+        if ($framework !== PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM) {
+            return null;
+        }
+
+        $path = (string) parse_url((string) ($recommendation['target_url'] ?? ''), PHP_URL_PATH);
+        if ($path === '') {
+            return null;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram$#i', $path, $matches) === 1) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'entity_type' => PersonalityPublicContentAsset::ENTITY_HUB,
+                'entity_key' => 'enneagram',
+                'slug' => 'enneagram',
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/centers/(?<code>gut|heart|head)$#i', $path, $matches) === 1) {
+            $code = strtolower((string) $matches['code']);
+
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'entity_type' => PersonalityPublicContentAsset::ENTITY_CENTER,
+                'entity_key' => $code,
+                'slug' => 'enneagram/centers/'.$code,
+            ];
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/type-(?<type>[1-9])$#i', $path, $matches) === 1) {
+            $code = 'type-'.((string) $matches['type']);
+
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'entity_type' => PersonalityPublicContentAsset::ENTITY_CORE_TYPE,
+                'entity_key' => $code,
+                'slug' => 'enneagram/'.$code,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array{locale:string,entity_type:string,entity_key:string}  $identity
+     */
+    private function existingAsset(array $identity): ?PersonalityPublicContentAsset
+    {
+        return PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM)
+            ->where('entity_type', $identity['entity_type'])
+            ->where('entity_key', $identity['entity_key'])
+            ->where('locale', $identity['locale'])
+            ->first();
+    }
+
+    private function existingAssetIsWritableDraft(PersonalityPublicContentAsset $asset, string $sourceSha256): bool
+    {
+        return (string) $asset->source_hash === $sourceSha256
+            && (bool) $asset->is_public === false
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_DRAFT,
+                PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            ], true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @param  array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}  $identity
+     * @return array<string,mixed>
+     */
+    private function assetPayload(array $recommendation, array $identity, string $sourceSha256, string $qaSha256): array
+    {
+        $recommendations = is_array($recommendation['recommendations'] ?? null) ? $recommendation['recommendations'] : [];
+        $title = trim((string) ($recommendations['h1'] ?? $recommendations['title'] ?? 'Enneagram public profile draft'));
+        $seoTitle = trim((string) ($recommendations['title'] ?? $title));
+        $description = trim((string) ($recommendations['description'] ?? ''));
+        $quickAnswer = trim((string) ($recommendations['quick_answer'] ?? ''));
+
+        return [
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM,
+            'entity_type' => $identity['entity_type'],
+            'entity_key' => $identity['entity_key'],
+            'slug' => $identity['slug'],
+            'locale' => $identity['locale'],
+            'title' => $title,
+            'summary' => $quickAnswer !== '' ? $quickAnswer : $description,
+            'content_sections_json' => $this->contentSections($quickAnswer, $recommendations),
+            'seo_json' => [
+                'title' => $seoTitle,
+                'description' => $description,
+            ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'canonical_json' => [
+                'path' => $identity['path'],
+            ],
+            'hreflang_json' => [],
+            'faq_json' => array_values(is_array($recommendations['faq'] ?? null) ? $recommendations['faq'] : []),
+            'media_json' => [],
+            'schema_json' => [],
+            'method_boundary_json' => [
+                'summary' => 'Enneagram public profile drafts are reflective educational content only; they are not clinical diagnosis, hiring screening, official affiliation, or deterministic guidance.',
+                'not_for' => ['clinical diagnosis', 'employment screening', 'deterministic decisions'],
+            ],
+            'evidence_notes_json' => [
+                [
+                    'source_type' => 'agent_recommendation',
+                    'source' => self::SNAPSHOT_SOURCE,
+                    'package_sha256' => $sourceSha256,
+                    'qa_sha256' => $qaSha256,
+                ],
+            ],
+            'internal_links_json' => array_values(is_array($recommendations['internal_links'] ?? null) ? $recommendations['internal_links'] : []),
+            'is_public' => false,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            'review_state' => 'agent_draft_pending_review',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => self::SNAPSHOT_SOURCE,
+            'source_hash' => $sourceSha256,
+            'last_reviewed_at' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendations
+     * @return list<array<string,mixed>>
+     */
+    private function contentSections(string $quickAnswer, array $recommendations): array
+    {
+        $sections = [];
+        if ($quickAnswer !== '') {
+            $sections[] = [
+                'key' => 'quick_answer',
+                'title' => 'Quick answer',
+                'body_md' => $quickAnswer,
+            ];
+        }
+
+        foreach (array_values(is_array($recommendations['differentiation_notes'] ?? null) ? $recommendations['differentiation_notes'] : []) as $index => $note) {
+            if (! is_scalar($note) || trim((string) $note) === '') {
+                continue;
+            }
+
+            $sections[] = [
+                'key' => 'differentiation_'.((string) ($index + 1)),
+                'title' => 'Differentiation note',
+                'body_md' => trim((string) $note),
+            ];
+        }
+
+        return $sections;
+    }
+
+    private function qaDecisionPasses(string $decision): bool
+    {
+        return in_array($decision, [
+            'pass',
+            'PASS',
+            'PASS_READY_FOR_CMS_DRAFT',
+            'PASS_READY_FOR_APPROVAL_QUEUE',
+        ], true);
+    }
+
+    private function countRows(array $rows, string $entityType): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row['entity_type'] ?? null) === $entityType));
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function localeFromPrefix(string $prefix): string
+    {
+        return $prefix === 'zh' ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01',
+            'status' => 'pending',
+            'ok' => false,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM,
+            'package_artifact' => (string) ($package['artifact'] ?? ''),
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'qa_sha256' => $qaSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_attempted' => $write,
+            'writes_committed' => false,
+            'cms_write_attempted' => $write,
+            'cms_mutation_attempted' => $write,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityEnneagramCmsDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityEnneagramCmsDraftCommandTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityEnneagramCmsDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_twenty_six_enneagram_drafts_without_writes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(26, $payload['row_count']);
+        $this->assertSame(2, $payload['hub_row_count']);
+        $this->assertSame(6, $payload['center_row_count']);
+        $this->assertSame(18, $payload['core_type_row_count']);
+        $this->assertSame(26, $payload['would_create_asset_count']);
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_creates_non_public_noindex_draft_assets_only(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(26, $payload['row_count']);
+        $this->assertSame(26, $payload['created_asset_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('sitemap_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('llms_eligible', true)->count());
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)->count());
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_REVIEW)->count());
+    }
+
+    public function test_second_write_is_idempotent_for_same_source_hash(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+
+        $firstExitCode = Artisan::call('personality:enneagram-cms-draft', $options);
+        $this->assertSame(0, $firstExitCode);
+
+        $secondExitCode = Artisan::call('personality:enneagram-cms-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_asset_count']);
+        $this->assertSame(26, $payload['skipped_existing_count']);
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_requires_all_safety_flags_and_exact_operator_token(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('--draft-only is required with --write', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_wing_instinct_tritype_and_private_routes_fail_closed_with_zero_writes(): void
+    {
+        $package = [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram/type-1-wing-9', 'en', 'wing'),
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram/instinctual-subtypes', 'en', 'instinctual_subtype'),
+                $this->recommendation('https://fermatmind.com/zh/personality/enneagram/tritype', 'zh-CN', 'tritype'),
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram/type-1?token=secret', 'en', 'core_type'),
+            ],
+        ];
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'page_results' => array_map(
+                fn (array $recommendation): array => $this->qaRow((string) $recommendation['target_url']),
+                $package['recommendations']
+            ),
+        ]);
+
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_asset_count']);
+        $this->assertContains('unsupported_enneagram_target_url', array_column($payload['errors'], 'code'));
+        $this->assertContains('forbidden_private_route_pattern_present', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_existing_live_asset_blocks_draft_write_without_mutation(): void
+    {
+        PersonalityPublicContentAsset::query()->create([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM,
+            'entity_type' => PersonalityPublicContentAsset::ENTITY_HUB,
+            'entity_key' => 'enneagram',
+            'slug' => 'enneagram',
+            'locale' => 'en',
+            'title' => 'Live title',
+            'summary' => 'Live summary',
+            'content_sections_json' => [],
+            'seo_json' => ['title' => 'Live title'],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'canonical_json' => ['path' => '/en/personality/enneagram'],
+            'hreflang_json' => [],
+            'faq_json' => [],
+            'media_json' => [],
+            'schema_json' => [],
+            'method_boundary_json' => [],
+            'evidence_notes_json' => [],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'review_state' => 'placeholder',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => 'existing',
+            'source_hash' => 'existing',
+        ]);
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->singleHubPackage(), $this->singleHubQa());
+
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('existing_live_or_foreign_asset_blocks_draft_write', array_column($payload['errors'], 'code'));
+        $this->assertSame(1, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame('Live title', PersonalityPublicContentAsset::query()->first()?->title);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $recommendations = [];
+        foreach (['en', 'zh-CN'] as $locale) {
+            $prefix = $locale === 'zh-CN' ? 'zh' : 'en';
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram", $locale, 'hub');
+            foreach (['gut', 'heart', 'head'] as $center) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram/centers/{$center}", $locale, 'center');
+            }
+            for ($type = 1; $type <= 9; $type++) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram/type-{$type}", $locale, 'core_type');
+            }
+        }
+
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'enneagram.agent_pilot.v1',
+            'recommendations' => $recommendations,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validQa(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'page_results' => array_map(
+                fn (array $recommendation): array => $this->qaRow((string) $recommendation['target_url']),
+                $this->validPackage()['recommendations']
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubPackage(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram', 'en', 'hub'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubQa(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $targetUrl, string $locale, string $entityType): array
+    {
+        return [
+            'recommendation_id' => 'enneagram-agent:'.parse_url($targetUrl, PHP_URL_PATH),
+            'target_url' => $targetUrl,
+            'framework' => 'enneagram',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => 'Enneagram SEO Title',
+                'description' => 'Enneagram SEO description',
+                'h1' => 'Enneagram H1',
+                'quick_answer' => 'This is a reflective Enneagram draft, not a diagnosis or hiring screen.',
+                'faq' => [
+                    [
+                        'question' => 'Is this diagnostic?',
+                        'answer' => 'No. It is reflective educational content.',
+                    ],
+                ],
+                'internal_links' => [],
+                'differentiation_notes' => [
+                    'Keep this page distinct from neighboring Enneagram content.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qaRow(string $targetUrl): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'blockers' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeArtifacts(array $package, array $qa): array
+    {
+        $dir = storage_path('framework/testing/enneagram_cms_draft');
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/package.json';
+        $qaPath = $dir.'/qa.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath, string $qaPath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -390,6 +390,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_cms_draft_writer_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/EnneagramCmsDraftWriter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityEnneagramCmsDraft;',
+            '+        PersonalityEnneagramCmsDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -4389,6 +4404,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramCmsDraftFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -5459,6 +5478,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64CmsRevisionPromoteOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5680,6 +5700,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php',
             'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
             'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
+        ], true);
+    }
+
+    private function isEnneagramCmsDraftFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php',
+            'backend/app/Services/Cms/EnneagramCmsDraftWriter.php',
         ], true);
     }
 
@@ -9425,6 +9453,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityAgentApprovalQueueCommand\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramCmsDraftOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityEnneagramCmsDraft\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:enneagram-cms-draft` as a draft-only backend command for Enneagram public profile agent recommendations.
- Added `EnneagramCmsDraftWriter` to map the 26 Enneagram hub / center / core type recommendations into `personality_public_content_assets` as non-public review drafts.
- Registered the command in the console kernel and added focused feature coverage.
- Updated the Big Five runtime freeze classifier so this Enneagram draft-only command/service registration is not treated as a Big Five runtime body-preview change.

## Why
This gives Enneagram the same controlled CMS-draft handoff shape as the public-profile agent pipeline, without reusing MBTI64 profile/variant writers and without touching live content.

## Safety boundary
- Dry-run plans 26 rows and writes 0 rows.
- Write mode requires `--write --draft-only --no-publish --no-index --no-sitemap --no-llms --no-search-release --operator-approved=ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01`.
- Blocks wing, instinct, tritype, private/result/order/payment/account/share/token routes.
- Creates only review-state, non-public, noindex Enneagram public content asset drafts.
- No live CMS publish, frontend, sitemap/llms, search queue, external API, or production mutation is performed by this PR.

## Validation
- `php -l app/Services/Cms/EnneagramCmsDraftWriter.php`
- `php -l app/Console/Commands/PersonalityEnneagramCmsDraft.php`
- `php -l tests/Feature/Console/PersonalityEnneagramCmsDraftCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityEnneagramCmsDraftCommandTest.php tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings`
- `php artisan list --raw | rg '^personality:enneagram-cms-draft'`
- `php artisan test tests/Sre/MigrationSafetyTest.php tests/Unit/Migrations/MigrationSafetyTest.php --display-warnings`
- `bash scripts/ci_verify_mbti.sh`
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --display-warnings`
- GitHub-equivalent `verify-bigfive` commands under sqlite env: `scripts/ci/verify_big5_norms.sh`, `content:lint`, `content:compile`, and `artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi`
- `git diff --check`
- Scope validation: command/service/kernel/focused feature test plus Big Five runtime-freeze classifier test only.

## Deferred
- Production dry-run and production write gates remain separate tasks requiring explicit authorization.
- Promotion readiness, promotion write, runtime smoke, sitemap/llms, and search release remain out of scope.
