### PR TITLE
IQ-OWNER-30-SCORING-RUNTIME-BIND-01: Bind owner IQ 30 runtime scoring

### DIFF
--- a/backend/app/Services/Assessment/AssessmentEngine.php
+++ b/backend/app/Services/Assessment/AssessmentEngine.php
@@ -4,6 +4,7 @@ namespace App\Services\Assessment;
 
 use App\Services\Assessment\Drivers\DriverInterface;
 use App\Services\Content\ContentPacksIndex;
+use App\Services\Iq\IqOwnerOriginal30BankService;
 use App\Services\Scale\ScaleRegistry;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
@@ -137,10 +138,14 @@ class AssessmentEngine
         if (! is_array($scoringSpec)) {
             return $this->error('SCORING_SPEC_NOT_FOUND', 'scoring_spec.json not found or invalid.');
         }
+        $ownerOriginalIqScoringSpec = $this->ownerOriginalIqScoringSpecIfNeeded($scaleCode, $ctx);
+        if ($ownerOriginalIqScoringSpec !== null) {
+            $scoringSpec = $ownerOriginalIqScoringSpec;
+        }
 
         $scoringSpecVersion = (string) ($scoringSpec['version'] ?? ($scoringSpec['scoring_spec_version'] ?? ''));
         $selectedSpecVersion = trim((string) ($modelSelection['scoring_spec_version'] ?? ''));
-        if ($selectedSpecVersion !== '') {
+        if ($selectedSpecVersion !== '' && $ownerOriginalIqScoringSpec === null) {
             $scoringSpecVersion = $selectedSpecVersion;
         }
         $contentPackageVersion = (string) ($pack['content_package_version'] ?? '');
@@ -330,6 +335,28 @@ class AssessmentEngine
         $decoded = json_decode($raw, true);
 
         return is_array($decoded) ? $decoded : null;
+    }
+
+    private function ownerOriginalIqScoringSpecIfNeeded(string $scaleCode, array $ctx): ?array
+    {
+        if (! in_array($scaleCode, [IqOwnerOriginal30BankService::SCALE_CODE, IqOwnerOriginal30BankService::LEGACY_SCALE_CODE], true)) {
+            return null;
+        }
+
+        $formCodeValue = $ctx['form_code'] ?? null;
+        $bankIdValue = $ctx['bank_id'] ?? null;
+        $formCode = is_string($formCodeValue) || is_numeric($formCodeValue)
+            ? (string) $formCodeValue
+            : null;
+        $bankId = is_string($bankIdValue) || is_numeric($bankIdValue)
+            ? (string) $bankIdValue
+            : null;
+        $service = app(IqOwnerOriginal30BankService::class);
+        if (! $service->isOwnerOriginalRequest($formCode, $bankId)) {
+            return null;
+        }
+
+        return $service->runtimeScoringSpec();
     }
 
     private function resolveDriver(string $driverType): ?DriverInterface

--- a/backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
@@ -46,6 +46,8 @@ class AttemptSubmitCanonicalizeService
         $packReleaseManifestHash = trim((string) ($attemptMeta['pack_release_manifest_hash'] ?? ''));
         $policyHash = trim((string) ($attemptMeta['policy_hash'] ?? ''));
         $engineVersion = trim((string) ($attemptMeta['engine_version'] ?? ''));
+        $formCode = trim((string) ($attemptMeta['form_code'] ?? ''));
+        $bankId = trim((string) ($attemptMeta['bank_id'] ?? ''));
         $scoringSpecVersion = trim((string) ($attempt->scoring_spec_version ?? ''));
         $normVersion = trim((string) ($attempt->norm_version ?? ''));
         $submittedAt = now();
@@ -65,6 +67,8 @@ class AttemptSubmitCanonicalizeService
             'attempt_id' => $attemptId,
             'anon_id' => $actorAnonId,
             'user_id' => $actorUserId,
+            'form_code' => $formCode,
+            'bank_id' => $bankId,
             'validity_items' => $validityItems,
             'content_manifest_hash' => $packReleaseManifestHash,
             'policy_hash' => $policyHash,

--- a/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+++ b/backend/app/Services/Iq/IqOwnerOriginal30BankService.php
@@ -132,6 +132,75 @@ final class IqOwnerOriginal30BankService
         return count($this->items());
     }
 
