### PR TITLE
PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline

### DIFF
--- a/docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md
+++ b/docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md
@@ -21,24 +21,23 @@ EQ v1.6 production smoke confirms that the core backend and frontend delivery pa
 - v1.6 resolved assets are present, including result snapshot, conversion actions, quality confidence, psychometric evidence, career environment, Agent playbook assets, and SJT bridge.
 - SJT remains planned/unavailable and no clickable SJT take entry was found.
 - No visible paywall/SKU/raw technical tag leakage was found on the checked result pages.
-
-However, acceptance is **blocked by one P1 issue**:
-
-- `zh-CN` result route renders, but the report API still returns `locale=en` and English resolved assets for `?locale=zh-CN` and `?locale=zh`. This means the Chinese product path is not commercially acceptable yet.
+- The previous Chinese locale P1 was retested after PR-EQ-ASSET-04 reached production: `/report?locale=zh-CN` now returns `locale=zh-CN`, Chinese score labels, and Chinese resolved assets.
 
 Final gate:
 
-- Agent phase allowed: **No**
-- Reason: P1 locale resolution / resolved asset localization blocker on Chinese result path.
+- Agent phase allowed: **Yes**
+- Reason: EQ v1.6 all-free report delivery, resolved assets, no-paywall boundary, SJT planned boundary, and locale-specific resolved assets are production-verified.
 
 ## 2. Deployed SHAs And PR Coverage
 
 Backend production:
 
-- SHA: `8969804e481b3aeb271ed34b8ea80f26cba0213a`
-- Release: `eq-v16-assets-20260624`
+- Initial smoke SHA: `8969804e481b3aeb271ed34b8ea80f26cba0213a`
+- Locale retest SHA: `a189285dc43977e0a185a1c72857423f69b6e07e`
+- Release/revision: production `REVISION` verified at `a189285dc43977e0a185a1c72857423f69b6e07e`
 - Contains PR-EQ-ASSET-01: yes, previously verified in deploy readiness/deploy output
 - Contains PR-EQ-ASSET-02: yes, previously verified in deploy readiness/deploy output
+- Contains PR-EQ-ASSET-04: yes, `27f5b37dff2f8330d08fe382d3f46bf5fe9b3727` is included in deployed main history
 
 Frontend production:
 
@@ -70,6 +69,21 @@ Two production anonymous attempts were used because the first direct API smoke s
 - Interpretation: `developing_foundation`
 - Mechanism IDs: `ER_RM_low_low`
 - Action prescription: `emotion_labeling`
+
+### Attempt C: Locale Retest After PR-EQ-ASSET-04
+
+- Attempt ID: `1f869cf8-027b-4298-ab5a-a368a4c53fb9`
+- Session marker: `codex_eq_v16_locale_retest_20260624135749_lcbyq8`
+- Evidence directory: `/tmp/eq_v16_locale_retest_20260624135749/`
+- Purpose: verifies `/report?locale=zh-CN` resolves Chinese EQ v1.6 assets after PR-EQ-ASSET-04.
+- Question count: 60 in `en`, 60 in `zh-CN`
+- `report-access`: ready/full/all-free, `locked=false`, `offers=[]`, `upgrade_sku=null`, `blur_others=false`
+- `/report?locale=en`: `locale=en`, global label `Emotional & Relational Functioning Index`
+- `/report?locale=zh-CN`: `locale=zh-CN`, global label `情绪与关系综合指数`
+- Chinese resolved assets: present
+- English global label leakage in Chinese assets: not observed
+- `methodology.report_version`: `eq_report_v5_assets_commercial_ready_v1_6`
+- `next_module.available`: `false`
 
 Screenshots and raw JSON evidence are stored locally under:
 
@@ -258,7 +272,7 @@ Chinese route visible sections found:
 
 Important caveat:
 
-- Chinese route UI chrome is partially localized, but resolved report content remains English. See P1 below.
+- The initial smoke found English resolved assets on the Chinese route. The PR-EQ-ASSET-04 production retest closed this issue at the API payload layer. A separate browser visual smoke can still be used before a major launch campaign, but it is no longer a P1 blocker for the Agent-ready baseline.
 
 ## 8. Forbidden Terms / Fields Check
 
@@ -325,7 +339,7 @@ The low-confidence attempt was created by the audit's fast API submission and sh
 
 ## 11. Issues And Risks
 
