### PR TITLE
ENNEAGRAM-CMS-PROMOTION-CONTRACT-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnneagramCmsPromote.php
+++ b/backend/app/Console/Commands/PersonalityEnneagramCmsPromote.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\EnneagramCmsPromotionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityEnneagramCmsPromote extends Command
+{
+    private const OPERATOR_APPROVAL = 'ENNEAGRAM-CMS-PROMOTION-CONTRACT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'promote-live-content',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:enneagram-cms-promote
+        {--package= : Path to the Enneagram agent recommendation JSON package}
+        {--dry-run : Plan promotion without database writes}
+        {--write : Promote matching Enneagram public content draft assets to live content-ready state}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--promote-live-content : Required for --write; confirms live content promotion intent}
+        {--no-publish : Required for --write; confirms no published/index release state}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Promote Enneagram public profile CMS draft assets into live content-ready state with no index/search side effects.';
+
+    public function handle(EnneagramCmsPromotionService $service): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($service);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(EnneagramCmsPromotionService $service): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = $this->resolvePath(trim((string) $this->option('package')));
+        $raw = (string) File::get($packagePath);
+        $package = json_decode($raw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        $sourceSha256 = hash('sha256', $raw);
+        $summary = $write
+            ? $service->promote($package, $sourceSha256)
+            : $service->plan($package, $sourceSha256);
+
+        return array_merge($summary, [
+            'package_path' => $packagePath,
+            'command' => 'personality:enneagram-cms-promote',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('would_promote_count='.(string) ($summary['would_promote_count'] ?? 0));
+        $this->line('promoted_count='.(string) ($summary['promoted_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-CMS-PROMOTION-CONTRACT-01',
+            'command' => 'personality:enneagram-cms-promote',
+            'ok' => false,
+            'status' => 'fail',
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_attempted' => (bool) $this->option('write'),
+            'writes_committed' => false,
+            'content_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'row_count' => 0,
+            'would_promote_count' => 0,
+            'promoted_count' => 0,
+            'errors' => [
+                [
+                    'code' => $code,
+                    'message' => $message,
+                ],
+            ],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -184,6 +184,7 @@ use App\Console\Commands\PersonalityMbti64CmsInternalLinkDraft;
 use App\Console\Commands\PersonalityMbti64CmsProjectionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionDraft;
 use App\Console\Commands\PersonalityMbti64CmsRevisionPromote;
+use App\Console\Commands\PersonalityEnneagramCmsPromote;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\RefreshCareerAttributionDailyCommand;
 use App\Console\Commands\RiasecResultPageAssetAgentAuditCommand;
@@ -250,6 +251,7 @@ class Kernel extends ConsoleKernel
         FapWeeklyReport::class,
         PersonalityAgentApprovalQueueCommand::class,
         PersonalityBigFivePublicProfileAgentDraft::class,
+        PersonalityEnneagramCmsPromote::class,
         PersonalityEnneagramCmsDraft::class,
         PersonalityImportDesktopCloneBaseline::class,
         PersonalityMbti64GscQueryReadonlyExport::class,

--- a/backend/app/Services/Cms/EnneagramCmsPromotionService.php
+++ b/backend/app/Services/Cms/EnneagramCmsPromotionService.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Support\Facades\DB;
+
+final class EnneagramCmsPromotionService
+{
+    private const SNAPSHOT_SOURCE = 'enneagram_agent_projection_draft_v1';
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, string $sourceSha256): array
+    {
+        return $this->buildSummary($package, $sourceSha256, false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function promote(array $package, string $sourceSha256): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $sourceSha256, true));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        $rows = [];
+        $errors = [];
+
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $recommendationJson = $this->jsonString($recommendation);
+
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'unsupported_enneagram_target_url',
+                    'message' => 'Only Enneagram hub, center, and core type public URLs are supported.',
+                ];
+
+                continue;
+            }
+
+            if ($this->containsForbiddenRoutePattern($targetUrl) || $this->containsForbiddenRoutePattern($recommendationJson)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position),
+                    'code' => 'forbidden_private_route_pattern_present',
+                    'message' => 'Recommendation contains a private/result/order/payment/account/share route or sensitive query key.',
+                ];
+            }
+
+            $asset = $this->existingAsset($identity);
+            $action = 'promote_to_content_ready';
+            if (! $asset instanceof PersonalityPublicContentAsset) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'missing_draft_asset',
+                    'message' => 'A matching Enneagram draft asset is required before promotion.',
+                ];
+                $action = 'missing_draft_asset';
+            } elseif (! $this->assetMatchesSource($asset, $sourceSha256)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'source_hash_mismatch',
+                    'message' => 'The existing asset source hash does not match the promotion package hash.',
+                ];
+                $action = 'blocked_source_hash_mismatch';
+            } elseif ($this->assetIsLiveContent($asset)) {
+                $action = 'skip_existing_live_match';
+            } elseif (! $this->assetIsPromotableDraft($asset, $sourceSha256)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'asset_not_promotable_draft',
+                    'message' => 'Only non-public noindex draft/review Enneagram assets from the matching source can be promoted.',
+                ];
+                $action = 'blocked_not_promotable';
+            }
+
+            $rows[] = [
+                'position' => $position + 1,
+                'url' => $targetUrl,
+                'path' => $identity['path'],
+                'locale' => $identity['locale'],
+                'entity_type' => $identity['entity_type'],
+                'entity_key' => $identity['entity_key'],
+                'slug' => $identity['slug'],
+                'source_sha256' => $sourceSha256,
+                'recommendation_sha256' => hash('sha256', $recommendationJson),
+                'existing_asset_id' => $asset?->id !== null ? (int) $asset->id : null,
+                'action' => $action,
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($rows),
+                'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+                'center_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CENTER),
+                'core_type_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CORE_TYPE),
+                'would_promote_count' => 0,
+                'promoted_count' => 0,
+                'skipped_existing_count' => 0,
+                'missing_target_count' => $this->countErrorCode($errors, 'missing_draft_asset') + $this->countErrorCode($errors, 'unsupported_enneagram_target_url'),
+                'forbidden_route_count' => $this->countErrorCode($errors, 'forbidden_private_route_pattern_present'),
+                'stale_or_invalid_asset_count' => $this->countErrorCode($errors, 'source_hash_mismatch') + $this->countErrorCode($errors, 'asset_not_promotable_draft'),
+                'rows' => $rows,
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $promoted = 0;
+        $skipped = 0;
+        if ($write) {
+            foreach ($rows as &$row) {
+                if ($row['action'] === 'skip_existing_live_match') {
+                    $skipped++;
+
+                    continue;
+                }
+
+                PersonalityPublicContentAsset::query()
+                    ->withoutGlobalScopes()
+                    ->whereKey((int) $row['existing_asset_id'])
+                    ->update([
+                        'is_public' => true,
+                        'index_eligible' => false,
+                        'sitemap_eligible' => false,
+                        'llms_eligible' => false,
+                        'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+                        'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+                        'review_state' => 'agent_promoted_content_ready',
+                        'last_reviewed_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                $row['action'] = 'promoted_to_content_ready';
+                $promoted++;
+            }
+            unset($row);
+        }
+
+        return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'row_count' => count($rows),
+            'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+            'center_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CENTER),
+            'core_type_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_CORE_TYPE),
+            'would_promote_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['action'] ?? null) === 'promote_to_content_ready')),
+            'promoted_count' => $promoted,
+            'skipped_existing_count' => $write ? $skipped : count(array_filter($rows, static fn (array $row): bool => ($row['action'] ?? null) === 'skip_existing_live_match')),
+            'missing_target_count' => 0,
+            'forbidden_route_count' => 0,
+            'stale_or_invalid_asset_count' => 0,
+            'content_promotion_attempted' => $write,
+            'writes_committed' => $write && $promoted > 0,
+            'rows' => $rows,
+            'errors' => [],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        if ((string) ($recommendation['framework'] ?? '') !== PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM) {
+            return null;
+        }
+
+        $path = (string) parse_url((string) ($recommendation['target_url'] ?? ''), PHP_URL_PATH);
+        if ($path === '') {
+            return null;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram$#i', $path, $matches) === 1) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_HUB, 'enneagram', 'enneagram');
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/centers/(?<code>gut|heart|head)$#i', $path, $matches) === 1) {
+            $code = strtolower((string) $matches['code']);
+
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_CENTER, $code, 'enneagram/centers/'.$code);
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/enneagram/type-(?<type>[1-9])$#i', $path, $matches) === 1) {
+            $code = 'type-'.((string) $matches['type']);
+
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_CORE_TYPE, $code, 'enneagram/'.$code);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}
+     */
+    private function identity(string $path, string $prefix, string $entityType, string $entityKey, string $slug): array
+    {
+        return [
+            'path' => $path,
+            'locale' => $prefix === 'zh' ? 'zh-CN' : 'en',
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => $slug,
+        ];
+    }
+
+    /**
+     * @param  array{locale:string,entity_type:string,entity_key:string}  $identity
+     */
+    private function existingAsset(array $identity): ?PersonalityPublicContentAsset
+    {
+        return PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM)
+            ->where('entity_type', $identity['entity_type'])
+            ->where('entity_key', $identity['entity_key'])
+            ->where('locale', $identity['locale'])
+            ->first();
+    }
+
+    private function assetMatchesSource(PersonalityPublicContentAsset $asset, string $sourceSha256): bool
+    {
+        return (string) $asset->source_package === self::SNAPSHOT_SOURCE
+            && (string) $asset->source_hash === $sourceSha256;
+    }
+
+    private function assetIsPromotableDraft(PersonalityPublicContentAsset $asset, string $sourceSha256): bool
+    {
+        return $this->assetMatchesSource($asset, $sourceSha256)
+            && (bool) $asset->is_public === false
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_DRAFT,
+                PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            ], true);
+    }
+
+    private function assetIsLiveContent(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->is_public === true
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW
+            && $asset->launch_state === PersonalityPublicContentAsset::LAUNCH_CONTENT_READY;
+    }
+
+    private function countRows(array $rows, string $entityType): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row['entity_type'] ?? null) === $entityType));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function countErrorCode(array $errors, string $code): int
+    {
+        return count(array_filter($errors, static fn (array $error): bool => ($error['code'] ?? null) === $code));
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-CMS-PROMOTION-CONTRACT-01',
+            'status' => 'pending',
+            'ok' => false,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_ENNEAGRAM,
+            'package_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_attempted' => $write,
+            'writes_committed' => false,
+            'content_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -30,6 +30,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withCommands([
         __DIR__.'/../app/Console/Commands',
+        \App\Console\Commands\PersonalityEnneagramCmsPromote::class,
         \App\Console\Commands\FapResolvePack::class,
         \App\Console\Commands\RiasecResultPageAssetAgentAuditCommand::class,
     ])

