### PR TITLE
Fix career family hub authority fallback

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
+++ b/backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php
@@ -93,9 +93,13 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
     {
         $item = $this->itemForSlug($slug);
 
-        return is_array($item)
+        if (is_array($item)
             && ($item['public_resolution_type'] ?? null) === CareerPublicResolutionTypeMatrix::PUBLIC_FAMILY_HUB
-            && ($item['runtime_publish_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+            && ($item['runtime_publish_state'] ?? null) === CareerRuntimePublishProjectionService::STATE_PUBLISHED) {
+            return true;
+        }
+
+        return $this->familyHubLiveFromPublishedChildren($slug);
     }
 
     /**
@@ -147,6 +151,44 @@ final class CareerRuntimePublishProjectionLookup implements CareerRuntimePublish
         ));
 
         return $items;
+    }
+
+    private function familyHubLiveFromPublishedChildren(string $slug): bool
+    {
+        $slug = $this->normalizeSlug($slug);
+        if ($slug === null || str_ends_with($slug, '-all-other')) {
+            return false;
+        }
+
+        try {
+            $family = OccupationFamily::query()
+                ->where('canonical_slug', $slug)
+                ->first();
+        } catch (Throwable) {
+            return false;
+        }
+
+        if (! $family instanceof OccupationFamily) {
+            return false;
+        }
+
+        $childSlugs = Occupation::query()
+            ->where('family_id', $family->id)
+            ->pluck('canonical_slug')
+            ->all();
+
+        foreach ($childSlugs as $childSlug) {
+            if (! is_scalar($childSlug)) {
+                continue;
+            }
+
+            if ($this->detailRouteEnabled((string) $childSlug)
+                && $this->releaseGatePass((string) $childSlug)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hydrate(): void

--- a/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
+++ b/backend/tests/Unit/Services/Career/CareerRuntimePublishProjectionLookupTest.php
@@ -6,13 +6,18 @@ namespace Tests\Unit\Services\Career;
 
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
 use App\Services\Career\PublicCareerAuthorityResponseCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 final class CareerRuntimePublishProjectionLookupTest extends TestCase
 {
+    use RefreshDatabase;
+
     private string $projectionTimestamp = '99999999T999999Z';
 
     /**
@@ -77,6 +82,95 @@ final class CareerRuntimePublishProjectionLookupTest extends TestCase
         $this->assertFalse($lookup->robotsIndexable('software-developers'));
         $this->assertFalse($lookup->releaseGatePass('software-developers'));
         $this->assertFalse($lookup->familyHubLive('computer-and-information-technology'));
+    }
+
+    public function test_it_infers_family_hub_authority_from_published_child_projection_without_explicit_family_row(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'computer-and-information-technology',
+            'title_en' => 'Computer and Information Technology',
+            'title_zh' => '计算机与信息技术',
+        ]);
+
+        Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => 'data-scientists',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => 'Data Scientists',
+            'canonical_title_zh' => '数据科学家',
+            'search_h1_zh' => '数据科学家职业',
+            'structural_stability' => 0.84,
+            'task_prototype_signature' => ['analysis' => 0.9],
+            'market_semantics_gap' => 0.1,
+            'regulatory_divergence' => 0.1,
+            'toolchain_divergence' => 0.1,
+            'skill_gap_threshold' => 0.4,
+            'trust_inheritance_scope' => ['allow_task_truth' => true],
+        ]);
+
+        $this->writeProjection($this->projectionTimestamp, [
+            [
+                'slug' => 'data-scientists',
+                'locale' => 'en',
+                'public_resolution_type' => 'public_canonical_job',
+                'runtime_publish_state' => 'published',
+                'detail_route_enabled' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'sitemap_live' => true,
+                'llms_live' => true,
+                'llms_full_live' => true,
+                'canonical_self' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+            ],
+        ]);
+
+        $lookup = app(CareerRuntimePublishProjectionLookup::class);
+
+        $this->assertSame(1, Occupation::query()->where('family_id', $family->id)->count());
+        $this->assertTrue($lookup->detailRouteEnabled('data-scientists'));
+        $this->assertTrue($lookup->familyHubLive('computer-and-information-technology'));
+    }
+
+    public function test_it_does_not_infer_family_hub_authority_without_published_children_or_for_broad_holds(): void
+    {
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'empty-family',
+            'title_en' => 'Empty Family',
+            'title_zh' => '空家族',
+        ]);
+        OccupationFamily::query()->create([
+            'canonical_slug' => 'agricultural-workers-all-other',
+            'title_en' => 'Agricultural Workers, All Other',
+            'title_zh' => '其他农业工作者',
+        ]);
+
+        $this->writeProjection($this->projectionTimestamp, [
+            [
+                'slug' => 'data-scientists',
+                'locale' => 'en',
+                'public_resolution_type' => 'public_canonical_job',
+                'runtime_publish_state' => 'published',
+                'detail_route_enabled' => true,
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'sitemap_live' => true,
+                'llms_live' => true,
+                'llms_full_live' => true,
+                'canonical_self' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+            ],
+        ]);
+
+        $lookup = app(CareerRuntimePublishProjectionLookup::class);
+
+        $this->assertFalse($lookup->familyHubLive('empty-family'));
+        $this->assertFalse($lookup->familyHubLive('agricultural-workers-all-other'));
     }
 
     public function test_it_uses_newest_valid_projection_artifact_instead_of_lexical_directory_order(): void


### PR DESCRIPTION
## What changed
- Added a family hub authority fallback in `CareerRuntimePublishProjectionLookup`: when a materialized projection has no explicit family hub row, a family hub is considered live only if the backend family exists, is not an `*-all-other` broad hold, and has at least one child occupation with a live detail route and release gate pass.
- Added regression coverage for inferred family hub authority, zero-child families, and broad hold slugs.

## Why
Adjacent graph candidates need family hub route authority. Live family hub routes can currently 404 when the runtime projection only contains canonical job rows, even though the backend family and published child job authority are present.

## Validation
- `php artisan test --filter=CareerRuntimePublishProjectionLookupTest` (passes with existing PHPUnit warnings)
- `php artisan route:list --path=api/v0.5/career/family`
- `git diff --check`

## Intentionally deferred
- No content asset changes.
- No CMS write, staging write, production import, sitemap, llms, canonical, noindex, or JSON-LD changes.
- No fap-web rendering changes.
- Adjacent graph rebuild remains candidate-only and separate.