### PR TITLE
[codex] docs(eq): add Agent-ready acceptance report

### DIFF
--- a/docs/audits/eq/eq_agent_ready_content_os_acceptance_2026-06-25.md
+++ b/docs/audits/eq/eq_agent_ready_content_os_acceptance_2026-06-25.md
@@ -1,0 +1,237 @@
+# EQ Agent-Ready Content OS Acceptance Report
+
+Date: 2026-06-25
+
+## 1. Executive Summary
+
+EQ Agent-ready production smoke passed.
+
+The production EQ result page renders through `EQResultV5`, shows the Agent entry guard, does not fetch `/eq/agent-context` before user action, and lazy-fetches the read-only Agent context after click. The Agent context returns the required guardrails: read-only, no report mutation, no score mutation, no formulation override, no SJT enablement, no paid unlock language, and no raw technical tag exposure.
+
+Conclusion: Agent runtime phase is allowed to proceed, provided the next phase keeps the Agent read-only and keeps backend content pack / report composer as the authority layer.
+
+## 2. Environment
+
+| Item | Value |
+|---|---|
+| Web | `https://fermatmind.com` |
+| API | `https://api.fermatmind.com` |
+| Smoke type | Production read-only UI/API smoke, with anonymous EQ attempts |
+| Primary smoke attempt | `8d4c971b-7a84-45e6-9c7f-3431a13ea210` |
+| Report-access recheck attempt | `a383cde0-eb1d-43bd-96a2-6f6be89e3f9d` |
+| Artifact directory | `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/` |
+
+## 3. Deployment SHA Evidence
+
+Public production headers did not expose backend or frontend runtime Git SHAs during this smoke. The smoke therefore records both repository `origin/main` SHAs at acceptance time and runtime feature evidence.
+
+| Repo | `origin/main` at acceptance | Relevant merged EQ Agent commits present in history |
+|---|---:|---|
+| `fap-api` | `c2ae022b150748b797c5b524784dc02c07d1657d` | `c78654fc6` PR-EQ-AGENT-02, `a77bd63b7` PR-EQ-AGENT-04 |
+| `fap-web` | `6e635210c012f8aa14f0a634f5f64bb5d8fb6cc3` | `4c13a538` PR-EQ-AGENT-03 |
+
+Runtime evidence:
+
+- Production frontend rendered `EQResultV5` and `eq-agent-entry-guard`.
+- Production frontend lazy-fetched `/api/v0.3/attempts/{id}/eq/agent-context`.
+- Production backend returned `200` for `eq/agent-context` in both `en` and `zh-CN`.
+- Production backend returned v1.6 report payload with `methodology.report_version=eq_report_v5_assets_commercial_ready_v1_6`.
+
+## 4. API Smoke Summary
+
+### 4.1 EQ Questions
+
+| Check | Result |
+|---|---|
+| EQ question endpoint count | `60` |
+| 50-question regression | Not observed |
+| Attempt submit | Passed |
+
+### 4.2 Report Payload
+
+Primary attempt: `8d4c971b-7a84-45e6-9c7f-3431a13ea210`
+
+| Field | en | zh-CN |
+|---|---|---|
+| `eq_report_mode` | `self_report` | `self_report` |
+| `measurement_type` | `self_report_trait_mixed_ei` | `self_report_trait_mixed_ei` |
+| `scores.global` | Present | Present |
+| `scores.dimensions` | `EM`, `ER`, `RM`, `SA` | `SA`, `ER`, `EM`, `RM` |
+| `dimension_summary` | 4 rows | 4 rows |
+| `methodology.report_version` | `eq_report_v5_assets_commercial_ready_v1_6` | `eq_report_v5_assets_commercial_ready_v1_6` |
+| `next_module.available` | `false` | `false` |
+| `next_module.status` | `planned` | `planned` |
+
+Resolved asset groups observed:
+
+- `quality`
+- `mechanisms`
+- `sjt_bridge`
+- `score_system`
+- `reality_scenes`
+- `result_snapshot`
+- `core_formulation`
+- `career_environment`
+- `quality_confidence`
+- `action_prescription`
+- `scientific_contract`
+- `personalization_route`
+- `agent_dialogue_playbooks`
+- `cross_assessment_context`
+- `backend_integration_contract`
+- `psychometric_evidence_status`
+- `commercial_conversion_actions`
+
+### 4.3 Report Access
+
+Report-access was rechecked after report generation using attempt `a383cde0-eb1d-43bd-96a2-6f6be89e3f9d`.
+
+| Field | Result |
+|---|---|
+| HTTP status | `200` |
+| `access_state` | `ready` |
+| `report_state` | `ready` |
+| `access_level` | `full` |
+| `variant` | `full` |
+| `payload.access.all_results_free` | `true` |
+| `payload.access.locked` | `false` |
+| `payload.access.blur` | `false` |
+| `payload.access.paywall` | `false` |
+| `upgrade_sku` | `null` |
+| `offers` | `[]` |
+| `view_policy.blur_others` | `false` |
+
+Note: the primary smoke script initially sampled `report-access` before report readiness and saw a transient pending/locked state. A post-ready recheck showed the expected ready/full/all-free contract. This is not a final blocker, but future smoke scripts should read `report-access` after report readiness or poll it until ready.
+
+## 5. Agent Context Summary
+
+Endpoint:
+
+```text
+GET /api/v0.3/attempts/{attempt_id}/eq/agent-context?locale={locale}&intent=understand_my_result
+```
+
+| Locale | HTTP status | Context locale | Lazy fetch verified |
+|---|---:|---|---|
+| `en` | `200` | `en` | Yes |
+| `zh-CN` | `200` | `zh-CN` | Yes |
+
+Guardrails:
+
+| Guardrail | en | zh-CN |
+|---|---|---|
+| `ready` | `true` | `true` |
+| `read_only` | `true` | `true` |
+| `can_mutate_report` | `false` | `false` |
+| `can_mutate_scores` | `false` | `false` |
+| `can_override_formulation` | `false` | `false` |
+| `can_enable_sjt` | `false` | `false` |
+| `can_create_paid_unlock_language` | `false` | `false` |
+| `can_expose_raw_technical_tags` | `false` | `false` |
+| `content_authority` | `backend_content_pack_and_report_composer` | `backend_content_pack_and_report_composer` |
+
+SJT state from Agent context:
+
+```json
+{
+  "available": false,
+  "module_code": "EQ_SJT_16",
+  "status": "planned",
+  "cta_asset_id": "eq.sjt_bridge.planned"
+}
+```
+
+## 6. Page Checks
+
+| Check | en | zh |
+|---|---|---|
+| Result page opens | Passed | Passed |
+| `EQResultV5` visible | Passed | Passed |
+| Agent entry visible | Passed | Passed |
+| Agent entry auto-fetch before click | `0` calls | `0` calls |
+| Agent context lazy fetch after click | Passed | Passed |
+| Agent ready panel visible after click | Passed | Passed |
+| SJT clickable entry absent | Passed | Passed |
+| Paywall / SKU / unlock visible text absent | Passed | Passed |
+| Raw technical tags visible text absent | Passed | Passed |
+
+Result URLs:
+
+- `https://fermatmind.com/en/result/8d4c971b-7a84-45e6-9c7f-3431a13ea210`
+- `https://fermatmind.com/zh/result/8d4c971b-7a84-45e6-9c7f-3431a13ea210`
+
+Screenshot artifacts, not committed:
+
+- `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/result-en-before-agent.png`
+- `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/result-en-after-agent.png`
+- `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/result-zh-before-agent.png`
+- `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/result-zh-after-agent.png`
+- `/tmp/eq_agent_prod_smoke_2026-06-25T01-34-54-228Z/summary.json`
+
+## 7. Negative Checks
+
+No user-visible occurrences were observed on either result page:
+
+- `locked`
+- `blur`
+- `paywall`
+- `SKU_EQ_60_FULL_299`
+- `EQ_60_FULL`
+- `unlock`
+- `purchase`
+- `premium`
+- `upgrade`
+- `解锁`
+- `购买`
+- `付费`
+- `profile:*`
+- `quality_level:*`
+- `focus:*`
+- `bucket:*`
+
+Payload note: backend payload contains governance and safety metadata that may include words such as `paywall`, `quality_level`, or similar internal boundary terms inside asset/risk metadata. These were not rendered as user-visible raw tags or paid CTAs in the production result page.
+
+## 8. Risks and Follow-Ups
+
+### P0/P1
+
+None open.
+
+### P2
+
+1. Production does not expose runtime Git SHA in public response headers.
+   - Impact: deployment SHA must be inferred from deploy records plus feature evidence, not from runtime headers.
+   - Suggested follow-up: add a read-only, non-sensitive version endpoint or response header for operator-only deployment verification.
+
+2. Smoke script sampled `report-access` too early on the primary attempt.
+   - Impact: transient pending/locked state can create false alarms if access is checked before report readiness.
+   - Suggested follow-up: update smoke tooling to poll `report-access` until `ready`, or sequence it after `/report` readiness.
+
+3. Low-confidence Agent runtime was not live-forced.
+   - Impact: low-confidence behavior remains covered by fixtures/contracts, not by forced production abnormal answering.
+   - Rationale: do not intentionally generate abnormal production attempts just to force a low-confidence path.
+
+### P3
+
+1. Screenshot artifacts live in `/tmp` only and were intentionally not committed.
+2. No production Agent chat runtime was opened or tested; this acceptance only verifies the read-only entry guard and context payload.
+
+## 9. Acceptance Decision
+
+Agent phase allowed: yes.
+
+Conditions for the next phase:
+
+- Agent runtime must consume the read-only `eq/agent-context` payload.
+- Agent runtime must not mutate reports, scores, formulation, sections, SJT state, or commerce state.
+- Backend content pack and report composer remain the authority layer.
+- Agent responses must preserve forbidden-claim boundaries: no ability-test claim, no MSCEIT-like claim, no certified EI claim, no hiring suitability claim, no clinical diagnosis, no guaranteed outcome, no job-performance prediction, and no paid unlock requirement.
+
+## 10. Local Validation
+
+Planned validation after writing this report:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+git diff --check
+```


### PR DESCRIPTION
## What changed

Adds a docs-only EQ Agent-ready Content OS production acceptance report at:

`docs/audits/eq/eq_agent_ready_content_os_acceptance_2026-06-25.md`

The report records the production smoke results for the EQ Agent entry guard and read-only Agent context contract.

## Why

After the EQ v1.6 content baseline and Agent-ready context work landed, production needed an explicit acceptance artifact before moving into real Agent runtime work. This report captures the production evidence and the remaining boundaries.

## Validation

- `git diff --cached --check`
- Earlier report validation: `git diff --check`

## Notes

- Docs-only change.
- No backend code changes.
- No frontend code changes.
- No EQ scoring, question, norm, SJT, commerce, or runtime Agent changes.
- Production runtime headers did not expose Git SHAs, so the report records repository `origin/main` SHAs plus runtime feature evidence.

## Deferred

- Real Agent runtime implementation remains deferred.
- Any runtime deployment or smoke follow-up should be handled separately.
