### PR TITLE
BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01: Add Big Five approval queue integration

### DIFF
--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -162,6 +162,7 @@ final class PersonalityAgentApprovalQueueWriter
     {
         $sources = [
             $qa['page_results'] ?? null,
+            $qa['evaluations'] ?? null,
             $qa['results'] ?? null,
             $qa['items'] ?? null,
             $qa['recommendations'] ?? null,
@@ -206,6 +207,7 @@ final class PersonalityAgentApprovalQueueWriter
             'target_url' => (string) ($recommendation['target_url'] ?? ''),
             'path' => (string) ($identity['path'] ?? ''),
             'locale' => (string) ($identity['locale'] ?? $recommendation['locale'] ?? ''),
+            'entity_type' => (string) ($recommendation['entity_type'] ?? $identity['entity_type'] ?? ''),
             'page_type' => (string) ($identity['page_type'] ?? $recommendation['page_type'] ?? ''),
             'recommendation_id' => (string) ($recommendation['recommendation_id'] ?? ''),
             'recommendation_sha256' => hash('sha256', $recommendationJson),
@@ -288,6 +290,16 @@ final class PersonalityAgentApprovalQueueWriter
             return [
                 'path' => $path,
                 'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'entity_type' => 'enneagram_public_content_asset',
+                'page_type' => 'personality_public_content_asset',
+            ];
+        }
+
+        if ($this->isBigFivePublicContentAssetPath($path, $matches)) {
+            return [
+                'path' => $path,
+                'locale' => $this->localeFromPrefix((string) $matches['prefix']),
+                'entity_type' => 'big_five_public_content_asset',
                 'page_type' => 'personality_public_content_asset',
             ];
         }
@@ -317,6 +329,22 @@ final class PersonalityAgentApprovalQueueWriter
         }
 
         if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/type-[1-9]$#i', $path, $matches) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,string>  $matches
+     */
+    private function isBigFivePublicContentAssetPath(string $path, ?array &$matches = null): bool
+    {
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five$#i', $path, $matches) === 1) {
+            return true;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five/(?:facets|(?:high|low)-(?:agreeableness|conscientiousness|extraversion|neuroticism|openness)|agreeableness|conscientiousness|emotional-stability|extraversion|neuroticism|openness)$#i', $path, $matches) === 1) {
             return true;
         }
 
