### PR TITLE
PR-EQ-AGENT-HARDEN-01 EQ Agent guardrail alias normalization

### DIFF
--- a/backend/app/Services/Eq/EqAgentContextBuilder.php
+++ b/backend/app/Services/Eq/EqAgentContextBuilder.php
@@ -168,6 +168,7 @@ final class EqAgentContextBuilder
             'can_override_formulation' => false,
             'can_enable_sjt' => false,
             'can_create_paid_unlock_language' => false,
+            'can_use_paid_unlock_language' => false,
             'can_expose_raw_technical_tags' => false,
             'content_authority' => 'backend_content_pack_and_report_composer',
         ];

--- a/backend/app/Services/Eq/EqAgentRuntimeResponder.php
+++ b/backend/app/Services/Eq/EqAgentRuntimeResponder.php
@@ -296,6 +296,7 @@ final class EqAgentRuntimeResponder
             && $guardrails['can_override_formulation'] === false
             && $guardrails['can_enable_sjt'] === false
             && $guardrails['can_create_paid_unlock_language'] === false
+            && $guardrails['can_use_paid_unlock_language'] === false
             && $guardrails['can_expose_raw_technical_tags'] === false;
     }
 

--- a/backend/tests/Feature/Report/EqAgentContextApiTest.php
+++ b/backend/tests/Feature/Report/EqAgentContextApiTest.php
@@ -48,6 +48,8 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('guardrails.can_mutate_scores', false)
             ->assertJsonPath('guardrails.can_override_formulation', false)
             ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
             ->assertJsonPath('guardrails.content_authority', 'backend_content_pack_and_report_composer')
             ->assertJsonPath('agent_knowledge.authority.report_authority', 'backend_content_pack_and_report_composer')
             ->assertJsonPath('intent_context.matched', true)
@@ -113,7 +115,9 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('intent_context.matched_intent', 'understand_my_result')
             ->assertJsonPath('intent_context.reason_code', 'unknown_intent_defaulted')
             ->assertJsonPath('guardrails.can_mutate_report', false)
-            ->assertJsonPath('guardrails.can_enable_sjt', false);
+            ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false);
 
         $this->assertContains('asset:core_formulation', (array) $response->json('intent_context.retrieval_tags'));
     }
@@ -146,6 +150,7 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('guardrails.can_mutate_scores', false)
             ->assertJsonPath('guardrails.can_override_formulation', false)
             ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
             ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
             ->assertJsonPath('assistant_response.role', 'assistant')
             ->assertJsonPath('safety.no_paywall_language', true)
@@ -203,7 +208,9 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('ready', true)
             ->assertJsonPath('guardrails.read_only', true)
             ->assertJsonPath('guardrails.can_mutate_report', false)
-            ->assertJsonPath('guardrails.can_enable_sjt', false);
+            ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false);
 
         $this->assertContains('clinical_diagnosis', (array) $response->json('safety.detected_forbidden_claim_ids'));
         $this->assertContains('hiring_suitability', (array) $response->json('safety.detected_forbidden_claim_ids'));
@@ -252,6 +259,7 @@ final class EqAgentContextApiTest extends TestCase
                 ->assertJsonPath('guardrails.can_mutate_scores', false)
                 ->assertJsonPath('guardrails.can_override_formulation', false)
                 ->assertJsonPath('guardrails.can_enable_sjt', false)
+                ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
                 ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
                 ->assertJsonPath('safety.no_paywall_language', true)
                 ->assertJsonPath('safety.no_sjt_entry', true)
@@ -393,7 +401,9 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('guardrails.can_mutate_report', false)
             ->assertJsonPath('guardrails.can_mutate_scores', false)
             ->assertJsonPath('guardrails.can_override_formulation', false)