-### P1: Chinese Result Path Receives English Resolved Assets
+### Closed P1: Chinese Result Path Previously Received English Resolved Assets
 
 Evidence:
 
@@ -333,16 +347,22 @@ Evidence:
 - `GET /api/v0.3/attempts/adbc27ed-f1f4-47be-8548-e69cc54bbd47/report?locale=zh` also returned `locale=en`.
 - Chinese result route displayed Chinese UI chrome, but core resolved report assets such as `core_formulation`, `result_snapshot`, `quality_confidence`, and `action_prescription` were English.
 
-Impact:
+Original impact:
 
 - Blocks Chinese commercial-quality acceptance.
 - Blocks Agent phase because the Agent should not inherit unresolved locale authority behavior.
 
-Recommended follow-up:
+Resolution:
 
-- Fix report locale resolution so `/report?locale=zh-CN` returns Chinese resolved assets and `locale=zh-CN`.
-- Add production-safe contract coverage for report locale resolution.
-- Add frontend contract/e2e assertion that zh result route renders localized resolved assets, not English fallback.
+- PR-EQ-ASSET-04 fixed report locale resolution so explicit report locale requests are passed through report delivery and composer resolution.
+- Production retest attempt `1f869cf8-027b-4298-ab5a-a368a4c53fb9` confirmed `/report?locale=zh-CN` returns `locale=zh-CN`, Chinese score labels, and Chinese resolved assets.
+- The report snapshot remains attempt-locale-bound; localized live render does not overwrite the original attempt-locale snapshot.
+
+Status:
+
+- P1 closed.
+- Chinese commercial-quality API payload path accepted.
+- Agent phase gate can open after the v1.6 content baseline is frozen.
 
 ### P2: report-access Projection Latency
 
@@ -378,7 +398,7 @@ Recommended follow-up:
 
 ## 12. Final Acceptance Decision
 
-Production EQ v1.6 is partially accepted:
+Production EQ v1.6 is accepted as the first commercial-ready content baseline:
 
 - Backend v1.6 payload delivery: pass
 - Frontend EQResultV5 rendering: pass
@@ -386,14 +406,14 @@ Production EQ v1.6 is partially accepted:
 - SJT planned/unavailable boundary: pass
 - Low-confidence path safety: pass
 - English commercial result path: pass
-- Chinese commercial result path: **fail / P1**
+- Chinese commercial result path: pass after PR-EQ-ASSET-04 production retest
 
-Agent phase allowed: **No**
+Agent phase allowed: **Yes**
 
 Reason:
 
-- The Chinese result path currently receives English resolved assets from `/report`. The EQ Agent should not be built on top of a locale authority mismatch.
+- EQ v1.6 content authority, resolved assets, locale-specific report delivery, no-paywall contract, low-confidence safety path, and SJT planned boundary are now production-verified.
 
 Next recommended task:
 
-- PR-EQ-ASSET-04: Fix EQ report locale resolution for v1.6 resolved assets, then rerun this acceptance audit.
+- PR-EQ-ASSET-05: Freeze EQ v1.6 as the first commercial content baseline, then proceed to the Agent-ready content operating system train.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T21:12:00+08:00",
+  "updated_at": "2026-06-24T22:08:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60536,7 +60536,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-05-freeze-v16-baseline",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline",
     "depends_on": [
@@ -60548,8 +60548,35 @@
         "evidence": "User explicitly authorized manifest/state updates and sequential execution."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for PR-EQ-ASSET-04 locale acceptance fix to merge."
+        "status": "pass",
+        "evidence": "PR-EQ-ASSET-04 merged into main and production smoke verified /report?locale=zh-CN returns Chinese v1.6 resolved assets."
+      },
+      "production_locale_smoke": {
+        "status": "pass",
+        "evidence": "Production anonymous attempt 1f869cf8-027b-4298-ab5a-a368a4c53fb9 returned report.locale=zh-CN, Chinese global label, Chinese resolved assets, no English global label leakage, report_version=eq_report_v5_assets_commercial_ready_v1_6, next_module.available=false."
+      },
+      "acceptance_report_updated": {
+        "status": "pass",
+        "evidence": "Acceptance report updated to P1 closed and Agent phase allowed yes after production locale retest."
+      },
+      "baseline_freeze_doc": {
+        "status": "pass",
+        "evidence": "Added docs/product/eq/eq_v1_6_commercial_content_baseline_freeze_2026-06-24.md."
+      },
+      "manifest_yaml": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "evidence": "yaml ok."
+      },
+      "state_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "JSON parse passed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
       }
     },
     "failure_reason": null,
