### PR TITLE
PERSONALITY-AGENT-APPROVAL-QUEUE-NEXT-BATCH-3-CONTRACT-PATCH-01

### DIFF
--- a/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
+++ b/backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php
@@ -363,6 +363,7 @@ final class PersonalityAgentApprovalQueueWriter
             'PASS',
             'PASS_READY_FOR_CMS_DRAFT',
             'PASS_READY_FOR_APPROVAL_QUEUE',
+            'PASS_READY_FOR_APPROVAL_REVIEW',
             'READY_QUERY_BACKED_LOW_RISK_DRAFT_REVIEW',
         ], true);
     }

--- a/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php
@@ -40,6 +40,62 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
         $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
     }
 
+    public function test_next_batch_approval_review_pass_can_enter_human_approval_queue_dry_run_only(): void
+    {
+        [$packagePath, $qaPath] = $this->writeArtifacts($this->nextBatchThreePackage(), $this->nextBatchThreeQa());
+
+        $exitCode = Artisan::call('personality:agent-approval-queue', [
+            '--package' => $packagePath,
+            '--qa' => $qaPath,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('pass', $payload['status']);
+        $this->assertSame('mbti64', $payload['framework']);
+        $this->assertSame('PASS_READY_FOR_APPROVAL_REVIEW', $payload['qa_final_decision']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['write']);
+        $this->assertFalse($payload['writes_attempted']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertFalse($payload['cms_write_attempted']);
+        $this->assertFalse($payload['cms_mutation_attempted']);
+        $this->assertFalse($payload['publish_attempted']);
+        $this->assertFalse($payload['index_attempted']);
+        $this->assertFalse($payload['sitemap_llms_release_attempted']);
+        $this->assertFalse($payload['search_release_attempted']);
+        $this->assertFalse($payload['enqueue_attempted']);
+        $this->assertFalse($payload['external_calls_attempted']);
+        $this->assertFalse($payload['live_content_updated']);
+        $this->assertSame(3, $payload['planned_item_count']);
+        $this->assertSame(0, $payload['blocked_item_count']);
+        $this->assertSame(0, $payload['created_item_count']);
+        $this->assertSame([], $payload['errors']);
+        $this->assertSame(
+            [
+                'https://fermatmind.com/zh/personality/intp-a',
+                'https://fermatmind.com/zh/personality/esfp-a',
+                'https://fermatmind.com/en/personality/enfj-a',
+            ],
+            array_map(
+                static fn (array $item): string => (string) $item['target_url'],
+                $payload['items']
+            )
+        );
+        $this->assertSame(
+            ['PASS_READY_FOR_APPROVAL_REVIEW'],
+            array_values(array_unique(array_map(
+                static fn (array $item): string => (string) $item['qa_decision'],
+                $payload['items']
+            )))
+        );
+        $this->assertSame(0, DB::table('personality_agent_approval_batches')->count());
+        $this->assertSame(0, DB::table('personality_agent_approval_items')->count());
+    }
+
     public function test_write_creates_pending_human_approval_queue_items_only(): void
     {
         [$packagePath, $qaPath] = $this->writeArtifacts($this->validPackage(), $this->validQa());
@@ -550,6 +606,50 @@ final class PersonalityAgentApprovalQueueCommandTest extends TestCase
             'page_results' => [
                 $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_CMS_DRAFT'),
                 $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_CMS_DRAFT'),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function nextBatchThreePackage(): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-RECOMMENDATIONS-01',
+            'status' => 'pass_next_batch_recommendations_ready_for_qa',
+            'recommendations' => [
+                $this->recommendation(
+                    'personality-agent-next-batch:/zh/personality/intp-a',
+                    'https://fermatmind.com/zh/personality/intp-a',
+                    'zh-CN'
+                ),
+                $this->recommendation(
+                    'personality-agent-next-batch:/zh/personality/esfp-a',
+                    'https://fermatmind.com/zh/personality/esfp-a',
+                    'zh-CN'
+                ),
+                $this->recommendation(
+                    'personality-agent-next-batch:/en/personality/enfj-a',
+                    'https://fermatmind.com/en/personality/enfj-a',
+                    'en'
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function nextBatchThreeQa(): array
+    {
+        return [
+            'artifact' => 'PERSONALITY-AGENT-OPERATIONS-NEXT-BATCH-QA-01',
+            'final_decision' => 'PASS_READY_FOR_APPROVAL_REVIEW',
+            'page_results' => [
+                $this->qaRow('https://fermatmind.com/zh/personality/intp-a', 'PASS_READY_FOR_APPROVAL_REVIEW'),
+                $this->qaRow('https://fermatmind.com/zh/personality/esfp-a', 'PASS_READY_FOR_APPROVAL_REVIEW'),
+                $this->qaRow('https://fermatmind.com/en/personality/enfj-a', 'PASS_READY_FOR_APPROVAL_REVIEW'),
             ],
         ];
     }


### PR DESCRIPTION
## What changed
- Allow the approval queue contract to treat `PASS_READY_FOR_APPROVAL_REVIEW` as eligible for human approval queue intake.
- Add a focused dry-run test for the 3 next-batch MBTI64 URLs to prove they can be planned for approval review without creating approval rows or CMS drafts.

## Why
- The next-batch QA artifact uses `PASS_READY_FOR_APPROVAL_REVIEW` to mean ready for human review, not ready for direct CMS draft write.
- The approval queue should accept that state for pending review while preserving the separate CMS draft approval gate.

## Validation
- `php -l backend/app/Services/Cms/PersonalityAgentApprovalQueueWriter.php`
- `php -l backend/tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityAgentApprovalQueueCommandTest.php --display-warnings`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- Scope validation: only approval queue writer and focused approval queue command test changed.

## Deferred / not included
- No CMS draft writer behavior changes.
- No approval queue production write.
- No CMS live content, publish, index/search, sitemap/llms, queue enqueue/approve/submit, external API, or deploy actions.
