### PR TITLE
PR-EQ-AGENT-RUNTIME-01 Backend read-only EQ Agent runtime shell

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -25,6 +25,7 @@ use App\Services\Enneagram\EnneagramObservationStateService;
 use App\Services\Enneagram\EnneagramPublicFormSummaryBuilder;
 use App\Services\Enneagram\EnneagramPublicProjectionService;
 use App\Services\Eq\EqAgentContextBuilder;
+use App\Services\Eq\EqAgentRuntimeResponder;
 use App\Services\Eq\EqJourneyStateService;
 use App\Services\Iq\IqResultPayloadRedactor;
 use App\Services\Mbti\MbtiActionJourneyContractService;
@@ -75,6 +76,7 @@ class AttemptReadController extends Controller
         private EnneagramPublicFormSummaryBuilder $enneagramPublicFormSummaryBuilder,
         private EnneagramObservationStateService $enneagramObservationStateService,
         private EqAgentContextBuilder $eqAgentContextBuilder,
+        private EqAgentRuntimeResponder $eqAgentRuntimeResponder,
         private EqJourneyStateService $eqJourneyStateService,
         private RiasecPublicProjectionService $riasecPublicProjectionService,
         private RiasecPublicFormSummaryBuilder $riasecPublicFormSummaryBuilder,
@@ -819,6 +821,53 @@ class AttemptReadController extends Controller
         );
 
         return response()->json($payload);
