### PR TITLE
P0 CTR Article CMS Update Writer Adapter

### DIFF
--- a/backend/app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php
+++ b/backend/app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php
@@ -1,0 +1,695 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+final class SeoOpsP0CtrArticleCmsUpdateWriterCommand extends Command
+{
+    private const INPUT_SCHEMA = 'seo-ops-p0-ctr-repair-dry-run.v1';
+
+    private const OUTPUT_SCHEMA = 'seo-ops-p0-ctr-article-cms-update-writer.v1';
+
+    private const EXPECTED_ARTICLE_COUNT = 3;
+
+    private const FORBIDDEN_STRINGS = [
+        'raw_url',
+        'raw_query',
+        'credential_path',
+        'service_account_json',
+        'client_email',
+        'private_key',
+        'Bearer ',
+        'Cookie:',
+        'Set-Cookie:',
+        'content_html',
+        'content_md',
+        'cms_draft_body',
+    ];
+
+    protected $signature = 'seo-ops:p0-ctr-article-cms-update-writer
+        {--dry-run-evidence= : Path to seo-ops-p0-ctr-repair-dry-run.v1 evidence JSON}
+        {--confirm-dry-run-evidence-sha256= : Expected SHA-256 of the dry-run evidence}
+        {--artifact-dir= : Directory for writer evidence output}
+        {--execute : Apply the bounded article CMS update}
+        {--confirm-write= : Exact Gate B write confirmation phrase}
+        {--json : Emit JSON summary}';
+
+    protected $description = 'Controlled Gate B writer for P0 CTR article CMS updates from verified dry-run evidence; defaults to dry-run.';
+
+    public function handle(): int
+    {
+        $artifactDir = $this->artifactDir();
+        if ($artifactDir === null) {
+            return $this->finish($this->failureSummary(['artifact_dir_unwritable']));
+        }
+
+        $loaded = $this->loadDryRunEvidence();
+        if (($loaded['ok'] ?? false) !== true) {
+            $summary = $this->failureSummary((array) ($loaded['issues'] ?? ['dry_run_evidence_unreadable']), [
+                'dry_run_evidence' => $loaded['dry_run_evidence'] ?? null,
+            ]);
+            $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+            return $this->finish($summary);
+        }
+
+        $dryRunEvidence = (array) $loaded['dry_run_evidence_payload'];
+        $dryRunSha = (string) $loaded['dry_run_evidence_sha256'];
+        $articlePlans = array_values((array) data_get($dryRunEvidence, 'article_plans', []));
+        $issues = $this->validateDryRunEvidence($dryRunEvidence, $articlePlans);
+        $plans = array_map(fn (array $plan): array => $this->buildArticleWritePlan($plan), $articlePlans);
+
+        foreach ($plans as $plan) {
+            foreach ((array) ($plan['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        $issues = array_values(array_unique($issues));
+        $requiredPhrase = $this->requiredConfirmationPhrase($dryRunSha, $plans);
+        $execute = (bool) $this->option('execute');
+
+        if ($execute && ! hash_equals($requiredPhrase, trim((string) $this->option('confirm-write')))) {
+            $issues[] = 'confirm_write_phrase_mismatch';
+        }
+
+        $ok = $issues === [];
+        $writeResults = [];
+        if ($ok && $execute) {
+            $writeResults = $this->executePlans($plans, $dryRunSha);
+        }
+
+        $status = $ok ? ($execute ? 'success' : 'planned') : 'blocked';
+        $summary = [
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:p0-ctr-article-cms-update-writer',
+            'ok' => $ok,
+            'status' => $status,
+            'dry_run' => ! $execute,
+            'execute' => $execute,
+            'generated_at' => now()->utc()->toIso8601String(),
+            'dry_run_evidence' => [
+                'path' => (string) $loaded['dry_run_evidence_path'],
+                'sha256' => $dryRunSha,
+                'schema_version' => (string) ($dryRunEvidence['schema_version'] ?? ''),
+            ],
+            'planned_write_count' => [
+                'article_cms_updates' => count(array_filter($plans, static fn (array $plan): bool => ($plan['ready'] ?? false) === true)),
+                'landing_surfaces' => 0,
+                'total' => count(array_filter($plans, static fn (array $plan): bool => ($plan['ready'] ?? false) === true)),
+            ],
+            'target_lock' => [
+                'targets' => array_values(array_map(static fn (array $plan): string => (string) ($plan['target'] ?? ''), $plans)),
+                'expected_count' => self::EXPECTED_ARTICLE_COUNT,
+            ],
+            'required_confirmation_phrase' => $requiredPhrase,
+            'article_update_plans' => $plans,
+            'write_results' => $writeResults,
+            'protected_diff_summary' => [
+                'slug' => 'no_change',
+                'canonical' => 'no_change',
+                'locale' => 'no_change',
+                'article_id' => 'resolved_no_change',
+                'publication' => 'no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+            ],
+            'side_effects' => [
+                'database_write' => $execute && $ok,
+                'cms_article_update' => $execute && $ok,
+                'landing_surface_write' => false,
+                'cms_publish' => false,
+                'url_truth_write' => false,
+                'schema_enable' => false,
+                'hreflang_enable' => false,
+                'sitemap_write' => false,
+                'llms_write' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+                'baidu_submit' => false,
+                'gsc_request_indexing' => false,
+                'scheduler_start' => false,
+                'queue_worker_start' => false,
+                'external_api_call' => false,
+                'revalidation' => false,
+                'deploy' => false,
+            ],
+            'issues' => $issues,
+        ];
+        $summary['evidence'] = $this->writeEvidence($artifactDir, $summary);
+
+        return $this->finish($summary);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadDryRunEvidence(): array
+    {
+        $path = $this->readablePath((string) $this->option('dry-run-evidence'));
+        if ($path === null) {
+            return ['ok' => false, 'issues' => ['dry_run_evidence_unreadable']];
+        }
+
+        $raw = (string) file_get_contents($path);
+        $forbidden = $this->forbiddenStringsPresent($raw);
+        if ($forbidden !== []) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => ['path' => $path],
+                'issues' => ['forbidden_input_field_present'],
+                'forbidden_matches' => $forbidden,
+            ];
+        }
+
+        $actualSha = hash('sha256', $raw);
+        $expectedSha = trim((string) $this->option('confirm-dry-run-evidence-sha256'));
+        if ($expectedSha === '' || ! hash_equals($expectedSha, $actualSha)) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => [
+                    'path' => $path,
+                    'sha256' => $actualSha,
+                    'expected_sha256' => $expectedSha,
+                ],
+                'issues' => ['dry_run_evidence_sha_mismatch'],
+            ];
+        }
+
+        try {
+            $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => ['path' => $path, 'sha256' => $actualSha],
+                'issues' => ['dry_run_evidence_json_invalid'],
+            ];
+        }
+
+        if (! is_array($payload)) {
+            return [
+                'ok' => false,
+                'dry_run_evidence' => ['path' => $path, 'sha256' => $actualSha],
+                'issues' => ['dry_run_evidence_json_not_object'],
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'dry_run_evidence_payload' => $payload,
+            'dry_run_evidence_path' => $path,
+            'dry_run_evidence_sha256' => $actualSha,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $dryRunEvidence
+     * @param  array<int, mixed>  $articlePlans
+     * @return array<int, string>
+     */
+    private function validateDryRunEvidence(array $dryRunEvidence, array $articlePlans): array
+    {
+        $issues = [];
+        if (($dryRunEvidence['schema_version'] ?? null) !== self::INPUT_SCHEMA) {
+            $issues[] = 'dry_run_evidence_schema_invalid';
+        }
+        if (($dryRunEvidence['ok'] ?? null) !== true || ($dryRunEvidence['status'] ?? null) !== 'planned') {
+            $issues[] = 'dry_run_evidence_not_planned';
+        }
+        if ((bool) ($dryRunEvidence['dry_run'] ?? false) !== true || (bool) ($dryRunEvidence['execute'] ?? true) !== false) {
+            $issues[] = 'dry_run_evidence_mode_invalid';
+        }
+        if (count($articlePlans) !== self::EXPECTED_ARTICLE_COUNT) {
+            $issues[] = 'article_plan_count_unexpected';
+        }
+        if ((int) data_get($dryRunEvidence, 'planned_write_count.article_cms_updates') !== self::EXPECTED_ARTICLE_COUNT) {
+            $issues[] = 'planned_article_write_count_unexpected';
+        }
+        foreach ([
+            'database_write',
+            'cms_write',
+            'cms_publish',
+            'url_truth_write',
+            'schema_enable',
+            'hreflang_enable',
+            'sitemap_write',
+            'llms_write',
+            'search_channel_enqueue',
+            'indexnow_submit',
+            'baidu_submit',
+            'gsc_request_indexing',
+            'revalidation',
+            'deploy',
+        ] as $field) {
+            if ((bool) data_get($dryRunEvidence, 'negative_guarantees.'.$field) !== false) {
+                $issues[] = 'dry_run_negative_guarantee_invalid:'.$field;
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $inputPlan
+     * @return array<string, mixed>
+     */
+    private function buildArticleWritePlan(array $inputPlan): array
+    {
+        $target = trim((string) ($inputPlan['target'] ?? ''));
+        $slug = trim((string) ($inputPlan['slug'] ?? ''));
+        $locale = trim((string) ($inputPlan['resolved_locale'] ?? $inputPlan['input_locale'] ?? ''));
+        $safePath = trim((string) ($inputPlan['safe_path'] ?? ''));
+        $fields = (array) ($inputPlan['planned_fields'] ?? []);
+        $issues = [];
+
+        if (($inputPlan['resolved'] ?? null) !== true) {
+            $issues[] = 'article_plan_unresolved:'.$target;
+        }
+        if ((array) ($inputPlan['issues'] ?? []) !== []) {
+            $issues[] = 'article_plan_has_existing_issues:'.$target;
+        }
+
+        $articleId = $this->articleIdFromTarget($target);
+        $article = $articleId !== null
+            ? Article::query()
+                ->withoutGlobalScopes()
+                ->with([
+                    'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                    'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                ])
+                ->find($articleId)
+            : null;
+
+        if (! $article instanceof Article) {
+            $issues[] = 'article_not_found:'.$target;
+        }
+
+        $seoTitle = $this->boundedString($fields['seo_title'] ?? null, 60);
+        $seoDescription = $this->boundedString($fields['seo_description'] ?? null, 160);
+        $primaryCtaLabel = $this->boundedString($fields['primary_cta_label'] ?? null, 96);
+        $primaryCtaPath = $this->safePublicTestPath($fields['primary_cta_path'] ?? null);
+        $internalLinkTargets = $this->safeInternalPaths($fields['internal_link_targets'] ?? []);
+
+        if ($seoTitle === null) {
+            $issues[] = 'seo_title_missing_or_too_long:'.$target;
+        }
+        if ($seoDescription === null) {
+            $issues[] = 'seo_description_missing_or_too_long:'.$target;
+        }
+        if ($primaryCtaLabel === null) {
+            $issues[] = 'primary_cta_label_missing_or_too_long:'.$target;
+        }
+        if ($primaryCtaPath === null) {
+            $issues[] = 'primary_cta_path_invalid:'.$target;
+        }
+        if (($fields['internal_link_targets'] ?? []) !== [] && $internalLinkTargets === []) {
+            $issues[] = 'internal_link_targets_invalid:'.$target;
+        }
+
+        $protected = $article instanceof Article ? $this->currentProtectedSnapshot($article) : null;
+        if ($article instanceof Article) {
+            $this->validateCurrentArticle($article, $slug, $locale, $safePath, $issues);
+        }
+
+        return [
+            'target' => $target,
+            'article_id' => $article instanceof Article ? (int) $article->id : $articleId,
+            'slug' => $slug,
+            'locale' => $locale,
+            'safe_path' => $safePath,
+            'ready' => $issues === [],
+            'current_protected' => $protected,
+            'planned_fields' => [
+                'seo_title' => $seoTitle,
+                'seo_description' => $seoDescription,
+                'first_screen_summary_direction' => $this->boundedString($fields['first_screen_summary_direction'] ?? null, 240),
+                'primary_cta_label' => $primaryCtaLabel,
+                'primary_cta_path' => $primaryCtaPath,
+                'internal_link_targets' => $internalLinkTargets,
+                'claim_boundary_note' => $this->boundedString($fields['claim_boundary_note'] ?? null, 240),
+            ],
+            'protected_diff' => [
+                'slug' => 'no_change',
+                'canonical' => 'no_change',
+                'locale' => 'no_change',
+                'article_id' => $article instanceof Article ? 'resolved_no_change' : 'unresolved',
+                'publication' => 'no_change',
+                'schema' => 'hold_no_change',
+                'hreflang' => 'hold_no_change',
+                'sitemap' => 'no_change',
+                'llms' => 'no_change',
+            ],
+            'runtime_projection_plan' => [
+                'published_revision_seo_title' => true,
+                'published_revision_seo_description' => true,
+                'article_seo_meta_title_description' => true,
+                'landing_surface_cta_bundle_from_editorial_metadata' => true,
+                'answer_surface_next_steps_from_editorial_metadata' => true,
+                'body_internal_link_rewrite' => false,
+            ],
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $plans
+     * @return list<array<string, mixed>>
+     */
+    private function executePlans(array $plans, string $dryRunSha): array
+    {
+        return DB::transaction(function () use ($plans, $dryRunSha): array {
+            $results = [];
+            foreach ($plans as $plan) {
+                /** @var Article $article */
+                $article = Article::query()
+                    ->withoutGlobalScopes()
+                    ->with([
+                        'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                        'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                    ])
+                    ->whereKey((int) $plan['article_id'])
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                $before = $this->currentProtectedSnapshot($article);
+                $this->assertProtectedMatchesPlan($article, $plan);
+
+                /** @var ArticleTranslationRevision $revision */
+                $revision = $article->publishedRevision;
+                $fields = (array) $plan['planned_fields'];
+                $revision->forceFill([
+                    'seo_title' => (string) $fields['seo_title'],
+                    'seo_description' => (string) $fields['seo_description'],
+                ])->save();
+
+                /** @var ArticleSeoMeta $seoMeta */
+                $seoMeta = $article->seoMeta instanceof ArticleSeoMeta
+                    ? $article->seoMeta
+                    : ArticleSeoMeta::query()->withoutGlobalScopes()->firstOrNew([
+                        'org_id' => (int) $article->org_id,
+                        'article_id' => (int) $article->id,
+                        'locale' => (string) $article->locale,
+                    ]);
+
+                $schema = is_array($seoMeta->schema_json) ? $seoMeta->schema_json : [];
+                $editorial = is_array($schema['editorial_package_v1'] ?? null) ? $schema['editorial_package_v1'] : [];
+                $editorial['source'] = 'seo_ops_p0_ctr_article_cms_update_writer';
+                $editorial['dry_run_evidence_sha256'] = $dryRunSha;
+                $editorial['first_screen_summary_direction'] = $fields['first_screen_summary_direction'];
+                $editorial['claim_boundary_note'] = $fields['claim_boundary_note'];
+                $editorial['internal_link_targets'] = $fields['internal_link_targets'];
+                $editorial['cta_slots'] = [[
+                    'key' => 'p0_ctr_primary_test_cta',
+                    'label' => (string) $fields['primary_cta_label'],
+                    'href' => (string) $fields['primary_cta_path'],
+                    'kind' => 'start_test',
+                ]];
+                $editorial['schema_hold'] = true;
+                $editorial['hreflang_hold'] = true;
+                $editorial['search_submission_allowed'] = false;
+                $editorial['sitemap_change_allowed'] = false;
+                $editorial['llms_change_allowed'] = false;
+                $schema['editorial_package_v1'] = $editorial;
+
+                $seoMeta->forceFill([
+                    'org_id' => (int) $article->org_id,
+                    'article_id' => (int) $article->id,
+                    'locale' => (string) $article->locale,
+                    'seo_title' => (string) $fields['seo_title'],
+                    'seo_description' => (string) $fields['seo_description'],
+                    'og_title' => (string) $fields['seo_title'],
+                    'og_description' => (string) $fields['seo_description'],
+                    'robots' => (bool) $article->is_indexable ? 'index,follow' : 'noindex,nofollow',
+                    'is_indexable' => (bool) $article->is_indexable,
+                    'schema_json' => $schema,
+                ])->save();
+
+                $article->refresh();
+                $article->load([
+                    'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                    'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                ]);
+                $after = $this->currentProtectedSnapshot($article);
+
+                if ($before !== $after) {
+                    throw new \RuntimeException('protected fields changed for '.$plan['target']);
+                }
+
+                $results[] = [
+                    'target' => (string) $plan['target'],
+                    'article_id' => (int) $article->id,
+                    'published_revision_id' => (int) $article->published_revision_id,
+                    'seo_title_sha256' => hash('sha256', (string) $fields['seo_title']),
+                    'seo_description_sha256' => hash('sha256', (string) $fields['seo_description']),
+                    'cta_slot_count' => 1,
+                    'protected_fields_preserved' => true,
+                ];
+            }
+
+            return $results;
+        });
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $plans
+     */
+    private function requiredConfirmationPhrase(string $dryRunSha, array $plans): string
+    {
+        $targets = implode(', ', array_values(array_map(static fn (array $plan): string => (string) ($plan['target'] ?? ''), $plans)));
+
+        return 'I explicitly approve Gate B P0 CTR repair article CMS update for 3 articles using dry-run evidence sha256 '
+            .$dryRunSha.'; targets '.$targets.'; no landing surface write, no publish, no Search Channel, no IndexNow/Baidu/GSC, no schema/hreflang, no sitemap/llms, no URL Truth, no deploy/revalidation.';
+    }
+
+    private function validateCurrentArticle(Article $article, string $slug, string $locale, string $safePath, array &$issues): void
+    {
+        if ((string) $article->slug !== $slug) {
+            $issues[] = 'slug_lock_mismatch:article:'.(int) $article->id;
+        }
+        if ((string) $article->locale !== $locale) {
+            $issues[] = 'locale_lock_mismatch:article:'.(int) $article->id;
+        }
+        if ((string) $article->status !== 'published' || ! $article->publishedRevision instanceof ArticleTranslationRevision) {
+            $issues[] = 'published_revision_missing:article:'.(int) $article->id;
+        }
+        if (! (bool) $article->is_public || ! (bool) $article->is_indexable) {
+            $issues[] = 'article_not_public_indexable:article:'.(int) $article->id;
+        }
+        $canonicalPath = $this->canonicalPath($article->seoMeta instanceof ArticleSeoMeta ? (string) $article->seoMeta->canonical_url : null);
+        if ($canonicalPath !== $safePath) {
+            $issues[] = 'canonical_lock_mismatch:article:'.(int) $article->id;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $plan
+     */
+    private function assertProtectedMatchesPlan(Article $article, array $plan): void
+    {
+        $issues = [];
+        $this->validateCurrentArticle(
+            $article,
+            (string) $plan['slug'],
+            (string) $plan['locale'],
+            (string) $plan['safe_path'],
+            $issues
+        );
+
+        if ($issues !== []) {
+            throw new \RuntimeException('protected lock mismatch: '.implode(', ', $issues));
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentProtectedSnapshot(Article $article): array
+    {
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'canonical_path' => $this->canonicalPath($article->seoMeta instanceof ArticleSeoMeta ? (string) $article->seoMeta->canonical_url : null),
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => $article->working_revision_id !== null ? (int) $article->working_revision_id : null,
+            'published_revision_id' => $article->published_revision_id !== null ? (int) $article->published_revision_id : null,
+            'published_at' => optional($article->published_at)->toIso8601String(),
+        ];
+    }
+
+    private function articleIdFromTarget(string $target): ?int
+    {
+        if (preg_match('/^article:(\d+):[A-Za-z-]+$/', $target, $matches) !== 1) {
+            return null;
+        }
+
+        return (int) $matches[1];
+    }
+
+    private function boundedString(mixed $value, int $max): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+        if ($string === '' || mb_strlen($string) > $max) {
+            return null;
+        }
+
+        return $string;
+    }
+
+    private function safePublicTestPath(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+        $path = trim((string) $value);
+        if (preg_match('#^/(en|zh)/tests/[a-z0-9][a-z0-9-]*$#i', $path) !== 1) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function safeInternalPaths(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $paths = [];
+        foreach ($value as $item) {
+            if (! is_scalar($item)) {
+                continue;
+            }
+            $path = trim((string) $item);
+            if (preg_match('#^/(en|zh)/(?:articles|tests|topics)/[a-z0-9][a-z0-9-]*$#i', $path) === 1) {
+                $paths[] = $path;
+            }
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    private function canonicalPath(?string $canonical): ?string
+    {
+        if ($canonical === null || trim($canonical) === '') {
+            return null;
+        }
+        $path = parse_url($canonical, PHP_URL_PATH);
+        if (is_string($path) && $path !== '') {
+            return $path;
+        }
+
+        return str_starts_with($canonical, '/') ? $canonical : null;
+    }
+
+    /**
+     * @param  array<int, string>  $issues
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function failureSummary(array $issues, array $extra = []): array
+    {
+        return array_replace([
+            'schema_version' => self::OUTPUT_SCHEMA,
+            'command' => 'php artisan seo-ops:p0-ctr-article-cms-update-writer',
+            'ok' => false,
+            'status' => 'blocked',
+            'dry_run' => ! (bool) $this->option('execute'),
+            'execute' => (bool) $this->option('execute'),
+            'generated_at' => now()->utc()->toIso8601String(),
+            'issues' => array_values(array_unique($issues)),
+        ], $extra);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function writeEvidence(string $artifactDir, array $summary): ?array
+    {
+        File::ensureDirectoryExists($artifactDir);
+        $path = rtrim($artifactDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR
+            .'seo-ops-p0-ctr-article-cms-update-writer-'.now()->utc()->format('Ymd\THis\Z').'.json';
+
+        $artifact = $summary;
+        unset($artifact['evidence']);
+        File::put($path, json_encode($artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+            'bytes' => filesize($path) ?: 0,
+        ];
+    }
+
+    private function finish(array $summary): int
+    {
+        if ($this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        } elseif (($summary['ok'] ?? false) === true) {
+            $this->info('P0 CTR article CMS update writer '.($summary['status'] ?? 'planned').': '.json_encode($summary['planned_write_count'] ?? []));
+        } else {
+            $this->error('P0 CTR article CMS update writer blocked: '.implode(', ', (array) ($summary['issues'] ?? [])));
+        }
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function readablePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '' || str_contains($path, "\0") || ! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function artifactDir(): ?string
+    {
+        $dir = trim((string) $this->option('artifact-dir'));
+        if ($dir === '' || str_contains($dir, "\0")) {
+            return null;
+        }
+        if (! is_dir($dir)) {
+            File::ensureDirectoryExists($dir);
+        }
+
+        return is_dir($dir) && is_writable($dir) ? $dir : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function forbiddenStringsPresent(string $raw): array
+    {
+        $matches = [];
+        foreach (self::FORBIDDEN_STRINGS as $needle) {
+            if (str_contains($raw, $needle)) {
+                $matches[] = $needle;
+            }
+        }
+
+        return $matches;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -221,6 +221,7 @@ use App\Console\Commands\SeoAgentRunCommand;
 use App\Console\Commands\SeoAgentRuntimeSeoQaScanCommand;
 use App\Console\Commands\SeoAgentWeeklyDraftWriteAutoCommand;
 use App\Console\Commands\SeoAgentWeeklyReadonlyRunnerCommand;
+use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
 use App\Console\Commands\SeoIntelSearchChannelQueueCommand;
 use App\Console\Commands\SeoIntelUrlTruthHandoffCommand;
 use App\Console\Commands\StorageControlPlaneSnapshot;
@@ -465,6 +466,7 @@ class Kernel extends ConsoleKernel
         SeoAgentRunCommand::class,
         SeoAgentWeeklyDraftWriteAutoCommand::class,
         SeoAgentWeeklyReadonlyRunnerCommand::class,
+        SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,
         SeoIntelUrlTruthHandoffCommand::class,
         SeoIntelSearchChannelQueueCommand::class,
         ContentReleaseRevalidate::class,

--- a/backend/docs/seo/generated/seo-ops-p0-ctr-article-cms-update-writer.v1.json
+++ b/backend/docs/seo/generated/seo-ops-p0-ctr-article-cms-update-writer.v1.json
@@ -1,0 +1,85 @@
+{
+  "version": "seo-ops-p0-ctr-article-cms-update-writer.v1",
+  "command": "php artisan seo-ops:p0-ctr-article-cms-update-writer",
+  "purpose": "Controlled Gate B writer for P0 CTR article CMS updates from verified seo-ops-p0-ctr-repair-dry-run.v1 evidence.",
+  "input_schema": "seo-ops-p0-ctr-repair-dry-run.v1",
+  "required_options": [
+    "--dry-run-evidence",
+    "--confirm-dry-run-evidence-sha256",
+    "--artifact-dir",
+    "--json"
+  ],
+  "execute_options": [
+    "--execute",
+    "--confirm-write"
+  ],
+  "default_mode": {
+    "dry_run": true,
+    "execute": false,
+    "database_write": false
+  },
+  "execute_gate": {
+    "requires_exact_confirmation_phrase": true,
+    "phrase_source": "required_confirmation_phrase emitted by dry-run",
+    "bounded_targets": 3,
+    "target_family": "article_cms_updates"
+  },
+  "writes_when_executed": {
+    "article_translation_revisions": [
+      "published revision seo_title",
+      "published revision seo_description"
+    ],
+    "article_seo_meta": [
+      "seo_title",
+      "seo_description",
+      "og_title",
+      "og_description",
+      "editorial_package_v1 CTA/internal-link/readback metadata"
+    ]
+  },
+  "protected_fields": {
+    "slug": "no_change",
+    "canonical": "no_change",
+    "locale": "no_change",
+    "article_id": "resolved_no_change",
+    "publication": "no_change",
+    "published_revision_id": "no_change",
+    "working_revision_id": "no_change",
+    "schema": "hold_no_change",
+    "hreflang": "hold_no_change",
+    "sitemap": "no_change",
+    "llms": "no_change"
+  },
+  "runtime_projection": {
+    "title_meta": "published revision + article_seo_meta",
+    "cta": "article_seo_meta.schema_json.editorial_package_v1.cta_slots -> landing_surface_v1.cta_bundle and answer_surface_v1.next_step_blocks",
+    "body_internal_link_rewrite": false
+  },
+  "evidence_outputs": [
+    "evidence.path",
+    "evidence.sha256",
+    "planned_write_count",
+    "article_update_plans",
+    "write_results",
+    "side_effects",
+    "protected_diff_summary"
+  ],
+  "side_effect_boundaries": {
+    "landing_surface_write": false,
+    "cms_publish": false,
+    "url_truth_write": false,
+    "schema_enable": false,
+    "hreflang_enable": false,
+    "sitemap_write": false,
+    "llms_write": false,
+    "search_channel_enqueue": false,
+    "indexnow_submit": false,
+    "baidu_submit": false,
+    "gsc_request_indexing": false,
+    "scheduler_start": false,
+    "queue_worker_start": false,
+    "external_api_call": false,
+    "revalidation": false,
+    "deploy": false
+  }
+}

--- a/backend/tests/Feature/SeoIntel/SeoOpsP0CtrArticleCmsUpdateWriterCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoOpsP0CtrArticleCmsUpdateWriterCommandTest.php
@@ -1,0 +1,460 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Console\Commands\SeoOpsP0CtrArticleCmsUpdateWriterCommand;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\LandingSurface;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoOpsP0CtrArticleCmsUpdateWriterCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(ConsoleKernel::class)->registerCommand(
+            $this->app->make(SeoOpsP0CtrArticleCmsUpdateWriterCommand::class)
+        );
+    }
+
+    #[Test]
+    public function dry_run_plans_three_article_updates_without_writes(): void
+    {
+        $this->seedAuthorityRows();
+        $dryRun = $this->writeDryRunEvidence();
+        $countsBefore = $this->rowCounts();
+
+        $exitCode = Artisan::call('seo-ops:p0-ctr-article-cms-update-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('planned', $summary['status'] ?? null);
+        $this->assertTrue((bool) ($summary['dry_run'] ?? false));
+        $this->assertFalse((bool) ($summary['execute'] ?? true));
+        $this->assertSame(3, data_get($summary, 'planned_write_count.article_cms_updates'));
+        $this->assertSame(0, data_get($summary, 'planned_write_count.landing_surfaces'));
+        $this->assertStringContainsString('I explicitly approve Gate B P0 CTR repair article CMS update', (string) ($summary['required_confirmation_phrase'] ?? ''));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.database_write', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.search_channel_enqueue', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+
+        $artifact = $this->readJson((string) data_get($summary, 'evidence.path'));
+        $this->assertSame('seo-ops-p0-ctr-article-cms-update-writer.v1', $artifact['schema_version'] ?? null);
+        $this->assertCount(3, $artifact['article_update_plans'] ?? []);
+    }
+
+    #[Test]
+    public function execute_updates_live_article_seo_and_cta_metadata_without_publish_or_search_side_effects(): void
+    {
+        $articles = $this->seedAuthorityRows();
+        $dryRun = $this->writeDryRunEvidence();
+        $plan = $this->writerPlan($dryRun);
+        $phrase = (string) $plan['required_confirmation_phrase'];
+        $countsBefore = $this->rowCounts();
+        $protectedBefore = $this->protectedSnapshots($articles);
+
+        $exitCode = Artisan::call('seo-ops:p0-ctr-article-cms-update-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--execute' => true,
+            '--confirm-write' => $phrase,
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertTrue((bool) ($summary['ok'] ?? false));
+        $this->assertSame('success', $summary['status'] ?? null);
+        $this->assertFalse((bool) ($summary['dry_run'] ?? true));
+        $this->assertTrue((bool) data_get($summary, 'side_effects.database_write'));
+        $this->assertTrue((bool) data_get($summary, 'side_effects.cms_article_update'));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.landing_surface_write', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.cms_publish', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.search_channel_enqueue', true));
+        $this->assertFalse((bool) data_get($summary, 'side_effects.indexnow_submit', true));
+        $this->assertSame($countsBefore, $this->rowCounts());
+        $this->assertSame($protectedBefore, $this->protectedSnapshots($articles));
+
+        $first = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+            ])
+            ->findOrFail((int) $articles[0]->id);
+
+        $this->assertSame('What Is RIASEC? Holland Code Career Test Guide', (string) $first->publishedRevision?->seo_title);
+        $this->assertSame('Learn what RIASEC means, how the Holland Code career interest model works, and when to use a free career interest test for exploration.', (string) $first->publishedRevision?->seo_description);
+        $this->assertSame('What Is RIASEC? Holland Code Career Test Guide', (string) $first->seoMeta?->seo_title);
+        $this->assertSame('Take the free RIASEC test', (string) data_get($first->seoMeta?->schema_json, 'editorial_package_v1.cta_slots.0.label'));
+        $this->assertSame('/en/tests/holland-career-interest-test-riasec', (string) data_get($first->seoMeta?->schema_json, 'editorial_package_v1.cta_slots.0.href'));
+        $this->assertSame('seo_ops_p0_ctr_article_cms_update_writer', (string) data_get($first->seoMeta?->schema_json, 'editorial_package_v1.source'));
+        $this->assertFalse((bool) data_get($first->seoMeta?->schema_json, 'editorial_package_v1.search_submission_allowed', true));
+        $this->assertTrue((bool) data_get($first->seoMeta?->schema_json, 'editorial_package_v1.schema_hold', false));
+    }
+
+    #[Test]
+    public function execute_requires_exact_confirmation_phrase(): void
+    {
+        $this->seedAuthorityRows();
+        $dryRun = $this->writeDryRunEvidence();
+
+        $exitCode = Artisan::call('seo-ops:p0-ctr-article-cms-update-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--execute' => true,
+            '--confirm-write' => 'wrong',
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('confirm_write_phrase_mismatch', $summary['issues'] ?? []);
+        $this->assertSame('Existing SEO description.', (string) ArticleSeoMeta::query()->withoutGlobalScopes()->first()?->seo_description);
+    }
+
+    #[Test]
+    public function writer_blocks_wrong_dry_run_evidence_sha(): void
+    {
+        $this->seedAuthorityRows();
+        $dryRun = $this->writeDryRunEvidence();
+
+        $exitCode = Artisan::call('seo-ops:p0-ctr-article-cms-update-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => str_repeat('0', 64),
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $summary['status'] ?? null);
+        $this->assertContains('dry_run_evidence_sha_mismatch', $summary['issues'] ?? []);
+    }
+
+    /**
+     * @return list<Article>
+     */
+    private function seedAuthorityRows(): array
+    {
+        $this->createLandingSurface('test_detail_mbti_personality_test_16_personality_types', 'MBTI免费测试');
+        $this->createLandingSurface('test_detail_holland_career_interest_test_riasec', '霍兰德职业兴趣测试');
+
+        return [
+            $this->createArticle('what-is-riasec-holland-code-career-interest-test', 'en', 'What Is RIASEC?', '/en/articles/what-is-riasec-holland-code-career-interest-test'),
+            $this->createArticle('riasec-holland-career-interest-test-explained', 'zh-CN', '霍兰德职业兴趣测试是什么？', '/zh/articles/riasec-holland-career-interest-test-explained'),
+            $this->createArticle('mbti-basics', 'zh-CN', 'MBTI 是什么？', '/zh/articles/mbti-basics'),
+        ];
+    }
+
+    private function createLandingSurface(string $surfaceKey, string $title): void
+    {
+        LandingSurface::query()->create([
+            'org_id' => 0,
+            'surface_key' => $surfaceKey,
+            'locale' => 'zh-CN',
+            'title' => $title,
+            'description' => 'Existing description.',
+            'schema_version' => 'v1',
+            'payload_json' => [
+                'seo_title' => $title.' | FermatMind',
+                'seo_description' => 'Existing SEO description.',
+                'h1_or_hero_title' => $title,
+                'primary_cta_label' => '开始测试',
+            ],
+            'status' => LandingSurface::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+        ]);
+    }
+
+    private function createArticle(string $slug, string $locale, string $title, string $canonicalPath): Article
+    {
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'translation_group_id' => (string) Str::uuid(),
+            'source_locale' => $locale,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown with a public link to [/articles](/'.($locale === 'en' ? 'en' : 'zh').'/articles).',
+            'content_html' => '<p>Existing HTML.</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now()->subDay(),
+        ]);
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => $locale,
+            'source_locale' => $locale,
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'title' => $title,
+            'excerpt' => 'Existing excerpt.',
+            'content_md' => 'Existing markdown.',
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'published_at' => now()->subHour(),
+        ]);
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->save();
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => $title.' | FermatMind',
+            'seo_description' => 'Existing SEO description.',
+            'canonical_url' => 'https://fermatmind.com'.$canonicalPath,
+            'robots' => 'index,follow',
+            'schema_json' => [['@type' => 'Article']],
+            'is_indexable' => true,
+        ]);
+
+        return $article->fresh(['publishedRevision', 'seoMeta']) ?? $article;
+    }
+
+    /**
+     * @return array{path:string,sha256:string}
+     */
+    private function writeDryRunEvidence(): array
+    {
+        $source = $this->writeJson($this->sourceArtifact());
+        $exitCode = Artisan::call('seo-ops:p0-ctr-repair-dry-run', [
+            '--artifact' => $source['path'],
+            '--confirm-artifact-sha256' => $source['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $path = (string) data_get($summary, 'evidence.path');
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+        ];
+    }
+
+    /**
+     * @param  array{path:string,sha256:string}  $dryRun
+     * @return array<string,mixed>
+     */
+    private function writerPlan(array $dryRun): array
+    {
+        $exitCode = Artisan::call('seo-ops:p0-ctr-article-cms-update-writer', [
+            '--dry-run-evidence' => $dryRun['path'],
+            '--confirm-dry-run-evidence-sha256' => $dryRun['sha256'],
+            '--artifact-dir' => $this->artifactDir(),
+            '--json' => true,
+        ]);
+        $summary = $this->jsonOutput();
+        $this->assertSame(0, $exitCode, Artisan::output());
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function sourceArtifact(): array
+    {
+        return [
+            'schema' => 'fermatmind-seo-ops-ctr-repair-p0-dry-run-preview.v1',
+            'generated_at' => now()->utc()->toIso8601String(),
+            'scope' => [
+                'read_only_package_prep' => true,
+                'cms_write_allowed' => false,
+                'publish_allowed' => false,
+                'search_submit_allowed' => false,
+                'url_truth_write_allowed' => false,
+                'sitemap_llms_mutation_allowed' => false,
+                'schema_enable_allowed' => false,
+                'hreflang_enable_allowed' => false,
+                'deploy_allowed' => false,
+            ],
+            'authority_groups' => [
+                'test_landing_surfaces' => [
+                    $this->landingCandidate('test_detail_mbti_personality_test_16_personality_types', 'mbti-personality-test-16-personality-types'),
+                    $this->landingCandidate('test_detail_holland_career_interest_test_riasec', 'holland-career-interest-test-riasec'),
+                ],
+                'article_cms_updates' => [
+                    $this->articleCandidate('what-is-riasec-holland-code-career-interest-test', 'en', 'What Is RIASEC? Holland Code Career Test Guide', 'Take the free RIASEC test'),
+                    $this->articleCandidate('riasec-holland-career-interest-test-explained', 'zh', 'RIASEC 是什么？霍兰德职业兴趣测试解释', '免费做霍兰德职业兴趣测试'),
+                    $this->articleCandidate('mbti-basics', 'zh', 'MBTI 是什么？16 型人格测试入门指南', '开始免费 MBTI 测试'),
+                ],
+            ],
+            'negative_guarantees' => [
+                'db_write' => false,
+                'cms_write' => false,
+                'cms_publish' => false,
+                'search_channel_enqueue' => false,
+                'indexnow_submit' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function landingCandidate(string $surfaceKey, string $slug): array
+    {
+        return [
+            'payload_key' => 'test_landing_surface::'.$surfaceKey.'::zh',
+            'authority_source' => 'backend landing_surfaces payload',
+            'surface_key' => $surfaceKey,
+            'locale' => 'zh',
+            'safe_path' => '/zh/tests/'.$slug,
+            'slug' => $slug,
+            'proposed_payload_json_updates' => [
+                'seo_title' => '新的测试页标题 | FermatMind',
+                'seo_description' => '新的测试页描述。',
+                'h1_or_hero_title' => '新的 H1',
+                'primary_cta_label' => '开始免费测试',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function articleCandidate(string $slug, string $locale, string $seoTitle, string $ctaLabel): array
+    {
+        $segment = $locale === 'en' ? 'en' : 'zh';
+
+        return [
+            'payload_key' => 'article_cms_update::'.$slug.'::'.$locale,
+            'authority_source' => 'backend CMS Article detail',
+            'locale' => $locale,
+            'safe_path' => '/'.$segment.'/articles/'.$slug,
+            'slug' => $slug,
+            'proposed_cms_field_updates' => [
+                'seo_title' => $seoTitle,
+                'seo_description' => $locale === 'en'
+                    ? 'Learn what RIASEC means, how the Holland Code career interest model works, and when to use a free career interest test for exploration.'
+                    : '解释 RIASEC 六种职业兴趣类型、霍兰德测试能说明什么，以及如何把结果用于专业和职业探索。',
+                'first_screen_summary_direction' => $locale === 'en'
+                    ? 'Answer what RIASEC means first, then route testing intent to the free RIASEC test page.'
+                    : '首屏聚焦公开解释，并把测试入口作为清晰下一步。',
+                'primary_cta_label' => $ctaLabel,
+                'primary_cta_path' => '/'.$segment.'/tests/'.($slug === 'mbti-basics' ? 'mbti-personality-test-16-personality-types' : 'holland-career-interest-test-riasec'),
+                'internal_link_targets' => [
+                    '/'.$segment.'/tests/'.($slug === 'mbti-basics' ? 'mbti-personality-test-16-personality-types' : 'holland-career-interest-test-riasec'),
+                ],
+                'claim_boundary_note' => $locale === 'en'
+                    ? 'Use as career exploration input, not as a promise of job fit or career outcome.'
+                    : '用于探索参考，不承诺录取、岗位适配或职业结果。',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array{path:string,sha256:string}
+     */
+    private function writeJson(array $payload): array
+    {
+        $path = $this->artifactDir().'/source.json';
+        File::put($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL);
+
+        return [
+            'path' => $path,
+            'sha256' => hash_file('sha256', $path),
+        ];
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function rowCounts(): array
+    {
+        return [
+            'landing_surfaces' => DB::table('landing_surfaces')->count(),
+            'articles' => DB::table('articles')->count(),
+            'article_seo_meta' => DB::table('article_seo_meta')->count(),
+            'article_translation_revisions' => DB::table('article_translation_revisions')->count(),
+        ];
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @return array<int,array<string,mixed>>
+     */
+    private function protectedSnapshots(array $articles): array
+    {
+        return array_map(static function (Article $article): array {
+            $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+
+            return [
+                'id' => (int) $fresh->id,
+                'slug' => (string) $fresh->slug,
+                'locale' => (string) $fresh->locale,
+                'translation_group_id' => (string) $fresh->translation_group_id,
+                'status' => (string) $fresh->status,
+                'is_public' => (bool) $fresh->is_public,
+                'is_indexable' => (bool) $fresh->is_indexable,
+                'sitemap_eligible' => (bool) $fresh->sitemap_eligible,
+                'llms_eligible' => (bool) $fresh->llms_eligible,
+                'working_revision_id' => (int) $fresh->working_revision_id,
+                'published_revision_id' => (int) $fresh->published_revision_id,
+            ];
+        }, $articles);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        return json_decode(trim(Artisan::output()), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path): array
+    {
+        return json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function artifactDir(): string
+    {
+        $dir = storage_path('framework/testing/seo-ops-p0-ctr-article-writer-'.Str::random(8));
+        File::ensureDirectoryExists($dir);
+
+        return $dir;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1280,13 +1280,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
-    public function test_runtime_freeze_classifier_ignores_seo_ops_p0_ctr_repair_dry_run_adapter(): void
+    public function test_runtime_freeze_classifier_ignores_seo_ops_p0_ctr_repair_adapters(): void
     {
         $changed = [
+            'backend/app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php',
             'backend/app/Console/Commands/SeoOpsP0CtrRepairDryRunCommand.php',
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\SeoOpsP0CtrArticleCmsUpdateWriterCommand;',
+            '+        SeoOpsP0CtrArticleCmsUpdateWriterCommand::class,',
         ];
 
-        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
     public function test_runtime_freeze_classifier_ignores_seo_agent_codex_review_runner_files(): void
@@ -5709,6 +5715,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsEnneagramCmsPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentDraftOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsBigFivePublicProfileAgentPromotionOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsTdkGapReadonlyScannerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCodexReviewRunnerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoAgentCmsDraftPackageDryRunOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -6461,7 +6468,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isSeoOpsP0CtrRepairDryRunFile(string $file): bool
     {
-        return $file === 'backend/app/Console/Commands/SeoOpsP0CtrRepairDryRunCommand.php';
+        return in_array($file, [
+            'backend/app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php',
+            'backend/app/Console/Commands/SeoOpsP0CtrRepairDryRunCommand.php',
+        ], true);
     }
 
     private function isSeoAgentCmsTdkGapReadonlyScannerFile(string $file): bool
@@ -8558,6 +8568,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\b(ArticleDiscoverabilityRelease|ArticleEnsureSeoMetaBaseline|ArticleTaxonomyHygiene|ArticleUpdateExistingSeoContentPackage|ArticleSeoGateRollout|ContentReleaseRevalidate|SeoIntelSearchChannelQueueCommand|SeoIntelUrlTruthHandoffCommand)\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoOpsP0CtrArticleCmsUpdateWriterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bSeoOpsP0CtrArticleCmsUpdateWriterCommand\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `seo-ops:p0-ctr-article-cms-update-writer`, a Gate B writer adapter for the P0 CTR repair article CMS updates.
- The command consumes verified `seo-ops-p0-ctr-repair-dry-run.v1` evidence, defaults to dry-run, and requires the exact generated approval phrase plus evidence SHA before execute.
- Execute mode is bounded to the 3 planned article CMS targets and updates only published-revision SEO title/description plus `article_seo_meta` SEO/CTA metadata.
- Registered the command, added the generated contract doc, focused feature tests, and updated the BigFive runtime freeze classifier guard to treat both P0 CTR adapters as non-runtime-result changes.

## Why
Gate B needs a backend-authoritative writer after the production dry-run evidence confirms authority/protected diff. Existing article draft/publish tools are not the right fit because this operation is a controlled CMS SEO update, not a draft publish or search propagation step.

## Validation
- `cd backend && php artisan list | rg 'seo-ops:p0-ctr-article-cms-update-writer'`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsP0CtrArticleCmsUpdateWriterCommandTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoOpsP0CtrRepairDryRunCommandTest`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=test_runtime_freeze_classifier_ignores_seo_ops_p0_ctr_repair_adapters`
- `cd backend && vendor/bin/pint --test app/Console/Commands/SeoOpsP0CtrArticleCmsUpdateWriterCommand.php tests/Feature/SeoIntel/SeoOpsP0CtrArticleCmsUpdateWriterCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && python3 -m json.tool docs/seo/generated/seo-ops-p0-ctr-article-cms-update-writer.v1.json >/dev/null && git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production deploy in this PR.
- No production Gate B writer dry-run or write execution in this PR.
- No article publish, URL Truth, Search Channel, IndexNow/Baidu/GSC, schema/hreflang, sitemap/llms, deploy, or revalidation.
- No article body/internal-link rewrite; the P0 payload contains direction and targets, not a concrete body patch.