+    /**
+     * @return array<string,mixed>
+     */
+    public function runtimeScoringSpec(): array
+    {
+        $scoringSpec = $this->readJson('scoring_spec.json');
+        $answerKeyDoc = $this->readJson('answer_key.json');
+        $answers = $answerKeyDoc['answers'] ?? null;
+        if (! is_array($answers)) {
+            throw new ApiProblemException(500, 'IQ_OWNER_ANSWER_KEY_INVALID', 'owner IQ answer key is invalid.');
+        }
+
+        $runtimeItems = [];
+        foreach ($this->items() as $item) {
+            $runtimeItems[] = $this->runtimeScoringItem($item, $answers);
+        }
+
+        if (count($runtimeItems) !== $this->questionCount()) {
+            throw new ApiProblemException(500, 'IQ_OWNER_ANSWER_KEY_INVALID', 'owner IQ runtime scoring item count is invalid.');
+        }
+
+        return [
+            'schema_version' => 'fm.iq.runtime_scoring_spec.v1',
+            'version' => 'iq_owner_original_30_runtime_scoring_v1',
+            'scoring_spec_version' => 'iq_owner_original_30_runtime_scoring_v1',
+            'scale_code' => self::SCALE_CODE,
+            'driver_type' => 'iq_test',
+            'engine_version' => 'owner_original_30_runtime_scoring_v1',
+            'scoring_engine_version' => 'iq_scoring_v2',
+            'scoring_mode' => 'scored',
+            'answer_key_version' => 'owner_original_30_answer_key_2026_06_23',
+            'norm_table_version' => 'unavailable',
+            'item_bank' => [
+                'bank_id' => self::BANK_ID,
+                'schema_version' => 'fm.iq.owner_image_bank.items.v1',
+                'status' => 'owner_original_runtime_scoring_bound',
+                'production_ready' => false,
+                'canonical_scale_code' => self::SCALE_CODE,
+                'item_count' => count($runtimeItems),
+                'option_codes' => ['A', 'B', 'C', 'D', 'E', 'F'],
+            ],
+            'quality_rules' => [
+                'speeding_seconds_lt' => 30,
+                'straightlining_run_len_gte' => 8,
+                'abnormal_quality_policy' => 'review_with_caution',
+            ],
+            'raw_score' => is_array($scoringSpec['raw_score'] ?? null) ? $scoringSpec['raw_score'] : [
+                'min' => 0,
+                'max' => count($runtimeItems),
+                'correct_item_value' => 1,
+                'incorrect_item_value' => 0,
+            ],
+            'dimension_counts' => is_array($scoringSpec['dimension_counts'] ?? null) ? $scoringSpec['dimension_counts'] : [],
+            'norm_policy' => is_array($scoringSpec['norm_policy'] ?? null) ? $scoringSpec['norm_policy'] : [],
+            'public_payload_policy' => [
+                'may_emit_answer_key' => false,
+                'may_emit_solution_rule' => false,
+                'may_emit_scoring_key' => false,
+            ],
+            'runtime_binding' => [
+                'enabled' => true,
+                'bound_by_pr' => 'IQ-OWNER-30-SCORING-RUNTIME-BIND-01',
+                'mode' => 'backend_private_answer_key',
+            ],
+            'items' => $runtimeItems,
+            'schema' => 'fap.report.rules.v1',
+        ];
+    }
+
     public function validateSubmit(Attempt $attempt, SubmitAttemptDTO $dto): void
     {
         if (! $this->isOwnerOriginalAttempt($attempt)) {
@@ -219,6 +288,77 @@ final class IqOwnerOriginal30BankService
         }
 
         return $map;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $answers
+     * @return array<string,mixed>
+     */
+    private function runtimeScoringItem(array $item, array $answers): array
+    {
+        $itemId = strtoupper(trim((string) ($item['item_id'] ?? '')));
+        $questionId = strtoupper(trim((string) ($item['question_id'] ?? '')));
+        $answer = is_array($answers[$itemId] ?? null) ? $answers[$itemId] : null;
+
+        if ($itemId === '' || $questionId === '' || ! is_array($answer)) {
+            throw new ApiProblemException(500, 'IQ_OWNER_ANSWER_KEY_INVALID', 'owner IQ answer key is missing an item.');
+        }
+
+        $answerQuestionId = strtoupper(trim((string) ($answer['question_id'] ?? '')));
+        $correctAnswer = strtoupper(trim((string) ($answer['correct_answer'] ?? '')));
+        $dimension = strtoupper(trim((string) ($answer['dimension'] ?? '')));
+        if (
+            $answerQuestionId !== $questionId
+            || preg_match('/^[A-F]$/', $correctAnswer) !== 1
+            || ! in_array($dimension, ['VSPR', 'VSI', 'NPR'], true)
+        ) {
+            throw new ApiProblemException(500, 'IQ_OWNER_ANSWER_KEY_INVALID', 'owner IQ answer key has invalid item data.');
+        }
+
+        return [
+            'item_id' => $itemId,
+            'question_id' => $questionId,
+            'dimension' => $dimension,
+            'correct_answer' => $correctAnswer,
+            'raw_points' => 1.0,
+            'item_family' => 'owner_original_30_visual_reasoning',
+            'difficulty_level' => 'level_'.max(1, (int) ($answer['difficulty_level'] ?? 1)),
+            'solution_rule' => 'backend_private_owner_answer_key',
+            'distractor_logic' => 'owner_original_six_option_bank',
+            'assets' => $this->runtimeScoringAssets($item),
+            'asset_hashes' => is_array($item['asset_hashes'] ?? null) ? $item['asset_hashes'] : [],
+            'generator_metadata' => [
+                'source' => 'owner_original_backend_private_runtime_contract',
+                'bank_id' => self::BANK_ID,
+                'runtime_binding' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    private function runtimeScoringAssets(array $item): array
+    {
+        $options = [];
+        foreach (($item['options'] ?? []) as $option) {
+            if (! is_array($option)) {
+                continue;
+            }
+
+            $code = strtoupper(trim((string) ($option['code'] ?? '')));
+            $image = trim((string) data_get($option, 'assets.image', ''));
+            if ($code !== '' && $image !== '') {
+                $options[$code] = $image;
+            }
+        }
+
+        return [
+            'stem' => trim((string) data_get($item, 'stem.assets.image', '')),
+            'options' => $options,
+        ];
     }
 
     /**

--- a/backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+++ b/backend/scripts/iq/iq_owner_original30_image_bank_lib.php
@@ -396,8 +396,8 @@ function iqOwner30VerifyCommittedArtifacts(): void
     if (($manifest['bank_id'] ?? null) !== iqOwner30BankId() || ($itemsPayload['bank_id'] ?? null) !== iqOwner30BankId()) {
         throw new RuntimeException('Bank id mismatch');
     }
-    if (($manifest['runtime_bound'] ?? true) !== false) {
-        throw new RuntimeException('Owner bank must remain runtime-unbound in PR1');
+    if (($manifest['runtime_bound'] ?? false) !== true) {
+        throw new RuntimeException('Owner bank must be runtime-bound after scoring runtime bind');
     }
     if (($manifest['public_payload_policy']['may_emit_answer_key'] ?? true) !== false) {
         throw new RuntimeException('Manifest must not allow public answer key emission');
@@ -473,8 +473,11 @@ function iqOwner30VerifyPrivateScoringArtifacts(): void
     if (($answerKey['storage_policy'] ?? '') !== 'backend_only_never_emit_to_public_api') {
         throw new RuntimeException('Answer key storage policy must be backend-only');
     }
-    if (($scoring['runtime_binding']['enabled'] ?? true) !== false) {
-        throw new RuntimeException('Scoring spec must remain runtime-unbound in PR2');
+    if (($scoring['runtime_binding']['enabled'] ?? false) !== true) {
+        throw new RuntimeException('Scoring spec must be runtime-bound');
+    }
+    if (($scoring['runtime_binding']['mode'] ?? '') !== 'backend_private_answer_key') {
+        throw new RuntimeException('Scoring runtime binding must use backend private answer key mode');
     }
     if (($scoring['norm_policy']['iq_claims_enabled'] ?? true) !== false) {
         throw new RuntimeException('IQ claims must remain disabled before norm authority');

--- a/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+++ b/backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Content;
 
+use App\Services\Iq\IqOwnerOriginal30BankService;
 use App\Services\Iq\IqResultPayloadRedactor;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -24,7 +25,7 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
     }
 
     #[Test]
-    public function private_answer_key_and_scoring_spec_are_present_but_runtime_unbound(): void
+    public function private_answer_key_and_scoring_spec_are_present_and_runtime_bound(): void
     {
         $manifest = $this->readJson('manifest.json');
         $answerKey = $this->readJson('answer_key.json');
@@ -33,7 +34,7 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
         $this->assertSame('IQ_OWNER_ORIGINAL_30', $manifest['bank_id']);
         $this->assertSame('answer_key.json', $manifest['files']['answer_key']);
         $this->assertSame('scoring_spec.json', $manifest['files']['scoring_spec']);
-        $this->assertFalse($manifest['runtime_bound']);
+        $this->assertTrue($manifest['runtime_bound']);
         $this->assertFalse($manifest['public_payload_policy']['may_emit_answer_key']);
         $this->assertFalse($answerKey['public_payload']);
         $this->assertSame('backend_only_never_emit_to_public_api', $answerKey['storage_policy']);
@@ -41,7 +42,33 @@ final class IqOwnerOriginal30PrivateScoringTest extends TestCase
         $this->assertSame(30, $scoring['raw_score']['max']);
         $this->assertSame(1, $scoring['raw_score']['correct_item_value']);
         $this->assertFalse($scoring['norm_policy']['iq_claims_enabled']);
-        $this->assertFalse($scoring['runtime_binding']['enabled']);
+        $this->assertTrue($scoring['runtime_binding']['enabled']);
+        $this->assertSame('backend_private_answer_key', $scoring['runtime_binding']['mode']);
+    }
+
+    #[Test]
+    public function runtime_scoring_spec_matches_driver_contract_without_becoming_public_payload(): void
+    {
+        $spec = app(IqOwnerOriginal30BankService::class)->runtimeScoringSpec();
+
+        $this->assertSame('IQ_OWNER_ORIGINAL_30', data_get($spec, 'item_bank.bank_id'));
+        $this->assertSame('scored', $spec['scoring_mode'] ?? null);
+        $this->assertSame('unavailable', $spec['norm_table_version'] ?? null);
+        $this->assertFalse((bool) data_get($spec, 'norm_policy.iq_claims_enabled'));
+        $this->assertFalse((bool) data_get($spec, 'public_payload_policy.may_emit_answer_key'));
+        $this->assertCount(30, $spec['items'] ?? []);
+
+        foreach (($spec['items'] ?? []) as $item) {
+            $this->assertContains($item['correct_answer'] ?? null, ['A', 'B', 'C', 'D', 'E', 'F']);
+            $this->assertContains($item['dimension'] ?? null, ['VSPR', 'VSI', 'NPR']);
+            $this->assertNotEmpty($item['item_family'] ?? '');
+            $this->assertNotEmpty($item['difficulty_level'] ?? '');
+            $this->assertNotEmpty($item['solution_rule'] ?? '');
+            $this->assertNotEmpty($item['distractor_logic'] ?? '');
+            $this->assertNotEmpty($item['assets'] ?? []);
+            $this->assertNotEmpty($item['asset_hashes'] ?? []);
+            $this->assertNotEmpty($item['generator_metadata'] ?? []);
+        }
     }
 
     #[Test]

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -192,6 +192,56 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
         }
     }
 
+    #[Test]
+    public function owner_original_submit_scores_with_private_answer_key_without_public_answer_leak(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+
+        $anonId = 'anon_iq_owner_runtime_score';
+        $token = $this->issueAnonToken($anonId);
+        $attempt = $this->createOwnerAttempt($anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit?mode=sync_legacy', [
+            'attempt_id' => (string) $attempt->id,
+            'answers' => $this->perfectAnswers(),
+            'duration_ms' => 120000,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'result' => [
+                'raw_score' => 30,
+                'final_score' => 30,
+                'normed_json' => [
+                    'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+                    'bank_id' => 'IQ_OWNER_ORIGINAL_30',
+                    'status' => 'scored',
+                    'scoring_mode' => 'scored',
+                    'raw_score' => 30,
+                    'quality' => [
+                        'level' => 'A',
+                        'flags' => [],
+                    ],
+                    'norms' => [
+                        'iq_estimate' => null,
+                        'percentile' => null,
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertSame('iq_owner_original_30_runtime_scoring_v1', $response->json('meta.scoring_spec_version'));
+        $this->assertCount(3, $response->json('result.normed_json.dimension_scores'));
+        $this->assertSame(30, array_sum(array_map(
+            static fn (array $row): int => (int) ($row['correct_count'] ?? 0),
+            $response->json('result.normed_json.dimension_scores')
+        )));
+        $this->assertPayloadHasNoPrivateIqFields($response->json());
+    }
+
     private function issueAnonToken(string $anonId): string
     {
         $token = 'fm_'.(string) Str::uuid();
@@ -257,6 +307,29 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
                 'code' => 'A',
             ];
         }
+
+        return $answers;
+    }
+
+    /**
+     * @return array<int,array{question_id:string,code:string}>
+     */
+    private function perfectAnswers(): array
+    {
+        $path = base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json');
+        $doc = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($doc);
+
+        $answers = [];
+        foreach (($doc['answers'] ?? []) as $item) {
+            $this->assertIsArray($item);
+            $answers[] = [
+                'question_id' => (string) ($item['question_id'] ?? ''),
+                'code' => (string) ($item['correct_answer'] ?? ''),
+            ];
+        }
+
+        $this->assertCount(30, $answers);
 
         return $answers;
     }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -837,6 +837,27 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_eq_agent_runtime_read_only_shell_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Eq/EqAgentRuntimeResponder.php',
+            'backend/routes/api.php',
+        ];
+        $routeChangedLines = [
+            "+            Route::post('/attempts/{id}/eq/agent-runtime/messages', [AttemptReadController::class, 'eqAgentRuntimeMessage'])",
+            "+                ->middleware('uuid:id')",
+            "+                ->defaults('public_realm', true)",
+            "+                ->name('api.v0_3.attempts.eq.agent_runtime.messages');",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            routeChangedLines: $routeChangedLines
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -5319,6 +5340,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEqAgentRuntimeReadOnlyShellChange($file)) {
+                continue;
+            }
+
             if ($this->isEq60FreeReportContractChange($file, $repoRoot, $baseRef)) {
                 continue;
             }
@@ -5333,6 +5358,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsEqAgentContextReadOnlyContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsEqAgentRuntimeReadOnlyShellOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -7290,6 +7322,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEqAgentContextReadOnlyContractChange(string $file): bool
     {
         return $file === 'backend/app/Services/Eq/EqAgentContextBuilder.php';
+    }
+
+    private function isEqAgentRuntimeReadOnlyShellChange(string $file): bool
+    {
+        return $file === 'backend/app/Services/Eq/EqAgentRuntimeResponder.php';
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool
@@ -9999,6 +10036,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/eq\\/agent-context|eqAgentContext|api\\.v0_3\\.attempts\\.eq\\.agent_context|uuid:id|public_realm/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsEqAgentRuntimeReadOnlyShellOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (preg_match('/^\+\s*$/u', $line) === 1) {
+                continue;
+            }
+
+            if (preg_match('/eq\\/agent-runtime\\/messages|eqAgentRuntimeMessage|api\\.v0_3\\.attempts\\.eq\\.agent_runtime\\.messages|uuid:id|public_realm/u', $line) !== 1) {
                 return false;
             }
         }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -837,27 +837,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
-    public function test_runtime_freeze_classifier_ignores_eq_agent_runtime_read_only_shell_changes(): void
-    {
-        $changed = [
-            'backend/app/Services/Eq/EqAgentRuntimeResponder.php',
-            'backend/routes/api.php',
-        ];
-        $routeChangedLines = [
-            "+            Route::post('/attempts/{id}/eq/agent-runtime/messages', [AttemptReadController::class, 'eqAgentRuntimeMessage'])",
-            "+                ->middleware('uuid:id')",
-            "+                ->defaults('public_realm', true)",
-            "+                ->name('api.v0_3.attempts.eq.agent_runtime.messages');",
-        ];
-
-        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
-            $changed,
-            '',
-            '',
-            routeChangedLines: $routeChangedLines
-        ));
-    }
-
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -5340,10 +5319,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isEqAgentRuntimeReadOnlyShellChange($file)) {
-                continue;
-            }
-
             if ($this->isEq60FreeReportContractChange($file, $repoRoot, $baseRef)) {
                 continue;
             }