--- a/backend/tests/Feature/Console/PersonalityEnneagramCmsPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityEnneagramCmsPromoteCommandTest.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\PersonalityEnneagramCmsPromote;
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityEnneagramCmsPromoteCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_twenty_six_enneagram_promotions_without_writes(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->seedDrafts($packagePath, $qaPath);
+
+        $exitCode = $this->callPromote([
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(26, $payload['row_count']);
+        $this->assertSame(2, $payload['hub_row_count']);
+        $this->assertSame(6, $payload['center_row_count']);
+        $this->assertSame(18, $payload['core_type_row_count']);
+        $this->assertSame(26, $payload['would_promote_count']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_REVIEW)->count());
+    }
+
+    public function test_write_promotes_twenty_six_drafts_to_live_content_ready_without_index_search_side_effects(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->seedDrafts($packagePath, $qaPath);
+
+        $exitCode = $this->callPromote($this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(26, $payload['promoted_count']);
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->count());
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('sitemap_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('llms_eligible', true)->count());
+    }
+
+    public function test_second_write_is_idempotent_when_assets_already_match_live_content_ready_state(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->seedDrafts($packagePath, $qaPath);
+        $this->assertSame(0, $this->callPromote($this->promoteWriteOptions($packagePath)));
+
+        $secondExitCode = $this->callPromote($this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(26, $payload['skipped_existing_count']);
+        $this->assertSame(26, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->count());
+    }
+
+    public function test_write_requires_all_safety_flags_and_exact_operator_token(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
+        $this->seedDrafts($packagePath, $qaPath);
+
+        $exitCode = $this->callPromote([
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('--promote-live-content is required with --write', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+    }
+
+    public function test_missing_or_foreign_source_draft_fails_closed_without_partial_promotion(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->singleHubPackage(), $this->singleHubQa());
+        $this->seedDrafts($packagePath, $qaPath);
+        PersonalityPublicContentAsset::query()->update(['source_hash' => 'different-source']);
+
+        $exitCode = $this->callPromote($this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertContains('source_hash_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+    }
+
+    public function test_private_or_unsupported_target_fails_closed_without_writes(): void
+    {
+        $package = [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram/type-1?token=secret', 'en', 'core_type'),
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram/type-1-wing-9', 'en', 'wing'),
+            ],
+        ];
+        [$packagePath] = $this->writeArtifacts($package, [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'page_results' => [],
+        ]);
+
+        $exitCode = $this->callPromote($this->promoteWriteOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('unsupported_enneagram_target_url', array_column($payload['errors'], 'code'));
+        $this->assertContains('forbidden_private_route_pattern_present', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function callPromote(array $options): int
+    {
+        Artisan::registerCommand($this->app->make(PersonalityEnneagramCmsPromote::class));
+
+        return Artisan::call('personality:enneagram-cms-promote', $options);
+    }
+
+    private function seedDrafts(string $packagePath, string $qaPath): void
+    {
+        $exitCode = Artisan::call('personality:enneagram-cms-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--write' => true,
+            '--json' => true,
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'ENNEAGRAM-CMS-DRAFT-WRITER-CONTRACT-01',
+        ]);
+        $this->assertSame(0, $exitCode, Artisan::output());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $recommendations = [];
+        foreach (['en', 'zh-CN'] as $locale) {
+            $prefix = $locale === 'zh-CN' ? 'zh' : 'en';
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram", $locale, 'hub');
+            foreach (['gut', 'heart', 'head'] as $center) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram/centers/{$center}", $locale, 'center');
+            }
+            for ($type = 1; $type <= 9; $type++) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/enneagram/type-{$type}", $locale, 'core_type');
+            }
+        }
+
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'enneagram.agent_pilot.v1',
+            'recommendations' => $recommendations,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validQa(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'page_results' => array_map(
+                fn (array $recommendation): array => $this->qaRow((string) $recommendation['target_url']),
+                $this->validPackage()['recommendations']
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubPackage(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/enneagram', 'en', 'hub'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubQa(): array
+    {
+        return [
+            'artifact' => 'ENNEAGRAM-PUBLIC-PROFILE-AGENT-QA-01',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/en/personality/enneagram'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $targetUrl, string $locale, string $entityType): array
+    {
+        return [
+            'recommendation_id' => 'enneagram-agent:'.parse_url($targetUrl, PHP_URL_PATH),
+            'target_url' => $targetUrl,
+            'framework' => 'enneagram',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => 'Enneagram SEO Title',
+                'description' => 'Enneagram SEO description',
+                'h1' => 'Enneagram H1',
+                'quick_answer' => 'This is a reflective Enneagram draft, not a diagnosis or hiring screen.',
+                'faq' => [
+                    [
+                        'question' => 'Is this diagnostic?',
+                        'answer' => 'No. It is reflective educational content.',
+                    ],
+                ],
+                'internal_links' => [],
+                'differentiation_notes' => [
+                    'Keep this page distinct from neighboring Enneagram content.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qaRow(string $targetUrl): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'blockers' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @param  array<string,mixed>  $qa
+     * @return array{0:string,1:string}
+     */
+    private function writeArtifacts(array $package, array $qa): array
+    {
+        $dir = storage_path('framework/testing/enneagram_cms_promote');
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/package.json';
+        $qaPath = $dir.'/qa.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($qaPath, json_encode($qa, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return [$packagePath, $qaPath];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function promoteWriteOptions(string $packagePath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+            '--promote-live-content' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'ENNEAGRAM-CMS-PROMOTION-CONTRACT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -405,6 +405,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_cms_promotion_contract_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityEnneagramCmsPromote.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/EnneagramCmsPromotionService.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityEnneagramCmsPromote;',
+            '+        PersonalityEnneagramCmsPromote::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_draft_writer_files(): void
     {
         $changed = [
@@ -4423,6 +4438,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramCmsPromotionFile($file)) {
+                continue;
+            }
+
             if ($this->isBigFivePublicProfileAgentDraftFile($file)) {
                 continue;
             }
@@ -5498,6 +5517,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsMbti64GscReadonlyExportOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsPersonalityAgentApprovalQueueOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsEnneagramCmsPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5728,6 +5748,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityEnneagramCmsDraft.php',
             'backend/app/Services/Cms/EnneagramCmsDraftWriter.php',
+        ], true);
+    }
+
+    private function isEnneagramCmsPromotionFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityEnneagramCmsPromote.php',
+            'backend/app/Services/Cms/EnneagramCmsPromotionService.php',
         ], true);
     }
 
@@ -9500,6 +9528,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityEnneagramCmsDraft\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsEnneagramCmsPromotionOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityEnneagramCmsPromote\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Add `personality:enneagram-cms-promote` as a controlled Enneagram public profile promotion contract.
- Add `EnneagramCmsPromotionService` to plan/promote only the 26 supported Enneagram public profile assets: hub, centers, and core types.
- Register the command and add focused feature coverage for dry-run, write guards, idempotency, source matching, missing draft fail-closed behavior, and forbidden route blocking.

## Why
The Enneagram agent pipeline already supports draft-only CMS asset creation. Promotion readiness is blocked until there is an explicit backend contract that can dry-run and later promote the 26 draft assets under strong operator approval and no SEO/search side effects.

## Validation
- `php artisan test tests/Feature/Console/PersonalityEnneagramCmsDraftCommandTest.php tests/Feature/Console/PersonalityEnneagramCmsPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only Enneagram promotion command/service/test and command registration files changed.

## Safety / Deferred
- No production command was run in this PR.
- No CMS production write, live promotion, publish, index/search, sitemap, llms, queue, external API, or frontend mutation is performed by this PR.
- Production deploy, production promotion dry-run, promotion write, and runtime smoke remain separate gates with exact SHA/operator authorization.

## Repository Rule Impact
Backend remains the CMS authority for public personality content assets. This PR adds a backend-only controlled promotion command; it does not introduce frontend fallback content or change public SEO generation behavior.