-            ->assertJsonPath('guardrails.can_enable_sjt', false);
+            ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false);
 
         foreach ($this->forbiddenClaimCases() as $case) {
             $claimId = (string) ($case['claim_id'] ?? '');
@@ -445,6 +455,8 @@ final class EqAgentContextApiTest extends TestCase
             ->assertJsonPath('report_context.next_module.available', false)
             ->assertJsonPath('report_context.next_module.status', 'planned')
             ->assertJsonPath('guardrails.can_enable_sjt', false)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
             ->assertJsonPath('intent_context.matched', true)
             ->assertJsonPath('intent_context.matched_intent', 'ask_for_sjt')
             ->assertJsonPath('intent_context.allowed_response_mode', 'planned_unavailable_boundary');
@@ -489,6 +501,8 @@ final class EqAgentContextApiTest extends TestCase
                 ->assertJsonPath('guardrails.read_only', true)
                 ->assertJsonPath('guardrails.can_mutate_report', false)
                 ->assertJsonPath('guardrails.can_enable_sjt', false)
+                ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+                ->assertJsonPath('guardrails.can_use_paid_unlock_language', false)
                 ->assertJsonPath('intent_context.matched_intent', 'quality_or_confidence_question')
                 ->assertJsonPath('intent_context.allowed_response_mode', 'confidence_boundary_and_retest_guidance');
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T11:35:00+08:00",
+  "updated_at": "2026-06-25T12:40:00+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -61713,6 +61713,123 @@
         "at": "2026-06-25T04:01:50Z",
         "status": "ready_to_merge",
         "note": "PR #2413 checks passed at head bdf632e941af4635de440315e96ab6b52433aa85 and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, sitemap, llms, DB migration, or frontend work included."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-HARDEN-01": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-harden-01-guardrail-alias",
+    "base": "main",
+    "status": "pr_opened_rebased",
+    "train_scope": "eq_agent_runtime_hardening",
+    "title": "PR-EQ-AGENT-HARDEN-01 EQ Agent guardrail alias normalization",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-04"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-AGENT-HARDEN-01 and PR-EQ-AGENT-SMOKE-02 as PR-train items."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-RUNTIME-04 acceptance update merged as PR #2414 and origin/main contains 7af581948918e05fe81e4ad83fee578b32f22223."
+      },
+      "eq_agent_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent",
+        "evidence": "10 tests passed, 628 assertions. PHPUnit emitted existing file_get_contents warnings, exit code 0."
+      },
+      "eq60_v5_report_contract_test": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest",
+        "evidence": "10 tests passed, 404 assertions. PHPUnit emitted existing file_get_contents warnings, exit code 0."
+      },
+      "manifest_yaml": {
+        "status": "pass",
+        "command": "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+        "evidence": "yaml ok."
+      },
+      "state_json": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "evidence": "json ok."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "No whitespace errors."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to EQ Agent guardrail services, EqAgent contract test, and PR train metadata."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2416",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T12:10:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit user authorization and started from latest origin/main in a clean temporary worktree."
+      },
+      {
+        "at": "2026-06-25T12:20:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Normalized paid-language guardrail aliases in context/runtime payloads and extended EqAgent contract assertions; local checks passed."
+      },
+      {
+        "at": "2026-06-25T12:30:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened GitHub PR #2416 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-25T12:40:00+08:00",
+        "from": "pr_opened",
+        "to": "pr_opened_rebased",
+        "notes": "Rebased onto latest origin/main and reconciled PR train state with upstream ledger changes."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-SMOKE-02": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-smoke-02-normal-confidence-report",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime_hardening",
+    "title": "PR-EQ-AGENT-SMOKE-02 EQ Agent normal-confidence production smoke report",
+    "depends_on": [
+      "PR-EQ-AGENT-HARDEN-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized PR-EQ-AGENT-HARDEN-01 and PR-EQ-AGENT-SMOKE-02 as PR-train items."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waits for PR-EQ-AGENT-HARDEN-01 to merge and deploy before production normal-confidence smoke."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T12:10:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-HARDEN-01."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -718,6 +718,74 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: PR-EQ-AGENT-HARDEN-01
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-04]
+    branch: codex/pr-eq-agent-harden-01-guardrail-alias
+    title: "PR-EQ-AGENT-HARDEN-01 EQ Agent guardrail alias normalization"
+    train_scope: eq_agent_runtime_hardening
+    scope:
+      - Normalize EQ Agent guardrail aliases so context and runtime payloads both expose paid-language guardrails.
+      - Add backend contract coverage for context and runtime read-only guardrails across key EQ Agent paths.
+    allowed_paths:
+      - backend/app/Services/Eq/EqAgentContextBuilder.php
+      - backend/app/Services/Eq/EqAgentRuntimeResponder.php
+      - backend/tests/Feature/Report/EqAgentContextApiTest.php
+      - backend/tests/Feature/Report/Eq60V5ReportContractTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend.
+      - Add live LLM/provider integration.
+      - Add Agent write endpoints or persistence.
+      - Modify EQ questions, scoring, norms, report prose, SJT runtime, commerce, CMS, SEO, deploy, or production state.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-SMOKE-02
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-HARDEN-01]
+    branch: codex/pr-eq-agent-smoke-02-normal-confidence-report
+    title: "PR-EQ-AGENT-SMOKE-02 EQ Agent normal-confidence production smoke report"
+    train_scope: eq_agent_runtime_hardening
+    scope:
+      - Add docs-only production smoke acceptance report for a normal-confidence EQ Agent runtime flow.
+      - Record deployed SHAs, attempt/session details, context/runtime summaries, screenshot paths, risks, and normal-confidence acceptance decision.
+    allowed_paths:
+      - docs/audits/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime code, frontend, content assets, scoring, SJT runtime, CMS, SEO, deploy, or production state.
+      - Enable live LLM/provider integration.
+      - Create paid/unlock/SKU behavior.
+    validation:
+      - git diff --check
+      - git diff --cached --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-PER-01
     repo: fap-api
     branch: codex/pr-eq-per-01-all-free-copy-contract-cleanup


### PR DESCRIPTION
## Summary
- Normalizes EQ Agent paid-language guardrails so both context and runtime payloads expose `can_create_paid_unlock_language=false` and `can_use_paid_unlock_language=false`.
- Extends EqAgent contract coverage across context, runtime, SJT planned boundary, low-confidence, unknown intent, and forbidden-claim paths.
- Adds PR train manifest/state entries for `PR-EQ-AGENT-HARDEN-01` and `PR-EQ-AGENT-SMOKE-02`.

## Why
Production acceptance showed context/runtime guardrail naming drift. The runtime response already included the frontend-facing alias, but context did not. This PR makes the backend contract explicit and test-covered before the normal-confidence production smoke.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent`
  - Passed: 10 tests, 628 assertions; existing `file_get_contents` warnings did not fail the command.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest`
  - Passed: 10 tests, 404 assertions; existing `file_get_contents` warnings did not fail the command.
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No frontend changes.
- No EQ scoring, question, norm, report prose, SJT, commerce, CMS, SEO, or deployment changes.
- No live LLM/provider integration.
- Normal-confidence production smoke is deferred to `PR-EQ-AGENT-SMOKE-02` after this PR is merged and deployed.