@@ -5358,13 +5333,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             if (
                 $file === 'backend/routes/api.php'
                 && $this->routeDiffIsEqAgentContextReadOnlyContractOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
-            ) {
-                continue;
-            }
-
-            if (
-                $file === 'backend/routes/api.php'
-                && $this->routeDiffIsEqAgentRuntimeReadOnlyShellOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
             ) {
                 continue;
             }
@@ -7322,11 +7290,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEqAgentContextReadOnlyContractChange(string $file): bool
     {
         return $file === 'backend/app/Services/Eq/EqAgentContextBuilder.php';
-    }
-
-    private function isEqAgentRuntimeReadOnlyShellChange(string $file): bool
-    {
-        return $file === 'backend/app/Services/Eq/EqAgentRuntimeResponder.php';
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool
@@ -10036,32 +9999,6 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/eq\\/agent-context|eqAgentContext|api\\.v0_3\\.attempts\\.eq\\.agent_context|uuid:id|public_realm/u', $line) !== 1) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param  list<string>  $changedLines
-     */
-    private function routeDiffIsEqAgentRuntimeReadOnlyShellOnly(array $changedLines): bool
-    {
-        if ($changedLines === []) {
-            return false;
-        }
-
-        foreach ($changedLines as $line) {
-            if (str_starts_with($line, '-')) {
-                return false;
-            }
-
-            if (preg_match('/^\+\s*$/u', $line) === 1) {
-                continue;
-            }
-
-            if (preg_match('/eq\\/agent-runtime\\/messages|eqAgentRuntimeMessage|api\\.v0_3\\.attempts\\.eq\\.agent_runtime\\.messages|uuid:id|public_realm/u', $line) !== 1) {
                 return false;
             }
         }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2962,6 +2962,71 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_owner_original30_runtime_scoring_bind(): void
+    {
+        $changed = [
+            'backend/app/Services/Assessment/AssessmentEngine.php',
+            'backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php',
+            'backend/app/Services/Iq/IqOwnerOriginal30BankService.php',
+        ];
+        $assessmentEngineChangedLines = [
+            '+use App\\Services\\Iq\\IqOwnerOriginal30BankService;',
+            '+        $ownerOriginalIqScoringSpec = $this->ownerOriginalIqScoringSpecIfNeeded($scaleCode, $ctx);',
+            '+        if ($ownerOriginalIqScoringSpec !== null) {',
+            '+            $scoringSpec = $ownerOriginalIqScoringSpec;',
+            '+        }',
+            "-        if (\$selectedSpecVersion !== '') {",
+            "+        if (\$selectedSpecVersion !== '' && \$ownerOriginalIqScoringSpec === null) {",
+            '+    private function ownerOriginalIqScoringSpecIfNeeded(string $scaleCode, array $ctx): ?array',
+            '+    {',
+            '+        if (! in_array($scaleCode, [IqOwnerOriginal30BankService::SCALE_CODE, IqOwnerOriginal30BankService::LEGACY_SCALE_CODE], true)) {',
+            '+            return null;',
+            '+        }',
+            '+',
+            "+        \$formCodeValue = \$ctx['form_code'] ?? null;",
+            "+        \$bankIdValue = \$ctx['bank_id'] ?? null;",
+            '+        $formCode = is_string($formCodeValue) || is_numeric($formCodeValue)',
+            '+            ? (string) $formCodeValue',
+            '+            : null;',
+            '+        $bankId = is_string($bankIdValue) || is_numeric($bankIdValue)',
+            '+            ? (string) $bankIdValue',
+            '+            : null;',
+            '+        $service = app(IqOwnerOriginal30BankService::class);',
+            '+        if (! $service->isOwnerOriginalRequest($formCode, $bankId)) {',
+            '+            return null;',
+            '+        }',
+            '+',
+            '+        return $service->runtimeScoringSpec();',
+            '+    }',
+            '+',
+        ];
+        $attemptSubmitCanonicalizeChangedLines = [
+            "+        \$formCode = trim((string) (\$attemptMeta['form_code'] ?? ''));",
+            "+        \$bankId = trim((string) (\$attemptMeta['bank_id'] ?? ''));",
+            "+            'form_code' => \$formCode,",
+            "+            'bank_id' => \$bankId,",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            assessmentEngineChangedLines: $assessmentEngineChangedLines,
+            attemptSubmitCanonicalizeChangedLines: $attemptSubmitCanonicalizeChangedLines,
+        ));
+        $this->assertSame(
+            ['backend/app/Services/Assessment/AssessmentEngine.php'],
+            $this->mbtiImpactingRuntimeChanges(
+                ['backend/app/Services/Assessment/AssessmentEngine.php'],
+                '',
+                '',
+                assessmentEngineChangedLines: [
+                    '+        $driverType = "big_five";',
+                ],
+            ),
+        );
+    }
+
     public function test_runtime_freeze_classifier_ignores_attempt_submission_reliability_hardening(): void
     {
         $changed = [
@@ -4411,10 +4476,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $articleControllerChangedLines = null,
         ?array $attributionControllerChangedLines = null,
         ?array $attemptSubmitServiceChangedLines = null,
+        ?array $attemptSubmitCanonicalizeChangedLines = null,
         ?array $webRouteChangedLines = null,
         ?array $resolveOrgContextChangedLines = null,
         ?array $contentPacksIndexChangedLines = null,
         ?array $bootstrapAppChangedLines = null,
+        ?array $assessmentEngineChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -5367,6 +5434,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isIqOwnerOriginal30SessionDeliveryBackendFile($file)) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Services/Assessment/AssessmentEngine.php'
+                && $this->assessmentEngineDiffIsIqOwnerOriginal30RuntimeScoringOnly(
+                    $assessmentEngineChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php'
+                && $this->attemptSubmitCanonicalizeDiffIsIqOwnerOriginal30RuntimeScoringOnly(
+                    $attemptSubmitCanonicalizeChangedLines ?? (
+                        $repoRoot !== '' && $baseRef !== ''
+                            ? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                            : []
+                    )
+                )
+            ) {
                 continue;
             }
 
@@ -6859,6 +6952,57 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqResultSecrecyRedactionFile(string $file): bool
     {
         return $file === 'backend/app/Services/Iq/IqResultPayloadRedactor.php';
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function assessmentEngineDiffIsIqOwnerOriginal30RuntimeScoringOnly(array $changedLines): bool
+    {
+        return $changedLines === [
+            '+use App\\Services\\Iq\\IqOwnerOriginal30BankService;',
+            '+        $ownerOriginalIqScoringSpec = $this->ownerOriginalIqScoringSpecIfNeeded($scaleCode, $ctx);',
+            '+        if ($ownerOriginalIqScoringSpec !== null) {',
+            '+            $scoringSpec = $ownerOriginalIqScoringSpec;',
+            '+        }',
+            "-        if (\$selectedSpecVersion !== '') {",
+            "+        if (\$selectedSpecVersion !== '' && \$ownerOriginalIqScoringSpec === null) {",
+            '+    private function ownerOriginalIqScoringSpecIfNeeded(string $scaleCode, array $ctx): ?array',
+            '+    {',
+            '+        if (! in_array($scaleCode, [IqOwnerOriginal30BankService::SCALE_CODE, IqOwnerOriginal30BankService::LEGACY_SCALE_CODE], true)) {',
+            '+            return null;',
+            '+        }',
+            '+',
+            "+        \$formCodeValue = \$ctx['form_code'] ?? null;",
+            "+        \$bankIdValue = \$ctx['bank_id'] ?? null;",
+            '+        $formCode = is_string($formCodeValue) || is_numeric($formCodeValue)',
+            '+            ? (string) $formCodeValue',
+            '+            : null;',
+            '+        $bankId = is_string($bankIdValue) || is_numeric($bankIdValue)',
+            '+            ? (string) $bankIdValue',
+            '+            : null;',
+            '+        $service = app(IqOwnerOriginal30BankService::class);',
+            '+        if (! $service->isOwnerOriginalRequest($formCode, $bankId)) {',
+            '+            return null;',
+            '+        }',
+            '+',
+            '+        return $service->runtimeScoringSpec();',
+            '+    }',
+            '+',
+        ];
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function attemptSubmitCanonicalizeDiffIsIqOwnerOriginal30RuntimeScoringOnly(array $changedLines): bool
+    {
+        return $changedLines === [
+            "+        \$formCode = trim((string) (\$attemptMeta['form_code'] ?? ''));",
+            "+        \$bankId = trim((string) (\$attemptMeta['bank_id'] ?? ''));",
+            "+            'form_code' => \$formCode,",
+            "+            'bank_id' => \$bankId,",
+        ];
     }
 
     /**

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
@@ -3,8 +3,8 @@
     "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
     "bank_id": "IQ_OWNER_ORIGINAL_30",
     "name": "FermatMind IQ Owner Original 30",
-    "status": "owner_original_private_scoring_ready_runtime_unbound",
-    "runtime_bound": false,
+    "status": "owner_original_runtime_scoring_bound",
+    "runtime_bound": true,
     "locale": "zh-CN",
     "market": "CN_MAINLAND",
     "item_count": 30,
@@ -50,14 +50,13 @@
         "asset_integrity_gate",
         "ownership_gate",
         "answer_key_gate",
-        "scoring_gate",
+        "scoring_runtime_binding_gate",
         "frontend_renderer_gate",
         "runtime_switch_gate"
     ],
     "deferred_prs": [
-        "IQ-OWNER-30-BACKEND-SCORING-02",
         "IQ-OWNER-30-FE-IMAGE-RENDERER-03",
         "IQ-OWNER-30-FE-FORMCODE-04",
-        "IQ-SESSION-QUESTION-DELIVERY-05"
+        "IQ-SESSION-QUESTION-DELIVERY-05B"
     ]
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "fm.iq.scoring_spec.v1",
     "bank_id": "IQ_OWNER_ORIGINAL_30",
-    "status": "owner_original_private_scoring_ready_runtime_unbound",
+    "status": "owner_original_runtime_scoring_bound",
     "raw_score": {
         "min": 0,
         "max": 30,
@@ -26,7 +26,8 @@
         "may_emit_scoring_key": false
     },
     "runtime_binding": {
-        "enabled": false,
-        "deferred_to_pr": "IQ-OWNER-30-FE-FORMCODE-04"
+        "enabled": true,
+        "bound_by_pr": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01",
+        "mode": "backend_private_answer_key"
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -167,7 +167,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -43784,7 +43784,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-dash-collector-02-write-gate",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "seo_intel_controlled_collector_write_gate",
     "title": "docs(seo): define controlled collector write gate",
     "checks": {
@@ -61138,6 +61138,81 @@
         "at": "2026-06-24T13:23:50Z",
         "status": "ready_to_merge",
         "note": "PR #2395 checks are green and mergeStateStatus is CLEAN on head ff047e4ad56faa92d156224aa36d1f29e3d4d7a6. Ready for squash merge; no staging wait, production deploy, CMS write, publish, search, indexing, sitemap, llms, or frontend runtime work included."
+      }
+    ]
+  },
+  "IQ-OWNER-30-SCORING-RUNTIME-BIND-01": {
+    "repo": "fap-api",
+    "branch": "codex/iq-owner-30-scoring-runtime-bind-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "iq_owner_original_30_launch",
+    "title": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01: Bind owner IQ 30 runtime scoring",
+    "depends_on": [
+      "IQ-SESSION-QUESTION-DELIVERY-05A"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for IQ-OWNER-30-SCORING-RUNTIME-BIND-01, then implementing backend runtime scoring binding."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-SESSION-QUESTION-DELIVERY-05A is merged: PR #2371 merged at 2026-06-23T16:16:38Z with merge commit ab7af7144bbb4016e19928dcf8081a95d8e36201, and origin/main contains that merge commit."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php",
+          "php -l backend/app/Services/Assessment/AssessmentEngine.php",
+          "php -l backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php",
+          "php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php",
+          "php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php",
+          "php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php",
+          "php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi",
+          "cd backend && bash scripts/pr74_verify.sh",
+          "cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null",
+          "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: private scoring verifier; PHP syntax checks for AssessmentEngine.php, AttemptSubmitCanonicalizeService.php, IqOwnerOriginal30BankService.php, iq_owner_original30_image_bank_lib.php, IqOwnerOriginal30PrivateScoringTest.php, and IqOwnerOriginal30SessionDeliveryTest.php; php artisan test --filter=IqOwnerOriginal30 (11 tests, 5244 assertions); PR74 constructor injection check; scoped Pint; JSON/YAML parse checks; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the IQ_OWNER_ORIGINAL_30 backend runtime scoring binding scope: AssessmentEngine, submit canonicalization score context, owner bank service/verifier, focused IQ tests, owner bank manifest/scoring_spec, and docs/codex train metadata."
+      },
+      "github": {
+        "status": "not_started",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T00:00:00Z",
+        "status": "in_progress",
+        "note": "Started backend-only runtime scoring binding from latest fap-api origin/main. Scope is IQ_OWNER_ORIGINAL_30 submit-time scoring with private answer key, owner bank runtime metadata, focused tests, and docs/codex train metadata. No frontend, CMS, SEO, sitemap, llms, DB migration, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-25T02:18:36Z",
+        "status": "local_validated",
+        "note": "Local acceptance and scope validation passed. Runtime scoring binding produces raw score, dimension scores, and quality metadata for IQ_OWNER_ORIGINAL_30 while public IQ payload redaction keeps answer keys, correct answers, solution rules, asset hashes, and generator metadata out of submit/read responses."
+      },
+      {
+        "at": "2026-06-25T02:18:36Z",
+        "status": "committed",
+        "note": "Created local scoped commit 36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -167,7 +167,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -61193,7 +61193,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "6d354623680e48187834916c22039fe46f41109f",
+    "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -61212,7 +61212,7 @@
       {
         "at": "2026-06-25T02:18:36Z",
         "status": "committed",
-        "note": "Created local scoped commit 6d354623680e48187834916c22039fe46f41109f."
+        "note": "Created local scoped commit 36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T02:47:02.247762Z",
+  "updated_at": "2026-06-25T02:58:10Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -25051,6 +25051,11 @@
             "python3 -m json.tool changed JSON files; ruby YAML.load_file docs/codex/pr-train.yaml; git diff --check"
           ],
           "completed_at": "2026-06-25T02:47:02.247762Z"
+        },
+        "github": {
+          "status": "pass",
+          "evidence": "GitHub checks passed for PR #2409 at head cf6a960dfe22be7c5cdd5f899efda6bc265b419d; mergeStateStatus CLEAN; PR open and non-draft.",
+          "checked_at": "2026-06-25T02:58:10Z"
         }
       },
       "failure_reason": null,
@@ -25103,11 +25108,19 @@
           "note": "Local Big Five freeze classifier fix and IQ_OWNER_ORIGINAL_30 runtime scoring validation passed; ready to commit and push CI fix."
         }
       ],
-      "status": "ci_fix_validated",
-      "commit_sha": "ffc7ff2bc2a0ad2d8f7c1931d9dee09002aba971",
+      "status": "ready_to_merge",
+      "commit_sha": "cf6a960dfe22be7c5cdd5f899efda6bc265b419d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2409",
       "pr_number": 2409,
-      "updated_at": "2026-06-25T02:47:02.247762Z"
+      "updated_at": "2026-06-25T02:47:02.247762Z",
+      "timeline": [
+        {
+          "at": "2026-06-25T02:58:10Z",
+          "from": "ci_fix_validated",
+          "to": "ready_to_merge",
+          "note": "All GitHub checks passed for PR #2409 at head cf6a960dfe22be7c5cdd5f899efda6bc265b419d and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {
@@ -61235,7 +61248,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-scoring-runtime-bind-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "ready_to_merge",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01: Bind owner IQ 30 runtime scoring",
     "depends_on": [
@@ -61278,13 +61291,14 @@
         "evidence": "Changed files are limited to the IQ_OWNER_ORIGINAL_30 backend runtime scoring binding scope: AssessmentEngine, submit canonicalization score context, owner bank service/verifier, focused IQ tests, owner bank manifest/scoring_spec, and docs/codex train metadata."
       },
       "github": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2409 at head cf6a960dfe22be7c5cdd5f899efda6bc265b419d; mergeStateStatus CLEAN; PR open and non-draft.",
+        "checked_at": "2026-06-25T02:58:10Z"
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "cf6a960dfe22be7c5cdd5f899efda6bc265b419d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2409",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -61303,6 +61317,14 @@
         "at": "2026-06-25T02:18:36Z",
         "status": "committed",
         "note": "Created local scoped commit 36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1."
+      }
+    ],
+    "timeline": [
+      {
+        "at": "2026-06-25T02:58:10Z",
+        "from": "in_progress",
+        "to": "ready_to_merge",
+        "note": "All GitHub checks passed for PR #2409 at head cf6a960dfe22be7c5cdd5f899efda6bc265b419d and mergeStateStatus was CLEAN. Recording ready_to_merge before squash merge per PR-train ledger policy."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T01:35:00+08:00",
+  "updated_at": "2026-06-25T02:47:02.247762Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -25018,6 +25018,96 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false
+    },
+    "IQ-OWNER-30-SCORING-RUNTIME-BIND-01": {
+      "id": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-owner-30-scoring-runtime-bind-01",
+      "base": "main",
+      "title": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01: Bind owner IQ 30 runtime scoring",
+      "depends_on": [
+        "IQ-SESSION-QUESTION-DELIVERY-05A"
+      ],
+      "checks": {
+        "github_verify_bigfive_initial": {
+          "status": "failed_current_pr_scoped_fix_in_progress",
+          "evidence": [
+            "PR #2409 verify-bigfive failed in Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff.",
+            "Failure listed backend/app/Services/Assessment/AssessmentEngine.php and backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php as runtime-impacting.",
+            "The flagged files are current PR scope for IQ_OWNER_ORIGINAL_30 runtime scoring bind and require a narrow Big Five freeze classifier allowance."
+          ],
+          "inspected_at": "2026-06-25T02:45:09.382758Z"
+        },
+        "ci_fix_local_validation": {
+          "status": "passed",
+          "commands": [
+            "php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|runtime_freeze_classifier_ignores_iq_owner_original30_runtime_scoring_bind' --no-ansi",
+            "php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php",
+            "php -l backend/app/Services/Assessment/AssessmentEngine.php && php -l backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php && php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php && php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php && php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php && php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+            "cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi",
+            "cd backend && bash scripts/pr74_verify.sh",
+            "cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "python3 -m json.tool changed JSON files; ruby YAML.load_file docs/codex/pr-train.yaml; git diff --check"
+          ],
+          "completed_at": "2026-06-25T02:47:02.247762Z"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": false,
+        "post_merge_revalidated": null,
+        "changed_files_expected": [
+          "backend/app/Services/Assessment/AssessmentEngine.php",
+          "backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php",
+          "backend/app/Services/Iq/IqOwnerOriginal30BankService.php",
+          "backend/scripts/iq/iq_owner_original30_image_bank_lib.php",
+          "backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php",
+          "backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json",
+          "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ],
+        "changed_files": [
+          "backend/app/Services/Assessment/AssessmentEngine.php",
+          "backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php",
+          "backend/app/Services/Iq/IqOwnerOriginal30BankService.php",
+          "backend/scripts/iq/iq_owner_original30_image_bank_lib.php",
+          "backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php",
+          "backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json",
+          "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ]
+      },
+      "transitions": [
+        {
+          "at": "2026-06-25T02:45:09.382758Z",
+          "from": "pr_open_checks_pending",
+          "to": "ci_fix_in_progress",
+          "note": "Inspected verify-bigfive failure and started scoped freeze classifier fix for IQ_OWNER_ORIGINAL_30 runtime scoring bind shared service files."
+        },
+        {
+          "at": "2026-06-25T02:47:02.247762Z",
+          "from": "ci_fix_in_progress",
+          "to": "ci_fix_validated",
+          "note": "Local Big Five freeze classifier fix and IQ_OWNER_ORIGINAL_30 runtime scoring validation passed; ready to commit and push CI fix."
+        }
+      ],
+      "status": "ci_fix_validated",
+      "commit_sha": "ffc7ff2bc2a0ad2d8f7c1931d9dee09002aba971",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2409",
+      "pr_number": 2409,
+      "updated_at": "2026-06-25T02:47:02.247762Z"
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -167,7 +167,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1",
+    "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -61193,7 +61193,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "6d354623680e48187834916c22039fe46f41109f",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -61212,7 +61212,7 @@
       {
         "at": "2026-06-25T02:18:36Z",
         "status": "committed",
-        "note": "Created local scoped commit 36c2aacd470b839a6d6ff0a62fc5ae5285f32cd1."
+        "note": "Created local scoped commit 6d354623680e48187834916c22039fe46f41109f."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -95,6 +95,62 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: IQ-OWNER-30-SCORING-RUNTIME-BIND-01
+    repo: fap-api
+    depends_on:
+      - IQ-SESSION-QUESTION-DELIVERY-05A
+    branch: codex/iq-owner-30-scoring-runtime-bind-01
+    title: "IQ-OWNER-30-SCORING-RUNTIME-BIND-01: Bind owner IQ 30 runtime scoring"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Bind IQ_OWNER_ORIGINAL_30 owner attempts to the backend-private runtime scoring contract.
+      - Convert private items, answer_key, and scoring_spec into an IqTestDriver scored contract at submit time.
+      - Persist raw_score, dimension_scores, quality, and result stability without emitting answer keys, correct answers, solution rules, or generator metadata in public result payloads.
+      - Keep IQ and percentile claims disabled until a norm authority exists.
+    allowed_paths:
+      - backend/app/Services/Assessment/AssessmentEngine.php
+      - backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
+      - backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+      - backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+      - backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+      - backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend rendering, frontend adapters, CMS, SEO runtime, sitemap, llms, JSON-LD, production imports, staging deploy, or production deploy.
+      - Add DB migrations, production writes, or CMS writes.
+      - Enable IQ estimate or percentile claims without a norm authority.
+      - Emit correct answers, answer keys, solution rules, generator metadata, private provenance, or source capture URLs in public delivery or result payloads.
+    validation:
+      - php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php
+      - php -l backend/app/Services/Assessment/AssessmentEngine.php
+      - php -l backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
+      - php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php
+      - php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php
+      - php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
+      - php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi
+      - cd backend && bash scripts/pr74_verify.sh
+      - cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
     repo: fap-api
     depends_on: []

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -115,6 +115,7 @@ prs:
       - backend/scripts/iq/iq_owner_original30_image_bank_lib.php
       - backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
       - backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json
       - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/scoring_spec.json
       - docs/codex/pr-train.yaml
@@ -132,9 +133,11 @@ prs:
       - php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php
       - php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php
       - php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|runtime_freeze_classifier_ignores_iq_owner_original30_runtime_scoring_bind' --no-ansi
       - cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi
       - cd backend && bash scripts/pr74_verify.sh
-      - cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/manifest.json >/dev/null
       - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/items.json >/dev/null
       - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_OWNER_ORIGINAL_30/answer_key.json >/dev/null


### PR DESCRIPTION
## What changed
- Added `IQ-OWNER-30-SCORING-RUNTIME-BIND-01` to the fap-api PR train manifest/state ledger.
- Bound `IQ_OWNER_ORIGINAL_30` owner attempts to a backend-private runtime scoring contract at submit time.
- Converted the private `answer_key.json`, item metadata, and scoring spec into the `IqTestDriver` contract without making answer data part of public delivery.
- Passed owner form/bank metadata into the score context so only owner-original IQ attempts use this scoring path.
- Updated owner bank verifier/tests to assert raw score, dimension scores, quality flags, and no private answer-field leakage.

## Why
The owner-original 30-question IQ bank was deliverable but runtime scoring still showed incomplete IQ estimates. This binds the existing backend-authoritative private answer key to runtime submission so completed attempts produce scored results while keeping IQ/percentile norm claims disabled until a norm authority exists.

## Validation
- `php backend/scripts/iq/verify_iq_owner_original30_private_scoring.php`
- `php -l backend/app/Services/Assessment/AssessmentEngine.php`
- `php -l backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php`
- `php -l backend/app/Services/Iq/IqOwnerOriginal30BankService.php`
- `php -l backend/scripts/iq/iq_owner_original30_image_bank_lib.php`
- `php -l backend/tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php`
- `php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- `cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi`
- `cd backend && bash scripts/pr74_verify.sh`
- `cd backend && vendor/bin/pint --test app/Services/Assessment/AssessmentEngine.php app/Services/Attempts/AttemptSubmitCanonicalizeService.php app/Services/Iq/IqOwnerOriginal30BankService.php tests/Feature/Content/IqOwnerOriginal30PrivateScoringTest.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php`
- JSON parse checks for owner bank manifest/items/answer_key/scoring_spec and PR train state
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- Frontend rendering/adapter changes.
- CMS, SEO runtime, sitemap, llms, JSON-LD, production import, staging deploy, production deploy.
- IQ estimate or percentile claims; those remain disabled until a norm authority is available.

## Repository rule impact
Backend remains the scoring/content authority for this IQ product surface. No frontend fallback content, CMS writes, SEO enumeration, DB migrations, or deploy workflow changes are introduced.