@@ -60564,6 +60591,18 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit authorization."
+      },
+      {
+        "at": "2026-06-24T22:00:00+08:00",
+        "from": "pending_dependency",
+        "to": "in_progress",
+        "notes": "Started PR-EQ-ASSET-05 after PR04 production locale smoke closed the P1 blocker."
+      },
+      {
+        "at": "2026-06-24T22:08:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Updated EQ v1.6 acceptance audit and froze the commercial content baseline after production locale smoke passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T22:13:00+08:00",
+  "updated_at": "2026-06-24T22:22:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60536,7 +60536,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-05-freeze-v16-baseline",
     "base": "main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline",
     "depends_on": [
@@ -60581,10 +60581,14 @@
       "pr_opened": {
         "status": "pass",
         "evidence": "GitHub PR #2396 opened for codex/pr-eq-asset-05-freeze-v16-baseline."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks green and mergeStateStatus CLEAN for PR #2396 at head 97f20611d5fe97f1c1922fcad521ea39f4ba00f5."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d919eb44d8bf5e59119b3de4019a039a8c746222",
+    "commit_sha": "97f20611d5fe97f1c1922fcad521ea39f4ba00f5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2396",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -60613,6 +60617,12 @@
         "from": "local_checks_passed",
         "to": "pr_opened",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2396 after docs-only validation passed."
+      },
+      {
+        "at": "2026-06-24T22:22:00+08:00",
+        "from": "pr_opened",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks green; PR #2396 is clean and ready for squash merge."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-24T22:08:00+08:00",
+  "updated_at": "2026-06-24T22:13:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -60536,7 +60536,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-05-freeze-v16-baseline",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "eq_v16_content_asset_productization",
     "title": "PR-EQ-ASSET-05 Freeze EQ v1.6 commercial content baseline",
     "depends_on": [
@@ -60577,11 +60577,15 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "No whitespace errors."
+      },
+      "pr_opened": {
+        "status": "pass",
+        "evidence": "GitHub PR #2396 opened for codex/pr-eq-asset-05-freeze-v16-baseline."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d919eb44d8bf5e59119b3de4019a039a8c746222",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2396",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -60603,6 +60607,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Updated EQ v1.6 acceptance audit and froze the commercial content baseline after production locale smoke passed."
+      },
+      {
+        "at": "2026-06-24T22:13:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2396 after docs-only validation passed."
       }
     ]
   },

--- a/docs/product/eq/eq_v1_6_commercial_content_baseline_freeze_2026-06-24.md
+++ b/docs/product/eq/eq_v1_6_commercial_content_baseline_freeze_2026-06-24.md
@@ -1,0 +1,212 @@
+# EQ v1.6 Commercial Content Baseline Freeze
+
+Date: 2026-06-24
+
+Status: Frozen baseline for Agent-ready content operations
+
+Source acceptance audit:
+
+- `docs/audits/eq/eq_v1_6_productization_acceptance_2026-06-24.md`
+
+## 1. Baseline Decision
+
+EQ v1.6 is frozen as FermatMind's first commercial-ready EQ-60 content baseline.
+
+This freeze applies to the EQ-60 self-report result experience only. It does not implement EQ-SJT, does not enable an Agent runtime, and does not change scoring, norms, questions, options, reverse keys, or report access semantics.
+
+Production acceptance gates passed:
+
+- EQ question delivery returns 60 items for `en` and `zh-CN`.
+- `/report-access` resolves ready/full/all-free with no user-visible paid, locked, blur, SKU, or offer path.
+- `/report` returns `eq_report_v5_assets_commercial_ready_v1_6`.
+- `/report?locale=en` returns English resolved assets.
+- `/report?locale=zh-CN` returns Chinese resolved assets.
+- `next_module.available=false` and `next_module.status=planned`.
+- Low-confidence result handling routes to cautious interpretation and retest reflection.
+
+Agent phase gate:
+
+- Agent phase allowed: yes.
+- Agent implementation may start only on top of this frozen structured asset baseline.
+
+## 2. Frozen Authority Layer
+
+The backend content pack and report composer remain the report authority.
+
+Frozen authority surfaces:
+
+- `backend/content_packs/EQ_60/v1/raw/report_assets/*.json`
+- `backend/content_packs/EQ_60/v1/compiled/report_assets.compiled.json`
+- `backend/content_packs/EQ_EMOTIONAL_INTELLIGENCE/v1/**` mirror assets
+- `Eq60ReportComposer` output contract
+- EQ canonical fixtures and report contract tests
+
+Frontend and future Agent surfaces must consume backend-provided payloads and resolved assets. They must not recreate final report prose, scoring labels, formulation interpretations, or claim boundaries from local copy.
+
+## 3. Frozen Asset Packs
+
+These v1.6 asset packs are baseline-stable:
+
+- `scientific_contract`
+- `score_system`
+- `core_formulations`
+- `mechanism_map`
+- `reality_translation`
+- `career_environment`
+- `action_prescriptions`
+- `sjt_bridge`
+- `result_snapshot`
+- `commercial_conversion_assets`
+- `quality_confidence`
+- `psychometric_evidence_status`
+- `agent_dialogue_playbooks`
+- `backend_integration_contract`
+- `seo_geo_authority`
+- `cross_assessment_context`
+- `personalization_route_matrix`
+
+Each pack is governed as structured data, not free-form copy. Future edits must preserve stable IDs, locale coverage, trigger semantics, risk notes, and claim boundaries.
+
+## 4. Stable ID Rules
+
+Stable IDs are part of the product contract.
+
+Do not rename IDs without a migration plan:
+
+- formulation IDs, for example `balanced_integrated`, `high_empathy_low_recovery`, `low_confidence_result`
+- mechanism IDs, for example `EM_ER_high_low`, `ER_RM_low_low`
+- scene IDs, for example `feedback`, `conflict`, `relationship_boundary`
+- career environment IDs, for example `emotional_labor_high`, `autonomy_recovery_medium`
+- action prescription IDs, for example `emotion_labeling`, `empathy_boundary`, `retest_reflection`
+- SJT bridge ID, for example `eq.sjt_bridge.planned`
+- quality/evidence IDs
+- Agent playbook IDs
+
+Allowed future changes:
+
+- Add new IDs behind tests.
+- Deprecate old IDs with compatibility mapping.
+- Improve localized wording while preserving the ID and claim boundary.
+
+Blocked changes:
+
+- Removing an ID that canonical fixtures or frontend contracts still reference.
+- Changing a trigger rule without updating golden cases and report fixtures.
+- Reusing an old ID for a different meaning.
+
+## 5. Trigger Rule Governance
+
+Trigger rules determine which asset is selected for a user result.
+
+Frozen trigger responsibilities:
+
+- Scorer: raw scores, quality, norms, validity signals.
+- Composer: formulation, strongest dimension, development lever, mechanisms, scenes, career environment IDs, action prescription, SJT planned bridge.
+- Content assets: human-readable interpretation, claim boundary, risk notes, actions, and localized text.
+- Frontend: deterministic rendering only.
+- Agent: explanation and guided reflection over selected assets only.
+
+Trigger changes require:
+
+- backend contract test coverage
+- golden case coverage when applicable
+- zh-CN/en fixture coverage
+- no-paywall/no-SJT-entry invariant coverage
+- low-confidence path coverage when quality logic is affected
+
+## 6. Claim Boundaries
+
+The frozen baseline allows:
+
+- self-report emotional and relational pattern interpretation
+- subjective self-perception reflection
+- workplace and relationship scenario translation
+- career environment variable discussion
+- coaching-style action suggestions
+- cautious Agent dialogue grounded in resolved assets
+
+The frozen baseline forbids:
+
+- claiming EQ-60 measures true emotional ability
+- claiming EQ-SJT is MSCEIT or MSCEIT-like
+- claiming certified emotional intelligence measurement
+- clinical diagnosis or treatment guidance
+- hiring, promotion, or screening suitability
+- guaranteed outcomes
+- job performance prediction
+- specific career recommendations as a deterministic result of EQ
+- paid/locked/upgrade language for EQ v1.6
+
+All future Agent prompts, retrieval payloads, UI entries, and generated responses must inherit these boundaries.
+
+## 7. Risk Notes
+
+Known accepted risks:
+
+- EQ-60 is self-report and can reflect self-perception bias.
+- Low-confidence results need cautious interpretation and retest guidance.
+- Career environment recommendations must stay variable-based, not occupation-prescriptive.
+- SJT remains planned/unavailable until the SJT train implements content, scorer, route, and validation.
+- Agent output can overclaim if not constrained by asset IDs and forbidden-claim metadata.
+
+Open governance risks:
+
+- Legacy report payloads may contain diagnostic fields that should remain hidden from user-facing and Agent-facing surfaces.
+- Report-access projection can briefly lag immediately after submit; report delivery fallback currently protects user-visible report access.
+- English and Chinese wording quality must be reviewed as product copy evolves, but review must keep stable IDs and claim boundaries intact.
+
+## 8. Agent Maintenance Rules
+
+The future EQ Agent may maintain:
+
+- retrieval tags
+- intent mappings
+- user question routing
+- asset summaries
+- contraindication and escalation metadata
+- forbidden-claim metadata
+- evaluation fixtures
+- content improvement proposals tied to stable asset IDs
+
+The future EQ Agent must not:
+
+- mutate report scores
+- override formulation selection
+- rewrite final report prose at runtime
+- create new report authority outside backend assets
+- expose raw diagnostic tags as user-facing content
+- turn SJT planned state into an available entry
+- introduce paid/locked copy
+- answer as if the test were clinical, hiring-grade, certified, or ability-based
+
+Agent content edits must be proposed as structured asset updates through the backend content pack workflow, not as ad-hoc prose patches in frontend code or runtime prompts.
+
+## 9. Freeze Validation
+
+Freeze evidence:
+
+- production retest attempt `1f869cf8-027b-4298-ab5a-a368a4c53fb9`
+- `/report?locale=en`: `locale=en`, English resolved assets
+- `/report?locale=zh-CN`: `locale=zh-CN`, Chinese resolved assets
+- `methodology.report_version=eq_report_v5_assets_commercial_ready_v1_6`
+- `next_module.available=false`
+
+Local validation for this freeze PR:
+
+- YAML manifest parse
+- JSON state parse
+- `git diff --check`
+- `git diff --cached --check`
+
+Runtime tests are not required for this docs-only freeze PR because runtime behavior was verified by PR-EQ-ASSET-04 and production smoke.
+
+## 10. Next PRs
+
+The Agent-ready content operating system can now proceed:
+
+- PR-EQ-AGENT-01: EQ Agent knowledge base schema, retrieval tags, and intent map
+- PR-EQ-AGENT-02: backend EQ Agent context payload and retrieval API
+- PR-EQ-AGENT-03: frontend EQ Agent entry guard
+- PR-EQ-AGENT-04: Agent safety and forbidden-claims eval fixtures
+
+These PRs must preserve this baseline unless a later PR explicitly changes the frozen baseline with fixtures, tests, and governance notes.


### PR DESCRIPTION
## What changed
- Updated the EQ v1.6 production acceptance audit to record the PR-EQ-ASSET-04 production retest result.
- Marked the previous `/report?locale=zh-CN` English-resolved-assets P1 as closed.
- Added `docs/product/eq/eq_v1_6_commercial_content_baseline_freeze_2026-06-24.md` as the EQ v1.6 commercial content baseline freeze document.
- Recorded PR-EQ-ASSET-05 local validation and production locale smoke evidence in the PR train state ledger.

## Why
EQ v1.6 can only become the Agent-ready content baseline after locale-specific resolved assets are production-verified. Production retest attempt `1f869cf8-027b-4298-ab5a-a368a4c53fb9` confirmed that `/report?locale=zh-CN` now returns `locale=zh-CN`, Chinese score labels, Chinese resolved assets, no English global-label leakage, `eq_report_v5_assets_commercial_ready_v1_6`, and `next_module.available=false`.

## Validation
- Production smoke: anonymous attempt `1f869cf8-027b-4298-ab5a-a368a4c53fb9`
  - `/report-access`: ready/full/all-free, locked=false, offers=[], upgrade_sku=null, blur_others=false
  - `/report?locale=en`: locale=en, English resolved assets
  - `/report?locale=zh-CN`: locale=zh-CN, Chinese resolved assets
  - SJT: planned/unavailable
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- Scope validation: changed files limited to PR-EQ-ASSET-05 allowed paths.

## Intentionally deferred
- No runtime code changes.
- No EQ content asset rewrites.
- No scoring, norm, question, option, or reverse-key changes.
- No frontend changes.
- No Agent runtime.
- No SJT implementation or availability change.

## Repository rule impact
- This PR is docs-only.
- It freezes the backend content pack/composer as the EQ report authority baseline.
- Future Agent work must maintain structured asset IDs, triggers, risk notes, and claim boundaries; it must not move report authority into frontend code or runtime Agent prose.
