### PR TITLE
IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy

### DIFF
--- a/backend/app/Services/Assessment/Drivers/IqTestDriver.php
+++ b/backend/app/Services/Assessment/Drivers/IqTestDriver.php
@@ -60,6 +60,11 @@ class IqTestDriver implements DriverInterface
             $rawScore,
             $ctx
         );
+        $claimPolicy = is_array($norms['claim_policy'] ?? null) ? $norms['claim_policy'] : [];
+        $scoreClaimLevel = trim((string) ($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? 'raw_score_only')));
+        $claimWarnings = is_array($norms['claim_warnings'] ?? null)
+            ? array_values(array_map('strval', $norms['claim_warnings']))
+            : [];
         $scorePayload = [
             'scale_code' => $contract['scale_code'],
             'bank_id' => $contract['bank_id'],
@@ -67,6 +72,9 @@ class IqTestDriver implements DriverInterface
             'scoring_mode' => 'scored',
             'answer_key_version' => $contract['answer_key_version'],
             'norm_table_version' => $contract['norm_table_version'],
+            'score_claim_level' => $scoreClaimLevel !== '' ? $scoreClaimLevel : 'raw_score_only',
+            'claim_policy' => $claimPolicy,
+            'claim_warnings' => $claimWarnings,
             'scoring_engine_version' => $contract['scoring_engine_version'],
             'raw_score' => $rawScore,
             'final_score' => $rawScore,
@@ -531,22 +539,29 @@ class IqTestDriver implements DriverInterface
             'iq_estimate' => null,
             'percentile' => null,
             'confidence_interval' => null,
-            'norm_table_version' => $normTableVersion,
+            'norm_table_version' => null,
+            'score_claim_level' => 'raw_score_only',
+            'claim_warnings' => ['no_norm_table'],
             'claim_policy' => [
                 'claim_eligible' => false,
+                'score_claim_level' => 'raw_score_only',
                 'reason_code' => null,
+                'claim_warnings' => ['no_norm_table'],
+                'iq_estimate_allowed' => false,
                 'source' => 'iq_norm_authority',
             ],
         ];
 
         if ($base['status'] === 'unavailable_without_norm_table') {
-            $base['claim_policy']['reason_code'] = 'norm_table_version_unavailable';
+            $base['claim_policy']['reason_code'] = 'no_norm_table';
 
             return $base;
         }
 
         if ($scaleCode !== IqNormAuthorityContract::SCALE_CODE || ! Schema::hasTable('iq_norm_authorities')) {
             $base['claim_policy']['reason_code'] = 'iq_norm_authority_unavailable';
+            $base['claim_warnings'] = ['iq_norm_authority_unavailable'];
+            $base['claim_policy']['claim_warnings'] = $base['claim_warnings'];
 
             return $base;
         }
@@ -570,6 +585,8 @@ class IqTestDriver implements DriverInterface
 
         if (! $record) {
             $base['claim_policy']['reason_code'] = 'iq_norm_authority_not_found';
+            $base['claim_warnings'] = ['iq_norm_authority_not_found'];
+            $base['claim_policy']['claim_warnings'] = $base['claim_warnings'];
 
             return $base;
         }
@@ -588,14 +605,22 @@ class IqTestDriver implements DriverInterface
         $base['status'] = (bool) ($gate['claim_eligible'] ?? false)
             ? strtolower(trim((string) ($authority['status'] ?? 'production_normed')))
             : 'unavailable_without_claim_eligible_norm_authority';
-        $base['norm_table_version'] = (string) ($authority['norm_table_version'] ?? $normTableVersion);
         $base['population_key'] = (string) ($authority['population_key'] ?? $populationKey);
         $base['locale'] = (string) ($authority['locale'] ?? $locale);
         $base['sample_size'] = (int) ($authority['sample_size'] ?? 0);
