### PR TITLE
PR-EQ-ASSET-04 Fix EQ v1.6 report locale resolved assets

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -427,6 +427,7 @@ class AttemptReadController extends Controller
     {
         $refreshRaw = strtolower(trim((string) $request->query('refresh', '0')));
         $forceRefresh = in_array($refreshRaw, ['1', 'true', 'yes', 'on'], true);
+        $requestedReportLocale = $this->normalizeReportLocale((string) $request->query('locale', ''));
 
         $orgId = $this->currentOrgContext()->orgId();
         $userId = $this->resolveUserId($request);
@@ -482,6 +483,7 @@ class AttemptReadController extends Controller
             $this->currentOrgContext()->role(),
             $this->shouldUsePublicArtifactFallback($request, $attempt),
             $forceRefresh,
+            $requestedReportLocale,
         );
 
         $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
@@ -1552,7 +1554,8 @@ class AttemptReadController extends Controller
         ?string $anonId,
         ?string $role,
         bool $forceSystemAccess,
-        bool $forceRefresh
+        bool $forceRefresh,
+        ?string $reportLocale = null
     ): array {
         $gate = $this->reportGatekeeper->resolve(
             $orgId,
@@ -1562,6 +1565,7 @@ class AttemptReadController extends Controller
             $role,
             $forceSystemAccess,
             $forceRefresh,
+            $reportLocale,
         );
 
         if ($gate['ok'] ?? false) {
@@ -1584,6 +1588,16 @@ class AttemptReadController extends Controller
         }
 
         throw new ApiProblemException($status, $errorCode !== '' ? $errorCode : 'REPORT_FAILED', $message);
+    }
+
+    private function normalizeReportLocale(string $locale): ?string
+    {
+        $locale = strtolower(trim($locale));
+        if ($locale === '') {
+            return null;
+        }
+
+        return str_starts_with($locale, 'zh') ? 'zh-CN' : 'en';
     }
 
     /**

--- a/backend/app/Services/Report/Eq60ReportComposer.php
+++ b/backend/app/Services/Report/Eq60ReportComposer.php
@@ -28,7 +28,9 @@ final class Eq60ReportComposer
             $version = Eq60PackLoader::PACK_VERSION;
         }
 
-        $locale = $this->packLoader->normalizeLocale((string) ($attempt->locale ?? 'zh-CN'));
+        $locale = $this->packLoader->normalizeLocale(
+            (string) ($ctx['locale'] ?? ($attempt->locale ?? 'zh-CN'))
+        );
         $reportCompiled = $this->packLoader->readCompiledJson('report.compiled.json', $version);
         if (! is_array($reportCompiled)) {
             return [

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -118,7 +118,8 @@ class ReportGatekeeper
         ?string $anonId,
         ?string $role = null,
         bool $forceSystemAccess = false,
-        bool $forceRefresh = false
+        bool $forceRefresh = false,
+        ?string $reportLocale = null
     ): array {
         $attemptId = trim($attemptId);
         if ($attemptId === '') {
@@ -140,6 +141,11 @@ class ReportGatekeeper
         if ($scaleCode === '') {
             return $this->badRequest('SCALE_REQUIRED', 'scale_code missing on attempt.');
         }
+        $requestedReportLocale = $this->normalizeReportLocale($reportLocale);
+        $attemptReportLocale = $this->normalizeReportLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
+        $localeSpecificLiveRender = $scaleCode === ReportAccess::SCALE_EQ_60
+            && $requestedReportLocale !== null
+            && $requestedReportLocale !== $attemptReportLocale;
         $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? $result->scale_code_v2 ?? '')));
         $isMbtiContract = $this->isMbtiReportContractEnabled($scaleCode, $scaleCodeV2);
 
@@ -452,6 +458,12 @@ class ReportGatekeeper
 
                 if ($snapshotRow) {
                     $report = $this->snapshotReportForVariant($snapshotRow, $renderVariant);
+                    $snapshotLocaleMismatch = false;
+                    if ($localeSpecificLiveRender && $this->reportLocale($report) !== $requestedReportLocale) {
+                        $report = [];
+                        $snapshotLocaleMismatch = true;
+                    }
+
                     if ($report !== []) {
                         return $this->responsePayload(
                             $locked,
@@ -473,7 +485,7 @@ class ReportGatekeeper
                         );
                     }
 
-                    if ($snapshotStrictMode) {
+                    if ($snapshotStrictMode && ! $snapshotLocaleMismatch) {
                         $this->enqueueSnapshotBuild($effectiveOrgId, $attempt, $result);
 
                         return $this->responsePayload(
@@ -534,7 +546,8 @@ class ReportGatekeeper
             $result,
             $renderVariant,
             $modulesAllowed,
-            $modulesPreview
+            $modulesPreview,
+            $requestedReportLocale
         );
         if (! ($built['ok'] ?? false)) {
             return $built;
@@ -551,14 +564,15 @@ class ReportGatekeeper
             $report = $this->applyTeaser($report, $viewPolicy);
         }
 
-        if ($shouldUseSnapshot && $renderVariant === ReportAccess::VARIANT_FULL) {
+        if ($shouldUseSnapshot && $renderVariant === ReportAccess::VARIANT_FULL && ! $localeSpecificLiveRender) {
             $reportFreeBuilt = $this->buildReportVariant(
                 $scaleCode,
                 $attempt,
                 $result,
                 ReportAccess::VARIANT_FREE,
                 ReportAccess::defaultModulesAllowedForLocked($scaleCode),
-                $modulesPreview
+                $modulesPreview,
+                $requestedReportLocale
             );
             $reportFree = is_array($reportFreeBuilt['report'] ?? null) ? $reportFreeBuilt['report'] : [];
             $this->upsertSnapshotVariants($effectiveOrgId, $attempt, $result, $reportFree, $report);
@@ -839,7 +853,8 @@ class ReportGatekeeper
         Result $result,
         string $variant,
         array $modulesAllowed = [],
-        array $modulesPreview = []
+        array $modulesPreview = [],
+        ?string $reportLocale = null
     ): array {
         try {
             $composed = $this->composerRegistry->composeVariant(
@@ -857,6 +872,7 @@ class ReportGatekeeper
                     },
                     'modules_allowed' => $modulesAllowed,
                     'modules_preview' => $modulesPreview,
+                    ...($reportLocale !== null ? ['locale' => $reportLocale] : []),
                 ]
             );
             if (! ($composed['ok'] ?? false)) {
@@ -902,6 +918,24 @@ class ReportGatekeeper
         }
 
         return [];
+    }
+
+    private function normalizeReportLocale(?string $locale): ?string
+    {
+        $locale = strtolower(trim((string) $locale));
+        if ($locale === '') {
+            return null;
+        }
+
+        return str_starts_with($locale, 'zh') ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     */
+    private function reportLocale(array $report): ?string
+    {
+        return $this->normalizeReportLocale((string) ($report['locale'] ?? ''));
     }
 
     private function snapshotReportForVariant(object $snapshotRow, string $variant): array

