### PR TITLE
PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -24,6 +24,7 @@ use App\Services\Content\EnneagramPackLoader;
 use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
+use App\Services\Eq\EqAgentContextBuilder;
 use App\Services\Eq\EqJourneyStateService;
 use App\Services\Iq\IqResultPayloadRedactor;
 use App\Services\Mbti\MbtiActionJourneyContractService;
@@ -73,6 +74,7 @@ class AttemptReadController extends Controller
         private EnneagramPublicProjectionService $enneagramPublicProjectionService,
         private EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private EnneagramObservationStateService $enneagramObservationStateService,
+        private EqAgentContextBuilder $eqAgentContextBuilder,
         private EqJourneyStateService $eqJourneyStateService,
         private RiasecPublicProjectionService $riasecPublicProjectionService,
         private RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
@@ -708,6 +710,115 @@ class AttemptReadController extends Controller
         }
 
         return response()->json($responsePayload);
+    }
+
+    /**
+     * GET /api/v0.3/attempts/{id}/eq/agent-context
+     */
+    public function eqAgentContext(Request $request, string $id): JsonResponse
+    {
+        $requestedReportLocale = $this->normalizeReportLocale((string) $request->query('locale', ''));
+        $orgId = $this->currentOrgContext()->orgId();
+        $userId = $this->resolveUserId($request);
+        $anonId = $this->resolveAnonId($request);
+        $submissionPayload = $this->latestReadableSubmission($request, $id);
+        if (($submissionPayload['ok'] ?? false) === true) {
+            $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+            if (in_array($submissionState, ['pending', 'running'], true)) {
+                return response()->json(array_merge(
+                    $this->eqAgentContextBuilder->nonReady($id, 'submission_pending', 'EQ_60'),
+                    [
+                        'submission_state' => $submissionState,
+                        'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                    ]
+                ), 202);
+            }
+
+            if ($submissionState === 'failed') {
+                return response()->json(array_merge(
+                    $this->eqAgentContextBuilder->nonReady($id, 'submission_failed', 'EQ_60'),
+                    [
+                        'ok' => false,
+                        'submission_state' => $submissionState,
+                        'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                    ]
+                ), 409);
+            }
+        }
+
+        $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
+        if (! $result instanceof Result) {
+            if (($submissionPayload['ok'] ?? false) === true) {
+                $submissionState = strtolower(trim((string) data_get($submissionPayload, 'submission.state', 'pending')));
+                if ($submissionState === 'succeeded') {
+                    return response()->json(array_merge(
+                        $this->eqAgentContextBuilder->nonReady($id, 'result_not_ready', 'EQ_60'),
+                        [
+                            'submission_state' => $submissionState,
+                            'submission' => is_array($submissionPayload['submission'] ?? null) ? $submissionPayload['submission'] : [],
+                        ]
+                    ), 202);
+                }
+            }
+
+            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
+        }
+
+        $responseCodes = $this->resolveResponseScaleCodes($result);
+        $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
+        $attempt = $this->resolveAttemptForReportRead($request, $id, $scaleCode);
+        $this->enforceEmailBindingForRead($request, $orgId, $attempt, $scaleCode);
+        if (! in_array($scaleCode, ['EQ_60', 'EQ_EMOTIONAL_INTELLIGENCE'], true)) {
+            throw new ApiProblemException(422, 'SCALE_NOT_SUPPORTED', 'Agent context is only available for EQ attempts.');
+        }
+        $emailTokenActor = $this->resultEmailReadAccess()->tokenActorForRequest($request, $orgId, $id);
+        $readUserId = $emailTokenActor['user_id'] ?? ($userId !== null ? (string) $userId : null);
+        $readAnonId = $emailTokenActor['anon_id'] ?? $anonId;
+
+        $gate = $this->resolveReportGate(
+            $orgId,
+            $id,
+            $readUserId,
+            $readAnonId,
+            $this->currentOrgContext()->role(),
+            $this->shouldUsePublicArtifactFallback($request, $attempt),
+            false,
+            $requestedReportLocale,
+        );
+
+        if (isset($gate['report']) && is_array($gate['report'])) {
+            $gate['report'] = $this->projectScaleCodePayload($gate['report'], $responseCodes);
+        }
+
+        if ((bool) ($gate['generating'] ?? false) || ! is_array($gate['report'] ?? null)) {
+            return response()->json(array_merge(
+                $this->eqAgentContextBuilder->nonReady($id, 'report_not_ready', $responseCodes['scale_code']),
+                [
+                    'access_state' => (string) ($gate['access_state'] ?? ''),
+                    'report_state' => (string) ($gate['report_state'] ?? ''),
+                    'variant' => (string) ($gate['variant'] ?? ''),
+                    'access_level' => (string) ($gate['access_level'] ?? ''),
+                ]
+            ), 202);
+        }
+
+        $reportEnvelope = array_merge($gate, [
+            'scale_code' => $responseCodes['scale_code'],
+            'scale_code_legacy' => $responseCodes['scale_code_legacy'],
+            'scale_code_v2' => $responseCodes['scale_code_v2'],
+            'scale_uid' => $responseCodes['scale_uid'],
+        ]);
+
+        $payload = $this->eqAgentContextBuilder->build(
+            $attempt,
+            $result,
+            $reportEnvelope,
+            $responseCodes,
+            $requestedReportLocale,
+            (string) $request->query('intent', '')
+        );
+
+        return response()->json($payload);
     }
 
     /**

--- a/backend/app/Services/Eq/EqAgentContextBuilder.php
+++ b/backend/app/Services/Eq/EqAgentContextBuilder.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Content\Eq60PackLoader;
+
+final class EqAgentContextBuilder
+{
+    public function __construct(
+        private Eq60PackLoader $packLoader,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $reportEnvelope
+     * @param  array{scale_code:string,scale_code_legacy:string,scale_code_v2:string,scale_uid:?string}  $responseCodes
+     * @return array<string,mixed>
+     */
+    public function build(
+        Attempt $attempt,
+        Result $result,
+        array $reportEnvelope,
+        array $responseCodes,
+        ?string $locale,
+        ?string $intent
+    ): array {
+        $resolvedLocale = $this->packLoader->normalizeLocale($locale !== null && $locale !== '' ? $locale : (string) ($attempt->locale ?? 'zh-CN'));
+        $report = is_array($reportEnvelope['report'] ?? null) ? $reportEnvelope['report'] : $reportEnvelope;
+        $assets = is_array($report['assets'] ?? null) ? $report['assets'] : [];
+        $agentKnowledge = $this->agentKnowledgeSchema();
+
+        return [
+            'schema' => 'eq.agent_context.v1',
+            'ok' => true,
+            'ready' => true,
+            'attempt_id' => (string) $attempt->id,
+            'result_id' => (string) $result->id,
+            'scale_code' => $responseCodes['scale_code'],
+            'scale_code_legacy' => $responseCodes['scale_code_legacy'],
+            'scale_code_v2' => $responseCodes['scale_code_v2'],
+            'scale_uid' => $responseCodes['scale_uid'],
+            'locale' => $resolvedLocale,
+            'report_context' => $this->reportContext($report),
+            'resolved_assets' => $this->resolvedAssets($assets),
+            'agent_knowledge' => $agentKnowledge,
+            'guardrails' => $this->guardrails(),
+            'intent_context' => $this->intentContext($agentKnowledge, $intent, $resolvedLocale),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function nonReady(string $attemptId, string $reasonCode, ?string $scaleCode = null): array
+    {
+        return [
+            'schema' => 'eq.agent_context.v1',
+            'ok' => true,
+            'ready' => false,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'reason_code' => $reasonCode,
+            'guardrails' => $this->guardrails(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    private function reportContext(array $report): array
+    {
+        return [
+            'eq_report_mode' => $report['eq_report_mode'] ?? null,
+            'measurement_type' => $report['measurement_type'] ?? null,
+            'scores' => is_array($report['scores'] ?? null) ? $report['scores'] : [],
+            'dimension_summary' => is_array($report['dimension_summary'] ?? null) ? $report['dimension_summary'] : [],
+            'quality' => is_array($report['quality'] ?? null) ? $report['quality'] : [],
+            'interpretation' => is_array($report['interpretation'] ?? null) ? $report['interpretation'] : [],
+            'next_module' => is_array($report['next_module'] ?? null) ? $report['next_module'] : [],
+            'methodology' => is_array($report['methodology'] ?? null) ? $report['methodology'] : [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $assets
+     * @return array<string,mixed>
+     */
+    private function resolvedAssets(array $assets): array
+    {
+        return [
+            'result_snapshot' => $this->arrayOrEmpty($assets['result_snapshot'] ?? null),
+            'core_formulation' => $this->arrayOrEmpty($assets['core_formulation'] ?? null),
+            'mechanisms' => $this->listOrEmpty($assets['mechanisms'] ?? null),
+            'reality_scenes' => $this->listOrEmpty($assets['reality_scenes'] ?? null),
+            'career_environment' => $this->listOrEmpty($assets['career_environment'] ?? null),
+            'action_prescription' => $this->arrayOrEmpty($assets['action_prescription'] ?? null),
+            'scientific_contract' => $this->arrayOrEmpty($assets['scientific_contract'] ?? null),
+            'score_system' => $this->arrayOrEmpty($assets['score_system'] ?? null),
+            'quality_confidence' => $this->arrayOrEmpty($assets['quality_confidence'] ?? null),
+            'psychometric_evidence_status' => $this->arrayOrEmpty($assets['psychometric_evidence_status'] ?? null),
+            'sjt_bridge' => $this->arrayOrEmpty($assets['sjt_bridge'] ?? null),
+            'conversion_agent_entry' => $this->conversionAgentEntry($assets),
+            'agent_dialogue_playbooks' => $this->listOrEmpty($assets['agent_dialogue_playbooks'] ?? null),
+            'backend_integration_contract' => $this->listOrEmpty($assets['backend_integration_contract'] ?? null),
+            'personalization_route' => $this->arrayOrEmpty($assets['personalization_route'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function agentKnowledgeSchema(): array
+    {
+        $compiled = $this->packLoader->readCompiledJson('report_assets.compiled.json', Eq60PackLoader::PACK_VERSION);
+        $schema = is_array($compiled) ? data_get($compiled, 'assets.agent_knowledge_base_schema') : null;
+
+        return is_array($schema) ? $schema : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $schema
+     * @return array<string,mixed>
+     */
+    private function intentContext(array $schema, ?string $intent, string $locale): array
+    {
+        $requestedIntent = strtolower(trim((string) $intent));
+        $intents = is_array(data_get($schema, 'user_intent_map.intents'))
+            ? data_get($schema, 'user_intent_map.intents')
+            : [];
+
+        $defaultIntentId = 'understand_my_result';
+        $match = is_array($intents[$requestedIntent] ?? null)
+            ? $intents[$requestedIntent]
+            : (is_array($intents[$defaultIntentId] ?? null) ? $intents[$defaultIntentId] : []);
+        $matchedIntentId = (string) ($match['intent_id'] ?? ($requestedIntent !== '' ? $requestedIntent : $defaultIntentId));
+        $matched = $requestedIntent !== '' && $matchedIntentId === $requestedIntent;
+        $localized = is_array($match[$locale] ?? null) ? $match[$locale] : [];
+
+        return [
+            'requested_intent' => $requestedIntent !== '' ? $requestedIntent : null,
+            'matched' => $matched,
+            'matched_intent' => $matchedIntentId,
+            'reason_code' => $matched ? null : ($requestedIntent === '' ? 'default_intent' : 'unknown_intent_defaulted'),
+            'retrieval_tags' => array_values(array_filter((array) ($match['retrieval_tags'] ?? []), static fn (mixed $value): bool => is_string($value) && trim($value) !== '')),
+            'preferred_asset_types' => array_values(array_filter((array) ($match['preferred_asset_types'] ?? []), static fn (mixed $value): bool => is_string($value) && trim($value) !== '')),
+            'forbidden_claim_ids' => array_values(array_filter((array) ($match['forbidden_claim_ids'] ?? []), static fn (mixed $value): bool => is_string($value) && trim($value) !== '')),
+            'escalation_flags' => array_values(array_filter((array) ($match['escalation_flags'] ?? []), static fn (mixed $value): bool => is_string($value) && trim($value) !== '')),
+            'allowed_response_mode' => (string) ($match['allowed_response_mode'] ?? 'explain_existing_assets_only'),
+            'label' => (string) ($localized['label'] ?? ''),
+            'agent_goal' => (string) ($localized['agent_goal'] ?? ''),
+            'safe_opening' => (string) ($localized['safe_opening'] ?? ''),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function guardrails(): array
+    {
+        return [
+            'read_only' => true,
+            'can_mutate_report' => false,
+            'can_mutate_scores' => false,
+            'can_override_formulation' => false,
+            'can_enable_sjt' => false,
+            'can_create_paid_unlock_language' => false,
+            'can_expose_raw_technical_tags' => false,
+            'content_authority' => 'backend_content_pack_and_report_composer',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $assets
+     * @return array<string,mixed>
+     */
+    private function conversionAgentEntry(array $assets): array
+    {
+        $actions = is_array($assets['commercial_conversion_actions'] ?? null)
+            ? $assets['commercial_conversion_actions']
+            : [];
+        foreach ($actions as $action) {
+            if (! is_array($action)) {
+                continue;
+            }
+            $id = (string) data_get($action, 'id', data_get($action, 'meta.id', ''));
+            if ($id === 'eq.conversion.agent_entry') {
+                return $action;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function listOrEmpty(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = array_values(array_filter($value, static fn (mixed $item): bool => is_array($item)));
+
+        return $items;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -461,6 +461,30 @@
                 "x-laravel-name": "api.v0_3.attempts.enneagram.observation.day7"
             }
         },
+        "/api/v0.3/attempts/{id}/eq/agent-context": {
+            "get": {
+                "operationId": "api.v0_3.attempts.eq.agent_context",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@eqAgentContext",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.eq.agent_context"
+            }
+        },
         "/api/v0.3/attempts/{id}/eq/journey": {
             "get": {
                 "operationId": "api.v0_3.attempts.eq.journey.show",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -286,6 +286,10 @@ Route::prefix('v0.3')->middleware([
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)
                 ->name('api.v0_3.attempts.report_access');
+            Route::get('/attempts/{id}/eq/agent-context', [AttemptReadController::class, 'eqAgentContext'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.eq.agent_context');
             Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)

--- a/backend/tests/Feature/Report/EqAgentContextApiTest.php
+++ b/backend/tests/Feature/Report/EqAgentContextApiTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Assessment\Scorers\Eq60ScorerV1NormedValidity;
+use App\Services\Content\Eq60PackLoader;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EqAgentContextApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_eq_agent_context_returns_read_only_payload_from_ready_eq_report(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_agent_context_ready';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'zh-CN');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-context?locale=zh-CN&intent=career_environment_fit');
+
+        $response->assertOk()
+            ->assertJsonPath('schema', 'eq.agent_context.v1')
+            ->assertJsonPath('ready', true)
+            ->assertJsonPath('scale_code_legacy', 'EQ_60')
+            ->assertJsonPath('locale', 'zh-CN')
+            ->assertJsonPath('report_context.eq_report_mode', 'self_report')
+            ->assertJsonPath('report_context.measurement_type', 'self_report_trait_mixed_ei')
+            ->assertJsonPath('report_context.next_module.available', false)
+            ->assertJsonPath('report_context.next_module.status', 'planned')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('guardrails.can_mutate_scores', false)
+            ->assertJsonPath('guardrails.can_override_formulation', false)
+            ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.content_authority', 'backend_content_pack_and_report_composer')
+            ->assertJsonPath('agent_knowledge.authority.report_authority', 'backend_content_pack_and_report_composer')
+            ->assertJsonPath('intent_context.matched', true)
+            ->assertJsonPath('intent_context.matched_intent', 'career_environment_fit')
+            ->assertJsonPath('intent_context.allowed_response_mode', 'environment_variables_only');
+
+        $this->assertIsArray($response->json('report_context.scores.global'));
+        foreach (['SA', 'ER', 'EM', 'RM'] as $code) {
+            $this->assertIsArray($response->json('report_context.scores.dimensions.'.$code));
+        }
+        $this->assertCount(4, (array) $response->json('report_context.dimension_summary'));
+        $this->assertNotSame('', (string) $response->json('report_context.quality.confidence_label'));
+        $this->assertNotSame('', (string) $response->json('report_context.interpretation.core_formulation_id'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.core_formulation'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.result_snapshot'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.career_environment'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.action_prescription'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.quality_confidence'));
+        $this->assertNotEmpty((array) $response->json('resolved_assets.psychometric_evidence_status'));
+        $this->assertSame('eq.conversion.agent_entry', (string) $response->json('resolved_assets.conversion_agent_entry.id'));
+        $this->assertContains('asset:career_environment', (array) $response->json('intent_context.retrieval_tags'));
+        $this->assertContains('hiring_suitability', (array) $response->json('intent_context.forbidden_claim_ids'));
+
+        $json = json_encode([
+            'report_context' => $response->json('report_context'),
+            'resolved_assets' => $response->json('resolved_assets'),
+            'intent_context' => $response->json('intent_context'),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        foreach ([
+            'SKU_EQ_60_FULL_299',
+            'EQ_60_FULL',
+            '"locked":true',
+            '"paywall":true',
+            '"blur_others":true',
+            'profile:',
+            'quality_level:',
+            'focus:',
+            'bucket:',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $json);
+        }
+    }
+
+    public function test_eq_agent_context_unknown_intent_defaults_to_safe_understanding_intent(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_agent_context_unknown_intent';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-context?locale=en&intent=please_diagnose_me');
+
+        $response->assertOk()
+            ->assertJsonPath('ready', true)
+            ->assertJsonPath('locale', 'en')
+            ->assertJsonPath('intent_context.requested_intent', 'please_diagnose_me')
+            ->assertJsonPath('intent_context.matched', false)
+            ->assertJsonPath('intent_context.matched_intent', 'understand_my_result')
+            ->assertJsonPath('intent_context.reason_code', 'unknown_intent_defaulted')
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('guardrails.can_enable_sjt', false);
+
+        $this->assertContains('asset:core_formulation', (array) $response->json('intent_context.retrieval_tags'));
+    }
+
+    public function test_eq_agent_context_rejects_non_eq_attempt_after_report_read_guard(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
+
+        $anonId = 'anon_eq_agent_context_mbti_rejected';
+        $token = $this->issueAuthToken($anonId);
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-context?locale=en');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error_code', 'SCALE_NOT_SUPPORTED');
+    }
+
+    private function prepareEqContent(): void
+    {
+        $this->artisan('content:compile --pack=EQ_60 --pack-version=v1')->assertExitCode(0);
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueFmToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function issueAuthToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('auth_tokens')->insert([
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createEqAttemptWithResult(string $anonId, string $locale = 'zh-CN'): string
+    {
+        $locale = str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh-CN' : 'en';
+        $attemptId = (string) Str::uuid();
+        $attempt = Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 60,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'eq_agent_context'],
+            'started_at' => now()->subMinutes(8),
+            'submitted_at' => now(),
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+        ]);
+
+        $score = $this->scoreEq60([
+            'started_at' => $attempt->started_at,
+            'submitted_at' => $attempt->submitted_at,
+            'locale' => $locale,
+            'region' => 'CN_MAINLAND',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'EQ_60',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => (array) ($score['scores'] ?? []),
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'scale_code' => 'EQ_60',
+                'quality' => $score['quality'] ?? [],
+                'norms' => $score['norms'] ?? [],
+                'scores' => $score['scores'] ?? [],
+                'report_tags' => $score['report_tags'] ?? [],
+                'version_snapshot' => $score['version_snapshot'] ?? [],
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'EQ_60',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'eq60_spec_2026_v2',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'eq_agent_context_non_eq'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => ['EI' => 50, 'SN' => 50, 'TF' => 50, 'JP' => 50, 'AT' => 50],
+            'axis_states' => ['EI' => 'clear', 'SN' => 'clear', 'TF' => 'clear', 'JP' => 'clear', 'AT' => 'clear'],
+            'content_package_version' => 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array<string,mixed>
+     */
+    private function scoreEq60(array $ctx = []): array
+    {
+        /** @var Eq60PackLoader $loader */
+        $loader = app(Eq60PackLoader::class);
+        /** @var Eq60ScorerV1NormedValidity $scorer */
+        $scorer = app(Eq60ScorerV1NormedValidity::class);
+
+        $answers = [];
+        for ($i = 1; $i <= 60; $i++) {
+            $answers[$i] = 'C';
+        }
+
+        return $scorer->score(
+            $answers,
+            $loader->loadQuestionIndex('v1'),
+            $loader->loadPolicy('v1'),
+            array_merge([
+                'pack_id' => 'EQ_60',
+                'dir_version' => 'v1',
+                'score_map' => data_get($loader->loadOptions('v1'), 'score_map', []),
+                'server_duration_seconds' => 420,
+            ], $ctx)
+        );
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -801,6 +801,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_eq_agent_context_read_only_contract_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Eq/EqAgentContextBuilder.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            "+            Route::get('/attempts/{id}/eq/agent-context', [AttemptReadController::class, 'eqAgentContext'])",
+            "+                ->middleware('uuid:id')",
+            "+                ->defaults('public_realm', true)",
+            "+                ->name('api.v0_3.attempts.eq.agent_context');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -5262,6 +5283,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEqAgentContextReadOnlyContractChange($file)) {
+                continue;
+            }
+
             if ($this->isEq60FreeReportContractChange($file, $repoRoot, $baseRef)) {
                 continue;
             }
@@ -5269,6 +5294,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsEq60JourneyStateContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsEqAgentContextReadOnlyContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -7207,6 +7239,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Eq/EqJourneyStateService.php',
             'backend/database/migrations/2026_05_31_083300_create_eq_journey_states_table.php',
         ], true);
+    }
+
+    private function isEqAgentContextReadOnlyContractChange(string $file): bool
+    {
+        return $file === 'backend/app/Services/Eq/EqAgentContextBuilder.php';
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool
@@ -9871,6 +9908,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/eq\\/journey|eqJourney|submitEqJourney|api\\.v0_3\\.attempts\\.eq\\.journey|FmTokenAuth|uuid:id|public_realm/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsEqAgentContextReadOnlyContractOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/^\+\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/eq\\/agent-context|eqAgentContext|api\\.v0_3\\.attempts\\.eq\\.agent_context|uuid:id|public_realm/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60640,7 +60640,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-01-knowledge-schema",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-01 EQ Agent knowledge base schema and intent map",
     "depends_on": [
@@ -60701,14 +60701,22 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub checks green and mergeStateStatus CLEAN for PR #2397 at head d86d93e9e08b909a0a3edcdfe8e7a173f8868339."
+      },
+      "github_merge": {
+        "status": "pass",
+        "evidence": "GitHub PR #2397 is MERGED at 09610cceb9726840e000a93947c8f78192dd81f8; origin/main contains the merge commit."
+      },
+      "remote_branch_deleted": {
+        "status": "pass",
+        "evidence": "origin/codex/pr-eq-agent-01-knowledge-schema is not present after fetch/prune."
       }
     },
     "failure_reason": null,
-    "commit_sha": "4a7d31e9e471145627dc15338646abc50d5448b9",
+    "commit_sha": "09610cceb9726840e000a93947c8f78192dd81f8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2397",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-24T14:58:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-24T20:45:00+08:00",
@@ -60739,6 +60747,12 @@
         "from": "pr_opened",
         "to": "ready_to_merge",
         "notes": "GitHub checks green; PR #2397 is clean and ready for squash merge."
+      },
+      {
+        "at": "2026-06-24T23:17:24+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled stale ledger after verifying GitHub PR #2397 merged and origin/main contains 09610cceb9726840e000a93947c8f78192dd81f8."
       }
     ]
   },
@@ -60746,7 +60760,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-02-context-payload-api",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
     "depends_on": [
@@ -60758,8 +60772,47 @@
         "evidence": "User explicitly authorized manifest/state updates and sequential execution."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for PR-EQ-AGENT-01 to merge."
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-01 merged as GitHub PR #2397 at 09610cceb9726840e000a93947c8f78192dd81f8 and is present in origin/main."
+      },
+      "branch_base": {
+        "status": "pass",
+        "evidence": "codex/pr-eq-agent-02-context-payload-api fast-forwarded to origin/main 4fa6ece177b5f2080c945fc1771d154e310e2924 before implementation."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list",
+        "evidence": "route-list ok; api.v0_3.attempts.eq.agent_context resolves to GET /api/v0.3/attempts/{id}/eq/agent-context."
+      },
+      "eq60_v5_report_contract_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "evidence": "10 tests passed, 404 assertions."
+      },
+      "eq_agent_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent",
+        "evidence": "3 tests passed, 59 assertions."
+      },
+      "manifest_yaml": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "evidence": "yaml ok."
+      },
+      "state_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "JSON parse passed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check",
+        "evidence": "No whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "command": "Manual changed-file validation against PR-EQ-AGENT-02 allowed_paths.",
+        "evidence": "Changed files are confined to backend/routes/api.php, AttemptReadController, backend/app/Services/Eq/EqAgentContextBuilder.php, backend/tests/Feature/Report/EqAgentContextApiTest.php, and docs/codex/pr-train-state.json."
       }
     },
     "failure_reason": null,
@@ -60774,6 +60827,18 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit authorization."
+      },
+      {
+        "at": "2026-06-24T23:17:24+08:00",
+        "from": "pending_dependency",
+        "to": "in_progress",
+        "notes": "Started PR-EQ-AGENT-02 after reconciling PR-EQ-AGENT-01 merged dependency."
+      },
+      {
+        "at": "2026-06-24T23:20:39+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Added read-only EQ Agent context API, context builder, focused EqAgent feature tests, and passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60760,7 +60760,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-02-context-payload-api",
     "base": "main",
-    "status": "pr_opened",
+    "status": "ci_fix_pushed_pending_checks",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
     "depends_on": [
@@ -60787,7 +60787,7 @@
       "eq60_v5_report_contract_test": {
         "status": "pass",
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
-        "evidence": "10 tests passed, 404 assertions."
+        "evidence": "10 tests passed, 404 assertions after rerunning sequentially to avoid content compile timestamp race."
       },
       "eq_agent_test": {
         "status": "pass",
@@ -60811,8 +60811,8 @@
       },
       "scope_validation": {
         "status": "pass",
-        "command": "Manual changed-file validation against PR-EQ-AGENT-02 allowed_paths.",
-        "evidence": "Changed files are confined to backend/routes/api.php, AttemptReadController, backend/app/Services/Eq/EqAgentContextBuilder.php, backend/tests/Feature/Report/EqAgentContextApiTest.php, and docs/codex/pr-train-state.json."
+        "command": "Manual changed-file validation against amended PR-EQ-AGENT-02 allowed_paths.",
+        "evidence": "Changed files include the original PR-EQ-AGENT-02 files plus authorized runtime freeze guard test and docs/codex/pr-train.yaml/state updates."
       },
       "commit_created": {
         "status": "pass",
@@ -60821,6 +60821,19 @@
       "pr_opened": {
         "status": "pass",
         "evidence": "GitHub PR #2399 opened for codex/pr-eq-agent-02-context-payload-api."
+      },
+      "github_checks_initial": {
+        "status": "fail",
+        "evidence": "GitHub PR #2399 required checks failed in verify-mbti-legacy, verify-mbti-v2, and verify-bigfive because the shared runtime freeze guard flagged backend/routes/api.php and backend/app/Services/Eq/EqAgentContextBuilder.php."
+      },
+      "scope_amendment": {
+        "status": "pass",
+        "evidence": "User authorized fixing CI; PR-EQ-AGENT-02 allowed_paths now includes BigFiveResultPageV2CoreBodyPreviewTest.php for the runtime freeze exception test."
+      },
+      "runtime_freeze_guard_fix": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_eq_agent_context_read_only_contract_changes'",
+        "evidence": "1 test passed, 1 assertion."
       }
     },
     "failure_reason": null,
@@ -60853,6 +60866,12 @@
         "from": "local_checks_passed",
         "to": "pr_opened",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/2399 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-24T23:40:01+08:00",
+        "from": "pr_opened",
+        "to": "ci_fix_pushed_pending_checks",
+        "notes": "Fixed required CI by adding a scoped EQ Agent context read-only runtime freeze exception and amending PR-EQ-AGENT-02 allowed_paths."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60850,7 +60850,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "pending_openapi_snapshot_fix_commit",
+    "commit_sha": "7f2e02a57",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2399",
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60760,7 +60760,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-02-context-payload-api",
     "base": "main",
-    "status": "ci_fix_openapi_snapshot_pending_checks",
+    "status": "ready_to_merge",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
     "depends_on": [
@@ -60847,10 +60847,14 @@
         "status": "pass",
         "command": "cd backend && bash scripts/export_openapi.sh --check",
         "evidence": "OpenAPI snapshot regenerated for api.v0_3.attempts.eq.agent_context and check reports snapshot up-to-date."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "evidence": "GitHub PR #2399 required checks are green after the runtime freeze guard and OpenAPI snapshot fixes; mergeStateStatus is CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "7f2e02a57",
+    "commit_sha": "e8b50c24f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2399",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -60891,6 +60895,12 @@
         "from": "ci_fix_pushed_pending_checks",
         "to": "ci_fix_openapi_snapshot_pending_checks",
         "notes": "Fixed required CI OpenAPI drift by regenerating backend/docs/contracts/openapi.snapshot.json and adding it to PR-EQ-AGENT-02 scope."
+      },
+      {
+        "at": "2026-06-25T00:06:00+08:00",
+        "from": "ci_fix_openapi_snapshot_pending_checks",
+        "to": "ready_to_merge",
+        "notes": "All GitHub checks passed and PR #2399 mergeStateStatus is CLEAN."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60760,7 +60760,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-02-context-payload-api",
     "base": "main",
-    "status": "ci_fix_pushed_pending_checks",
+    "status": "ci_fix_openapi_snapshot_pending_checks",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
     "depends_on": [
@@ -60834,10 +60834,23 @@
         "status": "pass",
         "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_eq_agent_context_read_only_contract_changes'",
         "evidence": "1 test passed, 1 assertion."
+      },
+      "github_checks_after_runtime_guard_fix": {
+        "status": "fail",
+        "evidence": "GitHub PR #2399 verify-mbti-legacy and verify-mbti-v2 failed after the runtime guard fix because backend/docs/contracts/openapi.snapshot.json drifted for GET /api/v0.3/attempts/{id}/eq/agent-context."
+      },
+      "openapi_snapshot_scope": {
+        "status": "pass",
+        "evidence": "User authorized fixing CI; PR-EQ-AGENT-02 allowed_paths and validation now include backend/docs/contracts/openapi.snapshot.json for the scoped read-only EQ Agent context route contract."
+      },
+      "openapi_snapshot": {
+        "status": "pass",
+        "command": "cd backend && bash scripts/export_openapi.sh --check",
+        "evidence": "OpenAPI snapshot regenerated for api.v0_3.attempts.eq.agent_context and check reports snapshot up-to-date."
       }
     },
     "failure_reason": null,
-    "commit_sha": "2d501ca8f",
+    "commit_sha": "pending_openapi_snapshot_fix_commit",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2399",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -60872,6 +60885,12 @@
         "from": "pr_opened",
         "to": "ci_fix_pushed_pending_checks",
         "notes": "Fixed required CI by adding a scoped EQ Agent context read-only runtime freeze exception and amending PR-EQ-AGENT-02 allowed_paths."
+      },
+      {
+        "at": "2026-06-25T00:02:00+08:00",
+        "from": "ci_fix_pushed_pending_checks",
+        "to": "ci_fix_openapi_snapshot_pending_checks",
+        "notes": "Fixed required CI OpenAPI drift by regenerating backend/docs/contracts/openapi.snapshot.json and adding it to PR-EQ-AGENT-02 scope."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -60760,7 +60760,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-02-context-payload-api",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "eq_agent_ready_content_os",
     "title": "PR-EQ-AGENT-02 Backend EQ Agent context payload and retrieval API",
     "depends_on": [
@@ -60813,11 +60813,19 @@
         "status": "pass",
         "command": "Manual changed-file validation against PR-EQ-AGENT-02 allowed_paths.",
         "evidence": "Changed files are confined to backend/routes/api.php, AttemptReadController, backend/app/Services/Eq/EqAgentContextBuilder.php, backend/tests/Feature/Report/EqAgentContextApiTest.php, and docs/codex/pr-train-state.json."
+      },
+      "commit_created": {
+        "status": "pass",
+        "evidence": "Local commit created: 2d501ca8f."
+      },
+      "pr_opened": {
+        "status": "pass",
+        "evidence": "GitHub PR #2399 opened for codex/pr-eq-agent-02-context-payload-api."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "2d501ca8f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2399",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -60839,6 +60847,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Added read-only EQ Agent context API, context builder, focused EqAgent feature tests, and passed local validation."
+      },
+      {
+        "at": "2026-06-24T23:21:36+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/2399 after local validation and scope validation passed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -357,6 +357,7 @@ prs:
       - backend/app/Services/Report/Eq60ReportComposer.php
       - backend/tests/Feature/**/Eq*Agent*
       - backend/tests/Feature/Report/*Eq60*
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/audits/eq/**
       - docs/product/eq/**
       - docs/codex/pr-train.yaml

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -355,6 +355,7 @@ prs:
       - backend/app/Http/Controllers/API/V0_3/**
       - backend/app/Services/Eq/**
       - backend/app/Services/Report/Eq60ReportComposer.php
+      - backend/docs/contracts/openapi.snapshot.json
       - backend/tests/Feature/**/Eq*Agent*
       - backend/tests/Feature/Report/*Eq60*
       - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -370,6 +371,8 @@ prs:
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && bash scripts/export_openapi.sh --check
+      - python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null
       - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - git diff --check


### PR DESCRIPTION
## What changed
- Added `GET /api/v0.3/attempts/{id}/eq/agent-context` for EQ-only read-only Agent context.
- Added `EqAgentContextBuilder` to expose report context, resolved assets, Agent knowledge schema, guardrails, and intent routing from backend-authoritative content/report assets.
- Added feature coverage for ready EQ Agent context, unknown intent safe defaulting, and non-EQ rejection after the existing report read guard.
- Reconciled stale PR-EQ-AGENT-01 ledger state because GitHub PR #2397 is already merged and present in `origin/main`.

## Why
PR-EQ-AGENT-02 needs a backend-only context contract so the future Agent can read EQ report context and safety metadata without mutating scores, report sections, formulation selection, SJT state, or paywall semantics.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No frontend Agent entry guard; that remains PR-EQ-AGENT-03.
- No Agent runtime write behavior.
- No report mutation, score mutation, formulation override, SJT enablement, or paid/unlock behavior.
- No EQ-SJT take entry or integrated report visibility.

## Repository rule impact
This adds a backend API runtime read surface. Backend report composer/content pack remains the authority; the new endpoint is read-only and cannot replace or override report authority.
