### PR TITLE
Fix owner IQ asset public URL origin

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php
@@ -45,7 +45,7 @@ final class AttemptQuestionDeliveryController extends Controller
         }
 
         return response()->json(
-            $this->ownerBank->publicQuestionPayload($attempt, (int) $index)
+            $this->ownerBank->publicQuestionPayload($attempt, (int) $index, $request)
         );
     }
 

--- a/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+++ b/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
@@ -7,7 +7,9 @@ namespace App\Services\Iq;
 use App\DTO\Attempts\SubmitAttemptDTO;
 use App\Exceptions\Api\ApiProblemException;
 use App\Models\Attempt;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 final class IqOwnerOriginal30BankService
@@ -82,7 +84,7 @@ final class IqOwnerOriginal30BankService
     /**
      * @return array<string,mixed>
      */
-    public function publicQuestionPayload(Attempt $attempt, int $index): array
+    public function publicQuestionPayload(Attempt $attempt, int $index, ?Request $request = null): array
     {
         $items = $this->items();
         $count = count($items);
@@ -116,7 +118,7 @@ final class IqOwnerOriginal30BankService
             ],
             'questions' => [
                 'schema_version' => 'fm.iq.owner_image_bank.items.public.v1',
-                'items' => [$this->publicItem($item)],
+                'items' => [$this->publicItem($item, $this->publicRequestOrigin($request))],
             ],
             'meta' => [
                 'source' => 'attempt_bound_owner_bank',
@@ -223,12 +225,12 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $item
      * @return array<string,mixed>
      */
-    private function publicItem(array $item): array
+    private function publicItem(array $item, string $publicAssetOrigin): array
     {
         $options = [];
         foreach (($item['options'] ?? []) as $option) {
             if (is_array($option)) {
-                $options[] = $this->onlyPublicOptionFields($option);
+                $options[] = $this->onlyPublicOptionFields($option, $publicAssetOrigin);
             }
         }
 
@@ -241,7 +243,10 @@ final class IqOwnerOriginal30BankService
             'sequence' => (int) ($item['sequence'] ?? 0),
             'order' => (int) ($item['sequence'] ?? 0),
             'title' => (string) ($item['title'] ?? ''),
-            'stem' => $this->onlyPublicMediaFields(is_array($item['stem'] ?? null) ? $item['stem'] : []),
+            'stem' => $this->onlyPublicMediaFields(
+                is_array($item['stem'] ?? null) ? $item['stem'] : [],
+                $publicAssetOrigin
+            ),
             'options' => $options,
         ];
     }
@@ -250,12 +255,12 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $option
      * @return array<string,mixed>
      */
-    private function onlyPublicOptionFields(array $option): array
+    private function onlyPublicOptionFields(array $option, string $publicAssetOrigin): array
     {
         return [
             'code' => strtoupper(trim((string) ($option['code'] ?? ''))),
             'label' => (string) ($option['label'] ?? $option['code'] ?? ''),
-            ...$this->onlyPublicMediaFields($option),
+            ...$this->onlyPublicMediaFields($option, $publicAssetOrigin),
         ];
     }
 
@@ -263,10 +268,13 @@ final class IqOwnerOriginal30BankService
      * @param  array<string,mixed>  $media
      * @return array<string,mixed>
      */
-    private function onlyPublicMediaFields(array $media): array
+    private function onlyPublicMediaFields(array $media, string $publicAssetOrigin): array
     {
         $assets = is_array($media['assets'] ?? null) ? $media['assets'] : [];
-        $publicUrl = $this->publicAssetUrl(is_string($assets['image'] ?? null) ? (string) $assets['image'] : '');
+        $publicUrl = $this->publicAssetUrl(
+            is_string($assets['image'] ?? null) ? (string) $assets['image'] : '',
+            $publicAssetOrigin
+        );
 
         return [
             'type' => (string) ($media['type'] ?? 'image'),
@@ -283,14 +291,35 @@ final class IqOwnerOriginal30BankService
         ];
     }
 