--- a/backend/tests/Feature/Report/Eq60V5ReportDeliveryTest.php
+++ b/backend/tests/Feature/Report/Eq60V5ReportDeliveryTest.php
@@ -123,6 +123,58 @@ final class Eq60V5ReportDeliveryTest extends TestCase
         $this->assertSame('ready', (string) DB::table('report_snapshots')->where('attempt_id', $attemptId)->value('status'));
     }
 
+    public function test_eq60_report_query_locale_resolves_matching_v16_assets_without_overwriting_attempt_locale_snapshot(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_v16_locale_report_delivery';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $english = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report?locale=en');
+
+        $english->assertOk()
+            ->assertJsonPath('report.locale', 'en')
+            ->assertJsonPath('report.scores.global.label', 'Emotional & Relational Functioning Index');
+
+        $snapshot = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('ready', (string) ($snapshot->status ?? ''));
+        $snapshotReport = json_decode((string) ($snapshot->report_full_json ?? ''), true);
+        $this->assertIsArray($snapshotReport);
+        $this->assertSame('en', (string) ($snapshotReport['locale'] ?? ''));
+
+        $chinese = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report?locale=zh-CN');
+
+        $chinese->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('generating', false)
+            ->assertJsonPath('report.locale', 'zh-CN')
+            ->assertJsonPath('report.scores.global.label', '情绪与关系综合指数');
+
+        $this->assertMatchesRegularExpression(
+            '/[\x{4e00}-\x{9fff}]/u',
+            (string) $chinese->json('report.assets.core_formulation.title')
+        );
+        $this->assertStringNotContainsString(
+            'Emotional & Relational Functioning Index',
+            json_encode($chinese->json('report.assets'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: ''
+        );
+
+        $snapshotAfter = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($snapshotAfter);
+        $snapshotAfterReport = json_decode((string) ($snapshotAfter->report_full_json ?? ''), true);
+        $this->assertIsArray($snapshotAfterReport);
+        $this->assertSame('en', (string) ($snapshotAfterReport['locale'] ?? ''));
+    }
+
     public function test_strict_snapshot_behavior_for_mbti_is_unchanged(): void
     {
         config()->set('fap.features.report_snapshot_strict_v2', true);
@@ -200,8 +252,9 @@ final class Eq60V5ReportDeliveryTest extends TestCase
         return $token;
     }
 
-    private function createEqAttemptWithResult(string $anonId): string
+    private function createEqAttemptWithResult(string $anonId, string $locale = 'zh-CN'): string
     {
+        $locale = str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh-CN' : 'en';
         $attemptId = (string) Str::uuid();
         $attempt = Attempt::create([
             'id' => $attemptId,
@@ -210,7 +263,7 @@ final class Eq60V5ReportDeliveryTest extends TestCase
             'scale_code' => 'EQ_60',
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
-            'locale' => 'zh-CN',
+            'locale' => $locale,
             'question_count' => 60,
             'client_platform' => 'test',
             'answers_summary_json' => ['stage' => 'seed'],
@@ -225,7 +278,7 @@ final class Eq60V5ReportDeliveryTest extends TestCase
         $score = $this->scoreEq60([
             'started_at' => $attempt->started_at,
             'submitted_at' => $attempt->submitted_at,
-            'locale' => 'zh-CN',
+            'locale' => $locale,
             'region' => 'CN_MAINLAND',
         ]);
 

--- a/docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md
+++ b/docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md
@@ -1,0 +1,399 @@
+# EQ v1.6 Productization Acceptance Audit
+
+Date: 2026-06-24
+
+Environment:
+
+- Web: https://fermatmind.com
+- API: https://api.fermatmind.com
+- Audit type: production smoke QA, docs-only
+- Mutation boundary: created anonymous production EQ attempts only; no deploy, no code changes, no frontend changes, no manifest/state changes
+
+## 1. Executive Summary
+
+EQ v1.6 production smoke confirms that the core backend and frontend delivery path is live:
+
+- Production EQ question delivery returns 60 EQ_60 items in both `en` and `zh-CN`.
+- Production EQ submit works through the public anonymous guest-token flow.
+- `/report-access` can converge to ready/full/all-free with no locked, blur, paywall, SKU, or paid offers.
+- `/report` returns `eq_report_v5_assets_commercial_ready_v1_6`.
+- Frontend result pages use `EQResultV5` for both English and Chinese routes.
+- v1.6 resolved assets are present, including result snapshot, conversion actions, quality confidence, psychometric evidence, career environment, Agent playbook assets, and SJT bridge.
+- SJT remains planned/unavailable and no clickable SJT take entry was found.
+- No visible paywall/SKU/raw technical tag leakage was found on the checked result pages.
+
+However, acceptance is **blocked by one P1 issue**:
+
+- `zh-CN` result route renders, but the report API still returns `locale=en` and English resolved assets for `?locale=zh-CN` and `?locale=zh`. This means the Chinese product path is not commercially acceptable yet.
+
+Final gate:
+
+- Agent phase allowed: **No**
+- Reason: P1 locale resolution / resolved asset localization blocker on Chinese result path.
+
+## 2. Deployed SHAs And PR Coverage
+
+Backend production:
+
+- SHA: `8969804e481b3aeb271ed34b8ea80f26cba0213a`
+- Release: `eq-v16-assets-20260624`
+- Contains PR-EQ-ASSET-01: yes, previously verified in deploy readiness/deploy output
+- Contains PR-EQ-ASSET-02: yes, previously verified in deploy readiness/deploy output
+
+Frontend production:
+
+- SHA: `764263e98a4a0f311bff89a00bf744dab82df579`
+- Contains PR-EQ-ASSET-03: yes, previously verified in deploy readiness/deploy output
+
+## 3. Smoke Attempts / Sessions
+
+Two production anonymous attempts were used because the first direct API smoke submitted too quickly and intentionally triggered the quality system's low-confidence path.
+
+### Attempt A: Low-Confidence Path
+
+- Attempt ID: `29e0804e-36b9-4426-be69-2094612557f9`
+- Session marker: `codex_eq_v1_6_prod_smoke_20260624_1782304443180`
+- Locale path tested: `en`, then result route also checked under `zh`
+- Purpose: validates low-confidence routing and retest guidance behavior
+- Quality result: level `D`, confidence `low`, flag `SPEEDING`
+- Interpretation: `low_confidence_result`
+- Action prescription: `retest_reflection`
+
+### Attempt B: Normal-Quality Path
+
+- Attempt ID: `adbc27ed-f1f4-47be-8548-e69cc54bbd47`
+- Session marker: `codex_eq_v1_6_prod_smoke_20260624_1782304582614`
+- Locale path tested: `en`, then result route also checked under `zh`
+- Purpose: validates normal v1.6 commercial-ready result path
+- Quality result: level `A`, confidence `high`
+- Completion time: 129 seconds
+- Interpretation: `developing_foundation`
+- Mechanism IDs: `ER_RM_low_low`
+- Action prescription: `emotion_labeling`
+
+Screenshots and raw JSON evidence are stored locally under:
+
+- `/tmp/eq_v1_6_prod_smoke_20260624/01_take_en_initial.png`
+- `/tmp/eq_v1_6_prod_smoke_20260624/02_result_en.png`
+- `/tmp/eq_v1_6_prod_smoke_20260624/03_result_zh.png`
+- `/tmp/eq_v1_6_prod_smoke_20260624/04_normal_result_en.png`
+- `/tmp/eq_v1_6_prod_smoke_20260624/05_normal_result_zh.png`
+- `/tmp/eq_v1_6_prod_smoke_20260624/report_en.json`
+- `/tmp/eq_v1_6_prod_smoke_20260624/normal_report_en.json`
+- `/tmp/eq_v1_6_prod_smoke_20260624/normal_report_zh.json`
+- `/tmp/eq_v1_6_prod_smoke_20260624/normal_report_access_en_recheck.json`
+
+The screenshots are not committed to the repository.
+
+## 4. Question Delivery
+
+Production API endpoints checked:
+
+- `GET /api/v0.3/scales/EQ_60/questions?locale=en`
+- `GET /api/v0.3/scales/EQ_60/questions?locale=zh-CN`
+
+Result:
+
+- HTTP status: 200 for both locales
+- `scale_code`: `EQ_60`
+- English item count: 60
+- Chinese item count: 60
+- Dimension codes observed: `EM`, `ER`, `RM`, `SA`
+- No 50-question regression observed.
+
+Example first question metadata:
+
+- English: question `1`, dimension `SA`, text starts with "I am very good at identifying..."
+- Chinese: question `1`, dimension `SA`, text starts with "我能精准捕捉..."
+
+## 5. Report Access Summary
+
+Attempt B final recheck:
+
+```json
+{
+  "ok": true,
+  "attempt_id": "adbc27ed-f1f4-47be-8548-e69cc54bbd47",
+  "access_state": "ready",
+  "report_state": "ready",
+  "pdf_state": "ready",
+  "reason_code": "projection_missing_result_ready",
+  "payload": {
+    "access_level": "full",
+    "variant": "full",
+    "access": {
+      "all_results_free": true,
+      "locked": false,
+      "blur": false,
+      "paywall": false
+    },
+    "locked": false,
+    "upgrade_sku": null,
+    "offers": [],
+    "modules_allowed": [
+      "eq_core",
+      "eq_full",
+      "eq_cross_insights",
+      "eq_growth_plan"
+    ],
+    "access_source": "free_full_report_mode",
+    "paywall_suppressed": true
+  }
+}
+```
+
+Notes:
+
+- The first report-access read for Attempt B briefly returned `access_state=locked`, `report_state=pending`, `access_level=free`, `variant=free`.
+- A later authenticated recheck converged to ready/full/all-free.
+- This was not page-visible in the final result route, but it should be tracked as a P2 projection-latency concern.
+
+## 6. Report Payload Summary
+
+Attempt B `/report?locale=en`:
+
+- HTTP status: 200
+- `generating`: false
+- `eq_report_mode`: `self_report`
+- `measurement_type`: `self_report_trait_mixed_ei`
+- `methodology.report_version`: `eq_report_v5_assets_commercial_ready_v1_6`
+- `next_module.status`: `planned`
+- `next_module.available`: false
+
+Global score:
+
+```json
+{
+  "band": "developing",
+  "label": "Emotional & Relational Functioning Index",
+  "raw_score": 198,
+  "percentile": 29.69,
+  "standard_score": 92
+}
+```
+
+Dimension summary:
+
+- `SA`: standard score 89, percentile 23, band `developing`
+- `ER`: standard score 79, percentile 8, band `foundational`
+- `EM`: standard score 113, percentile 81, band `proficient`
+- `RM`: standard score 87, percentile 19, band `developing`
+
+Resolved v1.6 asset keys present:
+
+- `action_prescription`
+- `agent_dialogue_playbooks`
+- `backend_integration_contract`
+- `career_environment`
+- `commercial_conversion_actions`
+- `core_formulation`
+- `cross_assessment_context`
+- `mechanisms`
+- `personalization_route`
+- `psychometric_evidence_status`
+- `quality`
+- `quality_confidence`
+- `reality_scenes`
+- `result_snapshot`
+- `scientific_contract`
+- `score_system`
+- `sjt_bridge`
+
+Asset references present:
+
+- `core_formulation_id`
+- `result_snapshot_id`
+- `commercial_conversion_ids`
+- `quality_confidence_id`
+- `psychometric_evidence_ids`
+- `mechanism_ids`
+- `scene_ids`
+- `career_environment_ids`
+- `action_prescription_id`
+- `agent_playbook_ids`
+- `sjt_bridge_id`
+- `scientific_contract_id`
+- `score_system_id`
+
+## 7. Frontend Renderer And Page Checks
+
+Result pages checked:
+
+- `https://fermatmind.com/en/result/adbc27ed-f1f4-47be-8548-e69cc54bbd47`
+- `https://fermatmind.com/zh/result/adbc27ed-f1f4-47be-8548-e69cc54bbd47`
+
+Renderer:
+
+- English route: `data-testid="eq-result-v5"` found
+- Chinese route: `data-testid="eq-result-v5"` found
+- No evidence of `RichResultReport` fallback takeover.
+
+English visible sections found:
+
+- Evidence Snapshot
+- Interpretation Confidence
+- Emotional Matrix
+- Mechanism
+- Reality
+- Career Environment
+- Action Prescription
+- Future scenario module
+- Scientific Boundary
+- Save / Email / PDF / Share / Retake
+- Agent entry text
+
+Chinese route visible sections found:
+
+- 证据
+- 置信
+- 情绪
+- 机制
+- 现实
+- 职业
+- 行动
+- 科学
+- 保存
+- 分享
+- Agent entry text
+
+Important caveat:
+
+- Chinese route UI chrome is partially localized, but resolved report content remains English. See P1 below.
+
+## 8. Forbidden Terms / Fields Check
+
+Visible page text checked for:
+
+- `SKU_EQ_60_FULL_299`
+- `EQ_60_FULL`
+- `paywall`
+- `locked`
+- `blur`
+- `profile:`
+- `quality_level:`
+- `focus:`
+- `bucket:`
+- raw IDs such as `high_empathy_low_recovery`, `EM_ER_high_low`, `eq60.signal_signature.v1`
+- `解锁`
+- `购买`
+- `付费`
+
+Result:
+
+- Attempt A English page: none found
+- Attempt A Chinese page: none found
+- Attempt B English page: none found
+- Attempt B Chinese page: none found
+
+Report payload note:
+
+- Raw backend report JSON still contains internal `report_tags` and some legacy/diagnostic fields. These were not visible on the page.
+- `report-access` still contains legacy `invite_unlock_*` diagnostic fields even though `access_source=free_full_report_mode`; this is P2 governance risk, not an observed user-visible paywall.
+
+## 9. SJT Bridge
+
+Attempt B report payload:
+
+```json
+{
+  "status": "planned",
+  "available": false,
+  "module_code": "EQ_SJT_16",
+  "cta_asset_id": "eq.sjt_bridge.planned"
+}
+```
+
+Page result:
+
+- Future scenario module is visible.
+- No clickable SJT take entry was found.
+- No MSCEIT / certified ability-test claim was observed.
+
+## 10. Low-Confidence Path
+
+Attempt A verifies the low-confidence path in production:
+
+- Quality level: `D`
+- Confidence: `low`
+- Flag: `SPEEDING`
+- Core formulation: `low_confidence_result`
+- Action prescription: `retest_reflection`
+- Page still renders through `EQResultV5`
+- No visible raw tags, paywall, SKU, locked, blur, or paid CTA found
+
+The low-confidence attempt was created by the audit's fast API submission and should be treated as a smoke artifact, not as a normal user-like result.
+
+## 11. Issues And Risks
+
+### P1: Chinese Result Path Receives English Resolved Assets
+
+Evidence:
+
+- `GET /api/v0.3/attempts/adbc27ed-f1f4-47be-8548-e69cc54bbd47/report?locale=zh-CN` returned `locale=en`.
+- `GET /api/v0.3/attempts/adbc27ed-f1f4-47be-8548-e69cc54bbd47/report?locale=zh` also returned `locale=en`.
+- Chinese result route displayed Chinese UI chrome, but core resolved report assets such as `core_formulation`, `result_snapshot`, `quality_confidence`, and `action_prescription` were English.
+
+Impact:
+
+- Blocks Chinese commercial-quality acceptance.
+- Blocks Agent phase because the Agent should not inherit unresolved locale authority behavior.
+
+Recommended follow-up:
+
+- Fix report locale resolution so `/report?locale=zh-CN` returns Chinese resolved assets and `locale=zh-CN`.
+- Add production-safe contract coverage for report locale resolution.
+- Add frontend contract/e2e assertion that zh result route renders localized resolved assets, not English fallback.
+
+### P2: report-access Projection Latency
+
+Evidence:
+
+- Attempt B first report-access read briefly returned pending/free/locked after `/report` was already deliverable.
+- Later authenticated recheck returned ready/full/all-free.
+
+Impact:
+
+- Not observed as a final user-visible failure in this smoke.
+- Could create brief readiness ambiguity immediately after submit.
+
+Recommended follow-up:
+
+- Re-check report-access projection refresh timing for EQ.
+- Ensure report-access ready/full/all-free aligns with `/report` fallback delivery as soon as result exists.
+
+### P2: Legacy invite_unlock Diagnostic Fields Remain In EQ report-access
+
+Evidence:
+
+- `report-access` includes `invite_unlock_v1` and `invite_unlock_diag_v1` while also returning `access_source=free_full_report_mode`.
+
+Impact:
+
+- Not page-visible in this smoke.
+- Future frontend or Agent consumers could mistakenly read these fields.
+
+Recommended follow-up:
+
+- Mark these as deprecated diagnostics for EQ or suppress them for all-free EQ report-access payloads.
+
+## 12. Final Acceptance Decision
+
+Production EQ v1.6 is partially accepted:
+
+- Backend v1.6 payload delivery: pass
+- Frontend EQResultV5 rendering: pass
+- All-free/no-paywall runtime: pass
+- SJT planned/unavailable boundary: pass
+- Low-confidence path safety: pass
+- English commercial result path: pass
+- Chinese commercial result path: **fail / P1**
+
+Agent phase allowed: **No**
+
+Reason:
+
+- The Chinese result path currently receives English resolved assets from `/report`. The EQ Agent should not be built on top of a locale authority mismatch.
+
+Next recommended task:
+
+- PR-EQ-ASSET-04: Fix EQ report locale resolution for v1.6 resolved assets, then rerun this acceptance audit.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T21:05:00+08:00",
+  "updated_at": "2026-06-24T21:12:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60451,7 +60451,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-04-report-locale-v16",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-04 Fix EQ v1.6 report locale resolved assets",
     "depends_on": [
@@ -60499,11 +60499,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to PR-EQ-ASSET-04 allowed paths plus manifest/state entries explicitly authorized by the user."
+      },
+      "pr_opened": {
+        "status": "pass",
+        "evidence": "GitHub PR #2393 opened for codex/pr-eq-asset-04-report-locale-v16."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9a1e4d9829cb038ed0897b3d130ca3bc2310b307",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2393",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -60519,6 +60523,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Locale resolved-assets fix implemented and local PR validation passed."
+      },
+      {
+        "at": "2026-06-24T21:12:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2393 after local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T12:47:00Z",
+  "updated_at": "2026-06-24T21:05:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60444,6 +60444,256 @@
         "at": "2026-06-24T12:47:00Z",
         "status": "ready_to_merge",
         "note": "PR #2392 checks are green and mergeStateStatus is CLEAN on head 79b7931eb59d29b9c778b0333bbcb9ccbcc45cd0. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, sitemap, llms, queue, search, or indexing changes included."
+      }
+    ]
+  },
+  "PR-EQ-ASSET-04": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-asset-04-report-locale-v16",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "eq_v16_content_asset_productization",
+    "title": "PR-EQ-ASSET-04 Fix EQ v1.6 report locale resolved assets",
+    "depends_on": [
+      "PR-EQ-ASSET-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-ASSET-04, PR-EQ-ASSET-05, PR-EQ-AGENT-01, PR-EQ-AGENT-02, PR-EQ-AGENT-03, and PR-EQ-AGENT-04 manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "Production deploy/readiness and acceptance audit confirmed PR-EQ-ASSET-01/02/03 are deployed; PR-EQ-ASSET-04 addresses the resulting EQ v1.6 locale P1."
+      },
+      "local_delivery_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportDeliveryTest",
+        "evidence": "4 passed, 82 assertions."
+      },
+      "local_contract_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "evidence": "10 passed, 404 assertions."
+      },
+      "local_paywall_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest",
+        "evidence": "4 passed, 118 assertions."
+      },
+      "manifest_yaml": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "evidence": "yaml ok."
+      },
+      "state_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "JSON parse passed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to PR-EQ-ASSET-04 allowed paths plus manifest/state entries explicitly authorized by the user."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit EQ v1.6 baseline freeze and Agent-ready content OS authorization."
+      },
+      {
+        "at": "2026-06-24T21:05:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Locale resolved-assets fix implemented and local PR validation passed."
+      }
+    ]
+  },
+  "PR-EQ-ASSET-05": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-asset-05-freeze-v16-baseline",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_v16_content_asset_productization",
+    "title": "PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline",
+    "depends_on": [
+      "PR-EQ-ASSET-04"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-ASSET-04 locale acceptance fix to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit authorization."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-01": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-01-knowledge-schema",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_ready_content_os",
+    "title": "PR-EQ-AGENT-01 EQ Agent knowledge base schema and intent map",
+    "depends_on": [
+      "PR-EQ-ASSET-05"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-ASSET-05 baseline freeze to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit authorization."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-02": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-02-context-payload-api",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_ready_content_os",
+    "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
+    "depends_on": [
+      "PR-EQ-AGENT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-01 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit authorization."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-03": {
+    "repo": "fap-web",
+    "branch": "codex/pr-eq-agent-03-frontend-entry-guard",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_ready_content_os",
+    "title": "PR-EQ-AGENT-03 Frontend EQ Agent entry guard",
+    "depends_on": [
+      "PR-EQ-AGENT-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-02 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit authorization."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-04": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-04-safety-evals",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_ready_content_os",
+    "title": "PR-EQ-AGENT-04 EQ Agent safety and forbidden claims eval fixtures",
+    "depends_on": [
+      "PR-EQ-AGENT-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates and sequential execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-03 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T20:45:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit authorization."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -175,6 +175,248 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+
+  - id: PR-EQ-ASSET-04
+    repo: fap-api
+    depends_on: [PR-EQ-ASSET-03]
+    branch: codex/pr-eq-asset-04-report-locale-v16
+    title: "PR-EQ-ASSET-04 Fix EQ v1.6 report locale resolved assets"
+    train_scope: eq_v16_content_asset_productization
+    scope:
+      - Fix EQ_60 report delivery so an explicit /report locale query resolves the matching v1.6 report assets.
+      - Ensure /report?locale=zh-CN and /report?locale=zh return locale=zh-CN and Chinese resolved assets even when the attempt was submitted in English.
+      - Include the EQ v1.6 production acceptance audit report as evidence for the P1 blocker.
+      - Keep report snapshots attempt-locale-bound; do not overwrite an English attempt snapshot with a Chinese live render.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/app/Services/Report/ReportGatekeeper.php
+      - backend/app/Services/Report/Eq60ReportComposer.php
+      - backend/tests/Feature/Report/Eq60V5ReportDeliveryTest.php
+      - docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change EQ-60 questions, options, reverse keys, scoring semantics, or norm algorithms.
+      - Modify raw EQ content prose.
+      - Modify fap-web.
+      - Implement or enable EQ-SJT.
+      - Add paid, locked, blur, SKU, or access-wall semantics.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportDeliveryTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-ASSET-05
+    repo: fap-api
+    depends_on: [PR-EQ-ASSET-04]
+    branch: codex/pr-eq-asset-05-freeze-v16-baseline
+    title: "PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline"
+    train_scope: eq_v16_content_asset_productization
+    scope:
+      - Mark EQ v1.6 as the first commercial content baseline after locale acceptance passes.
+      - Document frozen asset IDs, trigger rules, claim boundaries, risk notes, and Agent maintenance rules.
+      - State that future Agent workflows maintain structured assets and metadata, not ad-hoc report prose.
+    allowed_paths:
+      - docs/audits/eq/**
+      - docs/product/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change runtime code.
+      - Modify EQ content assets.
+      - Modify fap-web.
+      - Implement Agent runtime.
+    validation:
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-01
+    repo: fap-api
+    depends_on: [PR-EQ-ASSET-05]
+    branch: codex/pr-eq-agent-01-knowledge-schema
+    title: "PR-EQ-AGENT-01 EQ Agent knowledge base schema and intent map"
+    train_scope: eq_agent_ready_content_os
+    scope:
+      - Define Agent-consumable EQ knowledge schema over existing v1.6 assets.
+      - Add retrieval tags, user intent map, asset type taxonomy, forbidden-claim metadata, and escalation flags.
+      - Keep this as schema/content-contract work with no runtime Agent behavior.
+    allowed_paths:
+      - backend/content_packs/EQ_60/v1/raw/report_assets/**
+      - backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+      - backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/**
+      - backend/app/Services/Content/Eq60ContentCompileService.php
+      - backend/app/Services/Content/Eq60ContentLintService.php
+      - backend/tests/Feature/Content/Eq60ContentGateTest.php
+      - docs/audits/eq/**
+      - docs/product/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add Agent runtime endpoints.
+      - Modify scoring, norms, questions, or SJT availability.
+      - Modify fap-web.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:lint --pack=EQ_60 --pack-version=v1
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan content:compile --pack=EQ_60 --pack-version=v1
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ContentGateTest
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-02
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-01]
+    branch: codex/pr-eq-agent-02-context-payload-api
+    title: "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API"
+    train_scope: eq_agent_ready_content_os
+    scope:
+      - Expose read-only EQ Agent context from authoritative report/content-pack assets.
+      - Add a backend context payload or retrieval API that cannot mutate reports or override scoring and interpretation.
+      - Preserve backend report composer and content pack authority.
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/app/Http/Controllers/API/V0_3/**
+      - backend/app/Services/Eq/**
+      - backend/app/Services/Report/Eq60ReportComposer.php
+      - backend/tests/Feature/**/Eq*Agent*
+      - backend/tests/Feature/Report/*Eq60*
+      - docs/audits/eq/**
+      - docs/product/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Allow Agent writes or report mutation.
+      - Modify scoring, norms, questions, or SJT availability.
+      - Modify fap-web.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-03
+    repo: fap-web
+    depends_on: [PR-EQ-AGENT-02]
+    branch: codex/pr-eq-agent-03-frontend-entry-guard
+    title: "PR-EQ-AGENT-03 Frontend EQ Agent entry guard"
+    train_scope: eq_agent_ready_content_os
+    scope:
+      - Add a guarded Agent entry on the EQ result page after backend context contract exists.
+      - Keep Agent entry assistive and informational, not a report-authoring surface.
+      - Prevent Agent from altering report sections, scores, formulations, or content authority.
+    allowed_paths:
+      - components/result/eq/**
+      - lib/api/v0_3.ts
+      - tests/contracts/eq-result-v5-renderer.contract.test.tsx
+      - tests/e2e/iq-eq-result-regression.spec.ts
+      - tests/fixtures/eq/v5/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add frontend-owned official EQ report prose.
+      - Add SJT take entry.
+      - Add Agent report mutation controls.
+      - Add paid, locked, blur, SKU, or access-wall semantics.
+    validation:
+      - pnpm typecheck
+      - pnpm test:contract
+      - pnpm exec playwright test tests/e2e/iq-eq-result-regression.spec.ts
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-04
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-03]
+    branch: codex/pr-eq-agent-04-safety-evals
+    title: "PR-EQ-AGENT-04 EQ Agent safety and forbidden claims eval fixtures"
+    train_scope: eq_agent_ready_content_os
+    scope:
+      - Add EQ Agent safety fixtures and forbidden-claim tests.
+      - Cover ability-test, MSCEIT-like, hiring suitability, clinical diagnosis, guaranteed outcome, and job-performance prediction claims.
+      - Cover locale behavior, low-confidence behavior, no-paywall, and no-SJT-entry invariants.
+    allowed_paths:
+      - backend/tests/Fixtures/eq/agent/**
+      - backend/tests/Feature/**/Eq*Agent*
+      - backend/tests/Feature/Report/*Eq60*
+      - backend/content_packs/EQ_60/v1/raw/report_assets/**
+      - backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json
+      - backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/**
+      - docs/audits/eq/**
+      - docs/product/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add Agent runtime write paths.
+      - Modify scoring, norms, questions, or SJT availability.
+      - Modify fap-web unless split into a separate frontend PR.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-PER-01
     repo: fap-api
     branch: codex/pr-eq-per-01-all-free-copy-contract-cleanup


### PR DESCRIPTION
## What changed
- Added PR train manifest/state entries for PR-EQ-ASSET-04 through PR-EQ-AGENT-04 under the user-authorized EQ v1.6 baseline freeze and Agent-ready Content OS train.
- Fixed EQ_60 `/report?locale=...` delivery so an explicit report locale is passed through `AttemptReadController -> ReportGatekeeper -> Eq60ReportComposer`.
- Kept existing report snapshots bound to the attempt locale: if a ready English snapshot exists and `/report?locale=zh-CN` is requested, the API live-composes the Chinese EQ v1.6 payload without overwriting the English snapshot.
- Added regression coverage for an English submitted EQ attempt returning Chinese v1.6 resolved assets when requested via `/report?locale=zh-CN`.
- Added the production EQ v1.6 acceptance audit report as evidence of the P1 blocker this PR closes.

## Why
Production smoke QA found a P1 localization blocker: Chinese result routes were accessible, but `/report?locale=zh-CN` and `/report?locale=zh` still returned `locale=en` and English resolved assets for an English submitted attempt. That blocked freezing EQ v1.6 as the commercial baseline and blocked Agent-phase entry.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportDeliveryTest`
  - 4 passed, 82 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
  - 10 passed, 404 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60ReportPaywallTest`
  - 4 passed, 118 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60GoldenCasesTest`
  - 1 passed, 208 assertions
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60SubmitQualityContractTest`
  - 1 passed, 16 assertions
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: changed files limited to PR-EQ-ASSET-04 allowed paths.

## Intentionally deferred
- No EQ content rewrite.
- No scoring, norm, question, option, or reverse-key changes.
- No SJT enablement, SJT route, SJT scorer, or clickable SJT entry.
- No frontend changes.
- No paid, locked, blur, SKU, or access-wall behavior.
- No production deploy in this PR.

## Repository rule impact
- Content/report authority remains backend-side in content pack/composer/report delivery.
- Frontend remains deterministic consumer of backend resolved assets.
- This PR does not introduce a new content surface and does not move any content authority to frontend or CMS fallback.
