### PR TITLE
BIG-FIVE-PUBLIC-PROFILE-EMOTIONAL-STABILITY-IDENTITY-REPAIR-01: fix identity mapping

### DIFF
--- a/backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
+++ b/backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php
@@ -26,7 +26,6 @@ final class BigFivePublicProfileAgentDraftWriter
     private const DOMAIN_SLUGS = [
         'agreeableness',
         'conscientiousness',
-        'emotional-stability',
         'extraversion',
         'neuroticism',
         'openness',
@@ -336,6 +335,10 @@ final class BigFivePublicProfileAgentDraftWriter
         }
 
         $slug = strtolower((string) $matches['slug']);
+        if ($slug === 'emotional-stability') {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_POLARITY, $slug, 'big-five/'.$slug);
+        }
+
         if (in_array($slug, self::DOMAIN_SLUGS, true)) {
             return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_DOMAIN, $slug, 'big-five/'.$slug);
         }

--- a/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php
@@ -63,6 +63,47 @@ final class PersonalityBigFivePublicProfileAgentDraftCommandTest extends TestCas
         $this->assertSame(0, PersonalityPublicContentAsset::query()->count());
     }
 
+    public function test_emotional_stability_maps_to_big_five_polarity_not_domain(): void
+    {
+        $package = [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/emotional-stability', 'en', 'polarity'),
+                $this->recommendation('https://fermatmind.com/zh/personality/big-five/emotional-stability', 'zh-CN', 'polarity'),
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/neuroticism', 'en', 'domain'),
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/high-neuroticism', 'en', 'polarity'),
+            ],
+        ];
+        $qa = [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-QA-01',
+            'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'evaluations' => array_map(
+                fn (array $recommendation): array => $this->qaRow((string) $recommendation['target_url']),
+                $package['recommendations']
+            ),
+        ];
+        [$packagePath, $qaPath] = $this->writeArtifacts($package, $qa);
+
+        $exitCode = Artisan::call('personality:big-five-public-profile-agent-draft', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(1, $payload['domain_row_count']);
+        $this->assertSame(3, $payload['polarity_row_count']);
+
+        $rowsByPath = collect($payload['rows'])->keyBy('path');
+        $this->assertSame(PersonalityPublicContentAsset::ENTITY_POLARITY, $rowsByPath['/en/personality/big-five/emotional-stability']['entity_type']);
+        $this->assertSame(PersonalityPublicContentAsset::ENTITY_POLARITY, $rowsByPath['/zh/personality/big-five/emotional-stability']['entity_type']);
+        $this->assertSame(PersonalityPublicContentAsset::ENTITY_DOMAIN, $rowsByPath['/en/personality/big-five/neuroticism']['entity_type']);
+        $this->assertSame(PersonalityPublicContentAsset::ENTITY_POLARITY, $rowsByPath['/en/personality/big-five/high-neuroticism']['entity_type']);
+    }
+
     public function test_write_creates_non_public_noindex_draft_assets_after_approval_only(): void
     {
         $package = $this->validPackage();


### PR DESCRIPTION
## What changed
- Removed `emotional-stability` from the Big Five domain slug list in the public profile agent draft writer.
- Added an explicit mapping so `/personality/big-five/emotional-stability` resolves as `entity_type=polarity` for both en and zh-CN.
- Added a focused feature test proving emotional-stability is polarity while `neuroticism` remains domain and high/low neuroticism remains polarity.

## Why
Production public API and fap-web route inventory treat emotional-stability as a polarity entry. The draft writer was the remaining mismatched identity mapper and could classify the same route as a domain.

## Validation
- `php artisan test tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only `BigFivePublicProfileAgentDraftWriter.php` and `PersonalityBigFivePublicProfileAgentDraftCommandTest.php` changed.

## Deferred
- No production deploy.
- No production CMS write/import.
- No publish/index/search/sitemap/llms mutation.
- Big Five promotion contract remains a separate PR.