@@ -426,7 +454,7 @@ final class PersonalityAgentApprovalQueueWriter
             'summary_json' => $this->jsonString([
                 'source_version' => (string) ($package['version'] ?? ''),
                 'source_status' => (string) ($package['status'] ?? ''),
-                'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+                'qa_final_decision' => (string) ($qa['final_decision'] ?? $qa['decision'] ?? ''),
                 'blocked_items' => array_map(
                     static fn (array $item): array => [
                         'target_url' => (string) ($item['target_url'] ?? ''),
@@ -484,7 +512,7 @@ final class PersonalityAgentApprovalQueueWriter
             'source_package_sha256' => $sourceSha256,
             'qa_artifact' => (string) ($qa['artifact'] ?? ''),
             'qa_sha256' => $qaSha256,
-            'qa_final_decision' => (string) ($qa['final_decision'] ?? ''),
+            'qa_final_decision' => (string) ($qa['final_decision'] ?? $qa['decision'] ?? ''),
             'package_path' => (string) ($metadata['package_path'] ?? ''),
             'qa_path' => (string) ($metadata['qa_path'] ?? ''),
             'dry_run' => ! $write,

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -268,6 +268,142 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
     }
 
+    public function test_big_five_dry_run_plans_thirty_four_public_content_asset_items_without_writes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validBigFivePackage(), $this->validBigFiveQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('big_five', $payload['framework']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(34, $payload['planned_item_count']);
+        $this->assertSame(0, $payload['blocked_item_count']);
+        $this->assertSame(0, $payload['created_item_count']);
+        $this->assertSame('PASS_READY_FOR_APPROVAL_QUEUE', $payload['qa_final_decision']);
+        $this->assertEquals(
+            ['personality_public_content_asset'],
+            array_values(array_unique(array_map(
+                static fn (array $item): string => (string) $item['page_type'],
+                $payload['items']
+            )))
+        );
+        $this->assertEquals(
+            ['en', 'zh-CN'],
+            collect($payload['items'])->pluck('locale')->unique()->sort()->values()->all()
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
+    public function test_big_five_write_creates_pending_items_only_and_is_idempotent_for_same_hashes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validBigFivePackage(), $this->validBigFiveQa());
+        $options = $this->writeOptions($packagePath, $qaPath);
+
+        $firstExit = Artisan::call('personality:agent-approval-queue', $options);
+        $firstPayload = $this->jsonOutput();
+
+        $this->assertSame(0, $firstExit);
+        $this->assertTrue($firstPayload['ok']);
+        $this->assertSame('big_five', $firstPayload['framework']);
+        $this->assertTrue($firstPayload['writes_committed']);
+        $this->assertFalse($firstPayload['cms_write_attempted']);
+        $this->assertFalse($firstPayload['cms_mutation_attempted']);
+        $this->assertFalse($firstPayload['publish_attempted']);
+        $this->assertFalse($firstPayload['index_attempted']);
+        $this->assertFalse($firstPayload['sitemap_llms_release_attempted']);
+        $this->assertFalse($firstPayload['search_release_attempted']);
+        $this->assertFalse($firstPayload['enqueue_attempted']);
+        $this->assertFalse($firstPayload['external_calls_attempted']);
+        $this->assertSame(34, $firstPayload['created_item_count']);
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->where('framework', 'big_five')->count());
+        $this->assertSame(34, DB::table('personality_agent_approval_items')->where('framework', 'big_five')->count());
+        $this->assertSame(
+            ['pending'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('approval_state')->all()
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('approved_at')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->whereNotNull('rejected_at')->count());
+        $this->assertSame(
+            ['personality_public_content_asset'],
+            DB::table('personality_agent_approval_items')->distinct()->pluck('page_type')->all()
+        );
+
+        $firstItem = DB::table('personality_agent_approval_items')
+            ->where('framework', 'big_five')
+            ->orderBy('id')
+            ->first();
+        $this->assertNotNull($firstItem);
+        $this->assertSame('big_five', (string) $firstItem->framework);
+        $this->assertSame('pending', (string) $firstItem->approval_state);
+        $this->assertNotSame('', (string) $firstItem->recommendation_sha256);
+        $this->assertStringStartsWith('https://fermatmind.com/', (string) $firstItem->target_url);
+        $this->assertSame('pass', (string) $firstItem->qa_decision);
+
+        $secondExit = Artisan::call('personality:agent-approval-queue', $options);
+        $secondPayload = $this->jsonOutput();
+        $this->assertSame(0, $secondExit);
+        $this->assertTrue($secondPayload['ok']);
+        $this->assertFalse($secondPayload['writes_committed']);
+        $this->assertSame(0, $secondPayload['created_item_count']);
+        $this->assertSame(34, $secondPayload['skipped_existing_item_count']);
+        $this->assertSame(1, DB::table('personality_agent_approval_batches')->where('framework', 'big_five')->count());
+        $this->assertSame(34, DB::table('personality_agent_approval_items')->where('framework', 'big_five')->count());
+    }
+
+    public function test_big_five_failed_qa_and_private_routes_do_not_enter_approval_queue(): void
+    {
+        $package = $this->validBigFivePackage();
+        $package['recommendations'][0]['target_url'] = 'https://fermatmind.com/en/results/private-big-five';
+        $qa = $this->validBigFiveQa();
+        foreach ($qa['evaluations'] as $index => $evaluation) {
+            if (($evaluation['target_url'] ?? null) === 'https://fermatmind.com/zh/personality/big-five') {
+                $qa['evaluations'][$index] = $this->qaEvaluationRow(
+                    'https://fermatmind.com/zh/personality/big-five',
+                    'failed',
+                    ['claim_safety_gate']
+                );
+                break;
+            }
+        }
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('big_five', $payload['framework']);
+        $this->assertSame(32, $payload['planned_item_count']);
+        $this->assertSame(2, $payload['blocked_item_count']);
+        $this->assertSame(32, DB::table('personality_agent_approval_items')->where('framework', 'big_five')->count());
+        $this->assertSame(
+            0,
+            DB::table('personality_agent_approval_items')
+                ->where('target_url', 'like', '%/results/%')
+                ->count()
+        );
+        $this->assertSame(
+            0,
+            DB::table('personality_agent_approval_items')
+                ->where('target_url', 'https://fermatmind.com/zh/personality/big-five')
+                ->count()
+        );
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -321,6 +457,69 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
                     'core_type'
                 ),
             ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validBigFivePackage(): array
+    {
+        $paths = [
+            'big-five',
+            'big-five/agreeableness',
+            'big-five/conscientiousness',
+            'big-five/emotional-stability',
+            'big-five/extraversion',
+            'big-five/facets',
+            'big-five/high-agreeableness',
+            'big-five/high-conscientiousness',
+            'big-five/high-extraversion',
+            'big-five/high-neuroticism',
+            'big-five/high-openness',
+            'big-five/low-agreeableness',
+            'big-five/low-conscientiousness',
+            'big-five/low-extraversion',
+            'big-five/low-neuroticism',
+            'big-five/low-openness',
+            'big-five/openness',
+        ];
+        $recommendations = [];
+        foreach (['en' => 'en', 'zh-CN' => 'zh'] as $locale => $prefix) {
+            foreach ($paths as $path) {
+                $recommendations[] = $this->bigFiveRecommendation(
+                    'big-five-agent:/'.$prefix.'/personality/'.$path,
+                    'https://fermatmind.com/'.$prefix.'/personality/'.$path,
+                    $locale,
+                    $path === 'big-five' ? 'hub' : (str_contains($path, 'high-') || str_contains($path, 'low-') ? 'polarity' : ($path === 'big-five/facets' ? 'facet_hub' : 'domain'))
+                );
+            }
+        }
+
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'big_five.public_profile_agent_pilot.v1',
+            'status' => 'pass_ready_for_qa_gates',
+            'recommendations' => $recommendations,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validBigFiveQa(): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-QA-01',
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'evaluations' => array_map(
+                fn (array $recommendation): array => $this->qaEvaluationRow(
+                    (string) $recommendation['target_url'],
+                    'pass',
+                    []
+                ),
+                $this->validBigFivePackage()['recommendations']
+            ),
         ];
     }
 
@@ -381,6 +580,29 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
     /**
      * @return array<string,mixed>
      */
+    private function bigFiveRecommendation(string $id, string $targetUrl, string $locale, string $entityType): array
+    {
+        return [
+            'recommendation_id' => $id,
+            'target_url' => $targetUrl,
+            'framework' => 'big_five',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => ['recommended' => 'Big Five public profile title'],
+                'description' => ['recommended' => 'Big Five public profile description.'],
+                'h1' => ['recommended' => 'Big Five public profile H1'],
+                'quick_answer' => ['recommended' => 'Reflective Big Five quick answer.'],
+                'faq' => [],
+                'internal_links' => [],
+                'differentiation_notes' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
     private function recommendation(string $id, string $targetUrl, string $locale): array
     {
         return [
@@ -415,6 +637,21 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
             'target_url' => $targetUrl,
             'decision' => $decision,
             'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $failedGates
+     * @return array<string,mixed>
+     */
+    private function qaEvaluationRow(string $targetUrl, string $status, array $failedGates = []): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'qa_status' => $status,
+            'failed_gates' => $failedGates,
+            'eligible_for_approval_queue' => $status === 'pass' && $failedGates === [],
+            'eligible_for_cms_draft_path' => $status === 'pass' && $failedGates === [],
         ];
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T12:40:00Z",
+  "updated_at": "2026-06-24T12:47:00Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60391,7 +60391,7 @@
     "repo": "fap-api",
     "branch": "codex/big-five-agent-approval-queue-integration-01",
     "base": "main",
-    "status": "local_validated",
+    "status": "ready_to_merge",
     "train_scope": "big_five_public_profile_agent_expansion",
     "title": "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01: Add Big Five approval queue integration",
     "depends_on": [],
@@ -60419,13 +60419,13 @@
         "evidence": "Changed files are limited to the PR3 allowed paths: PersonalityAgentApprovalQueueWriter.php, PersonalityAgentApprovalQueueCommandTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No CMS write, public API route, frontend runtime, publish, queue, search, indexing, sitemap, llms, staging deploy, or production deploy changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #2392 head 79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0 is open, not draft, mergeStateStatus CLEAN, and all GitHub checks passed: hygiene, Semgrep blocking secrets, semgrep sarif non-blocking upload, Semgrep OSS, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, and verify-bigfive."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2392",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -60439,6 +60439,11 @@
         "at": "2026-06-24T12:40:00Z",
         "status": "local_validated",
         "note": "All PR3 local checks passed and scope validation passed. Validation covered focused approval queue PHPUnit, scoped Pint, ci_verify_mbti.sh, docs JSON/YAML parse, git diff --check, and changed-file scope validation."
+      },
+      {
+        "at": "2026-06-24T12:47:00Z",
+        "status": "ready_to_merge",
+        "note": "PR #2392 checks are green and mergeStateStatus is CLEAN on head 79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, sitemap, llms, queue, search, or indexing changes included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-23T16:40:00Z",
+  "updated_at": "2026-06-24T12:40:00Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60384,6 +60384,61 @@
         "at": "2026-06-23T16:40:00Z",
         "status": "ready_to_merge",
         "note": "PR #2371 checks green, mergeable, and scope validation green for head a91a0d645c5d5f0459b2760723b6740314f50967. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, sitemap, or llms changes included."
+      }
+    ]
+  },
+  "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01": {
+    "repo": "fap-api",
+    "branch": "codex/big-five-agent-approval-queue-integration-01",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big_five_public_profile_agent_expansion",
+    "title": "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01: Add Big Five approval queue integration",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided the Big Five public profile agent expansion train and authorized PR1-PR4 execution with PR3 scoped to backend approval queue integration."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php",
+          "php -l backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php",
+          "cd backend && php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Cms/PersonalityAgentApprovalQueueWriter.php tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php",
+          "cd backend && bash scripts/ci_verify_mbti.sh",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: php syntax checks for writer and focused test; PersonalityAgentApprovalQueueCommandTest (11 tests, 161 assertions); scoped Pint --test (2 files); ci_verify_mbti.sh including BigFive, MBTI smoke, auth, openapi, order security, migration, dependency, and regression gates; docs/codex JSON/YAML parse; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the PR3 allowed paths: PersonalityAgentApprovalQueueWriter.php, PersonalityAgentApprovalQueueCommandTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. No CMS write, public API route, frontend runtime, publish, queue, search, indexing, sitemap, llms, staging deploy, or production deploy changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T00:00:00Z",
+        "status": "in_progress",
+        "note": "Started PR3 from latest fap-api origin/main in a clean temp worktree. Scope is backend-only approval queue integration for Big Five public profile package and QA artifacts; no CMS write, publish, queue, search, indexing, sitemap, llms, frontend runtime, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-24T12:40:00Z",
+        "status": "local_validated",
+        "note": "All PR3 local checks passed and scope validation passed. Validation covered focused approval queue PHPUnit, scoped Pint, ci_verify_mbti.sh, docs JSON/YAML parse, git diff --check, and changed-file scope validation."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -95,6 +95,45 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/big-five-agent-approval-queue-integration-01
+    title: "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01: Add Big Five approval queue integration"
+    train_scope: big_five_public_profile_agent_expansion
+    status: user_authorized
+    scope:
+      - Extend the backend personality agent approval queue contract to accept Big Five public profile package and QA artifacts.
+      - Plan 34 pending human-review approval queue items for Big Five public profile URLs in dry-run mode.
+      - Support bounded write mode for pending approval queue rows only, with idempotency by package and QA hashes.
+      - Preserve fail-closed filtering for private routes, failed QA rows, CMS writes, publishing, queues, search, indexing, sitemap, llms, and frontend runtime.
+    allowed_paths:
+      - backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+      - backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Write CMS drafts, publish content, enqueue jobs, submit search/indexing requests, or mutate sitemap/llms/canonical/JSON-LD.
+      - Add public API routes, frontend runtime rendering, production imports, staging deploy, or production deploy.
+      - Accept raw private result URLs, failed QA rows, unreviewed claim states, or non-public Big Five profile paths into the approval queue.
+    validation:
+      - php -l backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+      - php -l backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+      - cd backend && php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Cms/PersonalityAgentApprovalQueueWriter.php tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-03
     repo: fap-web
     depends_on: [PR-EQ-ASSET-02]


### PR DESCRIPTION
## What changed
- Extended `PersonalityAgentApprovalQueueWriter` to read Big Five public profile QA `evaluations` rows.
- Added Big Five public content asset identity recognition for hub, facet hub, domain, and high/low polarity profile URLs.
- Preserved approval queue output as pending human-review rows only, including entity type metadata and idempotency by package/QA hashes.
- Added PR-train manifest/state entries for the Big Five approval queue integration scope.

## Why
PR1 generated the Big Five public profile candidate package and PR2 validated it. This PR adds the backend-only bridge that can plan or write approval queue rows for human review without creating CMS drafts or triggering runtime/public SEO surfaces.

## Validation
- `php -l backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php`
- `php -l backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php`
- `cd backend && php artisan test --filter=PersonalityAgentApprovalQueueCommandTest --no-ansi`
- `cd backend && vendor/bin/pint --test app/Services/Cms/PersonalityAgentApprovalQueueWriter.php tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No CMS draft write execution.
- No publishing, queue, search, indexing, sitemap, llms, canonical, JSON-LD, or frontend runtime change.
- No staging deploy or production deploy.
- Runtime queue/write gates remain separate exact-authorization tasks.
