### PR TITLE
docs(personality): sync Big Five promotion package

### DIFF
--- a/backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json
+++ b/backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json
@@ -1,0 +1,5307 @@
+{
+  "artifact": "BIG-FIVE-PUBLIC-PROFILE-AGENT-PILOT-01",
+  "version": "big_five.public_profile_agent_pilot.v1",
+  "generated_at": "2026-06-24T00:00:00.000Z",
+  "status": "pass_ready_for_qa_gates",
+  "scope": "Artifact-only draft recommendations for Big Five V1 public personality profiles. No CMS write, frontend runtime change, publish, indexability, sitemap/llms mutation, Search Queue, or search submission.",
+  "inputs": {
+    "package_root": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages",
+    "qa_root": "generated/public-profile-assets/big-five-v1-editorial-repair-01/qa",
+    "runner_schema": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+    "run_manifest": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+  },
+  "summary": {
+    "recommendation_count": 34,
+    "logical_entity_count": 17,
+    "locale_counts": {
+      "en": 17,
+      "zh-CN": 17
+    },
+    "entity_type_counts": {
+      "hub": 2,
+      "domain": 10,
+      "polarity": 20,
+      "facet_hub": 2,
+      "facet_detail": 0,
+      "OCEAN_32": 0
+    },
+    "gsc_evidence_state": "GSC_EVIDENCE_PENDING",
+    "qa_gate_required_count": 8
+  },
+  "negative_guarantees": {
+    "cms_write": false,
+    "frontend_runtime_change": false,
+    "publish": false,
+    "indexability_change": false,
+    "sitemap_mutation": false,
+    "llms_mutation": false,
+    "search_queue": false,
+    "search_submission": false
+  },
+  "coverage": {
+    "rows": [
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/agreeableness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/agreeableness",
+        "package_id": "big_five:en:agreeableness:editorial-repair-01",
+        "locale": "en",
+        "code": "agreeableness",
+        "slug": "big-five/agreeableness",
+        "entity_type": "domain",
+        "source_package_hash": "790c470a",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five",
+        "target_url": "https://fermatmind.com/en/personality/big-five",
+        "package_id": "big_five:en:big-five:editorial-repair-01",
+        "locale": "en",
+        "code": "big-five",
+        "slug": "big-five",
+        "entity_type": "hub",
+        "source_package_hash": "537abf0a",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/conscientiousness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/conscientiousness",
+        "package_id": "big_five:en:conscientiousness:editorial-repair-01",
+        "locale": "en",
+        "code": "conscientiousness",
+        "slug": "big-five/conscientiousness",
+        "entity_type": "domain",
+        "source_package_hash": "6219cb78",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/emotional-stability",
+        "target_url": "https://fermatmind.com/en/personality/big-five/emotional-stability",
+        "package_id": "big_five:en:emotional-stability:editorial-repair-01",
+        "locale": "en",
+        "code": "emotional-stability",
+        "slug": "big-five/emotional-stability",
+        "entity_type": "polarity",
+        "source_package_hash": "16327b0b",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/extraversion",
+        "target_url": "https://fermatmind.com/en/personality/big-five/extraversion",
+        "package_id": "big_five:en:extraversion:editorial-repair-01",
+        "locale": "en",
+        "code": "extraversion",
+        "slug": "big-five/extraversion",
+        "entity_type": "domain",
+        "source_package_hash": "507a417b",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/facets",
+        "target_url": "https://fermatmind.com/en/personality/big-five/facets",
+        "package_id": "big_five:en:facets:editorial-repair-01",
+        "locale": "en",
+        "code": "facets",
+        "slug": "big-five/facets",
+        "entity_type": "facet_hub",
+        "source_package_hash": "9b199157",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-agreeableness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/high-agreeableness",
+        "package_id": "big_five:en:high-agreeableness:editorial-repair-01",
+        "locale": "en",
+        "code": "high-agreeableness",
+        "slug": "big-five/high-agreeableness",
+        "entity_type": "polarity",
+        "source_package_hash": "8d6f9dc3",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-conscientiousness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/high-conscientiousness",
+        "package_id": "big_five:en:high-conscientiousness:editorial-repair-01",
+        "locale": "en",
+        "code": "high-conscientiousness",
+        "slug": "big-five/high-conscientiousness",
+        "entity_type": "polarity",
+        "source_package_hash": "808dde39",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-extraversion",
+        "target_url": "https://fermatmind.com/en/personality/big-five/high-extraversion",
+        "package_id": "big_five:en:high-extraversion:editorial-repair-01",
+        "locale": "en",
+        "code": "high-extraversion",
+        "slug": "big-five/high-extraversion",
+        "entity_type": "polarity",
+        "source_package_hash": "932e8870",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-neuroticism",
+        "target_url": "https://fermatmind.com/en/personality/big-five/high-neuroticism",
+        "package_id": "big_five:en:high-neuroticism:editorial-repair-01",
+        "locale": "en",
+        "code": "high-neuroticism",
+        "slug": "big-five/high-neuroticism",
+        "entity_type": "polarity",
+        "source_package_hash": "956553c0",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-openness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/high-openness",
+        "package_id": "big_five:en:high-openness:editorial-repair-01",
+        "locale": "en",
+        "code": "high-openness",
+        "slug": "big-five/high-openness",
+        "entity_type": "polarity",
+        "source_package_hash": "ad635547",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-agreeableness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/low-agreeableness",
+        "package_id": "big_five:en:low-agreeableness:editorial-repair-01",
+        "locale": "en",
+        "code": "low-agreeableness",
+        "slug": "big-five/low-agreeableness",
+        "entity_type": "polarity",
+        "source_package_hash": "43d1a3e9",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-conscientiousness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/low-conscientiousness",
+        "package_id": "big_five:en:low-conscientiousness:editorial-repair-01",
+        "locale": "en",
+        "code": "low-conscientiousness",
+        "slug": "big-five/low-conscientiousness",
+        "entity_type": "polarity",
+        "source_package_hash": "174eba19",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-extraversion",
+        "target_url": "https://fermatmind.com/en/personality/big-five/low-extraversion",
+        "package_id": "big_five:en:low-extraversion:editorial-repair-01",
+        "locale": "en",
+        "code": "low-extraversion",
+        "slug": "big-five/low-extraversion",
+        "entity_type": "polarity",
+        "source_package_hash": "4c6f969c",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-openness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/low-openness",
+        "package_id": "big_five:en:low-openness:editorial-repair-01",
+        "locale": "en",
+        "code": "low-openness",
+        "slug": "big-five/low-openness",
+        "entity_type": "polarity",
+        "source_package_hash": "2af4495d",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/neuroticism",
+        "target_url": "https://fermatmind.com/en/personality/big-five/neuroticism",
+        "package_id": "big_five:en:neuroticism:editorial-repair-01",
+        "locale": "en",
+        "code": "neuroticism",
+        "slug": "big-five/neuroticism",
+        "entity_type": "domain",
+        "source_package_hash": "aee3252f",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/openness",
+        "target_url": "https://fermatmind.com/en/personality/big-five/openness",
+        "package_id": "big_five:en:openness:editorial-repair-01",
+        "locale": "en",
+        "code": "openness",
+        "slug": "big-five/openness",
+        "entity_type": "domain",
+        "source_package_hash": "c7118936",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/agreeableness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/agreeableness",
+        "package_id": "big_five:zh-CN:agreeableness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "agreeableness",
+        "slug": "big-five/agreeableness",
+        "entity_type": "domain",
+        "source_package_hash": "6d82a84a",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five",
+        "target_url": "https://fermatmind.com/zh/personality/big-five",
+        "package_id": "big_five:zh-CN:big-five:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "big-five",
+        "slug": "big-five",
+        "entity_type": "hub",
+        "source_package_hash": "3af4ea08",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/conscientiousness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/conscientiousness",
+        "package_id": "big_five:zh-CN:conscientiousness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "conscientiousness",
+        "slug": "big-five/conscientiousness",
+        "entity_type": "domain",
+        "source_package_hash": "14370936",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/emotional-stability",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/emotional-stability",
+        "package_id": "big_five:zh-CN:emotional-stability:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "emotional-stability",
+        "slug": "big-five/emotional-stability",
+        "entity_type": "polarity",
+        "source_package_hash": "1d88ec95",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/extraversion",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/extraversion",
+        "package_id": "big_five:zh-CN:extraversion:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "extraversion",
+        "slug": "big-five/extraversion",
+        "entity_type": "domain",
+        "source_package_hash": "607ee061",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/facets",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/facets",
+        "package_id": "big_five:zh-CN:facets:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "facets",
+        "slug": "big-five/facets",
+        "entity_type": "facet_hub",
+        "source_package_hash": "3e45d9ff",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-agreeableness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/high-agreeableness",
+        "package_id": "big_five:zh-CN:high-agreeableness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "high-agreeableness",
+        "slug": "big-five/high-agreeableness",
+        "entity_type": "polarity",
+        "source_package_hash": "0924564f",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-conscientiousness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/high-conscientiousness",
+        "package_id": "big_five:zh-CN:high-conscientiousness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "high-conscientiousness",
+        "slug": "big-five/high-conscientiousness",
+        "entity_type": "polarity",
+        "source_package_hash": "7d409fb1",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-extraversion",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/high-extraversion",
+        "package_id": "big_five:zh-CN:high-extraversion:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "high-extraversion",
+        "slug": "big-five/high-extraversion",
+        "entity_type": "polarity",
+        "source_package_hash": "3ac918e6",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-neuroticism",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/high-neuroticism",
+        "package_id": "big_five:zh-CN:high-neuroticism:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "high-neuroticism",
+        "slug": "big-five/high-neuroticism",
+        "entity_type": "polarity",
+        "source_package_hash": "f015403e",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-openness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/high-openness",
+        "package_id": "big_five:zh-CN:high-openness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "high-openness",
+        "slug": "big-five/high-openness",
+        "entity_type": "polarity",
+        "source_package_hash": "f11560e7",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-agreeableness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/low-agreeableness",
+        "package_id": "big_five:zh-CN:low-agreeableness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "low-agreeableness",
+        "slug": "big-five/low-agreeableness",
+        "entity_type": "polarity",
+        "source_package_hash": "10b77ce3",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-conscientiousness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/low-conscientiousness",
+        "package_id": "big_five:zh-CN:low-conscientiousness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "low-conscientiousness",
+        "slug": "big-five/low-conscientiousness",
+        "entity_type": "polarity",
+        "source_package_hash": "8a10b4c5",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-extraversion",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/low-extraversion",
+        "package_id": "big_five:zh-CN:low-extraversion:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "low-extraversion",
+        "slug": "big-five/low-extraversion",
+        "entity_type": "polarity",
+        "source_package_hash": "87e73f78",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-openness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/low-openness",
+        "package_id": "big_five:zh-CN:low-openness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "low-openness",
+        "slug": "big-five/low-openness",
+        "entity_type": "polarity",
+        "source_package_hash": "5825d5af",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/neuroticism",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/neuroticism",
+        "package_id": "big_five:zh-CN:neuroticism:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "neuroticism",
+        "slug": "big-five/neuroticism",
+        "entity_type": "domain",
+        "source_package_hash": "8e2b1035",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      },
+      {
+        "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/openness",
+        "target_url": "https://fermatmind.com/zh/personality/big-five/openness",
+        "package_id": "big_five:zh-CN:openness:editorial-repair-01",
+        "locale": "zh-CN",
+        "code": "openness",
+        "slug": "big-five/openness",
+        "entity_type": "domain",
+        "source_package_hash": "37b84fd8",
+        "index_eligible": false,
+        "sitemap_eligible": false,
+        "llms_eligible": false,
+        "launch_state": "content_ready"
+      }
+    ]
+  },
+  "recommendations": [
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/agreeableness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/agreeableness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Agreeableness | Big Five guide",
+        "description": "Agreeableness describes stable tendencies around trust, cooperation, empathy, boundaries, conflict, and directness, helping explain learning, communication, and adaptation patterns.",
+        "h1": "Agreeableness",
+        "quick_answer": "Agreeableness concerns trust, cooperation, empathy, boundaries, conflict, and directness. It is not a type label and does not rank ability.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Agreeableness | Big Five guide",
+          "recommended": "Agreeableness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Agreeableness describes stable tendencies around trust, cooperation, empathy, boundaries, conflict, and directness, helping explain learning, communication, and adaptation patterns.",
+          "recommended": "Agreeableness describes stable tendencies around trust, cooperation, empathy, boundaries, conflict, and directness, helping explain learning, communicatio. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Agreeableness",
+          "recommended": "Agreeableness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Agreeableness concerns trust, cooperation, empathy, boundaries, conflict, and directness. It is not a type label and does not rank ability.",
+          "recommended": "Agreeableness concerns trust, cooperation, empathy, boundaries, conflict, and directness. It is not a type label and does not rank ability.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Agreeableness mainly describe?",
+            "answer": "Agreeableness describes tendencies around trust, cooperation, empathy, boundaries, conflict, and directness in choices and communication.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is higher or lower better?",
+            "answer": "No. Higher and lower are tendencies; usefulness depends on context.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I observe this domain?",
+            "answer": "Watch responses to stress, feedback, change, and collaboration rather than one behavior.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide work choices?",
+            "answer": "No. It can provide preference clues, but cannot replace ability, experience, and opportunity.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How does it relate to facets?",
+            "answer": "Facets are narrower layers inside the broad domain.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-agreeableness",
+            "anchor_text": "High Agreeableness",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-agreeableness",
+            "anchor_text": "Low Agreeableness",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five",
+      "target_url": "https://fermatmind.com/en/personality/big-five",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/big-five.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Big Five Personality | Big Five guide",
+        "description": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neuroticism.",
+        "h1": "Big Five Personality",
+        "quick_answer": "The Big Five is not a fixed personality type table. It describes stable tendencies through five continuous dimensions and supports self-understanding, communication, and learning reflection.",
+        "faq_count": 5,
+        "internal_link_count": 7
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Big Five Personality | Big Five guide",
+          "recommended": "Big Five Personality | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neuroticism.",
+          "recommended": "The Big Five describes personality differences through five continuous dimensions: openness, conscientiousness, extraversion, agreeableness, and neurotici. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Big Five Personality",
+          "recommended": "Big Five Personality",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "The Big Five is not a fixed personality type table. It describes stable tendencies through five continuous dimensions and supports self-understanding, communication, and learning reflection.",
+          "recommended": "The Big Five is not a fixed personality type table. It describes stable tendencies through five continuous dimensions and supports self-understanding, communication, and learning reflection.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "Is Big Five a personality type system?",
+            "answer": "No. Big Five is a dimensional model; it does not sort people into fixed types.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "What does OCEAN mean?",
+            "answer": "OCEAN is a common abbreviation for the five domains.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Are higher or lower traits better?",
+            "answer": "No. High and low describe tendency strength, and usefulness depends on task, relationship, and environment.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can Big Five decide a career?",
+            "answer": "No. It can describe preferences, but career choice also needs skills, experience, opportunity, and constraints.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "What are the 30 facets?",
+            "answer": "Facets are narrower explanations inside the five broad domains. This version provides an overview only.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/openness",
+            "anchor_text": "Openness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/conscientiousness",
+            "anchor_text": "Conscientiousness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/extraversion",
+            "anchor_text": "Extraversion",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type hub is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/conscientiousness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/conscientiousness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Conscientiousness | Big Five guide",
+        "description": "Conscientiousness describes stable tendencies around order, self-discipline, responsibility, planning, execution, and deliberation, helping explain learning, communication, and adaptation patterns.",
+        "h1": "Conscientiousness",
+        "quick_answer": "Conscientiousness concerns order, self-discipline, responsibility, planning, execution, and deliberation. It is not a type label and does not rank ability.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Conscientiousness | Big Five guide",
+          "recommended": "Conscientiousness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Conscientiousness describes stable tendencies around order, self-discipline, responsibility, planning, execution, and deliberation, helping explain learning, communication, and adaptation patterns.",
+          "recommended": "Conscientiousness describes stable tendencies around order, self-discipline, responsibility, planning, execution, and deliberation, helping explain learni. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Conscientiousness",
+          "recommended": "Conscientiousness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Conscientiousness concerns order, self-discipline, responsibility, planning, execution, and deliberation. It is not a type label and does not rank ability.",
+          "recommended": "Conscientiousness concerns order, self-discipline, responsibility, planning, execution, and deliberation. It is not a type label and does not rank ability.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Conscientiousness mainly describe?",
+            "answer": "Conscientiousness describes tendencies around order, self-discipline, responsibility, planning, execution, and deliberation in choices and communication.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is higher or lower better?",
+            "answer": "No. Higher and lower are tendencies; usefulness depends on context.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I observe this domain?",
+            "answer": "Watch responses to stress, feedback, change, and collaboration rather than one behavior.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide work choices?",
+            "answer": "No. It can provide preference clues, but cannot replace ability, experience, and opportunity.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How does it relate to facets?",
+            "answer": "Facets are narrower layers inside the broad domain.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-conscientiousness",
+            "anchor_text": "High Conscientiousness",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-conscientiousness",
+            "anchor_text": "Low Conscientiousness",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/emotional-stability",
+      "target_url": "https://fermatmind.com/en/personality/big-five/emotional-stability",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/emotional-stability.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Emotional Stability | Big Five guide",
+        "description": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "Emotional Stability",
+        "quick_answer": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/emotional-stability",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Emotional Stability | Big Five guide",
+          "recommended": "Emotional Stability | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Emotional Stability",
+          "recommended": "Emotional Stability",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Emotional Stability describes tendencies around lower relative stress response, faster recovery, less sustained high arousal; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Emotional Stability mean?",
+            "answer": "Emotional Stability means tendencies around lower relative stress response, faster recovery, less sustained high arousal are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/neuroticism",
+            "anchor_text": "Neuroticism / Emotional Sensitivity",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-neuroticism",
+            "anchor_text": "High Neuroticism / High Emotional Sensitivity",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/extraversion",
+      "target_url": "https://fermatmind.com/en/personality/big-five/extraversion",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Extraversion | Big Five guide",
+        "description": "Extraversion describes stable tendencies around social energy, expression, activity pace, stimulation, and external feedback, helping explain learning, communication, and adaptation patterns.",
+        "h1": "Extraversion",
+        "quick_answer": "Extraversion concerns social energy, expression, activity pace, stimulation, and external feedback. It is not a type label and does not rank ability.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Extraversion | Big Five guide",
+          "recommended": "Extraversion | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Extraversion describes stable tendencies around social energy, expression, activity pace, stimulation, and external feedback, helping explain learning, communication, and adaptation patterns.",
+          "recommended": "Extraversion describes stable tendencies around social energy, expression, activity pace, stimulation, and external feedback, helping explain learning, co. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Extraversion",
+          "recommended": "Extraversion",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Extraversion concerns social energy, expression, activity pace, stimulation, and external feedback. It is not a type label and does not rank ability.",
+          "recommended": "Extraversion concerns social energy, expression, activity pace, stimulation, and external feedback. It is not a type label and does not rank ability.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Extraversion mainly describe?",
+            "answer": "Extraversion describes tendencies around social energy, expression, activity pace, stimulation, and external feedback in choices and communication.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is higher or lower better?",
+            "answer": "No. Higher and lower are tendencies; usefulness depends on context.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I observe this domain?",
+            "answer": "Watch responses to stress, feedback, change, and collaboration rather than one behavior.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide work choices?",
+            "answer": "No. It can provide preference clues, but cannot replace ability, experience, and opportunity.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How does it relate to facets?",
+            "answer": "Facets are narrower layers inside the broad domain.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-extraversion",
+            "anchor_text": "High Extraversion",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-extraversion",
+            "anchor_text": "Low Extraversion",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/facets",
+      "target_url": "https://fermatmind.com/en/personality/big-five/facets",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/facets.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Big Five 30 Facets | Big Five guide",
+        "description": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait.",
+        "h1": "Big Five 30 Facets",
+        "quick_answer": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait. This page is an overview and glossary map only; it does not open facet detail pages.",
+        "faq_count": 5,
+        "internal_link_count": 7
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/facets",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Big Five 30 Facets | Big Five guide",
+          "recommended": "Big Five 30 Facets | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait.",
+          "recommended": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Big Five 30 Facets",
+          "recommended": "Big Five 30 Facets",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait. This page is an overview and glossary map only; it does not open facet detail pages.",
+          "recommended": "The 30 facets are narrower explanations beneath the five Big Five domains, showing why people can differ inside the same broad trait. This page is an overview and glossary map only; it does not open facet detail pages.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "Why are there 30 facets?",
+            "answer": "Common Big Five explanations can divide each broad domain into narrower facets; this page uses a 5 x 6 overview structure.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Does this open facet detail pages?",
+            "answer": "No. This stage is overview-only and does not generate 30 facet detail pages.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Are facets 30 personality types?",
+            "answer": "No. They are narrower explanations inside dimensions, not personality types.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How should I use facets?",
+            "answer": "Use them to make the five broad domains more precise, not to replace a full assessment.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Do facets have research support?",
+            "answer": "BFI-2 and other five-factor materials use hierarchical or facet language, although labels differ by instrument.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/openness",
+            "anchor_text": "Openness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/conscientiousness",
+            "anchor_text": "Conscientiousness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/extraversion",
+            "anchor_text": "Extraversion",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type facet_hub is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-agreeableness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/high-agreeableness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/high-agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "High Agreeableness | Big Five guide",
+        "description": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "High Agreeableness",
+        "quick_answer": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/high-agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "High Agreeableness | Big Five guide",
+          "recommended": "High Agreeableness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to und. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "High Agreeableness",
+          "recommended": "High Agreeableness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Agreeableness describes tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does High Agreeableness mean?",
+            "answer": "High Agreeableness means tendencies around prioritizing cooperation, tracking others’ feelings, softening conflict are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/agreeableness",
+            "anchor_text": "Agreeableness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-agreeableness",
+            "anchor_text": "Low Agreeableness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-conscientiousness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/high-conscientiousness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/high-conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "High Conscientiousness | Big Five guide",
+        "description": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "High Conscientiousness",
+        "quick_answer": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/high-conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "High Conscientiousness | Big Five guide",
+          "recommended": "High Conscientiousness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "High Conscientiousness",
+          "recommended": "High Conscientiousness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Conscientiousness describes tendencies around clear planning, stable commitments, checking risks early; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does High Conscientiousness mean?",
+            "answer": "High Conscientiousness means tendencies around clear planning, stable commitments, checking risks early are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/conscientiousness",
+            "anchor_text": "Conscientiousness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-conscientiousness",
+            "anchor_text": "Low Conscientiousness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-extraversion",
+      "target_url": "https://fermatmind.com/en/personality/big-five/high-extraversion",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/high-extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "High Extraversion | Big Five guide",
+        "description": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "High Extraversion",
+        "quick_answer": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/high-extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "High Extraversion | Big Five guide",
+          "recommended": "High Extraversion | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "High Extraversion",
+          "recommended": "High Extraversion",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Extraversion describes tendencies around gaining energy through interaction, thinking aloud, using external feedback; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does High Extraversion mean?",
+            "answer": "High Extraversion means tendencies around gaining energy through interaction, thinking aloud, using external feedback are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/extraversion",
+            "anchor_text": "Extraversion",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-extraversion",
+            "anchor_text": "Low Extraversion",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-neuroticism",
+      "target_url": "https://fermatmind.com/en/personality/big-five/high-neuroticism",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/high-neuroticism.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "High Neuroticism / High Emotional Sensitivity | Big Five guide",
+        "description": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "High Neuroticism / High Emotional Sensitivity",
+        "quick_answer": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/high-neuroticism",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "High Neuroticism / High Emotional Sensitivity | Big Five guide",
+          "recommended": "High Neuroticism / High Emotional Sensitivity | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; i. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "High Neuroticism / High Emotional Sensitivity",
+          "recommended": "High Neuroticism / High Emotional Sensitivity",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Neuroticism / High Emotional Sensitivity describes tendencies around noticing risks earlier, stronger stress response, needing more recovery space; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does High Neuroticism / High Emotional Sensitivity mean?",
+            "answer": "High Neuroticism / High Emotional Sensitivity means tendencies around noticing risks earlier, stronger stress response, needing more recovery space are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/neuroticism",
+            "anchor_text": "Neuroticism / Emotional Sensitivity",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/emotional-stability",
+            "anchor_text": "Emotional Stability",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/high-openness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/high-openness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/high-openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "High Openness | Big Five guide",
+        "description": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "High Openness",
+        "quick_answer": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/high-openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "High Openness | Big Five guide",
+          "recommended": "High Openness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to unders. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "High Openness",
+          "recommended": "High Openness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "High Openness describes tendencies around exploring new ideas, trying different paths, keeping room for imagination; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does High Openness mean?",
+            "answer": "High Openness means tendencies around exploring new ideas, trying different paths, keeping room for imagination are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/openness",
+            "anchor_text": "Openness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-openness",
+            "anchor_text": "Low Openness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-agreeableness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/low-agreeableness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/low-agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Low Agreeableness | Big Five guide",
+        "description": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "Low Agreeableness",
+        "quick_answer": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/low-agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Low Agreeableness | Big Five guide",
+          "recommended": "Low Agreeableness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to underst. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Low Agreeableness",
+          "recommended": "Low Agreeableness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Agreeableness describes tendencies around stating judgments directly, keeping boundaries, raising disagreement; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Low Agreeableness mean?",
+            "answer": "Low Agreeableness means tendencies around stating judgments directly, keeping boundaries, raising disagreement are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/agreeableness",
+            "anchor_text": "Agreeableness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-agreeableness",
+            "anchor_text": "High Agreeableness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-conscientiousness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/low-conscientiousness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/low-conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Low Conscientiousness | Big Five guide",
+        "description": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "Low Conscientiousness",
+        "quick_answer": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/low-conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Low Conscientiousness | Big Five guide",
+          "recommended": "Low Conscientiousness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to unde. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Low Conscientiousness",
+          "recommended": "Low Conscientiousness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Conscientiousness describes tendencies around keeping flexibility, reducing over-control, adjusting during change; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Low Conscientiousness mean?",
+            "answer": "Low Conscientiousness means tendencies around keeping flexibility, reducing over-control, adjusting during change are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/conscientiousness",
+            "anchor_text": "Conscientiousness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-conscientiousness",
+            "anchor_text": "High Conscientiousness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-extraversion",
+      "target_url": "https://fermatmind.com/en/personality/big-five/low-extraversion",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/low-extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Low Extraversion | Big Five guide",
+        "description": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "Low Extraversion",
+        "quick_answer": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/low-extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Low Extraversion | Big Five guide",
+          "recommended": "Low Extraversion | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Low Extraversion",
+          "recommended": "Low Extraversion",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Extraversion describes tendencies around needing solitude to recover, organizing internally first, controlling stimulation load; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Low Extraversion mean?",
+            "answer": "Low Extraversion means tendencies around needing solitude to recover, organizing internally first, controlling stimulation load are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/extraversion",
+            "anchor_text": "Extraversion",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-extraversion",
+            "anchor_text": "High Extraversion",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/low-openness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/low-openness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/low-openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Low Openness | Big Five guide",
+        "description": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to understand fit and communication strategy.",
+        "h1": "Low Openness",
+        "quick_answer": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to understand fit and communication strategy.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/low-openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Low Openness | Big Five guide",
+          "recommended": "Low Openness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to under. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Low Openness",
+          "recommended": "Low Openness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to understand fit and communication strategy.",
+          "recommended": "Low Openness describes tendencies around preferring familiar paths, valuing tested experience, reducing change costs; it is not a rank, but a way to understand fit and communication strategy.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Low Openness mean?",
+            "answer": "Low Openness means tendencies around preferring familiar paths, valuing tested experience, reducing change costs are more likely to appear in daily choices.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is this better?",
+            "answer": "No. It is a tendency pattern; usefulness depends on context and regulation.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Why read the other pole?",
+            "answer": "The other pole shows needs you may miss, such as stability, exploration, boundaries, or recovery.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide what work fits me?",
+            "answer": "No. It can describe work-style preferences, but it cannot decide a career by itself.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I use this practically?",
+            "answer": "Choose one situation, keep the strength of this pole, and add one small move from the other pole.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/openness",
+            "anchor_text": "Openness",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-openness",
+            "anchor_text": "High Openness",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/neuroticism",
+      "target_url": "https://fermatmind.com/en/personality/big-five/neuroticism",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/neuroticism.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Neuroticism / Emotional Sensitivity | Big Five guide",
+        "description": "Neuroticism / Emotional Sensitivity describes stable tendencies around stress response, risk alerts, emotional shifts, and recovery cost, helping explain learning, communication, and adaptation patterns.",
+        "h1": "Neuroticism / Emotional Sensitivity",
+        "quick_answer": "Neuroticism / Emotional Sensitivity concerns stress response, risk alerts, emotional shifts, and recovery cost. It is not a type label and does not rank ability.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/neuroticism",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Neuroticism / Emotional Sensitivity | Big Five guide",
+          "recommended": "Neuroticism / Emotional Sensitivity | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Neuroticism / Emotional Sensitivity describes stable tendencies around stress response, risk alerts, emotional shifts, and recovery cost, helping explain learning, communication, and adaptation patterns.",
+          "recommended": "Neuroticism / Emotional Sensitivity describes stable tendencies around stress response, risk alerts, emotional shifts, and recovery cost, helping explain. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Neuroticism / Emotional Sensitivity",
+          "recommended": "Neuroticism / Emotional Sensitivity",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Neuroticism / Emotional Sensitivity concerns stress response, risk alerts, emotional shifts, and recovery cost. It is not a type label and does not rank ability.",
+          "recommended": "Neuroticism / Emotional Sensitivity concerns stress response, risk alerts, emotional shifts, and recovery cost. It is not a type label and does not rank ability.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Neuroticism / Emotional Sensitivity mainly describe?",
+            "answer": "Neuroticism / Emotional Sensitivity describes tendencies around stress response, risk alerts, emotional shifts, and recovery cost in choices and communication.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is higher or lower better?",
+            "answer": "No. Higher and lower are tendencies; usefulness depends on context.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I observe this domain?",
+            "answer": "Watch responses to stress, feedback, change, and collaboration rather than one behavior.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide work choices?",
+            "answer": "No. It can provide preference clues, but cannot replace ability, experience, and opportunity.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How does it relate to facets?",
+            "answer": "Facets are narrower layers inside the broad domain.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-neuroticism",
+            "anchor_text": "High Neuroticism / High Emotional Sensitivity",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/emotional-stability",
+            "anchor_text": "Emotional Stability",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/en/personality/big-five/openness",
+      "target_url": "https://fermatmind.com/en/personality/big-five/openness",
+      "framework": "big_five",
+      "locale": "en",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/en/openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "Openness | Big Five guide",
+        "description": "Openness describes stable tendencies around new experience, imagination, aesthetics, abstract ideas, and change, helping explain learning, communication, and adaptation patterns.",
+        "h1": "Openness",
+        "quick_answer": "Openness concerns new experience, imagination, aesthetics, abstract ideas, and change. It is not a type label and does not rank ability.",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/en/personality/big-five/openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "Openness | Big Five guide",
+          "recommended": "Openness | FermatMind",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "Openness describes stable tendencies around new experience, imagination, aesthetics, abstract ideas, and change, helping explain learning, communication, and adaptation patterns.",
+          "recommended": "Openness describes stable tendencies around new experience, imagination, aesthetics, abstract ideas, and change, helping explain learning, communication,. Use it for self-understanding and communication reflection, not diagnosis, hiring or deterministic decisions.",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "Openness",
+          "recommended": "Openness",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "Openness concerns new experience, imagination, aesthetics, abstract ideas, and change. It is not a type label and does not rank ability.",
+          "recommended": "Openness concerns new experience, imagination, aesthetics, abstract ideas, and change. It is not a type label and does not rank ability.",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "What does Openness mainly describe?",
+            "answer": "Openness describes tendencies around new experience, imagination, aesthetics, abstract ideas, and change in choices and communication.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Is higher or lower better?",
+            "answer": "No. Higher and lower are tendencies; usefulness depends on context.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How can I observe this domain?",
+            "answer": "Watch responses to stress, feedback, change, and collaboration rather than one behavior.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "Can it decide work choices?",
+            "answer": "No. It can provide preference clues, but cannot replace ability, experience, and opportunity.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "How does it relate to facets?",
+            "answer": "Facets are narrower layers inside the broad domain.",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/en/personality/big-five",
+            "anchor_text": "Big Five Personality",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "Big Five test",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/facets",
+            "anchor_text": "30 facets overview",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/high-openness",
+            "anchor_text": "High Openness",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/en/personality/big-five/low-openness",
+            "anchor_text": "Low Openness",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/agreeableness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/agreeableness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "宜人性｜大五人格指南",
+        "description": "宜人性描述信任、合作、共情、边界、冲突和直接性等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+        "h1": "宜人性",
+        "quick_answer": "宜人性说明信任、合作、共情、边界、冲突和直接性。它不是类型标签，也不表示能力高低。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "宜人性｜大五人格指南",
+          "recommended": "宜人性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "宜人性描述信任、合作、共情、边界、冲突和直接性等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+          "recommended": "宜人性描述信任、合作、共情、边界、冲突和直接性等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "宜人性",
+          "recommended": "宜人性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "宜人性说明信任、合作、共情、边界、冲突和直接性。它不是类型标签，也不表示能力高低。",
+          "recommended": "宜人性说明信任、合作、共情、边界、冲突和直接性。它不是类型标签，也不表示能力高低。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "宜人性主要说明什么？",
+            "answer": "宜人性说明信任、合作、共情、边界、冲突和直接性等倾向如何在选择和沟通中出现。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "偏高或偏低有好坏之分吗？",
+            "answer": "没有。偏高和偏低都只是倾向，是否有帮助取决于场景。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "怎么观察这个维度？",
+            "answer": "观察你在压力、反馈、变化和合作中的反应，而不是只看一次行为。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定工作选择吗？",
+            "answer": "不能。它可以提供偏好线索，但不能替代能力、经验和机会判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它和 facets 有什么关系？",
+            "answer": "facets 是这个大维度内部更细的解释层。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-agreeableness",
+            "anchor_text": "高宜人性",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-agreeableness",
+            "anchor_text": "低宜人性",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five",
+      "target_url": "https://fermatmind.com/zh/personality/big-five",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/big-five.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "大五人格｜大五人格指南",
+        "description": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度，帮助描述人格差异与沟通偏好。",
+        "h1": "大五人格",
+        "quick_answer": "大五人格不是固定人格类型表，而是用五个连续维度描述稳定倾向。它适合组织自我理解、沟通偏好和学习反思。",
+        "faq_count": 5,
+        "internal_link_count": 7
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "大五人格｜大五人格指南",
+          "recommended": "大五人格 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度，帮助描述人格差异与沟通偏好。",
+          "recommended": "大五人格用开放性、尽责性、外向性、宜人性和神经质五个连续维度，帮助描述人格差异与沟通偏好。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "大五人格",
+          "recommended": "大五人格",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "大五人格不是固定人格类型表，而是用五个连续维度描述稳定倾向。它适合组织自我理解、沟通偏好和学习反思。",
+          "recommended": "大五人格不是固定人格类型表，而是用五个连续维度描述稳定倾向。它适合组织自我理解、沟通偏好和学习反思。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "大五人格是人格类型吗？",
+            "answer": "不是。大五是连续维度模型，不把人固定分成几类。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "OCEAN 是什么意思？",
+            "answer": "OCEAN 是五个英文维度的常见缩写。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "高低分代表好坏吗？",
+            "answer": "不代表。高低只是倾向强弱，具体价值取决于任务、关系和环境。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "大五能决定职业吗？",
+            "answer": "不能。它能帮助描述偏好，但不能替代综合判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "30 facets 是什么？",
+            "answer": "facets 是五个大维度下面更细的解释层，本版本只提供总览。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/openness",
+            "anchor_text": "开放性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/conscientiousness",
+            "anchor_text": "尽责性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/extraversion",
+            "anchor_text": "外向性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type hub is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/conscientiousness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/conscientiousness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "尽责性｜大五人格指南",
+        "description": "尽责性描述秩序、自律、责任、计划、执行和审慎等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+        "h1": "尽责性",
+        "quick_answer": "尽责性说明秩序、自律、责任、计划、执行和审慎。它不是类型标签，也不表示能力高低。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "尽责性｜大五人格指南",
+          "recommended": "尽责性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "尽责性描述秩序、自律、责任、计划、执行和审慎等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+          "recommended": "尽责性描述秩序、自律、责任、计划、执行和审慎等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "尽责性",
+          "recommended": "尽责性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "尽责性说明秩序、自律、责任、计划、执行和审慎。它不是类型标签，也不表示能力高低。",
+          "recommended": "尽责性说明秩序、自律、责任、计划、执行和审慎。它不是类型标签，也不表示能力高低。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "尽责性主要说明什么？",
+            "answer": "尽责性说明秩序、自律、责任、计划、执行和审慎等倾向如何在选择和沟通中出现。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "偏高或偏低有好坏之分吗？",
+            "answer": "没有。偏高和偏低都只是倾向，是否有帮助取决于场景。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "怎么观察这个维度？",
+            "answer": "观察你在压力、反馈、变化和合作中的反应，而不是只看一次行为。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定工作选择吗？",
+            "answer": "不能。它可以提供偏好线索，但不能替代能力、经验和机会判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它和 facets 有什么关系？",
+            "answer": "facets 是这个大维度内部更细的解释层。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-conscientiousness",
+            "anchor_text": "高尽责性",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-conscientiousness",
+            "anchor_text": "低尽责性",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/emotional-stability",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/emotional-stability",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/emotional-stability.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "情绪稳定性｜大五人格指南",
+        "description": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "情绪稳定性",
+        "quick_answer": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/emotional-stability",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "情绪稳定性｜大五人格指南",
+          "recommended": "情绪稳定性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "情绪稳定性",
+          "recommended": "情绪稳定性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "情绪稳定性描述压力反应相对较低、恢复较快、不易长期维持高唤醒的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "情绪稳定性主要是什么意思？",
+            "answer": "情绪稳定性表示压力反应相对较低、恢复较快、不易长期维持高唤醒更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/neuroticism",
+            "anchor_text": "神经质 / 情绪敏感性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-neuroticism",
+            "anchor_text": "高神经质 / 高情绪敏感性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/extraversion",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/extraversion",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "外向性｜大五人格指南",
+        "description": "外向性描述社交能量、表达、活动节奏、刺激需求和外部反馈等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+        "h1": "外向性",
+        "quick_answer": "外向性说明社交能量、表达、活动节奏、刺激需求和外部反馈。它不是类型标签，也不表示能力高低。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "外向性｜大五人格指南",
+          "recommended": "外向性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "外向性描述社交能量、表达、活动节奏、刺激需求和外部反馈等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+          "recommended": "外向性描述社交能量、表达、活动节奏、刺激需求和外部反馈等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "外向性",
+          "recommended": "外向性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "外向性说明社交能量、表达、活动节奏、刺激需求和外部反馈。它不是类型标签，也不表示能力高低。",
+          "recommended": "外向性说明社交能量、表达、活动节奏、刺激需求和外部反馈。它不是类型标签，也不表示能力高低。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "外向性主要说明什么？",
+            "answer": "外向性说明社交能量、表达、活动节奏、刺激需求和外部反馈等倾向如何在选择和沟通中出现。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "偏高或偏低有好坏之分吗？",
+            "answer": "没有。偏高和偏低都只是倾向，是否有帮助取决于场景。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "怎么观察这个维度？",
+            "answer": "观察你在压力、反馈、变化和合作中的反应，而不是只看一次行为。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定工作选择吗？",
+            "answer": "不能。它可以提供偏好线索，但不能替代能力、经验和机会判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它和 facets 有什么关系？",
+            "answer": "facets 是这个大维度内部更细的解释层。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-extraversion",
+            "anchor_text": "高外向性",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-extraversion",
+            "anchor_text": "低外向性",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/facets",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/facets",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/facets.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "大五人格 30 个细分面向｜大五人格指南",
+        "description": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。",
+        "h1": "大五人格 30 个细分面向",
+        "quick_answer": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。 本页只提供 overview 和术语地图，不开放 facet 详情页。",
+        "faq_count": 5,
+        "internal_link_count": 7
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/facets",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "大五人格 30 个细分面向｜大五人格指南",
+          "recommended": "大五人格 30 个细分面向 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。",
+          "recommended": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "大五人格 30 个细分面向",
+          "recommended": "大五人格 30 个细分面向",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。 本页只提供 overview 和术语地图，不开放 facet 详情页。",
+          "recommended": "30 个 facets 是大五五个维度下面的细分解释层，用来说明同一维度内部为什么会出现不同表现。 本页只提供 overview 和术语地图，不开放 facet 详情页。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "为什么是 30 个 facets？",
+            "answer": "常见五因素解释中，每个大维度可以拆成若干更细面向；本页采用 5 x 6 的 overview 结构。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这里会打开 facet 详情页吗？",
+            "answer": "不会。本阶段只做 overview，不生成 30 个 facet detail pages。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "facets 是 30 种人格吗？",
+            "answer": "不是。它们是维度内部的解释面向，不是人格类型。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我该怎么使用 facets？",
+            "answer": "用它们补充五个大维度，找到更具体的表现，而不是替代完整测评。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "facets 有研究基础吗？",
+            "answer": "BFI-2 和其他五因素资料都使用过层级或 facet 语言，但不同量表命名会有差异。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/openness",
+            "anchor_text": "开放性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/conscientiousness",
+            "anchor_text": "尽责性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/extraversion",
+            "anchor_text": "外向性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type facet_hub is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-agreeableness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/high-agreeableness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/high-agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "高宜人性｜大五人格指南",
+        "description": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "高宜人性",
+        "quick_answer": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/high-agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "高宜人性｜大五人格指南",
+          "recommended": "高宜人性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "高宜人性",
+          "recommended": "高宜人性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高宜人性描述优先合作、关注他人感受、缓和冲突的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "高宜人性主要是什么意思？",
+            "answer": "高宜人性表示优先合作、关注他人感受、缓和冲突更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/agreeableness",
+            "anchor_text": "宜人性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-agreeableness",
+            "anchor_text": "低宜人性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-conscientiousness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/high-conscientiousness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/high-conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "高尽责性｜大五人格指南",
+        "description": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "高尽责性",
+        "quick_answer": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/high-conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "高尽责性｜大五人格指南",
+          "recommended": "高尽责性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "高尽责性",
+          "recommended": "高尽责性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高尽责性描述计划清楚、承诺稳定、提前检查风险的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "高尽责性主要是什么意思？",
+            "answer": "高尽责性表示计划清楚、承诺稳定、提前检查风险更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/conscientiousness",
+            "anchor_text": "尽责性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-conscientiousness",
+            "anchor_text": "低尽责性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-extraversion",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/high-extraversion",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/high-extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "高外向性｜大五人格指南",
+        "description": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "高外向性",
+        "quick_answer": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/high-extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "高外向性｜大五人格指南",
+          "recommended": "高外向性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "高外向性",
+          "recommended": "高外向性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高外向性描述通过互动获得能量、边说边整理想法、需要外部反馈的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "高外向性主要是什么意思？",
+            "answer": "高外向性表示通过互动获得能量、边说边整理想法、需要外部反馈更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/extraversion",
+            "anchor_text": "外向性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-extraversion",
+            "anchor_text": "低外向性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-neuroticism",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/high-neuroticism",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/high-neuroticism.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "高神经质 / 高情绪敏感性｜大五人格指南",
+        "description": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "高神经质 / 高情绪敏感性",
+        "quick_answer": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/high-neuroticism",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "高神经质 / 高情绪敏感性｜大五人格指南",
+          "recommended": "高神经质 / 高情绪敏感性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "高神经质 / 高情绪敏感性",
+          "recommended": "高神经质 / 高情绪敏感性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高神经质 / 高情绪敏感性描述更早察觉风险、压力反应更强、恢复需要更多空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "高神经质 / 高情绪敏感性主要是什么意思？",
+            "answer": "高神经质 / 高情绪敏感性表示更早察觉风险、压力反应更强、恢复需要更多空间更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/neuroticism",
+            "anchor_text": "神经质 / 情绪敏感性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/emotional-stability",
+            "anchor_text": "情绪稳定性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/high-openness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/high-openness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/high-openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "高开放性｜大五人格指南",
+        "description": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "高开放性",
+        "quick_answer": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/high-openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "高开放性｜大五人格指南",
+          "recommended": "高开放性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "高开放性",
+          "recommended": "高开放性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "高开放性描述探索新想法、尝试不同路径、保留想象空间的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "高开放性主要是什么意思？",
+            "answer": "高开放性表示探索新想法、尝试不同路径、保留想象空间更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/openness",
+            "anchor_text": "开放性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-openness",
+            "anchor_text": "低开放性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-agreeableness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/low-agreeableness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/low-agreeableness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "低宜人性｜大五人格指南",
+        "description": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "低宜人性",
+        "quick_answer": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/low-agreeableness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "低宜人性｜大五人格指南",
+          "recommended": "低宜人性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "低宜人性",
+          "recommended": "低宜人性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低宜人性描述直接表达判断、保留边界、提出不同意见的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "低宜人性主要是什么意思？",
+            "answer": "低宜人性表示直接表达判断、保留边界、提出不同意见更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/agreeableness",
+            "anchor_text": "宜人性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-agreeableness",
+            "anchor_text": "高宜人性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-conscientiousness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/low-conscientiousness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/low-conscientiousness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "低尽责性｜大五人格指南",
+        "description": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "低尽责性",
+        "quick_answer": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/low-conscientiousness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "低尽责性｜大五人格指南",
+          "recommended": "低尽责性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "低尽责性",
+          "recommended": "低尽责性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低尽责性描述保留弹性、减少过度控制、在变化中调整的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "低尽责性主要是什么意思？",
+            "answer": "低尽责性表示保留弹性、减少过度控制、在变化中调整更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/conscientiousness",
+            "anchor_text": "尽责性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-conscientiousness",
+            "anchor_text": "高尽责性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-extraversion",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/low-extraversion",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/low-extraversion.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "低外向性｜大五人格指南",
+        "description": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "低外向性",
+        "quick_answer": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/low-extraversion",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "低外向性｜大五人格指南",
+          "recommended": "低外向性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "低外向性",
+          "recommended": "低外向性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低外向性描述需要独处恢复、先内部整理、控制刺激量的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "低外向性主要是什么意思？",
+            "answer": "低外向性表示需要独处恢复、先内部整理、控制刺激量更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/extraversion",
+            "anchor_text": "外向性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-extraversion",
+            "anchor_text": "高外向性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/low-openness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/low-openness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/low-openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "低开放性｜大五人格指南",
+        "description": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "h1": "低开放性",
+        "quick_answer": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/low-openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "低开放性｜大五人格指南",
+          "recommended": "低开放性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "低开放性",
+          "recommended": "低开放性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "recommended": "低开放性描述偏好熟悉路径、重视可验证经验、降低变化成本的倾向；它不是优劣判断，而是帮助理解场景适配和沟通策略。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "低开放性主要是什么意思？",
+            "answer": "低开放性表示偏好熟悉路径、重视可验证经验、降低变化成本更容易出现在日常选择中。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "这代表更好吗？",
+            "answer": "不代表。它只是一种倾向，是否有帮助取决于场景和调节方式。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "为什么要看另一端？",
+            "answer": "另一端能提醒你可能忽略的需求，例如稳定、探索、边界或恢复。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定我适合什么工作吗？",
+            "answer": "不能。它可以帮助描述工作方式偏好，但不能单独决定职业。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "我可以怎么练习？",
+            "answer": "选择一个场景，保留这一端的优势，再刻意加入另一端的一小步。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/openness",
+            "anchor_text": "开放性",
+            "reason": "Reviewed package relationship: domain.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-openness",
+            "anchor_text": "高开放性",
+            "reason": "Reviewed package relationship: paired_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type polarity is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/neuroticism",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/neuroticism",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/neuroticism.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "神经质 / 情绪敏感性｜大五人格指南",
+        "description": "神经质 / 情绪敏感性描述压力反应、风险预警、情绪波动和恢复成本等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+        "h1": "神经质 / 情绪敏感性",
+        "quick_answer": "神经质 / 情绪敏感性说明压力反应、风险预警、情绪波动和恢复成本。它不是类型标签，也不表示能力高低。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/neuroticism",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "神经质 / 情绪敏感性｜大五人格指南",
+          "recommended": "神经质 / 情绪敏感性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "神经质 / 情绪敏感性描述压力反应、风险预警、情绪波动和恢复成本等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+          "recommended": "神经质 / 情绪敏感性描述压力反应、风险预警、情绪波动和恢复成本等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "神经质 / 情绪敏感性",
+          "recommended": "神经质 / 情绪敏感性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "神经质 / 情绪敏感性说明压力反应、风险预警、情绪波动和恢复成本。它不是类型标签，也不表示能力高低。",
+          "recommended": "神经质 / 情绪敏感性说明压力反应、风险预警、情绪波动和恢复成本。它不是类型标签，也不表示能力高低。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "神经质 / 情绪敏感性主要说明什么？",
+            "answer": "神经质 / 情绪敏感性说明压力反应、风险预警、情绪波动和恢复成本等倾向如何在选择和沟通中出现。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "偏高或偏低有好坏之分吗？",
+            "answer": "没有。偏高和偏低都只是倾向，是否有帮助取决于场景。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "怎么观察这个维度？",
+            "answer": "观察你在压力、反馈、变化和合作中的反应，而不是只看一次行为。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定工作选择吗？",
+            "answer": "不能。它可以提供偏好线索，但不能替代能力、经验和机会判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它和 facets 有什么关系？",
+            "answer": "facets 是这个大维度内部更细的解释层。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-neuroticism",
+            "anchor_text": "高神经质 / 高情绪敏感性",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/emotional-stability",
+            "anchor_text": "情绪稳定性",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    },
+    {
+      "recommendation_id": "big-five-public-profile-agent-pilot:/zh/personality/big-five/openness",
+      "target_url": "https://fermatmind.com/zh/personality/big-five/openness",
+      "framework": "big_five",
+      "locale": "zh-CN",
+      "source_inputs": {
+        "cms_or_api_snapshot": "generated/public-profile-assets/big-five-v1-editorial-repair-01/packages/zh-CN/openness.content-package.json",
+        "reference_pack": "generated/public-profile-assets/big-five-v1-editorial-repair-01/handoff/backend-import-map.preview.json",
+        "seo_signal": "GSC_EVIDENCE_PENDING",
+        "source_ledger": "generated/public-profile-assets/big-five-v1-editorial-repair-01/run-manifest.json"
+      },
+      "current_surface": {
+        "title": "开放性｜大五人格指南",
+        "description": "开放性描述新经验、想象、审美、抽象想法和变化等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+        "h1": "开放性",
+        "quick_answer": "开放性说明新经验、想象、审美、抽象想法和变化。它不是类型标签，也不表示能力高低。",
+        "faq_count": 5,
+        "internal_link_count": 5
+      },
+      "observed_signal": {
+        "evidence_state": "gsc_pending",
+        "impressions": null,
+        "clicks": null,
+        "ctr": null,
+        "average_position": null,
+        "notes": [
+          "GSC URL/query evidence is pending for this artifact-only Big Five public profile pilot."
+        ]
+      },
+      "reference_patterns_used": [
+        {
+          "pattern_id": "big_five_reviewed_package_projection",
+          "source_url": "https://fermatmind.com/zh/personality/big-five/openness",
+          "how_used": "Used the reviewed noindex Big Five package as the current surface and projected draft-only recommendation fields."
+        },
+        {
+          "pattern_id": "public_profile_agent_runner_contract",
+          "source_url": ".agents/skills/public-profile-seo-asset-factory/schemas/public-profile-agent-recommendation.schema.json",
+          "how_used": "Kept output compatible with the shared public profile agent recommendation schema."
+        }
+      ],
+      "recommendations": {
+        "title": {
+          "current": "开放性｜大五人格指南",
+          "recommended": "开放性 | 费马测试",
+          "reason": "Normalize the title as a public Big Five profile recommendation while preserving noindex draft status."
+        },
+        "description": {
+          "current": "开放性描述新经验、想象、审美、抽象想法和变化等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。",
+          "recommended": "开放性描述新经验、想象、审美、抽象想法和变化等稳定倾向，帮助理解学习、沟通和适应不同场景的方式。 适合自我理解与沟通反思，不用于诊断、招聘或确定性判断。",
+          "reason": "Keep SERP-oriented summary bounded by public education and method-safety language."
+        },
+        "h1": {
+          "current": "开放性",
+          "recommended": "开放性",
+          "reason": "The reviewed package already provides a concise public H1 candidate."
+        },
+        "quick_answer": {
+          "current": "开放性说明新经验、想象、审美、抽象想法和变化。它不是类型标签，也不表示能力高低。",
+          "recommended": "开放性说明新经验、想象、审美、抽象想法和变化。它不是类型标签，也不表示能力高低。",
+          "reason": "Use the reviewed public quick-answer section as the draft recommendation source."
+        },
+        "faq": [
+          {
+            "question": "开放性主要说明什么？",
+            "answer": "开放性说明新经验、想象、审美、抽象想法和变化等倾向如何在选择和沟通中出现。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "偏高或偏低有好坏之分吗？",
+            "answer": "没有。偏高和偏低都只是倾向，是否有帮助取决于场景。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "怎么观察这个维度？",
+            "answer": "观察你在压力、反馈、变化和合作中的反应，而不是只看一次行为。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它能决定工作选择吗？",
+            "answer": "不能。它可以提供偏好线索，但不能替代能力、经验和机会判断。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          },
+          {
+            "question": "它和 facets 有什么关系？",
+            "answer": "facets 是这个大维度内部更细的解释层。",
+            "reason": "Reuses reviewed public package FAQ intent while preserving Big Five method boundaries."
+          }
+        ],
+        "internal_links": [
+          {
+            "href": "/zh/personality/big-five",
+            "anchor_text": "大五人格",
+            "reason": "Reviewed package relationship: hub.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "anchor_text": "大五人格测试",
+            "reason": "Reviewed package relationship: test_landing.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/facets",
+            "anchor_text": "30 个细分面向",
+            "reason": "Reviewed package relationship: facet_overview.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/high-openness",
+            "anchor_text": "高开放性",
+            "reason": "Reviewed package relationship: high_pole.",
+            "safe_public_route": true
+          },
+          {
+            "href": "/zh/personality/big-five/low-openness",
+            "anchor_text": "低开放性",
+            "reason": "Reviewed package relationship: low_pole.",
+            "safe_public_route": true
+          }
+        ],
+        "differentiation_notes": [
+          "Entity type domain is treated as a dimensional Big Five public profile, not an official type page.",
+          "High/low wording must remain descriptive and context-dependent, never good/bad ranking.",
+          "Draft recommendation is blocked from CMS write, publish, indexability, sitemap, llms and search release until later gates."
+        ]
+      },
+      "qa_required": [
+        "schema_validation",
+        "trademark_claim_gate",
+        "claim_risk_gate",
+        "duplicate_template_gate",
+        "private_route_gate",
+        "result_page_leakage_gate",
+        "seo_projection_gate",
+        "bilingual_consistency_gate"
+      ],
+      "blocked_reason": null,
+      "status": "qa_ready"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Sync the Big Five public profile agent pilot package into fap-api backend docs for the production promotion dry-run path.
- Preserve the source package hash expected by BIG-FIVE-CMS-PROMOTION-DRY-RUN-01.

## Validation
- jq empty backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json
- shasum -a 256 backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json
- php artisan test tests/Feature/Console/PersonalityBigFivePublicProfileAgentPromoteCommandTest.php --display-warnings
- git diff --check -- backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json
- scope validation: only backend/docs/seo/personality/big-five-public-profile-agent-pilot-2026-06-24.json staged

## Deferred
- No production deploy.
- No CMS write or promotion.
- No publish, index/search, sitemap/llms, queue, or external API action.

Repository rule impact: docs artifact sync only; no content authority or runtime behavior changes.