### PR TITLE
PERSONALITY-AGENT-OPS-REVIEW-SURFACE-01

### DIFF
--- a/backend/app/Console/Commands/PersonalityAgentApprovalQueueReviewCommand.php
+++ b/backend/app/Console/Commands/PersonalityAgentApprovalQueueReviewCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\PersonalityAgentApprovalQueueReadModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use InvalidArgumentException;
+use Throwable;
+
+final class PersonalityAgentApprovalQueueReviewCommand extends Command
+{
+    protected $signature = 'personality:agent-approval-queue-review
+        {--framework= : Optional framework filter: mbti64, big_five, or enneagram}
+        {--approval-state=pending : Approval state filter: pending, approved, rejected, or all}
+        {--limit=50 : Maximum rows to return, from 1 to 200}
+        {--json : Emit the full JSON read model}
+        {--output= : Optional path to write the JSON read model}';
+
+    protected $description = 'Read pending personality agent recommendation approvals and QA risk state without writing CMS or approval records.';
+
+    public function handle(PersonalityAgentApprovalQueueReadModel $readModel): int
+    {
+        try {
+            $payload = $readModel->read(
+                $this->nullableOption('framework'),
+                (string) $this->option('approval-state'),
+                (int) $this->option('limit')
+            );
+        } catch (InvalidArgumentException $exception) {
+            $payload = $this->failureSummary('invalid_option', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $payload = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->writeOutputFile($payload);
+        $this->emitPayload($payload);
+
+        return ($payload['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function nullableOption(string $name): ?string
+    {
+        $value = trim((string) $this->option($name));
+
+        return $value !== '' ? $value : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitPayload(array $payload): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode(
+                $payload,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+            ));
+
+            return;
+        }
+
+        $summary = is_array($payload['summary'] ?? null) ? $payload['summary'] : [];
+        $filters = is_array($payload['filters'] ?? null) ? $payload['filters'] : [];
+
+        $this->line('ok='.(($payload['ok'] ?? false) ? '1' : '0'));
+        $this->line('status='.(string) ($payload['status'] ?? 'fail'));
+        $this->line('read_only='.(($payload['read_only'] ?? false) ? '1' : '0'));
+        $this->line('framework='.(string) ($filters['framework'] ?? 'all'));
+        $this->line('approval_state='.(string) ($filters['approval_state'] ?? 'pending'));
+        $this->line('matched_item_count='.(string) ($summary['matched_item_count'] ?? 0));
+        $this->line('returned_item_count='.(string) ($summary['returned_item_count'] ?? 0));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function writeOutputFile(array $payload): void
+    {
+        $output = trim((string) $this->option('output'));
+        if ($output === '') {
+            return;
+        }
+
+        $resolved = str_starts_with($output, '/')
+            ? $output
+            : base_path($output);
+
+        File::ensureDirectoryExists(dirname($resolved));
+        File::put($resolved, ((string) json_encode(
+            $payload,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        )).PHP_EOL);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPS-REVIEW-SURFACE-01',
+            'status' => 'fail',
+            'ok' => false,
+            'read_only' => true,
+            'filters' => [
+                'framework' => $this->nullableOption('framework'),
+                'approval_state' => (string) $this->option('approval-state'),
+                'limit' => (int) $this->option('limit'),
+            ],
+            'summary' => [
+                'matched_item_count' => 0,
+                'returned_item_count' => 0,
+            ],
+            'items' => [],
+            'safety_boundary' => [
+                'read_only' => true,
+                'approval_state_mutation_attempted' => false,
+                'cms_write_attempted' => false,
+                'cms_mutation_attempted' => false,
+                'cms_live_promotion_attempted' => false,
+                'publish_attempted' => false,
+                'index_attempted' => false,
+                'sitemap_llms_release_attempted' => false,
+                'search_release_attempted' => false,
+                'enqueue_attempted' => false,
+                'external_calls_attempted' => false,
+            ],
+            'warnings' => [],
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -175,6 +175,7 @@ use App\Console\Commands\PacksPublish;
 use App\Console\Commands\PacksRollback;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\PersonalityAgentApprovalQueueCommand;
+use App\Console\Commands\PersonalityAgentApprovalQueueReviewCommand;
 use App\Console\Commands\PersonalityBigFivePublicProfileAgentDraft;
 use App\Console\Commands\PersonalityEnneagramCmsDraft;
 use App\Console\Commands\PersonalityImportDesktopCloneBaseline;
@@ -250,6 +251,7 @@ class Kernel extends ConsoleKernel
         FapValidateReport::class,
         FapWeeklyReport::class,
         PersonalityAgentApprovalQueueCommand::class,
+        PersonalityAgentApprovalQueueReviewCommand::class,
         PersonalityBigFivePublicProfileAgentDraft::class,
         PersonalityEnneagramCmsPromote::class,
         PersonalityEnneagramCmsDraft::class,

--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+final class PersonalityAgentApprovalQueueReadModel
+{
+    private const ALLOWED_FRAMEWORKS = ['mbti64', 'big_five', 'enneagram'];
+
+    private const ALLOWED_APPROVAL_STATES = ['pending', 'approved', 'rejected', 'all'];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function read(?string $framework = null, string $approvalState = 'pending', int $limit = 50): array
+    {
+        $framework = $framework !== null ? trim($framework) : null;
+        $approvalState = trim($approvalState) !== '' ? trim($approvalState) : 'pending';
+
+        if ($framework !== null && $framework !== '' && ! in_array($framework, self::ALLOWED_FRAMEWORKS, true)) {
+            throw new InvalidArgumentException('Unsupported framework filter: '.$framework);
+        }
+
+        if (! in_array($approvalState, self::ALLOWED_APPROVAL_STATES, true)) {
+            throw new InvalidArgumentException('Unsupported approval state filter: '.$approvalState);
+        }
+
+        if ($limit < 1 || $limit > 200) {
+            throw new InvalidArgumentException('--limit must be between 1 and 200.');
+        }
+
+        $baseQuery = $this->baseQuery($framework, $approvalState);
+
+        $items = (clone $baseQuery)
+            ->orderByDesc('items.created_at')
+            ->orderByDesc('items.id')
+            ->limit($limit)
+            ->get()
+            ->map(fn (object $row): array => $this->formatItem($row))
+            ->values()
+            ->all();
+
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPS-REVIEW-SURFACE-01',
+            'status' => 'pass',
+            'ok' => true,
+            'read_only' => true,
+            'filters' => [
+                'framework' => $framework !== '' ? $framework : null,
+                'approval_state' => $approvalState,
+                'limit' => $limit,
+            ],
+            'summary' => [
+                'matched_item_count' => (int) (clone $baseQuery)->count(),
+                'returned_item_count' => count($items),
+                'by_framework' => $this->countsBy($baseQuery, 'items.framework'),
+                'by_approval_state' => $this->countsBy($baseQuery, 'items.approval_state'),
+                'by_qa_decision' => $this->countsBy($baseQuery, 'items.qa_decision'),
+                'by_blocked_reason' => $this->countsBy($baseQuery, 'items.blocked_reason'),
+            ],
+            'items' => $items,
+            'safety_boundary' => $this->safetyBoundary(),
+            'warnings' => [],
+            'errors' => [],
+        ];
+    }
+
+    private function baseQuery(?string $framework, string $approvalState): Builder
+    {
+        $query = DB::table('personality_agent_approval_items as items')
+            ->join('personality_agent_approval_batches as batches', 'batches.id', '=', 'items.batch_id')
+            ->select([
+                'items.id',
+                'items.batch_id',
+                'items.framework',
+                'items.target_url',
+                'items.path',
+                'items.locale',
+                'items.page_type',
+                'items.recommendation_id',
+                'items.recommendation_sha256',
+                'items.qa_decision',
+                'items.approval_state',
+                'items.approved_at',
+                'items.rejected_at',
+                'items.blocked_reason',
+                'items.recommendation_json',
+                'items.qa_json',
+                'items.created_at',
+                'items.updated_at',
+                'batches.status as batch_status',
+                'batches.source_artifact',
+                'batches.source_artifact_path',
+                'batches.source_package_sha256',
+                'batches.qa_artifact',
+                'batches.qa_artifact_path',
+                'batches.qa_sha256',
+            ]);
+
+        if ($framework !== null && $framework !== '') {
+            $query->where('items.framework', $framework);
+        }
+
+        if ($approvalState !== 'all') {
+            $query->where('items.approval_state', $approvalState);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function countsBy(Builder $baseQuery, string $column): array
+    {
+        return (clone $baseQuery)
+            ->selectRaw($column.' as bucket, count(*) as aggregate')
+            ->groupBy($column)
+            ->orderBy($column)
+            ->get()
+            ->mapWithKeys(static function (object $row): array {
+                $bucket = (string) ($row->bucket ?? 'none');
+                if ($bucket === '') {
+                    $bucket = 'none';
+                }
+
+                return [$bucket => (int) $row->aggregate];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function formatItem(object $row): array
+    {
+        $recommendation = $this->jsonObject($row->recommendation_json ?? null);
+        $qa = $this->jsonObject($row->qa_json ?? null);
+
+        return [
+            'id' => (int) $row->id,
+            'batch_id' => (int) $row->batch_id,
+            'batch_status' => (string) $row->batch_status,
+            'framework' => (string) $row->framework,
+            'target_url' => (string) $row->target_url,
+            'path' => (string) $row->path,
+            'locale' => (string) $row->locale,
+            'page_type' => (string) $row->page_type,
+            'recommendation_id' => (string) $row->recommendation_id,
+            'recommendation_sha256' => (string) $row->recommendation_sha256,
+            'qa_decision' => (string) $row->qa_decision,
+            'approval_state' => (string) $row->approval_state,
+            'approved_at' => $row->approved_at !== null ? (string) $row->approved_at : null,
+            'rejected_at' => $row->rejected_at !== null ? (string) $row->rejected_at : null,
+            'blocked_reason' => $row->blocked_reason !== null ? (string) $row->blocked_reason : null,
+            'risk_reasons' => $this->riskReasons($qa, $row->blocked_reason !== null ? (string) $row->blocked_reason : null),
+            'recommendation_summary' => $this->recommendationSummary($recommendation),
+            'qa_summary' => $this->qaSummary($qa),
+            'source_artifact' => (string) $row->source_artifact,
+            'source_artifact_path' => (string) $row->source_artifact_path,
+            'source_package_sha256' => (string) $row->source_package_sha256,
+            'qa_artifact' => (string) $row->qa_artifact,
+            'qa_artifact_path' => (string) $row->qa_artifact_path,
+            'qa_sha256' => (string) $row->qa_sha256,
+            'created_at' => (string) $row->created_at,
+            'updated_at' => (string) $row->updated_at,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendationSummary(array $recommendation): array
+    {
+        $payload = is_array($recommendation['recommendations'] ?? null)
+            ? $recommendation['recommendations']
+            : [];
+
+        return [
+            'has_title' => array_key_exists('title', $payload),
+            'has_description' => array_key_exists('description', $payload),
+            'has_h1' => array_key_exists('h1', $payload),
+            'has_quick_answer' => array_key_exists('quick_answer', $payload),
+            'faq_count' => is_array($payload['faq'] ?? null) ? count($payload['faq']) : 0,
+            'internal_link_count' => is_array($payload['internal_links'] ?? null) ? count($payload['internal_links']) : 0,
+            'differentiation_note_count' => is_array($payload['differentiation_notes'] ?? null)
+                ? count($payload['differentiation_notes'])
+                : 0,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qaSummary(array $qa): array
+    {
+        return [
+            'decision' => (string) ($qa['decision'] ?? $qa['status'] ?? $qa['qa_status'] ?? ''),
+            'blocker_count' => is_array($qa['blockers'] ?? null) ? count($qa['blockers']) : 0,
+            'failed_gate_count' => is_array($qa['failed_gates'] ?? null) ? count($qa['failed_gates']) : 0,
+            'eligible_for_approval_queue' => (bool) ($qa['eligible_for_approval_queue'] ?? false),
+            'eligible_for_cms_draft_path' => (bool) ($qa['eligible_for_cms_draft_path'] ?? false),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function riskReasons(array $qa, ?string $blockedReason): array
+    {
+        $reasons = [];
+        if ($blockedReason !== null && $blockedReason !== '') {
+            $reasons[] = $blockedReason;
+        }
+
+        foreach (['blockers', 'failed_gates', 'risk_reasons'] as $field) {
+            if (! is_array($qa[$field] ?? null)) {
+                continue;
+            }
+
+            foreach ($qa[$field] as $reason) {
+                $value = trim((string) $reason);
+                if ($value !== '') {
+                    $reasons[] = $value;
+                }
+            }
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonObject(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function safetyBoundary(): array
+    {
+        return [
+            'read_only' => true,
+            'approval_state_mutation_attempted' => false,
+            'cms_write_attempted' => false,
+            'cms_mutation_attempted' => false,
+            'cms_live_promotion_attempted' => false,
+            'publish_attempted' => false,
+            'index_attempted' => false,
+            'sitemap_llms_release_attempted' => false,
+            'search_release_attempted' => false,
+            'enqueue_attempted' => false,
+            'external_calls_attempted' => false,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class PersonalityAgentApprovalQueueReviewCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_review_lists_pending_recommendations_with_qa_risk_and_hash_context_without_writes(): void
+    {
+        $batchId = $this->createBatch('mbti64');
+        $this->createItem($batchId, [
+            'framework' => 'mbti64',
+            'target_url' => 'https://fermatmind.com/en/personality/enfj-a',
+            'path' => '/en/personality/enfj-a',
+            'locale' => 'en',
+            'page_type' => 'personality_profile_variant',
+            'recommendation_id' => 'mbti64-next:/en/personality/enfj-a',
+            'qa_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'approval_state' => 'pending',
+            'recommendation_json' => $this->recommendation('https://fermatmind.com/en/personality/enfj-a'),
+            'qa_json' => [
+                'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+                'eligible_for_approval_queue' => true,
+                'eligible_for_cms_draft_path' => true,
+                'blockers' => [],
+                'failed_gates' => [],
+            ],
+        ]);
+        $this->createItem($batchId, [
+            'framework' => 'mbti64',
+            'target_url' => 'https://fermatmind.com/zh/personality/intp-a',
+            'path' => '/zh/personality/intp-a',
+            'locale' => 'zh-CN',
+            'page_type' => 'personality_profile_variant',
+            'recommendation_id' => 'mbti64-next:/zh/personality/intp-a',
+            'qa_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'approval_state' => 'approved',
+            'approved_at' => now(),
+            'recommendation_json' => $this->recommendation('https://fermatmind.com/zh/personality/intp-a'),
+            'qa_json' => [
+                'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+                'eligible_for_approval_queue' => true,
+                'eligible_for_cms_draft_path' => true,
+            ],
+        ]);
+
+        $beforeItems = DB::table('personality_agent_approval_items')->count();
+        $beforeBatches = DB::table('personality_agent_approval_batches')->count();
+
+        $exitCode = Artisan::call('personality:agent-approval-queue-review', [
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertSame('pending', $payload['filters']['approval_state']);
+        $this->assertSame(1, $payload['summary']['matched_item_count']);
+        $this->assertSame(1, $payload['summary']['returned_item_count']);
+        $this->assertSame(['mbti64' => 1], $payload['summary']['by_framework']);
+        $this->assertSame(['pending' => 1], $payload['summary']['by_approval_state']);
+        $this->assertSame('https://fermatmind.com/en/personality/enfj-a', $payload['items'][0]['target_url']);
+        $this->assertSame('PASS_READY_FOR_APPROVAL_QUEUE', $payload['items'][0]['qa_decision']);
+        $this->assertSame('pending', $payload['items'][0]['approval_state']);
+        $this->assertSame('source-sha-mbti64', $payload['items'][0]['source_package_sha256']);
+        $this->assertSame('qa-sha-mbti64', $payload['items'][0]['qa_sha256']);
+        $this->assertTrue($payload['items'][0]['recommendation_summary']['has_title']);
+        $this->assertTrue($payload['items'][0]['qa_summary']['eligible_for_approval_queue']);
+        $this->assertFalse($payload['safety_boundary']['approval_state_mutation_attempted']);
+        $this->assertFalse($payload['safety_boundary']['cms_write_attempted']);
+        $this->assertFalse($payload['safety_boundary']['search_release_attempted']);
+        $this->assertSame($beforeItems, DB::table('personality_agent_approval_items')->count());
+        $this->assertSame($beforeBatches, DB::table('personality_agent_approval_batches')->count());
+    }
+
+    public function test_review_filters_framework_state_and_exposes_risk_reasons(): void
+    {
+        $mbtiBatchId = $this->createBatch('mbti64');
+        $bigFiveBatchId = $this->createBatch('big_five');
+        $this->createItem($mbtiBatchId, [
+            'framework' => 'mbti64',
+            'target_url' => 'https://fermatmind.com/en/personality/enfp-a',
+            'path' => '/en/personality/enfp-a',
+            'locale' => 'en',
+            'page_type' => 'personality_profile_variant',
+            'recommendation_id' => 'mbti64-next:/en/personality/enfp-a',
+            'qa_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'approval_state' => 'pending',
+            'recommendation_json' => $this->recommendation('https://fermatmind.com/en/personality/enfp-a'),
+            'qa_json' => [
+                'decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+                'failed_gates' => [],
+            ],
+        ]);
+        $this->createItem($bigFiveBatchId, [
+            'framework' => 'big_five',
+            'target_url' => 'https://fermatmind.com/en/personality/big-five/openness',
+            'path' => '/en/personality/big-five/openness',
+            'locale' => 'en',
+            'page_type' => 'personality_public_content_asset',
+            'recommendation_id' => 'big-five-next:/en/personality/big-five/openness',
+            'qa_decision' => 'HOLD_REQUIRES_EVIDENCE_OR_EDITORIAL_REPAIR',
+            'approval_state' => 'rejected',
+            'rejected_at' => now(),
+            'blocked_reason' => 'duplicate_template_risk',
+            'recommendation_json' => $this->recommendation('https://fermatmind.com/en/personality/big-five/openness'),
+            'qa_json' => [
+                'decision' => 'HOLD_REQUIRES_EVIDENCE_OR_EDITORIAL_REPAIR',
+                'failed_gates' => ['duplicate_template_risk', 'claim_review_needed'],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('personality:agent-approval-queue-review', [
+            '--framework' => 'big_five',
+            '--approval-state' => 'rejected',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('big_five', $payload['filters']['framework']);
+        $this->assertSame('rejected', $payload['filters']['approval_state']);
+        $this->assertSame(1, $payload['summary']['matched_item_count']);
+        $this->assertSame(['big_five' => 1], $payload['summary']['by_framework']);
+        $this->assertSame(['duplicate_template_risk' => 1], $payload['summary']['by_blocked_reason']);
+        $this->assertSame(
+            ['duplicate_template_risk', 'claim_review_needed'],
+            $payload['items'][0]['risk_reasons']
+        );
+    }
+
+    public function test_review_fails_closed_for_unsupported_filters_without_mutating_queue(): void
+    {
+        $beforeItems = DB::table('personality_agent_approval_items')->count();
+        $beforeBatches = DB::table('personality_agent_approval_batches')->count();
+
+        $exitCode = Artisan::call('personality:agent-approval-queue-review', [
+            '--framework' => 'unsupported',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertTrue($payload['read_only']);
+        $this->assertSame('invalid_option', $payload['errors'][0]['code']);
+        $this->assertFalse($payload['safety_boundary']['approval_state_mutation_attempted']);
+        $this->assertFalse($payload['safety_boundary']['cms_write_attempted']);
+        $this->assertSame($beforeItems, DB::table('personality_agent_approval_items')->count());
+        $this->assertSame($beforeBatches, DB::table('personality_agent_approval_batches')->count());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function recommendation(string $targetUrl): array
+    {
+        return [
+            'target_url' => $targetUrl,
+            'recommendations' => [
+                'title' => ['recommended' => 'Recommended title'],
+                'description' => ['recommended' => 'Recommended description.'],
+                'h1' => ['recommended' => 'Recommended H1'],
+                'quick_answer' => ['recommended' => 'Recommended quick answer.'],
+                'faq' => [
+                    ['question' => 'What changes?', 'answer' => 'The public profile becomes clearer.'],
+                ],
+                'internal_links' => [
+                    ['target_url' => 'https://fermatmind.com/en/tests/big-five-personality-test-ocean-model'],
+                ],
+                'differentiation_notes' => ['Keep this page distinct from close variants.'],
+            ],
+        ];
+    }
+
+    private function createBatch(string $framework): int
+    {
+        return (int) DB::table('personality_agent_approval_batches')->insertGetId([
+            'framework' => $framework,
+            'source_artifact' => 'personality-agent-next-batch-recommendations',
+            'source_artifact_path' => 'docs/seo/personality/personality-agent-next-batch-recommendations.json',
+            'source_package_sha256' => 'source-sha-'.$framework,
+            'qa_artifact' => 'personality-agent-next-batch-qa',
+            'qa_artifact_path' => 'docs/seo/personality/personality-agent-next-batch-qa.json',
+            'qa_sha256' => 'qa-sha-'.$framework,
+            'status' => 'pending_review',
+            'planned_item_count' => 2,
+            'queued_item_count' => 2,
+            'blocked_item_count' => 0,
+            'safety_holds_json' => (string) json_encode(['approval_queue_only' => true]),
+            'summary_json' => (string) json_encode(['qa_final_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE']),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function createItem(int $batchId, array $overrides): void
+    {
+        $recommendationJson = (string) json_encode($overrides['recommendation_json'] ?? [], JSON_UNESCAPED_SLASHES);
+        DB::table('personality_agent_approval_items')->insert(array_merge([
+            'batch_id' => $batchId,
+            'framework' => 'mbti64',
+            'target_url' => 'https://fermatmind.com/en/personality/enfj-a',
+            'path' => '/en/personality/enfj-a',
+            'locale' => 'en',
+            'page_type' => 'personality_profile_variant',
+            'recommendation_id' => 'recommendation-id',
+            'recommendation_sha256' => hash('sha256', $recommendationJson),
+            'qa_decision' => 'PASS_READY_FOR_APPROVAL_QUEUE',
+            'approval_state' => 'pending',
+            'approved_at' => null,
+            'rejected_at' => null,
+            'blocked_reason' => null,
+            'safety_holds_json' => (string) json_encode(['approval_queue_only' => true]),
+            'recommendation_json' => $recommendationJson,
+            'qa_json' => (string) json_encode($overrides['qa_json'] ?? [], JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], array_diff_key($overrides, array_flip(['recommendation_json', 'qa_json']))));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -378,13 +378,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php',
+            'backend/app/Console/Commands/PersonalityAgentApprovalQueueReviewCommand.php',
             'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php',
             'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
             'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
         ];
         $kernelChangedLines = [
             '+use App\\Console\\Commands\\PersonalityAgentApprovalQueueCommand;',
+            '+use App\\Console\\Commands\\PersonalityAgentApprovalQueueReviewCommand;',
             '+        PersonalityAgentApprovalQueueCommand::class,',
+            '+        PersonalityAgentApprovalQueueReviewCommand::class,',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -5928,6 +5932,8 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityAgentApprovalQueueCommand.php',
+            'backend/app/Console/Commands/PersonalityAgentApprovalQueueReviewCommand.php',
+            'backend/app/Services/Cms/PersonalityAgentApprovalQueueReadModel.php',
             'backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php',
             'backend/database/migrations/2026_06_24_000100_create_personality_agent_approval_queue_tables.php',
         ], true);
@@ -9772,7 +9778,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
         foreach ($changedLines as $line) {
             $normalized = ltrim($line, '+-');
-            if (preg_match('/\bPersonalityAgentApprovalQueueCommand\b/u', $normalized) !== 1) {
+            if (preg_match('/\bPersonalityAgentApprovalQueue(?:Review)?Command\b/u', $normalized) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added a read-only `PersonalityAgentApprovalQueueReadModel` for pending/approved/rejected personality agent approval items.
- Added `personality:agent-approval-queue-review` to expose framework/state/limit filtered JSON or text summaries for ops review.
- Registered the command in the console kernel.
- Added focused feature coverage for pending review output, framework/state filters, risk reason exposure, invalid filter fail-closed behavior, and no-mutation guarantees.

## Why
The personality agent workflow needs an ops/read model surface so reviewers can inspect pending recommendations, QA state, risk reasons, target URLs, framework, hashes, and approval state before any downstream CMS draft writer consumes approved items.

## Validation
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php tests/Feature/Console/PersonalityAgentApprovalQueueReviewCommandTest.php --display-warnings` *(passes; local temp worktree emits expected missing .env warnings)*
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only approval queue review command/service/test plus Kernel registration changed.

## Intentionally deferred
- No approval/reject mutation UI or command.
- No CMS draft write, promotion, publish, index/search, sitemap/llms, queue enqueue/approve/submit, or external API behavior.

## Repository rule impact
Backend remains the authority for approval state and CMS write gates. This PR adds a read-only ops surface only and does not change public content ownership or publishing behavior.