-    private function publicAssetUrl(string $assetPath): ?string
+    private function publicAssetUrl(string $assetPath, string $publicAssetOrigin): ?string
     {
         $routePath = $this->publicRoutePathForAsset($assetPath);
         if ($routePath === null) {
             return null;
         }
 
-        return url('/api/v0.3/iq-owner-original-30/assets/'.$this->encodePublicPath($routePath));
+        return $publicAssetOrigin.'/api/v0.3/iq-owner-original-30/assets/'.$this->encodePublicPath($routePath);
+    }
+
+    private function publicRequestOrigin(?Request $request): string
+    {
+        if ($request !== null) {
+            $forwardedProto = trim((string) $request->headers->get('x-forwarded-proto', ''));
+            $forwardedHost = trim((string) $request->headers->get('x-forwarded-host', ''));
+
+            $scheme = $forwardedProto !== ''
+                ? strtolower(trim(Str::before($forwardedProto, ',')))
+                : $request->getScheme();
+            $host = $forwardedHost !== ''
+                ? trim(Str::before($forwardedHost, ','))
+                : $request->getHost();
+
+            if ($host !== '') {
+                return rtrim($scheme.'://'.$host, '/');
+            }
+        }
+
+        return rtrim((string) config('app.url'), '/');
     }
 
     private function publicRoutePathForAsset(string $assetPath): ?string

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
+use App\Services\Iq\IqOwnerOriginal30BankService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Test;
@@ -52,7 +54,12 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
 
         $response = $this->withHeaders([
             'X-Anon-Id' => $anonId,
+            'X-Forwarded-Proto' => 'https',
+            'X-Forwarded-Host' => 'api.fermatmind.com',
             'Authorization' => 'Bearer '.$token,
+        ])->withServerVariables([
+            'HTTPS' => 'on',
+            'HTTP_HOST' => 'api.fermatmind.com',
         ])->getJson('/api/v0.3/attempts/'.$attempt->id.'/questions?index=0');
 
         $response->assertStatus(200);
@@ -72,6 +79,38 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         $this->assertSame('IQOWNER30-Q01', $response->json('questions.items.0.question_id'));
         $this->assertOwnerOriginalQ1AssetsArePubliclyResolvable($response->json('questions.items.0'));
         $this->assertPayloadHasNoPrivateIqFields($response->json());
+    }
+
+    #[Test]
+    public function current_question_payload_uses_request_origin_instead_of_app_url_for_asset_urls(): void
+    {
+        config(['app.url' => 'https://139.224.130.204']);
+
+        $attempt = $this->createOwnerAttempt('anon_iq_owner_public_origin');
+        $request = Request::create(
+            '/api/v0.3/attempts/'.$attempt->id.'/questions?index=0',
+            'GET',
+            [],
+            [],
+            [],
+            [
+                'HTTPS' => 'on',
+                'HTTP_HOST' => 'api.fermatmind.com',
+                'HTTP_X_FORWARDED_PROTO' => 'https',
+                'HTTP_X_FORWARDED_HOST' => 'api.fermatmind.com',
+            ]
+        );
+
+        $this->assertSame('api.fermatmind.com', $request->getHost());
+        $this->assertSame('https', $request->headers->get('x-forwarded-proto'));
+
+        $payload = app(IqOwnerOriginal30BankService::class)->publicQuestionPayload($attempt, 0, $request);
+
+        $this->assertOwnerOriginalQ1AssetsArePubliclyResolvable(
+            $payload['questions']['items'][0],
+            'https://api.fermatmind.com'
+        );
+        $this->assertPayloadHasNoPrivateIqFields($payload);
     }
 
     #[Test]
@@ -248,7 +287,7 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         }
     }
 
-    private function assertOwnerOriginalQ1AssetsArePubliclyResolvable(array $item): void
+    private function assertOwnerOriginalQ1AssetsArePubliclyResolvable(array $item, ?string $expectedOrigin = null): void
     {
         $media = [
             'stem' => data_get($item, 'stem'),
@@ -269,8 +308,12 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
 
             $this->assertNotSame('', $src, $label.' src missing');
             $this->assertSame($src, $publicUrl, $label.' public_url should match src');
-            $this->assertStringStartsWith(url('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/'), $src);
+            if ($expectedOrigin !== null) {
+                $this->assertStringStartsWith($expectedOrigin.'/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/', $src);
+            }
+            $this->assertStringContainsString('/api/v0.3/iq-owner-original-30/assets/iq_owner_original_30/q01/', $src);
             $this->assertStringStartsWith('assets/iq_owner_original_30/q01/', $assetPath);
+            $this->assertStringNotContainsString('139.224.130.204', $src);
             $this->assertStringNotContainsString(base_path(), $src);
             $this->assertStringNotContainsString('/private/', $src);
             $this->assertStringNotContainsString('../', $src);


### PR DESCRIPTION
## What changed
- Pass the current delivery request into the IQ owner-original 30 question payload builder.
- Build owner-original IQ image `src`/`public_url` from the request origin instead of Laravel `url()`/`APP_URL`.
- Add regression coverage for the production failure mode where `APP_URL` is an HTTPS IP while the public API host is `api.fermatmind.com`.

## Why
Production delivery currently returns image URLs on `https://139.224.130.204/...`; browsers reject those assets because the TLS certificate does not match the IP. The same asset path works on `https://api.fermatmind.com/...`.

## Validation
- `php -l backend/app/Http/Controllers/API/V0_3/AttemptQuestionDeliveryController.php`
- `php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php`
- `php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `php artisan test --filter=IqOwnerOriginal30SessionDeliveryTest`
- `git diff --check`

## Deferred
- No frontend changes.
- No production deploy.
- No staging wait.
- No CMS/import/SEO changes.
