### PR TITLE
BIG-FIVE-CMS-PROMOTION-CONTRACT-01: add Big Five promotion contract

### DIFF
--- a/backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentPromote.php
+++ b/backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentPromote.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\BigFivePublicProfileAgentPromotionService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+final class PersonalityBigFivePublicProfileAgentPromote extends Command
+{
+    private const OPERATOR_APPROVAL = 'BIG-FIVE-CMS-PROMOTION-CONTRACT-01';
+
+    private const WRITE_SAFETY_FLAGS = [
+        'promote-live-content',
+        'no-publish',
+        'no-index',
+        'no-sitemap',
+        'no-llms',
+        'no-search-release',
+    ];
+
+    protected $signature = 'personality:big-five-public-profile-agent-promote
+        {--package= : Path to the Big Five agent recommendation JSON package}
+        {--dry-run : Plan promotion without database writes}
+        {--write : Promote matching Big Five public content draft assets to live content-ready state}
+        {--json : Emit the full JSON summary}
+        {--output= : Optional path to write the JSON summary}
+        {--promote-live-content : Required for --write; confirms live content promotion intent}
+        {--no-publish : Required for --write; confirms no published/index release state}
+        {--no-index : Required for --write; confirms no indexability action}
+        {--no-sitemap : Required for --write; confirms no sitemap action}
+        {--no-llms : Required for --write; confirms no llms action}
+        {--no-search-release : Required for --write; confirms no search release action}
+        {--operator-approved= : Required exact approval token for --write}';
+
+    protected $description = 'Promote Big Five public profile CMS draft assets into live content-ready state with no index/search side effects.';
+
+    public function handle(BigFivePublicProfileAgentPromotionService $service): int
+    {
+        try {
+            $summary = $this->buildCommandSummary($service);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($summary);
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildCommandSummary(BigFivePublicProfileAgentPromotionService $service): array
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($write && $dryRun) {
+            throw new RuntimeException('--write cannot be combined with --dry-run.');
+        }
+
+        if (! $write && ! $dryRun) {
+            throw new RuntimeException('Either --dry-run or --write is required.');
+        }
+
+        if ($write) {
+            $this->assertWriteGuards();
+        }
+
+        $packagePath = $this->resolvePath(trim((string) $this->option('package')));
+        $raw = (string) File::get($packagePath);
+        $package = json_decode($raw, true);
+        if (! is_array($package)) {
+            throw new RuntimeException('Package must be a JSON object.');
+        }
+
+        $sourceSha256 = hash('sha256', $raw);
+        $summary = $write
+            ? $service->promote($package, $sourceSha256)
+            : $service->plan($package, $sourceSha256);
+
+        return array_merge($summary, [
+            'package_path' => $packagePath,
+            'command' => 'personality:big-five-public-profile-agent-promote',
+        ]);
+    }
+
+    private function assertWriteGuards(): void
+    {
+        foreach (self::WRITE_SAFETY_FLAGS as $flag) {
+            if (! (bool) $this->option($flag)) {
+                throw new RuntimeException('--'.$flag.' is required with --write.');
+            }
+        }
+
+        if ((string) $this->option('operator-approved') !== self::OPERATOR_APPROVAL) {
+            throw new RuntimeException('--operator-approved='.self::OPERATOR_APPROVAL.' is required with --write.');
+        }
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $resolved = str_starts_with($path, '/')
+            ? $path
+            : base_path($path);
+
+        if (! File::isFile($resolved)) {
+            throw new RuntimeException('Package file not found: '.$resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $summary,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($summary['status'] ?? 'fail'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('write='.(($summary['write'] ?? false) ? '1' : '0'));
+        $this->line('writes_committed='.(($summary['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('would_promote_count='.(string) ($summary['would_promote_count'] ?? 0));
+        $this->line('promoted_count='.(string) ($summary['promoted_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($summary['skipped_existing_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function writeOutputFile(array $summary): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $summary,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-CMS-PROMOTION-CONTRACT-01',
+            'command' => 'personality:big-five-public-profile-agent-promote',
+            'ok' => false,
+            'status' => 'fail',
+            'dry_run' => (bool) $this->option('dry-run'),
+            'write' => (bool) $this->option('write'),
+            'writes_attempted' => (bool) $this->option('write'),
+            'writes_committed' => false,
+            'content_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+            'row_count' => 0,
+            'would_promote_count' => 0,
+            'promoted_count' => 0,
+            'errors' => [
+                [
+                    'code' => $code,
+                    'message' => $message,
+                ],
+            ],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Services/Cms/BigFivePublicProfileAgentPromotionService.php
+++ b/backend/app/Services/Cms/BigFivePublicProfileAgentPromotionService.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Support\Facades\DB;
+
+final class BigFivePublicProfileAgentPromotionService
+{
+    private const SNAPSHOT_SOURCE = 'big_five_agent_public_profile_draft_v1';
+
+    private const FORBIDDEN_ROUTE_PATTERNS = [
+        '#/results?(?:/|$)#i',
+        '#/orders?(?:/|$)#i',
+        '#/share(?:/|$)#i',
+        '#/pay(?:/|$)#i',
+        '#/payment(?:/|$)#i',
+        '#/history(?:/|$)#i',
+        '#/private(?:/|$)#i',
+        '#/account(?:/|$)#i',
+        '#[?&](?:token|session|user|result_id|report_id|order_no)=#i',
+    ];
+
+    private const DOMAIN_SLUGS = [
+        'agreeableness',
+        'conscientiousness',
+        'extraversion',
+        'neuroticism',
+        'openness',
+    ];
+
+    private const POLARITY_DOMAIN_SLUGS = [
+        'agreeableness',
+        'conscientiousness',
+        'extraversion',
+        'neuroticism',
+        'openness',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function plan(array $package, string $sourceSha256): array
+    {
+        return $this->buildSummary($package, $sourceSha256, false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    public function promote(array $package, string $sourceSha256): array
+    {
+        return DB::transaction(fn (): array => $this->buildSummary($package, $sourceSha256, true));
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function buildSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        $rows = [];
+        $errors = [];
+
+        foreach ($this->recommendations($package) as $position => $recommendation) {
+            $identity = $this->identityForRecommendation($recommendation);
+            $targetUrl = (string) ($recommendation['target_url'] ?? '');
+            $recommendationJson = $this->jsonString($recommendation);
+            $recommendationSha256 = hash('sha256', $recommendationJson);
+
+            if ($identity === null) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'unsupported_big_five_target_url',
+                    'message' => 'Only Big Five hub, facet hub, domain, and polarity public URLs are supported.',
+                ];
+
+                continue;
+            }
+
+            if ($this->containsForbiddenRoutePattern($targetUrl) || $this->containsForbiddenRoutePattern($recommendationJson)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position),
+                    'code' => 'forbidden_private_route_pattern_present',
+                    'message' => 'Recommendation contains a private/result/order/payment/account/share route or sensitive query key.',
+                ];
+            }
+
+            $asset = $this->existingAsset($identity);
+            $action = 'promote_to_content_ready';
+            if (! $asset instanceof PersonalityPublicContentAsset) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'missing_draft_asset',
+                    'message' => 'A matching Big Five draft asset is required before promotion.',
+                ];
+                $action = 'missing_draft_asset';
+            } elseif (! $this->assetMatchesSource($asset, $sourceSha256, $recommendationSha256)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'source_hash_mismatch',
+                    'message' => 'The existing asset source hash or recommendation hash does not match the promotion package.',
+                ];
+                $action = 'blocked_source_hash_mismatch';
+            } elseif ($this->assetIsLiveContent($asset)) {
+                $action = 'skip_existing_live_match';
+            } elseif (! $this->assetIsPromotableDraft($asset, $sourceSha256, $recommendationSha256)) {
+                $errors[] = [
+                    'field' => 'recommendations.'.((string) $position).'.target_url',
+                    'code' => 'asset_not_promotable_draft',
+                    'message' => 'Only non-public noindex draft/review Big Five assets from the matching source can be promoted.',
+                ];
+                $action = 'blocked_not_promotable';
+            }
+
+            $rows[] = [
+                'position' => $position + 1,
+                'url' => $targetUrl,
+                'path' => $identity['path'],
+                'locale' => $identity['locale'],
+                'entity_type' => $identity['entity_type'],
+                'entity_key' => $identity['entity_key'],
+                'slug' => $identity['slug'],
+                'source_sha256' => $sourceSha256,
+                'recommendation_sha256' => $recommendationSha256,
+                'existing_asset_id' => $asset?->id !== null ? (int) $asset->id : null,
+                'action' => $action,
+            ];
+        }
+
+        if ($errors !== []) {
+            return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+                'ok' => false,
+                'status' => 'fail',
+                'row_count' => count($rows),
+                'logical_entity_count' => $this->logicalEntityCount($rows),
+                'locale_counts' => $this->localeCounts($rows),
+                'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+                'domain_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_DOMAIN),
+                'polarity_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_POLARITY),
+                'facet_hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_FACET_HUB),
+                'would_promote_count' => 0,
+                'promoted_count' => 0,
+                'skipped_existing_count' => 0,
+                'missing_target_count' => $this->countErrorCode($errors, 'missing_draft_asset') + $this->countErrorCode($errors, 'unsupported_big_five_target_url'),
+                'forbidden_route_count' => $this->countErrorCode($errors, 'forbidden_private_route_pattern_present'),
+                'stale_or_invalid_asset_count' => $this->countErrorCode($errors, 'source_hash_mismatch') + $this->countErrorCode($errors, 'asset_not_promotable_draft'),
+                'rows' => $rows,
+                'errors' => $errors,
+                'warnings' => [],
+            ]);
+        }
+
+        $promoted = 0;
+        $skipped = 0;
+        if ($write) {
+            foreach ($rows as &$row) {
+                if ($row['action'] === 'skip_existing_live_match') {
+                    $skipped++;
+
+                    continue;
+                }
+
+                PersonalityPublicContentAsset::query()
+                    ->withoutGlobalScopes()
+                    ->whereKey((int) $row['existing_asset_id'])
+                    ->update([
+                        'is_public' => true,
+                        'index_eligible' => false,
+                        'sitemap_eligible' => false,
+                        'llms_eligible' => false,
+                        'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+                        'launch_state' => PersonalityPublicContentAsset::LAUNCH_CONTENT_READY,
+                        'review_state' => 'agent_promoted_content_ready',
+                        'last_reviewed_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                $row['action'] = 'promoted_to_content_ready';
+                $promoted++;
+            }
+            unset($row);
+        }
+
+        return array_merge($this->baseSummary($package, $sourceSha256, $write), [
+            'ok' => true,
+            'status' => 'pass',
+            'row_count' => count($rows),
+            'logical_entity_count' => $this->logicalEntityCount($rows),
+            'locale_counts' => $this->localeCounts($rows),
+            'hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_HUB),
+            'domain_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_DOMAIN),
+            'polarity_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_POLARITY),
+            'facet_hub_row_count' => $this->countRows($rows, PersonalityPublicContentAsset::ENTITY_FACET_HUB),
+            'would_promote_count' => $write ? 0 : count(array_filter($rows, static fn (array $row): bool => ($row['action'] ?? null) === 'promote_to_content_ready')),
+            'promoted_count' => $promoted,
+            'skipped_existing_count' => $write ? $skipped : count(array_filter($rows, static fn (array $row): bool => ($row['action'] ?? null) === 'skip_existing_live_match')),
+            'missing_target_count' => 0,
+            'forbidden_route_count' => 0,
+            'stale_or_invalid_asset_count' => 0,
+            'content_promotion_attempted' => $write,
+            'writes_committed' => $write && $promoted > 0,
+            'rows' => $rows,
+            'errors' => [],
+            'warnings' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return list<array<string,mixed>>
+     */
+    private function recommendations(array $package): array
+    {
+        return array_values(array_filter(
+            is_array($package['recommendations'] ?? null) ? $package['recommendations'] : [],
+            static fn (mixed $item): bool => is_array($item)
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $recommendation
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        if ((string) ($recommendation['framework'] ?? '') !== PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE) {
+            return null;
+        }
+
+        $path = (string) parse_url((string) ($recommendation['target_url'] ?? ''), PHP_URL_PATH);
+        if ($path === '') {
+            return null;
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five$#i', $path, $matches) === 1) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_HUB, 'big-five', 'big-five');
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five/facets$#i', $path, $matches) === 1) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_FACET_HUB, 'facets', 'big-five/facets');
+        }
+
+        if (preg_match('#^/(?<prefix>en|zh)/personality/big-five/(?<slug>[a-z-]+)$#i', $path, $matches) !== 1) {
+            return null;
+        }
+
+        $slug = strtolower((string) $matches['slug']);
+        if ($slug === 'emotional-stability') {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_POLARITY, $slug, 'big-five/'.$slug);
+        }
+
+        if (in_array($slug, self::DOMAIN_SLUGS, true)) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_DOMAIN, $slug, 'big-five/'.$slug);
+        }
+
+        if (preg_match('#^(?<polarity>high|low)-(?<domain>[a-z-]+)$#i', $slug, $polarityMatches) === 1
+            && in_array(strtolower((string) $polarityMatches['domain']), self::POLARITY_DOMAIN_SLUGS, true)) {
+            return $this->identity($path, (string) $matches['prefix'], PersonalityPublicContentAsset::ENTITY_POLARITY, $slug, 'big-five/'.$slug);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}
+     */
+    private function identity(string $path, string $prefix, string $entityType, string $entityKey, string $slug): array
+    {
+        return [
+            'path' => $path,
+            'locale' => $prefix === 'zh' ? 'zh-CN' : 'en',
+            'entity_type' => $entityType,
+            'entity_key' => $entityKey,
+            'slug' => $slug,
+        ];
+    }
+
+    /**
+     * @param  array{locale:string,entity_type:string,entity_key:string}  $identity
+     */
+    private function existingAsset(array $identity): ?PersonalityPublicContentAsset
+    {
+        return PersonalityPublicContentAsset::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('framework', PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE)
+            ->where('entity_type', $identity['entity_type'])
+            ->where('entity_key', $identity['entity_key'])
+            ->where('locale', $identity['locale'])
+            ->first();
+    }
+
+    private function assetMatchesSource(PersonalityPublicContentAsset $asset, string $sourceSha256, string $recommendationSha256): bool
+    {
+        return (string) $asset->source_package === self::SNAPSHOT_SOURCE
+            && (string) $asset->source_hash === $sourceSha256
+            && $this->assetEvidenceMatches($asset, $sourceSha256, $recommendationSha256);
+    }
+
+    private function assetIsPromotableDraft(PersonalityPublicContentAsset $asset, string $sourceSha256, string $recommendationSha256): bool
+    {
+        return $this->assetMatchesSource($asset, $sourceSha256, $recommendationSha256)
+            && (bool) $asset->is_public === false
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW
+            && in_array((string) $asset->launch_state, [
+                PersonalityPublicContentAsset::LAUNCH_DRAFT,
+                PersonalityPublicContentAsset::LAUNCH_REVIEW,
+            ], true);
+    }
+
+    private function assetIsLiveContent(PersonalityPublicContentAsset $asset): bool
+    {
+        return (bool) $asset->is_public === true
+            && (bool) $asset->index_eligible === false
+            && (bool) $asset->sitemap_eligible === false
+            && (bool) $asset->llms_eligible === false
+            && $asset->robots === PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW
+            && $asset->launch_state === PersonalityPublicContentAsset::LAUNCH_CONTENT_READY;
+    }
+
+    private function assetEvidenceMatches(PersonalityPublicContentAsset $asset, string $sourceSha256, string $recommendationSha256): bool
+    {
+        $notes = is_array($asset->evidence_notes_json) ? $asset->evidence_notes_json : [];
+        foreach ($notes as $note) {
+            if (! is_array($note)) {
+                continue;
+            }
+
+            if (
+                (string) ($note['package_sha256'] ?? '') === $sourceSha256
+                && (string) ($note['recommendation_sha256'] ?? '') === $recommendationSha256
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function countRows(array $rows, string $entityType): int
+    {
+        return count(array_filter($rows, static fn (array $row): bool => ($row['entity_type'] ?? null) === $entityType));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,int>
+     */
+    private function localeCounts(array $rows): array
+    {
+        $counts = [];
+        foreach ($rows as $row) {
+            $locale = (string) ($row['locale'] ?? '');
+            $counts[$locale] = ($counts[$locale] ?? 0) + 1;
+        }
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     */
+    private function logicalEntityCount(array $rows): int
+    {
+        return count(array_unique(array_map(
+            static fn (array $row): string => (string) ($row['entity_type'] ?? '').':'.(string) ($row['entity_key'] ?? ''),
+            $rows
+        )));
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function countErrorCode(array $errors, string $code): int
+    {
+        return count(array_filter($errors, static fn (array $error): bool => ($error['code'] ?? null) === $code));
+    }
+
+    private function containsForbiddenRoutePattern(string $value): bool
+    {
+        foreach (self::FORBIDDEN_ROUTE_PATTERNS as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     * @return array<string,mixed>
+     */
+    private function baseSummary(array $package, string $sourceSha256, bool $write): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-CMS-PROMOTION-CONTRACT-01',
+            'status' => 'pending',
+            'ok' => false,
+            'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+            'package_artifact' => (string) ($package['artifact'] ?? ''),
+            'source_sha256' => $sourceSha256,
+            'dry_run' => ! $write,
+            'write' => $write,
+            'writes_attempted' => $write,
+            'writes_committed' => false,
+            'content_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $value
+     */
+    private function jsonString(array $value): string
+    {
+        return (string) json_encode(
+            $value,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentPromoteCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityBigFivePublicProfileAgentPromoteCommandTest.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Console\Commands\PersonalityBigFivePublicProfileAgentPromote;
+use App\Models\PersonalityPublicContentAsset;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityBigFivePublicProfileAgentPromoteCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_thirty_four_big_five_promotions_without_writes(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->seedDrafts($packagePath);
+
+        $exitCode = $this->callPromote([
+            '--package' => $packagePath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(34, $payload['row_count']);
+        $this->assertSame(17, $payload['logical_entity_count']);
+        $this->assertSame(['en' => 17, 'zh-CN' => 17], $payload['locale_counts']);
+        $this->assertSame(2, $payload['hub_row_count']);
+        $this->assertSame(10, $payload['domain_row_count']);
+        $this->assertSame(20, $payload['polarity_row_count']);
+        $this->assertSame(2, $payload['facet_hub_row_count']);
+        $this->assertSame(34, $payload['would_promote_count']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_REVIEW)->count());
+    }
+
+    public function test_write_promotes_thirty_four_drafts_to_content_ready_without_index_search_side_effects(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->seedDrafts($packagePath);
+
+        $exitCode = $this->callPromote($this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['write']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertTrue($payload['content_promotion_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertSame(34, $payload['promoted_count']);
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->count());
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('robots', PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('index_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('sitemap_eligible', true)->count());
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('llms_eligible', true)->count());
+    }
+
+    public function test_second_write_is_idempotent_when_assets_are_already_content_ready(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->seedDrafts($packagePath);
+        $this->assertSame(0, $this->callPromote($this->writeOptions($packagePath)));
+
+        $secondExitCode = $this->callPromote($this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $secondExitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertSame(34, $payload['skipped_existing_count']);
+        $this->assertSame(34, PersonalityPublicContentAsset::query()->where('launch_state', PersonalityPublicContentAsset::LAUNCH_CONTENT_READY)->count());
+    }
+
+    public function test_write_requires_all_safety_flags_and_exact_operator_token(): void
+    {
+        $packagePath = $this->writePackage($this->validPackage());
+        $this->seedDrafts($packagePath);
+
+        $exitCode = $this->callPromote([
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertStringContainsString('--promote-live-content is required with --write', (string) ($payload['errors'][0]['message'] ?? ''));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+    }
+
+    public function test_source_or_recommendation_hash_mismatch_fails_closed_without_partial_promotion(): void
+    {
+        $packagePath = $this->writePackage($this->singleHubPackage());
+        $this->seedDrafts($packagePath);
+        PersonalityPublicContentAsset::query()->update(['source_hash' => 'different-source']);
+
+        $exitCode = $this->callPromote($this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['promoted_count']);
+        $this->assertContains('source_hash_mismatch', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+    }
+
+    public function test_missing_unsupported_or_private_target_fails_closed_without_writes(): void
+    {
+        $package = [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/openness', 'en', 'domain'),
+                $this->recommendation('https://fermatmind.com/en/personality/big-five/facet-adventurousness', 'en', 'facet'),
+                $this->recommendation('https://fermatmind.com/zh/personality/big-five/high-openness?token=secret', 'zh-CN', 'polarity'),
+            ],
+        ];
+        $packagePath = $this->writePackage($package);
+        $this->seedDrafts($packagePath, onlyFirst: true);
+
+        $exitCode = $this->callPromote($this->writeOptions($packagePath));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertContains('unsupported_big_five_target_url', array_column($payload['errors'], 'code'));
+        $this->assertContains('forbidden_private_route_pattern_present', array_column($payload['errors'], 'code'));
+        $this->assertContains('missing_draft_asset', array_column($payload['errors'], 'code'));
+        $this->assertSame(0, PersonalityPublicContentAsset::query()->where('is_public', true)->count());
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     */
+    private function callPromote(array $options): int
+    {
+        Artisan::registerCommand($this->app->make(PersonalityBigFivePublicProfileAgentPromote::class));
+
+        return Artisan::call('personality:big-five-public-profile-agent-promote', $options);
+    }
+
+    private function seedDrafts(string $packagePath, bool $onlyFirst = false): void
+    {
+        $raw = (string) File::get($packagePath);
+        $package = json_decode($raw, true);
+        $this->assertIsArray($package);
+        $sourceSha256 = hash('sha256', $raw);
+
+        foreach (array_values($package['recommendations'] ?? []) as $index => $recommendation) {
+            if ($onlyFirst && $index > 0) {
+                break;
+            }
+
+            $this->assertIsArray($recommendation);
+            $identity = $this->identityForRecommendation($recommendation);
+            if ($identity === null) {
+                continue;
+            }
+
+            $recommendationJson = json_encode($recommendation, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+            $recommendationSha256 = hash('sha256', (string) $recommendationJson);
+            PersonalityPublicContentAsset::query()->create([
+                'org_id' => 0,
+                'framework' => PersonalityPublicContentAsset::FRAMEWORK_BIG_FIVE,
+                'entity_type' => $identity['entity_type'],
+                'entity_key' => $identity['entity_key'],
+                'slug' => $identity['slug'],
+                'locale' => $identity['locale'],
+                'title' => 'Big Five H1',
+                'summary' => 'This is reflective Big Five educational content.',
+                'content_sections_json' => [],
+                'seo_json' => ['title' => 'Big Five SEO Title'],
+                'robots' => PersonalityPublicContentAsset::ROBOTS_NOINDEX_FOLLOW,
+                'canonical_json' => ['path' => $identity['path']],
+                'hreflang_json' => [],
+                'faq_json' => [],
+                'media_json' => [],
+                'schema_json' => [],
+                'method_boundary_json' => [],
+                'evidence_notes_json' => [
+                    [
+                        'source_type' => 'agent_recommendation',
+                        'source' => 'big_five_agent_public_profile_draft_v1',
+                        'package_sha256' => $sourceSha256,
+                        'qa_sha256' => 'test-qa-sha',
+                        'recommendation_sha256' => $recommendationSha256,
+                    ],
+                ],
+                'internal_links_json' => [],
+                'is_public' => false,
+                'index_eligible' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'launch_state' => PersonalityPublicContentAsset::LAUNCH_REVIEW,
+                'review_state' => 'agent_draft_pending_review',
+                'contract_version' => PersonalityPublicContentAsset::CONTRACT_VERSION_V1,
+                'source_package' => 'big_five_agent_public_profile_draft_v1',
+                'source_hash' => $sourceSha256,
+            ]);
+        }
+    }
+
+    /**
+     * @return array{path:string,locale:string,entity_type:string,entity_key:string,slug:string}|null
+     */
+    private function identityForRecommendation(array $recommendation): ?array
+    {
+        $path = (string) parse_url((string) ($recommendation['target_url'] ?? ''), PHP_URL_PATH);
+        if ($path === '') {
+            return null;
+        }
+
+        $prefix = str_starts_with($path, '/zh/') ? 'zh' : 'en';
+        $locale = $prefix === 'zh' ? 'zh-CN' : 'en';
+        if (preg_match('#^/(?:en|zh)/personality/big-five$#', $path) === 1) {
+            return ['path' => $path, 'locale' => $locale, 'entity_type' => PersonalityPublicContentAsset::ENTITY_HUB, 'entity_key' => 'big-five', 'slug' => 'big-five'];
+        }
+
+        if (preg_match('#^/(?:en|zh)/personality/big-five/facets$#', $path) === 1) {
+            return ['path' => $path, 'locale' => $locale, 'entity_type' => PersonalityPublicContentAsset::ENTITY_FACET_HUB, 'entity_key' => 'facets', 'slug' => 'big-five/facets'];
+        }
+
+        if (preg_match('#^/(?:en|zh)/personality/big-five/(?<slug>[a-z-]+)$#', $path, $matches) !== 1) {
+            return null;
+        }
+
+        $slug = strtolower((string) $matches['slug']);
+        $entityType = (string) ($recommendation['entity_type'] ?? '');
+        if (! in_array($entityType, [
+            PersonalityPublicContentAsset::ENTITY_DOMAIN,
+            PersonalityPublicContentAsset::ENTITY_POLARITY,
+        ], true)) {
+            return null;
+        }
+
+        return ['path' => $path, 'locale' => $locale, 'entity_type' => $entityType, 'entity_key' => $slug, 'slug' => 'big-five/'.$slug];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function validPackage(): array
+    {
+        $recommendations = [];
+        foreach (['en', 'zh-CN'] as $locale) {
+            $prefix = $locale === 'zh-CN' ? 'zh' : 'en';
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five", $locale, 'hub');
+            $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/facets", $locale, 'facet_hub');
+            foreach (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'] as $domain) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/{$domain}", $locale, 'domain');
+            }
+            foreach (['openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism'] as $domain) {
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/high-{$domain}", $locale, 'polarity');
+                $recommendations[] = $this->recommendation("https://fermatmind.com/{$prefix}/personality/big-five/low-{$domain}", $locale, 'polarity');
+            }
+        }
+
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'version' => 'big_five.agent_pilot.v1',
+            'recommendations' => $recommendations,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function singleHubPackage(): array
+    {
+        return [
+            'artifact' => 'BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01',
+            'recommendations' => [
+                $this->recommendation('https://fermatmind.com/en/personality/big-five', 'en', 'hub'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $targetUrl, string $locale, string $entityType): array
+    {
+        return [
+            'recommendation_id' => 'big-five-agent:'.parse_url($targetUrl, PHP_URL_PATH),
+            'target_url' => $targetUrl,
+            'framework' => 'big_five',
+            'locale' => $locale,
+            'entity_type' => $entityType,
+            'recommendations' => [
+                'title' => 'Big Five SEO Title',
+                'description' => 'Big Five SEO description',
+                'h1' => 'Big Five H1',
+                'quick_answer' => 'This is reflective Big Five educational content, not diagnosis or hiring screening.',
+                'faq' => [
+                    [
+                        'question' => 'Is this diagnostic?',
+                        'answer' => 'No. It is reflective educational content.',
+                    ],
+                ],
+                'internal_links' => [],
+                'differentiation_notes' => [
+                    'Keep this page distinct from neighboring Big Five content.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $package
+     */
+    private function writePackage(array $package): string
+    {
+        $dir = storage_path('framework/testing/big_five_public_profile_agent_promote');
+        File::ensureDirectoryExists($dir);
+        $packagePath = $dir.'/package.json';
+        File::put($packagePath, json_encode($package, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $packagePath;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function writeOptions(string $packagePath): array
+    {
+        return [
+            '--package' => $packagePath,
+            '--write' => true,
+            '--json' => true,
+            '--promote-live-content' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--no-search-release' => true,
+            '--operator-approved' => 'BIG-FIVE-CMS-PROMOTION-CONTRACT-01',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $decoded = json_decode(Artisan::output(), true);
+        $this->assertIsArray($decoded, Artisan::output());
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -435,6 +435,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_big_five_public_profile_agent_promotion_contract_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentPromote.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/BigFivePublicProfileAgentPromotionService.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\PersonalityBigFivePublicProfileAgentPromote;',
+            '+        PersonalityBigFivePublicProfileAgentPromote::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_at_difference_section_files(): void
     {
         $changed = [
@@ -4476,6 +4491,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isBigFivePublicProfileAgentPromotionFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityAtDifferenceSectionFile($file)) {
                 continue;
             }
@@ -5564,6 +5583,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramCmsDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsEnneagramCmsPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsBigFivePublicProfileAgentPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -5809,6 +5829,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentDraft.php',
             'backend/app/Services/Cms/BigFivePublicProfileAgentDraftWriter.php',
+        ], true);
+    }
+
+    private function isBigFivePublicProfileAgentPromotionFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityBigFivePublicProfileAgentPromote.php',
+            'backend/app/Services/Cms/BigFivePublicProfileAgentPromotionService.php',
         ], true);
     }
 
@@ -9621,6 +9649,25 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
             if (preg_match('/\bPersonalityBigFivePublicProfileAgentDraft\b/u', $normalized) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsBigFivePublicProfileAgentPromotionOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            $normalized = ltrim($line, '+-');
+            if (preg_match('/\bPersonalityBigFivePublicProfileAgentPromote\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `personality:big-five-public-profile-agent-promote` for Big Five public profile agent promotion.
- Added a Big Five promotion service that validates the 34 supported public-profile targets, source package hashes, recommendation hashes, and private-route safety before planning or promoting assets.
- Added focused feature tests for dry-run, write, idempotency, required safety flags, hash mismatch, missing target, unsupported target, and private route fail-closed behavior.
- Updated the Big Five runtime-freeze classifier so this backend promotion contract is not mistaken for Big Five result-page runtime body changes.

## Why
Big Five already has draft assets, but production closure was blocked by the lack of an explicit promotion contract. This PR adds the same dry-run/write safety shape used by the public profile agent pipeline while keeping Big Five content-ready and noindex-only.

## Validation
- `php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --display-warnings`
- `php artisan test tests/Feature/Console/PersonalityBigFivePublicProfileAgentDraftCommandTest.php tests/Feature/Console/PersonalityBigFivePublicProfileAgentPromoteCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only Big Five promotion command/service/tests plus Big Five runtime-freeze classifier test changed

## Deferred
- No production deploy.
- No production CMS write.
- No publish/index/search/sitemap/llms release.
- Runtime gates remain separate: `BIG-FIVE-CMS-PROMOTION-DRY-RUN-01`, `BIG-FIVE-CMS-PROMOTION-WRITE-01`, `BIG-FIVE-CMS-PROMOTION-RUNTIME-SMOKE-01`, and `BIG-FIVE-PUBLIC-PROFILE-AGENT-PRODUCTION-CLOSURE-02`.

## Repository rule impact
This adds a backend-authoritative promotion contract for CMS-managed Big Five public profile assets. It does not move content authority to frontend code and does not introduce publish/index/search automation.