+    }
+
+    /**
+     * POST /api/v0.3/attempts/{id}/eq/agent-runtime/messages
+     */
+    public function eqAgentRuntimeMessage(Request $request, string $id): JsonResponse
+    {
+        $message = trim((string) $request->input('message', ''));
+        if ($message === '') {
+            throw new ApiProblemException(422, 'MESSAGE_REQUIRED', 'message is required.');
+        }
+
+        if (mb_strlen($message) > 1200) {
+            throw new ApiProblemException(422, 'MESSAGE_TOO_LONG', 'message must be 1200 characters or fewer.');
+        }
+
+        $locale = $this->normalizeReportLocale((string) $request->input('locale', $request->query('locale', '')));
+        $intent = trim((string) $request->input('intent', $request->query('intent', '')));
+        $request->query->set('locale', $locale);
+        $request->query->set('intent', $intent);
+
+        $contextResponse = $this->eqAgentContext($request, $id);
+        $context = json_decode((string) $contextResponse->getContent(), true);
+        if (! is_array($context)) {
+            return response()->json(
+                $this->eqAgentRuntimeResponder->nonReady($id, 'context_decode_failed', $locale),
+                202
+            );
+        }
+
+        $runtimePayload = ((bool) ($context['ready'] ?? false))
+            ? $this->eqAgentRuntimeResponder->respond($context, $message, $intent, $locale)
+            : $this->eqAgentRuntimeResponder->nonReady(
+                $id,
+                (string) ($context['reason_code'] ?? 'context_not_ready'),
+                $locale,
+                is_array($context['guardrails'] ?? null) ? $context['guardrails'] : []
+            );
+
+        $status = (int) $contextResponse->getStatusCode();
+        if ((bool) ($runtimePayload['ready'] ?? false)) {
+            $status = Response::HTTP_OK;
+        } elseif ($status < Response::HTTP_BAD_REQUEST) {
+            $status = Response::HTTP_ACCEPTED;
+        }
+
+        return response()->json($runtimePayload, $status);
     }
 
     /**

--- a/backend/app/Services/Eq/EqAgentRuntimeResponder.php
+++ b/backend/app/Services/Eq/EqAgentRuntimeResponder.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+final class EqAgentRuntimeResponder
+{
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    public function respond(array $context, ?string $message, ?string $intent, ?string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale ?: (string) ($context['locale'] ?? 'en'));
+        $guardrails = $this->guardrails($context['guardrails'] ?? null);
+        if (($context['ready'] ?? false) !== true || ! $this->isSafeGuardrailSet($guardrails)) {
+            return $this->nonReady((string) ($context['attempt_id'] ?? ''), 'agent_context_not_ready', $guardrails, $resolvedLocale);
+        }
+
+        $messageText = trim((string) $message);
+        $agentKnowledge = $this->arrayOrEmpty($context['agent_knowledge'] ?? null);
+        $intentContext = $this->arrayOrEmpty($context['intent_context'] ?? null);
+        $resolvedAssets = $this->arrayOrEmpty($context['resolved_assets'] ?? null);
+        $reportContext = $this->arrayOrEmpty($context['report_context'] ?? null);
+        $detectedClaimIds = $this->detectForbiddenClaims($messageText, $agentKnowledge);
+        $intentClaimIds = $this->stringList($intentContext['forbidden_claim_ids'] ?? null);
+        $boundaryIds = array_values(array_unique(array_merge($intentClaimIds, $detectedClaimIds)));
+        $sourceAssetIds = $this->sourceAssetIds($resolvedAssets);
+
+        return [
+            'schema' => 'eq.agent_runtime_response.v1',
+            'ok' => true,
+            'ready' => true,
+            'mode' => 'deterministic_read_only',
+            'attempt_id' => (string) ($context['attempt_id'] ?? ''),
+            'result_id' => (string) ($context['result_id'] ?? ''),
+            'scale_code' => (string) ($context['scale_code'] ?? ''),
+            'locale' => $resolvedLocale,
+            'intent' => [
+                'requested_intent' => $intent !== null && trim($intent) !== '' ? trim($intent) : ($intentContext['requested_intent'] ?? null),
+                'matched_intent' => (string) ($intentContext['matched_intent'] ?? 'understand_my_result'),
+                'matched' => (bool) ($intentContext['matched'] ?? false),
+                'allowed_response_mode' => (string) ($intentContext['allowed_response_mode'] ?? 'explain_existing_assets_only'),
+            ],
+            'intent_context' => $intentContext,
+            'assistant_response' => [
+                'role' => 'assistant',
+                'text' => $this->responseText($resolvedLocale, $messageText, $intentContext, $resolvedAssets, $detectedClaimIds),
+                'summary_points' => $this->summaryPoints($resolvedLocale, $resolvedAssets, $reportContext, $detectedClaimIds),
+                'follow_up_question' => $this->followUpQuestion($resolvedLocale, $resolvedAssets, $detectedClaimIds),
+                'source_asset_ids' => $sourceAssetIds,
+                'boundary_claim_ids' => $boundaryIds,
+            ],
+            'safety' => [
+                'detected_forbidden_claim_ids' => $detectedClaimIds,
+                'applied_forbidden_claim_ids' => $boundaryIds,
+                'escalation_flags' => array_values(array_unique(array_merge(
+                    $this->stringList($intentContext['escalation_flags'] ?? null),
+                    $this->escalationFlagsForDetectedClaims($detectedClaimIds),
+                    $detectedClaimIds,
+                    $detectedClaimIds !== [] ? ['forbidden_claim_boundary_applied'] : []
+                ))),
+                'no_paywall_language' => true,
+                'no_sjt_entry' => true,
+                'no_raw_technical_tags' => true,
+            ],
+            'guardrails' => $guardrails,
+            'next_module' => $this->arrayOrEmpty($reportContext['next_module'] ?? null),
+            'context_summary' => [
+                'eq_report_mode' => (string) ($reportContext['eq_report_mode'] ?? ''),
+                'measurement_type' => (string) ($reportContext['measurement_type'] ?? ''),
+                'core_formulation_id' => (string) data_get($reportContext, 'interpretation.core_formulation_id', ''),
+                'quality_level' => (string) data_get($reportContext, 'quality.level', ''),
+                'confidence_label' => (string) data_get($reportContext, 'quality.confidence_label', ''),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $guardrails
+     * @return array<string,mixed>
+     */
+    public function nonReady(string $attemptId, string $reasonCode, array $guardrails = [], ?string $locale = null): array
+    {
+        return [
+            'schema' => 'eq.agent_runtime_response.v1',
+            'ok' => true,
+            'ready' => false,
+            'mode' => 'deterministic_read_only',
+            'attempt_id' => $attemptId,
+            'locale' => $this->normalizeLocale($locale),
+            'reason_code' => $reasonCode,
+            'guardrails' => $this->guardrails($guardrails),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $intentContext
+     * @param  array<string,mixed>  $resolvedAssets
+     * @param  list<string>  $detectedClaimIds
+     */
+    private function responseText(string $locale, string $message, array $intentContext, array $resolvedAssets, array $detectedClaimIds): string
+    {
+        if ($detectedClaimIds !== []) {
+            return $locale === 'zh-CN'
+                ? '我只能解释这份自我报告结果，不能把它用于高风险判断、认证结论或替代现实专业支持。下面我会按报告已有资产做安全解释。'
+                : 'I can only explain this self-report result. I cannot use it for high-risk decisions, certification, or as a substitute for real-world professional support. I will stay within the existing report assets.';
+        }
+
+        $safeOpening = trim((string) ($intentContext['safe_opening'] ?? ''));
+        $snapshot = $this->arrayOrEmpty($resolvedAssets['result_snapshot'] ?? null);
+        $core = trim((string) ($snapshot['core_judgment'] ?? $snapshot['headline'] ?? ''));
+        if ($safeOpening !== '' && $core !== '') {
+            return $safeOpening.' '.$core;
+        }
+
+        if ($core !== '') {
+            return $core;
+        }
+
+        return $locale === 'zh-CN'
+            ? '我会基于当前报告资产解释你的 EQ 结果，不会重新打分或替换报告判断。'
+            : 'I will explain your EQ result using the current report assets; I will not rescore or replace the report judgment.';
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolvedAssets
+     * @param  array<string,mixed>  $reportContext
+     * @param  list<string>  $detectedClaimIds
+     * @return list<string>
+     */
+    private function summaryPoints(string $locale, array $resolvedAssets, array $reportContext, array $detectedClaimIds): array
+    {
+        if ($detectedClaimIds !== []) {
+            return $locale === 'zh-CN'
+                ? ['这份报告只能用于自我理解。', '回复将保留科学边界。', '不会改写分数、画像或模块状态。']
+                : ['This report is for self-understanding only.', 'The response keeps the scientific boundary.', 'Scores, formulation, and module status are not changed.'];
+        }
+
+        $snapshot = $this->arrayOrEmpty($resolvedAssets['result_snapshot'] ?? null);
+        $action = $this->arrayOrEmpty($resolvedAssets['action_prescription'] ?? null);
+        $quality = $this->arrayOrEmpty($reportContext['quality'] ?? null);
+        $points = [];
+        foreach (['evidence_point', 'minimal_action'] as $key) {
+            $value = trim((string) ($snapshot[$key] ?? ''));
+            if ($value !== '') {
+                $points[] = $value;
+            }
+        }
+        $doToday = trim((string) ($action['do_today'] ?? ''));
+        if ($doToday !== '') {
+            $points[] = $doToday;
+        }
+        $confidence = trim((string) ($quality['confidence_label'] ?? ''));
+        if ($confidence !== '') {
+            $points[] = $locale === 'zh-CN' ? '解释置信度：'.$confidence : 'Interpretation confidence: '.$confidence;
+        }
+
+        return array_slice(array_values(array_unique($points)), 0, 4);
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolvedAssets
+     * @param  list<string>  $detectedClaimIds
+     */
+    private function followUpQuestion(string $locale, array $resolvedAssets, array $detectedClaimIds): string
+    {
+        if ($detectedClaimIds !== []) {
+            return $locale === 'zh-CN'
+                ? '你想把这个结果放回哪个低风险场景里理解：反馈、冲突、边界、协作还是压力恢复？'
+                : 'Which low-risk scene should we use to understand this result: feedback, conflict, boundary, collaboration, or recovery?';
+        }
+
+        foreach ($this->listOrEmpty($resolvedAssets['agent_dialogue_playbooks'] ?? null) as $playbook) {
+            $question = trim((string) ($playbook['clarifying_question'] ?? ''));
+            if ($question !== '') {
+                return $question;
+            }
+        }
+
+        return $locale === 'zh-CN'
+            ? '你想先讨论哪一个现实场景？'
+            : 'Which real-life scene would you like to discuss first?';
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolvedAssets
+     * @return list<string>
+     */
+    private function sourceAssetIds(array $resolvedAssets): array
+    {
+        $ids = [];
+        foreach (['result_snapshot', 'core_formulation', 'action_prescription', 'quality_confidence', 'psychometric_evidence_status', 'sjt_bridge', 'conversion_agent_entry'] as $key) {
+            $id = trim((string) data_get($resolvedAssets, $key.'.id', ''));
+            if ($id !== '') {
+                $ids[] = $id;
+            }
+        }
+        foreach (['mechanisms', 'reality_scenes', 'career_environment', 'agent_dialogue_playbooks'] as $key) {
+            foreach ($this->listOrEmpty($resolvedAssets[$key] ?? null) as $asset) {
+                $id = trim((string) ($asset['id'] ?? data_get($asset, 'meta.id', '')));
+                if ($id !== '') {
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @param  array<string,mixed>  $agentKnowledge
+     * @return list<string>
+     */
+    private function detectForbiddenClaims(string $message, array $agentKnowledge): array
+    {
+        $normalizedMessage = mb_strtolower($message);
+        if ($normalizedMessage === '') {
+            return [];
+        }
+
+        $claims = $this->arrayOrEmpty(data_get($agentKnowledge, 'forbidden_claims.claims'));
+        $detected = [];
+        foreach ($claims as $claimId => $claim) {
+            if (! is_array($claim)) {
+                continue;
+            }
+            if ((string) $claimId === 'hiring_suitability'
+                && str_contains($normalizedMessage, 'hiring')
+                && str_contains($normalizedMessage, 'suitab')) {
+                $detected[] = (string) $claimId;
+
+                continue;
+            }
+            foreach ($this->stringList($claim['blocked_patterns'] ?? null) as $pattern) {
+                if ($pattern !== '' && str_contains($normalizedMessage, mb_strtolower($pattern))) {
+                    $detected[] = (string) $claimId;
+                    break;
+                }
+            }
+        }
+
+        return array_values(array_unique($detected));
+    }
+
+    /**
+     * @param  list<string>  $claimIds
+     * @return list<string>
+     */
+    private function escalationFlagsForDetectedClaims(array $claimIds): array
+    {
+        $flags = [];
+        if (in_array('clinical_diagnosis', $claimIds, true)) {
+            $flags[] = 'clinical_distress';
+        }
+        if (in_array('hiring_suitability', $claimIds, true)) {
+            $flags[] = 'workplace_hiring_decision';
+        }
+        if (in_array('paid_unlock_required', $claimIds, true)) {
+            $flags[] = 'paid_unlock_boundary';
+        }
+
+        return $flags;
+    }
+
+    /**
+     * @param  array<string,mixed>|mixed  $guardrails
+     * @return array<string,mixed>
+     */
+    private function guardrails(mixed $guardrails): array
+    {
+        $source = is_array($guardrails) ? $guardrails : [];
+
+        return [
+            'read_only' => ($source['read_only'] ?? null) === true,
+            'can_mutate_report' => ($source['can_mutate_report'] ?? null) === false ? false : (bool) ($source['can_mutate_report'] ?? false),
+            'can_mutate_scores' => ($source['can_mutate_scores'] ?? null) === false ? false : (bool) ($source['can_mutate_scores'] ?? false),
+            'can_override_formulation' => ($source['can_override_formulation'] ?? null) === false ? false : (bool) ($source['can_override_formulation'] ?? false),
+            'can_enable_sjt' => ($source['can_enable_sjt'] ?? null) === false ? false : (bool) ($source['can_enable_sjt'] ?? false),
+            'can_create_paid_unlock_language' => ($source['can_create_paid_unlock_language'] ?? null) === false ? false : (bool) ($source['can_create_paid_unlock_language'] ?? false),
+            'can_use_paid_unlock_language' => false,
+            'can_expose_raw_technical_tags' => ($source['can_expose_raw_technical_tags'] ?? null) === false ? false : (bool) ($source['can_expose_raw_technical_tags'] ?? false),
+            'content_authority' => (string) ($source['content_authority'] ?? 'backend_content_pack_and_report_composer'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $guardrails
+     */
+    private function isSafeGuardrailSet(array $guardrails): bool
+    {
+        return $guardrails['read_only'] === true
+            && $guardrails['can_mutate_report'] === false
+            && $guardrails['can_mutate_scores'] === false
+            && $guardrails['can_override_formulation'] === false
+            && $guardrails['can_enable_sjt'] === false
+            && $guardrails['can_create_paid_unlock_language'] === false
+            && $guardrails['can_expose_raw_technical_tags'] === false;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function listOrEmpty(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item): bool => is_array($item)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        return array_values(array_filter((array) $value, static fn (mixed $item): bool => is_string($item) && trim($item) !== ''));
+    }
+
+    private function normalizeLocale(?string $locale): string
+    {
+        return str_starts_with(strtolower(trim((string) $locale)), 'zh') ? 'zh-CN' : 'en';
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -485,6 +485,30 @@
                 "x-laravel-name": "api.v0_3.attempts.eq.agent_context"
             }
         },
+        "/api/v0.3/attempts/{id}/eq/agent-runtime/messages": {
+            "post": {
+                "operationId": "api.v0_3.attempts.eq.agent_runtime.messages",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@eqAgentRuntimeMessage",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\ForcePublicAttemptRealm",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.eq.agent_runtime.messages"
+            }
+        },
         "/api/v0.3/attempts/{id}/eq/journey": {
             "get": {
                 "operationId": "api.v0_3.attempts.eq.journey.show",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -290,6 +290,10 @@ Route::prefix('v0.3')->middleware([
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)
                 ->name('api.v0_3.attempts.eq.agent_context');
+            Route::post('/attempts/{id}/eq/agent-runtime/messages', [AttemptReadController::class, 'eqAgentRuntimeMessage'])
+                ->middleware('uuid:id')
+                ->defaults('public_realm', true)
+                ->name('api.v0_3.attempts.eq.agent_runtime.messages');
             Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
                 ->middleware('uuid:id')
                 ->defaults('public_realm', true)

--- a/backend/tests/Feature/Report/EqAgentContextApiTest.php
+++ b/backend/tests/Feature/Report/EqAgentContextApiTest.php
@@ -118,6 +118,129 @@ final class EqAgentContextApiTest extends TestCase
         $this->assertContains('asset:core_formulation', (array) $response->json('intent_context.retrieval_tags'));
     }
 
+    public function test_eq_agent_runtime_message_returns_deterministic_read_only_response(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_agent_runtime_ready';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => 'Help me understand what this EQ result means.',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('schema', 'eq.agent_runtime_response.v1')
+            ->assertJsonPath('ready', true)
+            ->assertJsonPath('mode', 'deterministic_read_only')
+            ->assertJsonPath('locale', 'en')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('guardrails.can_mutate_scores', false)
+            ->assertJsonPath('guardrails.can_override_formulation', false)
+            ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
+            ->assertJsonPath('assistant_response.role', 'assistant')
+            ->assertJsonPath('safety.no_paywall_language', true)
+            ->assertJsonPath('safety.no_sjt_entry', true)
+            ->assertJsonPath('safety.no_raw_technical_tags', true)
+            ->assertJsonPath('next_module.available', false)
+            ->assertJsonPath('next_module.status', 'planned')
+            ->assertJsonPath('context_summary.eq_report_mode', 'self_report')
+            ->assertJsonPath('context_summary.measurement_type', 'self_report_trait_mixed_ei');
+
+        $this->assertNotSame('', (string) $response->json('assistant_response.text'));
+        $this->assertNotEmpty((array) $response->json('assistant_response.summary_points'));
+        $sourceAssetIds = (array) $response->json('assistant_response.source_asset_ids');
+        $this->assertNotEmpty($sourceAssetIds);
+        $this->assertNotContains('', $sourceAssetIds);
+        $this->assertContains('asset:core_formulation', (array) $response->json('intent_context.retrieval_tags'));
+
+        $json = json_encode($response->json(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        foreach ([
+            'SKU_EQ_60_FULL_299',
+            'EQ_60_FULL',
+            '"locked":true',
+            '"paywall":true',
+            '"blur_others":true',
+            'profile:',
+            'quality_level:',
+            'focus:',
+            'bucket:',
+            '/take',
+            'available":true',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $json);
+        }
+    }
+
+    public function test_eq_agent_runtime_message_applies_forbidden_claim_boundary(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_agent_runtime_forbidden_claim';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'clinical_or_hiring_boundary',
+            'message' => 'Can this diagnose me or be used for hiring suitability?',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ready', true)
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('guardrails.can_enable_sjt', false);
+
+        $this->assertContains('clinical_diagnosis', (array) $response->json('safety.detected_forbidden_claim_ids'));
+        $this->assertContains('hiring_suitability', (array) $response->json('safety.detected_forbidden_claim_ids'));
+        $this->assertContains('clinical_diagnosis', (array) $response->json('assistant_response.boundary_claim_ids'));
+        $this->assertContains('hiring_suitability', (array) $response->json('assistant_response.boundary_claim_ids'));
+        $this->assertContains('clinical_diagnosis', (array) $response->json('safety.escalation_flags'));
+        $this->assertContains('workplace_hiring_decision', (array) $response->json('safety.escalation_flags'));
+
+        $json = json_encode($response->json(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        $this->assertStringNotContainsString('SKU_EQ_60_FULL_299', $json);
+        $this->assertStringNotContainsString('EQ_60_FULL', $json);
+        $this->assertStringNotContainsString('"paywall":true', $json);
+        $this->assertStringNotContainsString('"locked":true', $json);
+    }
+
+    public function test_eq_agent_runtime_message_requires_non_empty_message(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->prepareEqContent();
+
+        $anonId = 'anon_eq_agent_runtime_message_required';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => '   ',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error_code', 'MESSAGE_REQUIRED');
+    }
+
     public function test_eq_agent_context_rejects_non_eq_attempt_after_report_read_guard(): void
     {
         (new ScaleRegistrySeeder)->run();

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -837,6 +837,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_eq_agent_runtime_read_only_shell_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Eq/EqAgentRuntimeResponder.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            "+            Route::post('/attempts/{id}/eq/agent-runtime/messages', [AttemptReadController::class, 'eqAgentRuntimeMessage'])",
+            "+                ->middleware('uuid:id')",
+            "+                ->defaults('public_realm', true)",
+            "+                ->name('api.v0_3.attempts.eq.agent_runtime.messages');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -5319,6 +5340,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEqAgentRuntimeReadOnlyShellChange($file)) {
+                continue;
+            }
+
             if ($this->isEq60FreeReportContractChange($file, $repoRoot, $baseRef)) {
                 continue;
             }
@@ -5333,6 +5358,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsEqAgentContextReadOnlyContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsEqAgentRuntimeReadOnlyShellOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -7290,6 +7322,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEqAgentContextReadOnlyContractChange(string $file): bool
     {
         return $file === 'backend/app/Services/Eq/EqAgentContextBuilder.php';
+    }
+
+    private function isEqAgentRuntimeReadOnlyShellChange(string $file): bool
+    {
+        return $file === 'backend/app/Services/Eq/EqAgentRuntimeResponder.php';
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool
@@ -9999,6 +10036,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/eq\\/agent-context|eqAgentContext|api\\.v0_3\\.attempts\\.eq\\.agent_context|uuid:id|public_realm/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsEqAgentRuntimeReadOnlyShellOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/^\+\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/eq\\/agent-runtime\\/messages|eqAgentRuntimeMessage|api\\.v0_3\\.attempts\\.eq\\.agent_runtime\\.messages|uuid:id|public_realm/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61030,11 +61030,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "5ec2d1c1a2f57c7b64337c4e526ae30ee730028e",
+    "commit_sha": "a77bd63b761f254a55d0ef9472fdf3baafd792a0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2401",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-24T17:07:37Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-24T20:45:00+08:00",
@@ -61065,6 +61065,158 @@
         "from": "pr_opened",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed and merge state is clean."
+      },
+      {
+        "at": "2026-06-25T09:55:00+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled while starting PR-EQ-AGENT-RUNTIME-01 after verifying GitHub PR #2401 merged and origin/main contains a77bd63b761f254a55d0ef9472fdf3baafd792a0."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-01": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-01-backend-shell",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "eq_agent_runtime",
+    "title": "PR-EQ-AGENT-RUNTIME-01 Backend read-only EQ Agent runtime shell",
+    "depends_on": [
+      "PR-EQ-AGENT-04"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the EQ Agent Runtime 4-PR plan and manifest/state updates."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-04 merged as GitHub PR #2401 at a77bd63b761f254a55d0ef9472fdf3baafd792a0 and is present in origin/main."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+          "cd backend && bash scripts/export_openapi.sh --check",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check",
+          "git diff --cached --check"
+        ],
+        "evidence": "All scoped commands passed. Eq60V5ReportContractTest was rerun serially after a concurrent content compile race in the first parallel attempt."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Staged diff is limited to EQ Agent runtime route/controller/service/tests, OpenAPI snapshot, and EQ runtime PR train metadata. Existing unrelated IQ dirty files and IQ manifest/state hunks remain unstaged."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T09:55:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit user authorization and started from latest main."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-02": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-02-response-evals",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime",
+    "title": "PR-EQ-AGENT-RUNTIME-02 EQ Agent response safety eval fixtures",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the EQ Agent Runtime 4-PR plan and manifest/state updates."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T09:55:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-01."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-03": {
+    "repo": "fap-web",
+    "branch": "codex/pr-eq-agent-runtime-03-frontend-drawer",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime",
+    "title": "PR-EQ-AGENT-RUNTIME-03 Frontend EQ Agent chat drawer",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the EQ Agent Runtime 4-PR plan and manifest/state updates."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T09:55:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-02."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-04": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-04-acceptance-report",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime",
+    "title": "PR-EQ-AGENT-RUNTIME-04 EQ Agent runtime production acceptance report",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the EQ Agent Runtime 4-PR plan and manifest/state updates."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T09:55:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-03 production availability."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -467,6 +467,152 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: PR-EQ-AGENT-RUNTIME-01
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-04]
+    branch: codex/pr-eq-agent-runtime-01-backend-shell
+    title: "PR-EQ-AGENT-RUNTIME-01 Backend read-only EQ Agent runtime shell"
+    train_scope: eq_agent_runtime
+    scope:
+      - Add deterministic read-only EQ Agent runtime message endpoint.
+      - Reuse existing EQ Agent context, report read guard, resolved assets, intent map, playbooks, and forbidden-claim metadata.
+      - Return eq.agent_runtime_response.v1 without persistence, external model calls, report mutation, score mutation, formulation override, SJT enablement, or paid unlock language.
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/app/Services/Eq/**
+      - backend/tests/Feature/Report/EqAgentContextApiTest.php
+      - backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+      - backend/docs/contracts/openapi.snapshot.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add live LLM/provider integration.
+      - Persist chat history or Agent messages.
+      - Add Agent write endpoints or content/report mutation.
+      - Modify EQ questions, scoring, norms, formulation selection, SJT availability, commerce, frontend, CMS, SEO, deploy, or production state.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - cd backend && bash scripts/export_openapi.sh --check
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-02
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-01]
+    branch: codex/pr-eq-agent-runtime-02-response-evals
+    title: "PR-EQ-AGENT-RUNTIME-02 EQ Agent response safety eval fixtures"
+    train_scope: eq_agent_runtime
+    scope:
+      - Add deterministic runtime message fixtures for forbidden claims and safety boundaries.
+      - Assert runtime responses remain read-only, cite stable asset IDs, preserve low-confidence boundaries, keep SJT planned/unavailable, and avoid paywall/SKU/unlock/raw-tag wording.
+    allowed_paths:
+      - backend/tests/Fixtures/eq/agent/**
+      - backend/tests/Feature/Report/EqAgentContextApiTest.php
+      - backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend.
+      - Add live LLM/provider integration.
+      - Add Agent write endpoints or persistence.
+      - Modify EQ questions, scoring, norms, content assets, SJT runtime, or commerce.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-03
+    repo: fap-web
+    depends_on: [PR-EQ-AGENT-RUNTIME-02]
+    branch: codex/pr-eq-agent-runtime-03-frontend-drawer
+    title: "PR-EQ-AGENT-RUNTIME-03 Frontend EQ Agent chat drawer"
+    train_scope: eq_agent_runtime
+    scope:
+      - Replace EQ Agent ready panel with a guarded read-only drawer.
+      - Lazy-load EQ Agent context and post messages to deterministic runtime endpoint.
+      - Fail closed when guardrails are missing or unsafe.
+    allowed_paths:
+      - app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+      - components/result/eq/**
+      - lib/api/v0_3.ts
+      - tests/contracts/**
+      - tests/e2e/iq-eq-result-regression.spec.ts
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Add official report prose in frontend.
+      - Add Agent mutation controls, SJT take entry, paywall, SKU, unlock copy, or raw technical tag rendering.
+      - Modify backend, EQ questions, scoring, norms, content assets, CMS, SEO, deploy, or production state.
+    validation:
+      - pnpm typecheck
+      - pnpm test:contract
+      - pnpm exec playwright test tests/e2e/iq-eq-result-regression.spec.ts
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-04
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-03]
+    branch: codex/pr-eq-agent-runtime-04-acceptance-report
+    title: "PR-EQ-AGENT-RUNTIME-04 EQ Agent runtime production acceptance report"
+    train_scope: eq_agent_runtime
+    scope:
+      - Add docs-only production smoke acceptance report for EQ Agent runtime.
+      - Record deployed SHAs, attempt IDs, endpoint summaries, screenshots in /tmp, risks, and Agent runtime phase allowed yes/no.
+    allowed_paths:
+      - docs/audits/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime code, frontend, content assets, scoring, SJT runtime, CMS, SEO, deploy, or production state.
+    validation:
+      - git diff --check
+      - git diff --cached --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-PER-01
     repo: fap-api
     branch: codex/pr-eq-per-01-all-free-copy-contract-cleanup


### PR DESCRIPTION
## What changed
- Added `POST /api/v0.3/attempts/{id}/eq/agent-runtime/messages` for a deterministic, read-only EQ Agent runtime shell.
- Reused the existing EQ Agent context/report access guard before producing any runtime response.
- Added `EqAgentRuntimeResponder` to generate safe structured responses from resolved assets, intent context, playbooks, and forbidden-claim boundaries.
- Updated OpenAPI snapshot and EqAgent contract tests for runtime response guardrails, forbidden-claim boundaries, empty message validation, no-paywall/no-SJT/no-raw-tag invariants.
- Added PR train manifest/state entries for PR-EQ-AGENT-RUNTIME-01 through PR-EQ-AGENT-RUNTIME-04 and reconciled PR-EQ-AGENT-04 as merged for dependency resolution.

## Why
This is the first Agent runtime PR. It establishes the backend contract and safety envelope without live LLM calls, persistence, report mutation, score mutation, formulation override, SJT enablement, or paid unlock language.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
- `cd backend && bash scripts/export_openapi.sh --check`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

Note: an initial parallel run of `EqAgent` and `Eq60V5ReportContractTest` hit an EQ content compile timestamp race; `Eq60V5ReportContractTest` passed when rerun serially.

## Intentionally deferred
- Live LLM/provider integration.
- Chat history persistence.
- Frontend drawer UI.
- Agent write endpoints or report/content mutation.
- EQ-SJT runtime/take entry.
- Production deploy or smoke.

## Pre-existing unrelated dirty files not staged
The worktree had unrelated IQ owner-original-30 changes and unrelated docs/codex hunks. They were left unstaged and are not part of this PR.
