### PR TITLE
Sanitize career detail raw enum projection

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Career/CareerJobDetailController.php
@@ -31,6 +31,19 @@ final class CareerJobDetailController extends Controller
         'index_state_id',
     ];
 
+    private const RAW_READER_PAYLOAD_VALUE_REPLACEMENTS = [
+        'industry_proxy_or_recruitment_sample_only' => 'recruitment-market reference only',
+        'industry_proxy / recruitment_sample' => 'recruitment-market reference',
+        'candidate_only_not_runtime_seo' => 'candidate reference only',
+        'source_bounded_reference_only' => 'source-bounded reference only',
+        'backend projection review' => 'reader projection review',
+        'search candidate only' => 'search reference candidate only',
+        'salary_and_outlook' => 'salary and outlook context',
+        'staging_preview_only' => 'preview only',
+        'industry_proxy' => 'recruitment-market reference',
+        'raw enum' => 'reader label',
+    ];
+
     public function __construct(
         private readonly PublicCareerAuthorityResponseCache $responseCache,
         private readonly CareerCnProxyPublicOwnerSurfaceBuilder $cnProxySurfaceBuilder,
@@ -81,9 +94,20 @@ final class CareerJobDetailController extends Controller
         foreach ($payload as $key => $value) {
             if (is_array($value)) {
                 $payload[$key] = $this->stripInternalReaderPayloadKeys($value);
+            } elseif (is_string($value)) {
+                $payload[$key] = $this->projectReaderSafeString($value);
             }
         }
 
         return $payload;
+    }
+
+    private function projectReaderSafeString(string $value): string
+    {
+        foreach (self::RAW_READER_PAYLOAD_VALUE_REPLACEMENTS as $rawValue => $readerSafeValue) {
+            $value = str_replace($rawValue, $readerSafeValue, $value);
+        }
+
+        return $value;
     }
 }

--- a/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDisplaySurfaceApiTest.php
@@ -202,6 +202,54 @@ final class CareerJobDisplaySurfaceApiTest extends TestCase
         }
     }
 
+    public function test_job_detail_projection_rewrites_internal_raw_enum_values(): void
+    {
+        $occupation = $this->seedCompiledOccupation('accountants-and-auditors');
+        $this->addCrosswalks($occupation, 'accountants-and-auditors');
+        $asset = $this->createDisplayAsset($occupation);
+
+        $pagePayload = $asset->page_payload_json;
+        $pagePayload['en']['fermat_decision_card'] = [
+            'search_intent_type' => ['career_exploration', 'salary_and_outlook'],
+            'body' => 'This source_bounded_reference_only signal is not candidate_only_not_runtime_seo.',
+        ];
+        $pagePayload['en']['market_signal_card'] = [
+            'salary_data_type' => 'industry_proxy_or_recruitment_sample_only',
+            'body' => 'Use industry_proxy / recruitment_sample, not raw enum text.',
+        ];
+        $pagePayload['zh']['fermat_decision_card'] = [
+            'search_intent_type' => ['career_exploration', 'salary_and_outlook'],
+            'body' => '这里是 source_bounded_reference_only，不应暴露 backend projection review。',
+        ];
+        $pagePayload['zh']['market_signal_card'] = [
+            'salary_data_type' => 'industry_proxy / recruitment_sample',
+            'body' => '只应展示 industry_proxy 的读者安全文案。',
+        ];
+        $asset->forceFill(['page_payload_json' => $pagePayload])->save();
+
+        $response = $this->getJson('/api/v0.5/career/jobs/accountants-and-auditors?locale=en')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'accountants-and-auditors');
+
+        $encoded = json_encode($response->json(), JSON_THROW_ON_ERROR);
+
+        foreach ([
+            'salary_and_outlook',
+            'industry_proxy',
+            'source_bounded_reference_only',
+            'candidate_only_not_runtime_seo',
+            'backend projection review',
+            'raw enum',
+            'staging_preview_only',
+        ] as $rawValue) {
+            $this->assertStringNotContainsString($rawValue, $encoded);
+        }
+
+        $this->assertStringContainsString('salary and outlook context', $encoded);
+        $this->assertStringContainsString('recruitment-market reference', $encoded);
+        $this->assertStringContainsString('source-bounded reference only', $encoded);
+    }
+
     public function test_it_adds_display_surface_for_selected_d5_assets(): void
     {
         foreach ([


### PR DESCRIPTION
## Summary
- Replace internal raw enum values in public career detail payloads with reader-safe labels.
- Keep the existing recursive internal lineage sanitizer in place.
- Add a feature regression that injects raw enum values and asserts the public JSON no longer exposes them.

## Validation
- php artisan test --filter=CareerJobDisplaySurfaceApiTest
- php artisan route:list --path=api/v0.5/career/jobs --no-ansi
- git diff --check

## Intentionally deferred
- No content asset edits.
- No career asset re-import.
- No route readiness changes.
- No runtime/SEO/CMS changes.
- No staging or production import.

## Repository rule impact
Public career detail APIs remain backend-authoritative. This PR only tightens reader-safe projection and does not add frontend fallback content or modify SEO/runtime enumeration.