### PR TITLE
BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01: Add Big Five CMS draft writer contract

### DIFF
--- a/backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php
+++ b/backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\BigFivePublicProfileAgentDraftWriter;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityBigFivePublicProfileAgentDraft extends Command
+{
+    private const OPERATOR_APPROVAL = 'BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'draft-only',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:big-five-public-profile-agent-draft
+        {--package= : Path to the Big Five agent recommendation JSON package}
+        {--qa= : Path to the Big Five agent QA JSON artifact}
+        {--dry-run : Validate and plan without database writes}
+        {--write : Create Big Five public content asset draft rows}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--draft-only : Required for --write; confirms draft-only content asset write}
+        {--no-publish : Required for --write; confirms no publish action}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Create Big Five public profile CMS draft assets with explicit no-publish/no-index guards.';
+
+    public function handle(BigFivePublicProfileAgentDraftWriter $writer): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($writer);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(BigFivePublicProfileAgentDraftWriter $writer): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = $this->resolvePath(trim((string) $this->option('package')), 'Package');
+        $qaPath = $this->resolvePath(trim((string) $this->option('qa')), 'QA artifact');
+        $packageRaw = (string) File::get($packagePath);
+        $qaRaw = (string) File::get($qaPath);
+        $package = json_decode($packageRaw, true);
+        $qa = json_decode($qaRaw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+        if (! is_array($qa)) {
+            throw new RuntimeException('QA artifact must be a JSON object.');
+        }
+
+        $summary = $write
+            ? $writer->write($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw))
+            : $writer->plan($package, $qa, hash('sha256', $packageRaw), hash('sha256', $qaRaw));
+
+        return array_merge($summary, [
+            'package_path' => $packagePath,
+            'qa_path' => $qaPath,
+            'command' => 'personality:big-five-public-profile-agent-draft',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path, string $label): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('--'.strtolower(str_replace(' artifact', '', $label)).' is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException($label.' file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('row_count='.(string) ($summary['row_count'] ?? 0));
+        $this->line('created_revision_count='.(string) ($summary['created_revision_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01',
+            'status' => 'fail',
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -175,6 +175,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityAgentApprovalQueueCommand;
+use App\Console\Commands\PersonalityBigFivePublicProfileAgentDraft;
 use App\Console\Commands\PersonalityEnneagramCmsDraft;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
 use App\Console\Commands\PersonalityMbti64GscQueryReadonlyExport;
@@ -248,6 +249,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityAgentApprovalQueueCommand::class,
+        PersonalityBigFivePublicProfileAgentDraft::class,
         PersonalityEnneagramCmsDraft::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64GscQueryReadonlyExport::class,

--- a/backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
+++ b/backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
@@ -1,0 +1,618 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Support\Facades\DB;
+
+final class BigFivePublicProfileAgentDraftWriter
+{
+    private const SNAPSHOT_SOURCE = 'big_five_agent_public_profile_draft_v1';
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    private const DOMAIN_SLUGS = [
+        'agreeableness',
+        'conscientiousness',
+        'emotional-stability',
+        'extraversion',
+        'neuroticism',
+        'openness',
+    ];
+
+    private const POLARITY_DOMAIN_SLUGS = [
+        'agreeableness',
+        'conscientiousness',
+        'extraversion',
+        'neuroticism',
+        'openness',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    {
+        return $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    public function write(array $package, array $qa, string $sourceSha256, string $qaSha256): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $qa, $sourceSha256, $qaSha256, true));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    {
+        $qaRows = $this->qaRowsByUrl($qa);
+        $approvedRows = $write ? $this->approvedRowsByUrl($sourceSha256, $qaSha256) : [];
+        $errors = [];
+        $rows = [];
+
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $qaRow = $qaRows[$targetUrl] ?? [];
+            $recommendationJson = $this->jsonString($recommendation);
+            $recommendationSha256 = hash('sha256', $recommendationJson);
+
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'unsupported_big_five_target_url',
+                    'message' => 'Only Big Five hub, facet hub, domain, and high/low polarity public URLs are supported.',
+                ];
+
+                continue;
+            }
+
+            if ($this->containsForbiddenRoutePattern($targetUrl) || $this->containsForbiddenRoutePattern($recommendationJson)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position),
+                    'code' => 'forbidden_private_route_pattern_present',
+                    'message' => 'Recommendation contains a private/result/order/payment/account/share route or sensitive query key.',
+                ];
+            }
+
+            if ($qaRow === [] || ! $this->qaDecisionPasses((string) ($qaRow['decision'] ?? $qaRow['status'] ?? $qaRow['qa_status'] ?? ''))) {
+                $errors[] = [
+                    'field' => 'qa.'.((string) $targetUrl),
+                    'code' => 'qa_pass_required',
+                    'message' => 'Every Big Five draft row requires a matching PASS QA row.',
+                ];
+            }
+
+            if ((array) ($qaRow['blockers'] ?? []) !== []) {
+                $errors[] = [
+                    'field' => 'qa.'.((string) $targetUrl).'.blockers',
+                    'code' => 'qa_blockers_present',
+                    'message' => 'QA blockers prevent CMS draft planning.',
+                ];
+            }
+
+            if ($write && ! $this->approvedRowPasses($approvedRows[$targetUrl] ?? null, $recommendationSha256)) {
+                $errors[] = [
+                    'field' => 'approval_queue.'.((string) $targetUrl),
+                    'code' => 'approved_approval_queue_item_required',
+                    'message' => 'Big Five CMS draft writes require an approved approval queue item matching target, package hash, QA hash, and recommendation hash.',
+                ];
+            }
+
+            $existing = $this->existingAsset($identity);
+            if ($existing instanceof PersonalityPublicContentAsset && ! $this->existingAssetIsWritableDraft($existing)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'existing_live_or_foreign_asset_blocks_draft_write',
+                    'message' => 'Existing public/content-ready/published/indexable asset blocks draft-only writes.',
+                ];
+            }
+
+            $sameSourceDraft = $existing instanceof PersonalityPublicContentAsset
+                && $this->existingAssetMatchesHashes($existing, $sourceSha256, $qaSha256, $recommendationSha256);
+
+            $rows[] = [
+                'position' => $position + 1,
+                'url' => $targetUrl,
+                'path' => $identity['path'],
+                'locale' => $identity['locale'],
+                'entity_type' => $identity['entity_type'],
+                'entity_key' => $identity['entity_key'],
+                'slug' => $identity['slug'],
+                'source_sha256' => $sourceSha256,
+                'qa_source_sha256' => $qaSha256,
+                'recommendation_sha256' => $recommendationSha256,
+                'existing_asset_id' => $existing?->id !== null ? (int) $existing->id : null,
+                'action' => $existing instanceof PersonalityPublicContentAsset
+                    ? ($sameSourceDraft ? 'skip_existing_same_source_draft' : 'update_existing_draft_revision_overlay')
+                    : 'create_draft_revision_overlay',
+                'asset_preview' => $this->assetPayload($recommendation, $identity, $sourceSha256, $qaSha256, $recommendationSha256),
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($rows),
+                'logical_entity_count' => $this->logicalEntityCount($rows),
+                'locale_counts' => $this->localeCounts($rows),
+                'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+                'domain_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_DOMAIN),
+                'polarity_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_POLARITY),
+                'facet_hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_FACET_HUB),
+                'would_create_revision_count' => 0,
+                'would_update_revision_count' => 0,
+                'created_revision_count' => 0,
+                'updated_revision_count' => 0,
+                'skipped_existing_count' => 0,
+                'missing_target_count' => $this->countErrorCode($errors, 'unsupported_big_five_target_url'),
+                'forbidden_route_count' => $this->countErrorCode($errors, 'forbidden_private_route_pattern_present'),
+                'rows' => $rows,
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $created = 0;
+        $updated = 0;
+        $skipped = 0;
+        if ($write) {
+            foreach ($rows as &$row) {
+                $existingId = $row['existing_asset_id'] ?? null;
+                if ($existingId !== null && $row['action'] === 'skip_existing_same_source_draft') {
+                    $row['action'] = 'skipped_existing';
+                    $skipped++;
+
+                    continue;
+                }
+
+                if ($existingId !== null) {
+                    PersonalityPublicContentAsset::query()
+                        ->withoutGlobalScopes()
+                        ->whereKey((int) $existingId)
+                        ->update((array) $row['asset_preview']);
+                    $row['action'] = 'updated_draft_revision_overlay';
+                    $updated++;
+
+                    continue;
+                }
+
+                PersonalityPublicContentAsset::query()->create((array) $row['asset_preview']);
+                $row['action'] = 'created_draft_revision_overlay';
+                $created++;
+            }
+            unset($row);
+        }
+
+        return array_merge($this->baseSummary($package, $qa, $sourceSha256, $qaSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'row_count' => count($rows),
+            'logical_entity_count' => $this->logicalEntityCount($rows),
+            'locale_counts' => $this->localeCounts($rows),
+            'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+            'domain_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_DOMAIN),
+            'polarity_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_POLARITY),
+            'facet_hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_FACET_HUB),
+            'would_create_revision_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['existing_asset_id'] ?? null) === null)),
+            'would_update_revision_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['existing_asset_id'] ?? null) !== null && $row['action'] !== 'skip_existing_same_source_draft')),
+            'created_revision_count' => $created,
+            'updated_revision_count' => $updated,
+            'created_asset_count' => $created,
+            'skipped_existing_count' => $skipped,
+            'missing_target_count' => 0,
+            'forbidden_route_count' => 0,
+            'writes_committed' => $write && ($created + $updated) > 0,
+            'rows' => $rows,
+            'errors' => [],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $qa
+     * @return array<string,array<string,mixed>>
+     */
+    private function qaRowsByUrl(array $qa): array
+    {
+        $rows = [];
+        foreach ([$qa['evaluations'] ?? null, $qa['page_results'] ?? null, $qa['results'] ?? null, $qa['items'] ?? null] as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            foreach ($source as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $url = (string) ($item['target_url'] ?? $item['url'] ?? '');
+                if ($url !== '') {
+                    $rows[$url] = $item;
+                }
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function approvedRowsByUrl(string $sourceSha256, string $qaSha256): array
+    {
+        $rows = [];
+        $items = DB::table('personality_agent_approval_items as items')
+            ->join('personality_agent_approval_batches as batches', 'batches.id', '=', 'items.batch_id')
+            ->where('batches.framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('batches.source_package_sha256', $sourceSha256)
+            ->where('batches.qa_sha256', $qaSha256)
+            ->where('items.framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('items.approval_state', 'approved')
+            ->whereNotNull('items.approved_at')
+            ->whereNull('items.rejected_at')
+            ->whereNull('items.blocked_reason')
+            ->select(['items.target_url', 'items.recommendation_sha256'])
+            ->get();
+
+        foreach ($items as $item) {
+            $rows[(string) $item->target_url] = [
+                'target_url' => (string) $item->target_url,
+                'recommendation_sha256' => (string) $item->recommendation_sha256,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $row
+     */
+    private function approvedRowPasses(?array $row, string $recommendationSha256): bool
+    {
+        return $row !== null && (string) ($row['recommendation_sha256'] ?? '') === $recommendationSha256;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        if ((string) ($recommendation['framework'] ?? '') !== PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE) {
+            return null;
+        }
+
+        $path = (string) parse_url((string) ($recommendation['target_url'] ?? ''), PHP_URL_PATH);
+        if ($path === '') {
+            return null;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five$#i', $path, $matches) === 1) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_HUB, 'big-five', 'big-five');
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five/facets$#i', $path, $matches) === 1) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_FACET_HUB, 'facets', 'big-five/facets');
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five/(?<slug>[a-z-]+)$#i', $path, $matches) !== 1) {
+            return null;
+        }
+
+        $slug = strtolower((string) $matches['slug']);
+        if (in_array($slug, self::DOMAIN_SLUGS, true)) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_DOMAIN, $slug, 'big-five/'.$slug);
+        }
+
+        if (preg_match('#^(?<polarity>high|low)-(?<domain>[a-z-]+)$#i', $slug, $polarityMatches) === 1
+            && in_array(strtolower((string) $polarityMatches['domain']), self::POLARITY_DOMAIN_SLUGS, true)) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_POLARITY, $slug, 'big-five/'.$slug);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}
+     */
+    private function identity(string $path, string $prefix, string $entityType, string $entityKey, string $slug): array
+    {
+        return [
+            'path' => $path,
+            'locale' => $this->localeFromPrefix($prefix),
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => $slug,
+        ];
+    }
+
+    /**
+     * @param  array{locale:string,entity_type:string,entity_key:string}  $identity
+     */
+    private function existingAsset(array $identity): ?PersonalityPublicContentAsset
+    {
+        return PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('entity_type', $identity['entity_type'])
+            ->where('entity_key', $identity['entity_key'])
+            ->where('locale', $identity['locale'])
+            ->first();
+    }
+
+    private function existingAssetIsWritableDraft(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->is_public === false
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_DRAFT,
+                PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            ], true);
+    }
+
+    private function existingAssetMatchesHashes(PersonalityPublicContentAsset $asset, string $sourceSha256, string $qaSha256, string $recommendationSha256): bool
+    {
+        if ((string) $asset->source_hash !== $sourceSha256) {
+            return false;
+        }
+
+        $notes = is_array($asset->evidence_notes_json) ? $asset->evidence_notes_json : [];
+        foreach ($notes as $note) {
+            if (! is_array($note)) {
+                continue;
+            }
+
+            if (
+                (string) ($note['package_sha256'] ?? '') === $sourceSha256
+                && (string) ($note['qa_sha256'] ?? '') === $qaSha256
+                && (string) ($note['recommendation_sha256'] ?? '') === $recommendationSha256
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @param  array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}  $identity
+     * @return array<string,mixed>
+     */
+    private function assetPayload(array $recommendation, array $identity, string $sourceSha256, string $qaSha256, string $recommendationSha256): array
+    {
+        $recommendations = is_array($recommendation['recommendations'] ?? null) ? $recommendation['recommendations'] : [];
+        $title = trim((string) ($recommendations['h1'] ?? $recommendations['title'] ?? 'Big Five public profile draft'));
+        $seoTitle = trim((string) ($recommendations['title'] ?? $title));
+        $description = trim((string) ($recommendations['description'] ?? ''));
+        $quickAnswer = trim((string) ($recommendations['quick_answer'] ?? ''));
+
+        return [
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => $identity['entity_type'],
+            'entity_key' => $identity['entity_key'],
+            'slug' => $identity['slug'],
+            'locale' => $identity['locale'],
+            'title' => $title,
+            'summary' => $quickAnswer !== '' ? $quickAnswer : $description,
+            'content_sections_json' => $this->contentSections($quickAnswer, $recommendations),
+            'seo_json' => [
+                'title' => $seoTitle,
+                'description' => $description,
+            ],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'canonical_json' => [
+                'path' => $identity['path'],
+            ],
+            'hreflang_json' => [],
+            'faq_json' => array_values(is_array($recommendations['faq'] ?? null) ? $recommendations['faq'] : []),
+            'media_json' => [],
+            'schema_json' => [],
+            'method_boundary_json' => [
+                'summary' => 'Big Five public profile drafts are reflective educational content only; they are not clinical diagnosis, employment screening, official affiliation, or deterministic guidance.',
+                'not_for' => ['clinical diagnosis', 'employment screening', 'deterministic decisions'],
+            ],
+            'evidence_notes_json' => [
+                [
+                    'source_type' => 'agent_recommendation',
+                    'source' => self::SNAPSHOT_SOURCE,
+                    'package_sha256' => $sourceSha256,
+                    'qa_sha256' => $qaSha256,
+                    'recommendation_sha256' => $recommendationSha256,
+                ],
+            ],
+            'internal_links_json' => array_values(is_array($recommendations['internal_links'] ?? null) ? $recommendations['internal_links'] : []),
+            'is_public' => false,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            'review_state' => 'agent_draft_pending_review',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => self::SNAPSHOT_SOURCE,
+            'source_hash' => $sourceSha256,
+            'last_reviewed_at' => null,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendations
+     * @return list<array<string,mixed>>
+     */
+    private function contentSections(string $quickAnswer, array $recommendations): array
+    {
+        $sections = [];
+        if ($quickAnswer !== '') {
+            $sections[] = [
+                'key' => 'quick_answer',
+                'title' => 'Quick answer',
+                'body_md' => $quickAnswer,
+            ];
+        }
+
+        foreach (array_values(is_array($recommendations['differentiation_notes'] ?? null) ? $recommendations['differentiation_notes'] : []) as $index => $note) {
+            if (! is_scalar($note) || trim((string) $note) === '') {
+                continue;
+            }
+
+            $sections[] = [
+                'key' => 'differentiation_'.((string) ($index + 1)),
+                'title' => 'Differentiation note',
+                'body_md' => trim((string) $note),
+            ];
+        }
+
+        return $sections;
+    }
+
+    private function qaDecisionPasses(string $decision): bool
+    {
+        return in_array($decision, [
+            'pass',
+            'PASS',
+            'PASS_READY_FOR_CMS_DRAFT',
+            'PASS_READY_FOR_APPROVAL_QUEUE',
+        ], true);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     */
+    private function countRows(array $rows, string $entityType): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row['entity_type'] ?? null) === $entityType));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,int>
+     */
+    private function localeCounts(array $rows): array
+    {
+        $counts = [];
+        foreach ($rows as $row) {
+            $locale = (string) ($row['locale'] ?? '');
+            $counts[$locale] = ($counts[$locale] ?? 0) + 1;
+        }
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     */
+    private function logicalEntityCount(array $rows): int
+    {
+        return count(array_unique(array_map(
+            static fn (array $row): string => (string) ($row['entity_type'] ?? '').':'.(string) ($row['entity_key'] ?? ''),
+            $rows
+        )));
+    }
+
+    /**
+     * @param  list<array<string,string>>  $errors
+     */
+    private function countErrorCode(array $errors, string $code): int
+    {
+        return count(array_filter($errors, static fn (array $error): bool => ($error['code'] ?? null) === $code));
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function localeFromPrefix(string $prefix): string
+    {
+        return $prefix === 'zh' ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, array $qa, string $sourceSha256, string $qaSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01',
+            'status' => 'pending',
+            'ok' => false,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'package_artifact' => (string) ($package['artifact'] ?? ''),
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'qa_sha256' => $qaSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_attempted' => $write,
+            'writes_committed' => false,
+            'cms_write_attempted' => $write,
+            'cms_mutation_attempted' => $write,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
@@ -1,0 +1,467 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityBigFivePublicProfileAgentDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_thirty_four_big_five_drafts_without_writes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(34, $payload['row_count']);
+        $this->assertSame(17, $payload['logical_entity_count']);
+        $this->assertSame(['en' => 17, 'zh-CN' => 17], $payload['locale_counts']);
+        $this->assertSame(2, $payload['hub_row_count']);
+        $this->assertSame(10, $payload['domain_row_count']);
+        $this->assertSame(20, $payload['polarity_row_count']);
+        $this->assertSame(2, $payload['facet_hub_row_count']);
+        $this->assertSame(34, $payload['would_create_revision_count']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_requires_approved_approval_queue_items(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertContains('approved_approval_queue_item_required', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_write_creates_non_public_noindex_draft_assets_after_approval_only(): void
+    {
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->approvePackageRows($packagePath, $qaPath, $package, $qa);
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(34, $payload['row_count']);
+        $this->assertSame(34, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['updated_revision_count']);
+        $this->assertSame(0, $payload['skipped_existing_count']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('framework', 'big_five')->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('sitemap_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('llms_eligible', true)->count());
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)->count());
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_REVIEW)->count());
+    }
+
+    public function test_second_write_is_idempotent_for_same_package_qa_and_recommendation_hashes(): void
+    {
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->approvePackageRows($packagePath, $qaPath, $package, $qa);
+        $options = $this->writeOptions($packagePath, $qaPath);
+
+        $firstExitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $options);
+        $this->assertSame(0, $firstExitCode);
+
+        $secondExitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $options);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(0, $payload['updated_revision_count']);
+        $this->assertSame(34, $payload['skipped_existing_count']);
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_source_hash_change_updates_existing_draft_overlay_without_live_publication(): void
+    {
+        $package = $this->validPackage();
+        $qa = $this->validQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->approvePackageRows($packagePath, $qaPath, $package, $qa);
+        $this->assertSame(0, Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($packagePath, $qaPath)));
+
+        $updatedPackage = $this->validPackage('Updated Big Five SEO description');
+        [$updatedPackagePath, $updatedQaPath] = $this->writeArtifacts($updatedPackage, $qa, 'updated-package.json', 'updated-qa.json');
+        $this->approvePackageRows($updatedPackagePath, $updatedQaPath, $updatedPackage, $qa);
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($updatedPackagePath, $updatedQaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(0, $payload['created_revision_count']);
+        $this->assertSame(34, $payload['updated_revision_count']);
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+    }
+
+    public function test_write_requires_all_safety_flags_and_exact_operator_token(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('--draft-only is required with --write', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_failed_qa_and_private_routes_fail_closed_with_zero_writes(): void
+    {
+        $package = [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/openness', 'en', 'domain'),
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/facet-adventurousness', 'en', 'facet'),
+                $this->recommendation('https://fermatmind.com/zh/personality/big-five/high-openness?token=secret', 'zh-CN', 'polarity'),
+            ],
+        ];
+        $qa = [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-QA-01',
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'evaluations' => [
+                $this->qaRow('https://fermatmind.com/en/personality/big-five/openness', 'failed', ['claim_safety_gate']),
+                $this->qaRow('https://fermatmind.com/en/personality/big-five/facet-adventurousness'),
+                $this->qaRow('https://fermatmind.com/zh/personality/big-five/high-openness?token=secret'),
+            ],
+        ];
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->approvePackageRows($packagePath, $qaPath, $package, $qa);
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('qa_pass_required', array_column($payload['errors'], 'code'));
+        $this->assertContains('unsupported_big_five_target_url', array_column($payload['errors'], 'code'));
+        $this->assertContains('forbidden_private_route_pattern_present', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    public function test_existing_live_asset_blocks_draft_write_without_mutation(): void
+    {
+        PersonalityPublicContentAsset::query()->create([
+            'org_id' => 0,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'entity_type' => PersonalityPublicContentAsset::ENTITY_HUB,
+            'entity_key' => 'big-five',
+            'slug' => 'big-five',
+            'locale' => 'en',
+            'title' => 'Live title',
+            'summary' => 'Live summary',
+            'content_sections_json' => [],
+            'seo_json' => ['title' => 'Live title'],
+            'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+            'canonical_json' => ['path' => '/en/personality/big-five'],
+            'hreflang_json' => [],
+            'faq_json' => [],
+            'media_json' => [],
+            'schema_json' => [],
+            'method_boundary_json' => [],
+            'evidence_notes_json' => [],
+            'internal_links_json' => [],
+            'is_public' => true,
+            'index_eligible' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+            'review_state' => 'placeholder',
+            'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+            'source_package' => 'existing',
+            'source_hash' => 'existing',
+        ]);
+        $package = $this->singleHubPackage();
+        $qa = $this->singleHubQa();
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+        $this->approvePackageRows($packagePath, $qaPath, $package, $qa);
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', $this->writeOptions($packagePath, $qaPath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('existing_live_or_foreign_asset_blocks_draft_write', array_column($payload['errors'], 'code'));
+        $this->assertSame(1, PersonalityPublicContentAsset::query()->count());
+        $this->assertSame('Live title', PersonalityPublicContentAsset::query()->first()?->title);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(string $description = 'Big Five SEO description'): array
+    {
+        $recommendations = [];
+        foreach (['en', 'zh-CN'] as $locale) {
+            $prefix = $locale === 'zh-CN' ? 'zh' : 'en';
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five", $locale, 'hub', $description);
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/facets", $locale, 'facet_hub', $description);
+            foreach (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'] as $domain) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/{$domain}", $locale, 'domain', $description);
+            }
+            foreach (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'] as $domain) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/high-{$domain}", $locale, 'polarity', $description);
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/low-{$domain}", $locale, 'polarity', $description);
+            }
+        }
+
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'big_five.agent_pilot.v1',
+            'recommendations' => $recommendations,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validQa(): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-QA-01',
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'evaluations' => array_map(
+                fn (array $recommendation): array => $this->qaRow((string) $recommendation['target_url']),
+                $this->validPackage()['recommendations']
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubPackage(): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/big-five', 'en', 'hub'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubQa(): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-QA-01',
+            'evaluations' => [
+                $this->qaRow('https://fermatmind.com/en/personality/big-five'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $targetUrl, string $locale, string $entityType, string $description = 'Big Five SEO description'): array
+    {
+        return [
+            'recommendation_id' => 'big-five-agent:'.parse_url($targetUrl, PHP_URL_PATH),
+            'target_url' => $targetUrl,
+            'framework' => 'big_five',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => 'Big Five SEO Title',
+                'description' => $description,
+                'h1' => 'Big Five H1',
+                'quick_answer' => 'This is reflective Big Five educational content, not diagnosis or hiring screening.',
+                'faq' => [
+                    [
+                        'question' => 'Is this diagnostic?',
+                        'answer' => 'No. It is reflective educational content.',
+                    ],
+                ],
+                'internal_links' => [],
+                'differentiation_notes' => [
+                    'Keep this page distinct from neighboring Big Five content.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qaRow(string $targetUrl, string $decision = 'PASS_READY_FOR_APPROVAL_QUEUE', array $blockers = []): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'qa_status' => $decision === 'PASS_READY_FOR_APPROVAL_QUEUE' ? 'pass' : $decision,
+            'decision' => $decision,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeArtifacts(array $package, array $qa, string $packageName = 'package.json', string $qaName = 'qa.json'): array
+    {
+        $dir = storage_path('framework/testing/big_five_public_profile_agent_draft');
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/'.$packageName;
+        $qaPath = $dir.'/'.$qaName;
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     */
+    private function approvePackageRows(string $packagePath, string $qaPath, array $package, array $qa): void
+    {
+        $packageSha256 = hash_file('sha256', $packagePath);
+        $qaSha256 = hash_file('sha256', $qaPath);
+        $batchId = (int) DB::table('personality_agent_approval_batches')->insertGetId([
+            'framework' => 'big_five',
+            'source_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_artifact_path' => $packagePath,
+            'source_package_sha256' => $packageSha256,
+            'qa_artifact' => (string) ($qa['artifact'] ?? ''),
+            'qa_artifact_path' => $qaPath,
+            'qa_sha256' => $qaSha256,
+            'status' => 'approved_for_draft_writer',
+            'planned_item_count' => count($package['recommendations'] ?? []),
+            'queued_item_count' => count($package['recommendations'] ?? []),
+            'blocked_item_count' => 0,
+            'safety_holds_json' => json_encode([]),
+            'summary_json' => json_encode(['test_fixture' => true]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $qaRows = [];
+        foreach (($qa['evaluations'] ?? $qa['page_results'] ?? []) as $row) {
+            if (is_array($row) && isset($row['target_url'])) {
+                $qaRows[(string) $row['target_url']] = $row;
+            }
+        }
+
+        foreach ($package['recommendations'] ?? [] as $recommendation) {
+            if (! is_array($recommendation)) {
+                continue;
+            }
+            $recommendationJson = json_encode($recommendation, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            DB::table('personality_agent_approval_items')->insert([
+                'batch_id' => $batchId,
+                'framework' => 'big_five',
+                'target_url' => $targetUrl,
+                'path' => (string) parse_url($targetUrl, PHP_URL_PATH),
+                'locale' => (string) ($recommendation['locale'] ?? ''),
+                'page_type' => 'personality_public_content_asset',
+                'recommendation_id' => (string) ($recommendation['recommendation_id'] ?? ''),
+                'recommendation_sha256' => hash('sha256', (string) $recommendationJson),
+                'qa_decision' => (string) ($qaRows[$targetUrl]['qa_status'] ?? $qaRows[$targetUrl]['decision'] ?? 'pass'),
+                'approval_state' => 'approved',
+                'approved_at' => now(),
+                'rejected_at' => null,
+                'blocked_reason' => null,
+                'safety_holds_json' => json_encode([]),
+                'recommendation_json' => (string) $recommendationJson,
+                'qa_json' => json_encode($qaRows[$targetUrl] ?? []),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath, string $qaPath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -405,6 +405,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityBigFivePublicProfileAgentDraft;',
+            '+        PersonalityBigFivePublicProfileAgentDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -4408,6 +4423,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFivePublicProfileAgentDraftFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -5479,6 +5498,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5708,6 +5728,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php',
             'backend/app/Services/Cms/EnneagramCmsDraftWriter.php',
+        ], true);
+    }
+
+    private function isBigFivePublicProfileAgentDraftFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php',
+            'backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php',
         ], true);
     }
 
@@ -9472,6 +9500,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityEnneagramCmsDraft\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBigFivePublicProfileAgentDraftOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityBigFivePublicProfileAgentDraft\b/u', $normalized) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60711,7 +60711,7 @@
     "repo": "fap-api",
     "branch": "codex/big-five-cms-draft-writer-contract-01",
     "base": "main",
-    "status": "local_validated",
+    "status": "ready_to_merge",
     "train_scope": "big_five_public_profile_agent_expansion",
     "title": "BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01: Add Big Five CMS draft writer contract",
     "depends_on": [
@@ -60747,12 +60747,12 @@
         "evidence": "Changed files are scoped to backend command/service/tests, Kernel registration, runtime-freeze classifier allowance, and docs/codex manifest/state metadata for BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01. No frontend runtime, CMS publish, production DB write, queue, search, indexing, sitemap, llms, deploy, or public route changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2395 opened and GitHub checks are pending on head 69bc2522bc19690c2979f770bea97e661b2f5393."
+        "status": "pass",
+        "evidence": "PR #2395 GitHub checks are green and mergeStateStatus is CLEAN on head ff047e4ad56faa92d156224aa36d1f29e3d4d7a6."
       }
     },
     "failure_reason": null,
-    "commit_sha": "69bc2522bc19690c2979f770bea97e661b2f5393",
+    "commit_sha": "ff047e4ad56faa92d156224aa36d1f29e3d4d7a6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2395",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -60772,6 +60772,11 @@
         "at": "2026-06-24T13:12:32Z",
         "status": "github_checks_pending",
         "note": "Opened PR #2395 at https://github.com/fermatmind/fap-api/pull/2395 on head 69bc2522bc19690c2979f770bea97e661b2f5393. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, publish, search, indexing, sitemap, llms, or frontend runtime work."
+      },
+      {
+        "at": "2026-06-24T13:23:50Z",
+        "status": "ready_to_merge",
+        "note": "PR #2395 checks are green and mergeStateStatus is CLEAN on head ff047e4ad56faa92d156224aa36d1f29e3d4d7a6. Ready for squash merge; no staging wait, production deploy, CMS write, publish, search, indexing, sitemap, llms, or frontend runtime work included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60706,5 +60706,73 @@
         "notes": "Initialized from explicit authorization."
       }
     ]
+  },
+  "BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01": {
+    "repo": "fap-api",
+    "branch": "codex/big-five-cms-draft-writer-contract-01",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "big_five_public_profile_agent_expansion",
+    "title": "BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01: Add Big Five CMS draft writer contract",
+    "depends_on": [
+      "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided the Big Five public profile agent expansion train and authorized PR4 scoped to backend CMS draft writer contract."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01 is merged as PR #2392 with merge commit 52d9e9961acfe43651c0663d8e517d8ffc054407, and origin/main contains that merge commit."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php",
+          "php -l backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php",
+          "php -l backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php",
+          "cd backend && php artisan test --filter=PersonalityBigFivePublicProfileAgentDraftCommandTest --no-ansi",
+          "cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files' --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "cd backend && bash scripts/ci_verify_mbti.sh",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "All PR4 local checks passed: PHP syntax checks, focused PersonalityBigFivePublicProfileAgentDraftCommandTest, focused runtime-freeze classifier test, scoped Pint --test, full backend ci_verify_mbti.sh, docs JSON/YAML parse, and git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are scoped to backend command/service/tests, Kernel registration, runtime-freeze classifier allowance, and docs/codex manifest/state metadata for BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01. No frontend runtime, CMS publish, production DB write, queue, search, indexing, sitemap, llms, deploy, or public route changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2395 opened and GitHub checks are pending on head 69bc2522bc19690c2979f770bea97e661b2f5393."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "69bc2522bc19690c2979f770bea97e661b2f5393",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2395",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-24T13:00:00Z",
+        "status": "in_progress",
+        "note": "Started PR4 from latest fap-api origin/main after PR3 merge cleanup. Scope is backend-only Big Five public profile CMS draft writer contract for personality_public_content_assets; no live content mutation, CMS publish, queue, search, indexing, sitemap, llms, frontend runtime, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-24T13:10:23Z",
+        "status": "local_validated",
+        "note": "All local checks passed and scope validation passed. Validation covered syntax checks, focused command PHPUnit, focused runtime-freeze classifier PHPUnit, scoped Pint, full ci_verify_mbti.sh, docs JSON/YAML parse, git diff --check, and changed-file scope validation."
+      },
+      {
+        "at": "2026-06-24T13:12:32Z",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2395 at https://github.com/fermatmind/fap-api/pull/2395 on head 69bc2522bc19690c2979f770bea97e661b2f5393. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, publish, search, indexing, sitemap, llms, or frontend runtime work."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -134,6 +134,52 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01
+    repo: fap-api
+    depends_on:
+      - BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
+    branch: codex/big-five-cms-draft-writer-contract-01
+    title: "BIG-FIVE-CMS-DRAFT-WRITER-CONTRACT-01: Add Big Five CMS draft writer contract"
+    train_scope: big_five_public_profile_agent_expansion
+    status: user_authorized
+    scope:
+      - Add a backend-only Big Five public profile agent draft writer command and service for personality_public_content_assets.
+      - Support dry-run planning for 34 Big Five public profile rows without database writes.
+      - Require QA PASS plus approved approval queue items before write mode can create or update draft-only rows.
+      - Keep all writes draft/review, non-public, noindex, and excluded from sitemap, llms, search, queues, frontend runtime, and publication.
+    allowed_paths:
+      - backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php
+      - backend/app/Console/Kernel.php
+      - backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
+      - backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Reuse MBTI64 personality_profile or variant writers.
+      - Publish content, mutate live content, enqueue jobs, submit search/indexing requests, or mutate sitemap/llms/canonical/JSON-LD.
+      - Add frontend runtime rendering, public SEO route enumeration, staging deploy, or production deploy.
+      - Allow failed QA, unapproved approval queue rows, private/result/order/payment/account/share routes, or live/indexable assets into write mode.
+    validation:
+      - php -l backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php
+      - php -l backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
+      - php -l backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
+      - cd backend && php artisan test --filter=PersonalityBigFivePublicProfileAgentDraftCommandTest --no-ansi
+      - cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files' --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-ASSET-03
     repo: fap-web
     depends_on: [PR-EQ-ASSET-02]


### PR DESCRIPTION
## What changed
- Added backend command `personality:big-five-public-profile-agent-draft` for Big Five public profile agent draft planning/writes.
- Added `BigFivePublicProfileAgentDraftWriter` to validate package + QA artifacts, require approval queue rows, and create/update only non-public draft overlays in `personality_public_content_assets`.
- Registered the command and added focused PHPUnit coverage for dry-run, safety flags, approval-gated write, idempotency, draft overlay update, unsupported/private URL rejection, and live asset protection.
- Added runtime-freeze classifier allowance for this backend-only draft writer scope.
- Added PR-train manifest/state metadata for this scoped PR.

## Why
This is PR4 of the Big Five public profile agent expansion train. It establishes the CMS draft writer contract after the recommendation package, QA validator, and approval queue integration are merged.

## Validation
- `php -l backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php`
- `php -l backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php`
- `php -l backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php`
- `cd backend && php artisan test --filter=PersonalityBigFivePublicProfileAgentDraftCommandTest --no-ansi`
- `cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files' --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No production deploy.
- No production CMS write/import.
- No publish, queue, search, indexing, sitemap, llms, canonical, or frontend runtime changes.
- Any runtime write gate requires separate exact authorization.