+        $base['claim_warnings'] = (bool) ($gate['claim_eligible'] ?? false)
+            ? []
+            : array_values(array_unique(array_filter(array_map(
+                'strval',
+                (array) ($gate['errors'] ?? [$gate['reason_code'] ?? 'iq_norm_authority_not_claim_eligible'])
+            ))));
         $base['claim_policy'] = [
             'claim_eligible' => (bool) ($gate['claim_eligible'] ?? false),
+            'score_claim_level' => (bool) ($gate['claim_eligible'] ?? false) ? 'iq_estimate' : 'raw_score_only',
             'reason_code' => $gate['reason_code'] ?? null,
             'errors' => $gate['errors'] ?? [],
+            'claim_warnings' => $base['claim_warnings'],
+            'iq_estimate_allowed' => (bool) ($gate['claim_eligible'] ?? false),
             'source' => 'iq_norm_authority',
         ];
 
@@ -603,13 +628,21 @@ class IqTestDriver implements DriverInterface
             return $base;
         }
 
+        $base['norm_table_version'] = (string) ($authority['norm_table_version'] ?? $normTableVersion);
+        $base['score_claim_level'] = 'iq_estimate';
         $mean = (float) ($authority['mean'] ?? 0.0);
         $standardDeviation = (float) ($authority['standard_deviation'] ?? 0.0);
         if ($standardDeviation <= 0.0) {
             $base['status'] = 'unavailable_without_claim_eligible_norm_authority';
+            $base['norm_table_version'] = null;
+            $base['score_claim_level'] = 'raw_score_only';
+            $base['claim_warnings'] = ['standard_deviation_must_be_positive'];
             $base['claim_policy']['claim_eligible'] = false;
+            $base['claim_policy']['score_claim_level'] = 'raw_score_only';
             $base['claim_policy']['reason_code'] = 'standard_deviation_must_be_positive';
             $base['claim_policy']['errors'] = ['standard_deviation_must_be_positive'];
+            $base['claim_policy']['claim_warnings'] = $base['claim_warnings'];
+            $base['claim_policy']['iq_estimate_allowed'] = false;
 
             return $base;
         }

--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -145,7 +145,10 @@ final class IqReportBuilder
                 'scoring_mode' => $this->stringOrNull($score['scoring_mode'] ?? null),
                 'bank_id' => $this->stringOrNull($score['bank_id'] ?? null),
                 'answer_key_version' => $this->stringOrNull($score['answer_key_version'] ?? null),
-                'norm_table_version' => $this->stringOrNull($score['norm_table_version'] ?? null),
+                'norm_table_version' => $this->stringOrNull($summary['norm_table_version'] ?? null),
+                'score_claim_level' => $this->stringOrNull($summary['score_claim_level'] ?? null) ?? 'raw_score_only',
+                'claim_policy' => is_array($summary['claim_policy'] ?? null) ? $summary['claim_policy'] : [],
+                'claim_warnings' => is_array($summary['claim_warnings'] ?? null) ? $summary['claim_warnings'] : [],
                 'scoring_engine_version' => $this->stringOrNull($score['scoring_engine_version'] ?? null),
             ],
             'access' => [
@@ -199,6 +202,10 @@ final class IqReportBuilder
                 'percentile' => null,
                 'confidence_interval' => null,
                 'norms_status' => $this->stringOrNull($summary['norms_status'] ?? null),
+                'norm_table_version' => $this->stringOrNull($summary['norm_table_version'] ?? null),
+                'score_claim_level' => $this->stringOrNull($summary['score_claim_level'] ?? null) ?? 'raw_score_only',
+                'claim_policy' => is_array($summary['claim_policy'] ?? null) ? $summary['claim_policy'] : [],
+                'claim_warnings' => is_array($summary['claim_warnings'] ?? null) ? $summary['claim_warnings'] : [],
             ],
             'access' => [
                 'report_access_level' => $reportAccessLevel,
@@ -266,6 +273,10 @@ final class IqReportBuilder
         $norms = is_array($score['norms'] ?? null) ? $score['norms'] : [];
         $scored = $status === 'scored';
         $hasNormAuthority = $this->hasNormAuthority($norms);
+        $claimPolicy = $this->normalizeClaimPolicy($norms);
+        $scoreClaimLevel = $this->stringOrNull($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? null))
+            ?? 'raw_score_only';
+        $claimWarnings = $this->normalizeStringList($norms['claim_warnings'] ?? ($claimPolicy['claim_warnings'] ?? []));
 
         return [
             'raw_score' => $scored ? $this->floatOrNull($score['raw_score'] ?? null) : null,
@@ -275,7 +286,52 @@ final class IqReportBuilder
                 ? $norms['confidence_interval']
                 : null,
             'norms_status' => $this->stringOrNull($norms['status'] ?? null),
+            'norm_table_version' => $this->stringOrNull($norms['norm_table_version'] ?? null),
+            'score_claim_level' => $scoreClaimLevel,
+            'claim_policy' => $claimPolicy,
+            'claim_warnings' => $claimWarnings,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $norms
+     * @return array<string,mixed>
+     */
+    private function normalizeClaimPolicy(array $norms): array
+    {
+        $claimPolicy = is_array($norms['claim_policy'] ?? null) ? $norms['claim_policy'] : [];
+        $claimEligible = ($claimPolicy['claim_eligible'] ?? null) === true;
+        $scoreClaimLevel = $this->stringOrNull($norms['score_claim_level'] ?? ($claimPolicy['score_claim_level'] ?? null))
+            ?? ($claimEligible ? 'iq_estimate' : 'raw_score_only');
+        $claimWarnings = $this->normalizeStringList($norms['claim_warnings'] ?? ($claimPolicy['claim_warnings'] ?? []));
+
+        $claimPolicy['claim_eligible'] = $claimEligible;
+        $claimPolicy['score_claim_level'] = $scoreClaimLevel;
+        $claimPolicy['claim_warnings'] = $claimWarnings;
+        $claimPolicy['iq_estimate_allowed'] = $scoreClaimLevel !== 'raw_score_only';
+        $claimPolicy['source'] = $this->stringOrNull($claimPolicy['source'] ?? null) ?? 'iq_norm_authority';
+
+        return $claimPolicy;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = trim((string) $item);
+            if ($normalized !== '') {
+                $items[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($items));
     }
 
     /**

--- a/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+++ b/backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
@@ -229,10 +229,24 @@ final class IqOwnerOriginal30SessionDeliveryTest extends TestCase
                     'norms' => [
                         'iq_estimate' => null,
                         'percentile' => null,
+                        'confidence_interval' => null,
+                        'norm_table_version' => null,
+                        'score_claim_level' => 'raw_score_only',
+                        'claim_warnings' => ['no_norm_table'],
+                        'claim_policy' => [
+                            'claim_eligible' => false,
+                            'score_claim_level' => 'raw_score_only',
+                        ],
                     ],
                 ],
             ],
         ]);
+        $this->assertSame('raw_score_only', $response->json('result.normed_json.score_claim_level'));
+        $this->assertContains('no_norm_table', $response->json('result.normed_json.claim_warnings'));
+        $this->assertFalse((bool) $response->json('result.normed_json.claim_policy.claim_eligible'));
+        $this->assertSame('raw_score_only', $response->json('result.normed_json.claim_policy.score_claim_level'));
+        $this->assertFalse((bool) $response->json('result.normed_json.norms.claim_policy.claim_eligible'));
+        $this->assertContains('no_norm_table', $response->json('result.normed_json.norms.claim_warnings'));
         $this->assertSame('iq_owner_original_30_runtime_scoring_v1', $response->json('meta.scoring_spec_version'));
         $this->assertCount(3, $response->json('result.normed_json.dimension_scores'));
         $this->assertSame(30, array_sum(array_map(

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -88,6 +88,17 @@ final class IqReportContractTest extends TestCase
                 'iq_estimate' => null,
                 'percentile' => null,
                 'confidence_interval' => null,
+                'norm_table_version' => null,
+                'score_claim_level' => 'raw_score_only',
+                'claim_warnings' => ['no_norm_table'],
+                'claim_policy' => [
+                    'claim_eligible' => false,
+                    'score_claim_level' => 'raw_score_only',
+                    'reason_code' => 'no_norm_table',
+                    'claim_warnings' => ['no_norm_table'],
+                    'iq_estimate_allowed' => false,
+                    'source' => 'iq_norm_authority',
+                ],
             ],
             'dimension_scores' => [
                 'VSI' => [
@@ -385,6 +396,11 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.summary.iq_estimate'));
         $this->assertNull(data_get($payload, 'report.summary.percentile'));
         $this->assertNull(data_get($payload, 'report.summary.confidence_interval'));
+        $this->assertNull(data_get($payload, 'report.summary.norm_table_version'));
+        $this->assertSame('raw_score_only', data_get($payload, 'report.summary.score_claim_level'));
+        $this->assertSame('raw_score_only', data_get($payload, 'report.scoring.score_claim_level'));
+        $this->assertContains('no_norm_table', data_get($payload, 'report.summary.claim_warnings'));
+        $this->assertFalse((bool) data_get($payload, 'report.summary.claim_policy.claim_eligible'));
         $this->assertNull(data_get($payload, 'report.answer_key'));
         $this->assertNull(data_get($payload, 'report.correct_answers'));
     }

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -87,6 +87,9 @@ final class IqReportBuilderTest extends TestCase
         $this->assertNull(data_get($payload, 'report.summary.percentile'));
         $this->assertNull(data_get($payload, 'report.summary.confidence_interval'));
         $this->assertSame('unavailable_without_norm_table', data_get($payload, 'report.summary.norms_status'));
+        $this->assertSame('raw_score_only', data_get($payload, 'report.summary.score_claim_level'));
+        $this->assertSame('raw_score_only', data_get($payload, 'report.scoring.score_claim_level'));
+        $this->assertFalse((bool) data_get($payload, 'report.summary.claim_policy.claim_eligible'));
         $this->assertSame('stable', data_get($payload, 'report.stability.status'));
         $this->assertSame('A', data_get($payload, 'report.quality.level'));
         $this->assertSame(75.0, data_get($payload, 'report.dimensions.visual_spatial_insight.percent_correct'));
@@ -117,6 +120,8 @@ final class IqReportBuilderTest extends TestCase
         $this->assertSame(109.0, data_get($payload, 'report.summary.iq_estimate'));
         $this->assertSame(72.57, data_get($payload, 'report.summary.percentile'));
         $this->assertSame([104.5, 113.5], data_get($payload, 'report.summary.confidence_interval'));
+        $this->assertSame('iq_estimate', data_get($payload, 'report.summary.score_claim_level'));
+        $this->assertTrue((bool) data_get($payload, 'report.summary.claim_policy.claim_eligible'));
 
         $lockedResult = new Result([
             'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
@@ -131,6 +136,9 @@ final class IqReportBuilderTest extends TestCase
         $this->assertNull(data_get($lockedPayload, 'report.summary.iq_estimate'));
         $this->assertNull(data_get($lockedPayload, 'report.summary.percentile'));
         $this->assertNull(data_get($lockedPayload, 'report.summary.confidence_interval'));
+        $this->assertSame('raw_score_only', data_get($lockedPayload, 'report.summary.score_claim_level'));
+        $this->assertSame('raw_score_only', data_get($lockedPayload, 'report.scoring.score_claim_level'));
+        $this->assertFalse((bool) data_get($lockedPayload, 'report.summary.claim_policy.claim_eligible'));
     }
 
     public function test_builder_keeps_blocked_unscored_legacy_demo_report_explicit(): void
@@ -198,9 +206,15 @@ final class IqReportBuilderTest extends TestCase
                 'iq_estimate' => 109.0,
                 'percentile' => 72.57,
                 'confidence_interval' => [104.5, 113.5],
+                'norm_table_version' => $claimEligible ? 'iq_norm_prod_v1' : null,
+                'score_claim_level' => $claimEligible ? 'iq_estimate' : 'raw_score_only',
+                'claim_warnings' => $claimEligible ? [] : ['license_verification_required'],
                 'claim_policy' => [
                     'claim_eligible' => $claimEligible,
+                    'score_claim_level' => $claimEligible ? 'iq_estimate' : 'raw_score_only',
                     'reason_code' => $claimEligible ? null : 'license_verification_required',
+                    'claim_warnings' => $claimEligible ? [] : ['license_verification_required'],
+                    'iq_estimate_allowed' => $claimEligible,
                     'source' => 'iq_norm_authority',
                 ],
             ],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61675,6 +61675,11 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to the backend owner IQ 30 claim policy scope: IqTestDriver, IqReportBuilder, focused owner 30/report tests, and docs/codex train metadata."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2413 at head bdf632e941af4635de440315e96ab6b52433aa85; mergeStateStatus CLEAN; PR open and non-draft.",
+        "checked_at": "2026-06-25T04:01:50Z"
       }
     },
     "failure_reason": null,
@@ -61703,6 +61708,11 @@
         "at": "2026-06-25T03:54:44Z",
         "status": "github_checks_pending",
         "note": "Rebased PR #2413 onto latest origin/main after GitHub reported mergeStateStatus DIRTY. The only rebase conflict was docs/codex/pr-train-state.json; main-side fap-web EQ Agent closeout facts were preserved and 02A state was updated to head 6f3ffe1626c80cda7ed4605758213575b7f61188."
+      },
+      {
+        "at": "2026-06-25T04:01:50Z",
+        "status": "ready_to_merge",
+        "note": "PR #2413 checks passed at head bdf632e941af4635de440315e96ab6b52433aa85 and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, sitemap, llms, DB migration, or frontend work included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61678,8 +61678,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "6f3ffe1626c80cda7ed4605758213575b7f61188",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2413",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -61698,6 +61698,11 @@
         "at": "2026-06-25T03:49:40Z",
         "status": "github_checks_pending",
         "note": "Opened PR #2413 at https://github.com/fermatmind/fap-api/pull/2413 on head 1932d42e71661a0be4e28d8d9503e10a52992c15. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, SEO, sitemap, llms, DB migration, or frontend work included."
+      },
+      {
+        "at": "2026-06-25T03:54:44Z",
+        "status": "github_checks_pending",
+        "note": "Rebased PR #2413 onto latest origin/main after GitHub reported mergeStateStatus DIRTY. The only rebase conflict was docs/codex/pr-train-state.json; main-side fap-web EQ Agent closeout facts were preserved and 02A state was updated to head 6f3ffe1626c80cda7ed4605758213575b7f61188."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61693,6 +61693,11 @@
         "at": "2026-06-25T03:46:50Z",
         "status": "local_validated",
         "note": "Local checks and scope validation passed. Owner 30 submit/report payloads now carry backend-authoritative raw_score_only claim policy, null IQ estimate/percentile/confidence interval/norm table claims, no_norm_table warning, and no public answer leakage."
+      },
+      {
+        "at": "2026-06-25T03:49:40Z",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2413 at https://github.com/fermatmind/fap-api/pull/2413 on head 1932d42e71661a0be4e28d8d9503e10a52992c15. Waiting for required GitHub checks; no staging deploy wait, production deploy, CMS write, SEO, sitemap, llms, DB migration, or frontend work included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -61635,5 +61635,65 @@
     "pr_head_sha": "4e1cbe9ae0956f903948231a301761a39bfe73c5",
     "pr_number": 2409,
     "merge_commit_sha": "953ba036a0d5ca8dad855b9f0f226664dc376fef"
+  },
+  "IQ-OWNER-30-NORM-CLAIM-POLICY-02A": {
+    "repo": "fap-api",
+    "branch": "codex/iq-owner-30-norm-claim-policy-02a",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "iq_owner_original_30_launch",
+    "title": "IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy",
+    "depends_on": [
+      "IQ-OWNER-30-SCORING-RUNTIME-BIND-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json updates for IQ-OWNER-30-NORM-CLAIM-POLICY-02A and requested backend runtime claim policy binding."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01 is recorded merged with merge commit 953ba036a0d5ca8dad855b9f0f226664dc376fef and origin/main contained it before this branch started."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php",
+          "php -l backend/app/Services/Report/IqReportBuilder.php",
+          "php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php",
+          "php -l backend/tests/Feature/V0_3/IqReportContractTest.php",
+          "php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php",
+          "cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi",
+          "cd backend && php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php app/Services/Report/IqReportBuilder.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Unit/Services/Report/IqReportBuilderTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: PHP syntax checks for IqTestDriver.php, IqReportBuilder.php, IqOwnerOriginal30SessionDeliveryTest.php, IqReportContractTest.php, and IqReportBuilderTest.php; php artisan test --filter=IqOwnerOriginal30 (11 tests, 5323 assertions); IqReportBuilderTest (3 tests, 41 assertions); scoped Pint; JSON/YAML parse checks; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the backend owner IQ 30 claim policy scope: IqTestDriver, IqReportBuilder, focused owner 30/report tests, and docs/codex train metadata."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T03:37:25Z",
+        "status": "in_progress",
+        "note": "Started backend-only owner IQ 30 claim policy binding from latest fap-api origin/main. Scope is result/report payload claim policy for raw-score-only display without IQ estimate, percentile, confidence interval, norm table claim, answer leak, frontend, CMS, SEO, DB migration, staging deploy, or production deploy."
+      },
+      {
+        "at": "2026-06-25T03:46:50Z",
+        "status": "local_validated",
+        "note": "Local checks and scope validation passed. Owner 30 submit/report payloads now carry backend-authoritative raw_score_only claim policy, null IQ estimate/percentile/confidence interval/norm table claims, no_norm_table warning, and no public answer leakage."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -154,6 +154,52 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: IQ-OWNER-30-NORM-CLAIM-POLICY-02A
+    repo: fap-api
+    depends_on:
+      - IQ-OWNER-30-SCORING-RUNTIME-BIND-01
+    branch: codex/iq-owner-30-norm-claim-policy-02a
+    title: "IQ-OWNER-30-NORM-CLAIM-POLICY-02A: Bind owner IQ 30 raw-score-only claim policy"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Add backend-authoritative raw-score-only claim policy for IQ_OWNER_ORIGINAL_30 result and report payloads.
+      - Keep IQ estimate, percentile, confidence interval, and norm table claims null until a claim-eligible norm authority exists.
+      - Preserve raw_score, dimension_scores, quality, and stability without exposing answer keys or private scoring metadata.
+    allowed_paths:
+      - backend/app/Services/Assessment/Drivers/IqTestDriver.php
+      - backend/app/Services/Report/IqReportBuilder.php
+      - backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - backend/tests/Feature/V0_3/IqReportContractTest.php
+      - backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend rendering, question bank assets, answer keys, CMS, SEO runtime, sitemap, llms, JSON-LD, production imports, staging deploy, or production deploy.
+      - Add DB migrations, production writes, or CMS writes.
+      - Enable IQ estimate, percentile, ranking, or normed IQ claims without a claim-eligible backend norm authority.
+      - Emit correct answers, answer keys, solution rules, generator metadata, private provenance, or source capture URLs in public result/report payloads.
+    validation:
+      - php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php
+      - php -l backend/app/Services/Report/IqReportBuilder.php
+      - php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
+      - php -l backend/tests/Feature/V0_3/IqReportContractTest.php
+      - php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+      - cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi
+      - cd backend && php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi
+      - cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php app/Services/Report/IqReportBuilder.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Unit/Services/Report/IqReportBuilderTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
     repo: fap-api
     depends_on: []


### PR DESCRIPTION
## What changed
- Added backend-authoritative raw-score-only claim policy fields to IQ owner 30 result payloads.
- Propagated the same claim policy through IQ report summary and scoring payloads.
- Added focused assertions that owner 30 returns raw score and dimension/quality/stability data while IQ estimate, percentile, confidence interval, and public norm table claims remain null.
- Registered the PR-train manifest/state entry for this scoped backend item.

## Why
Owner IQ 30 currently has no compliant norm table. The backend must explicitly tell consumers that this result is raw-score-only so the frontend does not infer or display IQ estimate, percentile, ranking, or confidence interval claims.

## Validation
- php -l backend/app/Services/Assessment/Drivers/IqTestDriver.php
- php -l backend/app/Services/Report/IqReportBuilder.php
- php -l backend/tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php
- php -l backend/tests/Feature/V0_3/IqReportContractTest.php
- php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php
- cd backend && php artisan test --filter=IqOwnerOriginal30 --no-ansi
- cd backend && php artisan test tests/Unit/Services/Report/IqReportBuilderTest.php --no-ansi
- cd backend && vendor/bin/pint --test app/Services/Assessment/Drivers/IqTestDriver.php app/Services/Report/IqReportBuilder.php tests/Feature/V0_3/IqOwnerOriginal30SessionDeliveryTest.php tests/Feature/V0_3/IqReportContractTest.php tests/Unit/Services/Report/IqReportBuilderTest.php
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
- git diff --check

## Intentionally deferred
- No frontend rendering changes; fap-web 02B will consume this backend policy.
- No norm import, IQ estimate enablement, percentile display, CMS/SEO changes, DB migration, staging wait, production deploy, or manual deploy.

## Repository rule impact
Backend remains the authority for IQ scoring and claim policy. No frontend/content authority changes in this PR.