### PR TITLE
PR-EQ-AGENT-RUNTIME-V2-01 EQ Agent LLM provider design

### DIFF
--- a/docs/audits/eq/eq_agent_runtime_v2_provider_design_2026-06-25.md
+++ b/docs/audits/eq/eq_agent_runtime_v2_provider_design_2026-06-25.md
@@ -1,0 +1,159 @@
+# EQ Agent Runtime V2 Provider Design
+
+## 1. Purpose
+
+EQ Agent Runtime V2 introduces an LLM-provider-ready architecture for the EQ result-page Agent while keeping the current deterministic read-only runtime as the production default.
+
+The first provider strategy is OpenAI-first, but live LLM calls must remain disabled unless a staging or later production rollout explicitly enables the feature flag. The Agent remains an explanation layer over the existing EQ report context and resolved content assets. It must not become the authority for scores, formulations, report sections, SJT availability, commerce state, or content assets.
+
+## 2. Non-Goals
+
+- Do not replace `Eq60ReportComposer`, content packs, or resolved report assets.
+- Do not let the provider rescore, reclassify, or override `core_formulation_id`.
+- Do not enable EQ-SJT or create any SJT take entry.
+- Do not introduce paid unlock language, SKU suggestions, or premium-report claims.
+- Do not persist chat history or raw provider prompts/responses as business records.
+- Do not enable production LLM traffic in V2-01, V2-02, or V2-03.
+
+## 3. Current Runtime Baseline
+
+Current production behavior is deterministic:
+
+- `GET /api/v0.3/attempts/{id}/eq/agent-context`
+- `POST /api/v0.3/attempts/{id}/eq/agent-runtime/messages`
+- response schema: `eq.agent_runtime_response.v1`
+- mode: `deterministic_read_only`
+- context source: report payload, resolved assets, intent map, guardrails, forbidden-claim metadata
+- guardrails: read-only, no report mutation, no score mutation, no formulation override, no SJT enablement, no paid-unlock language, no raw technical tags
+
+V2 must preserve this outer contract so the existing frontend drawer continues to work without becoming provider-aware.
+
+## 4. Provider Strategy
+
+### 4.1 Default
+
+OpenAI is the first real provider adapter, but provider traffic is off by default:
+
+- `EQ_AGENT_LLM_ENABLED=false`
+- `EQ_AGENT_LLM_PROVIDER=openai`
+- `EQ_AGENT_LLM_STAGING_ONLY=true`
+
+The deterministic runtime remains the fallback and production default until a later explicit rollout PR changes the policy.
+
+### 4.2 Provider Abstraction
+
+The backend should introduce a small provider boundary, for example:
+
+- `EqAgentProviderClient`
+- `EqAgentProviderRequest`
+- `EqAgentProviderResponse`
+- `OpenAiEqAgentProviderClient`
+- `DeterministicEqAgentRuntimeResponder` remains available as fallback
+
+The runtime endpoint chooses the provider only after context readiness and guardrail validation pass.
+
+## 5. Retrieval Input Contract
+
+The provider request must be built only from already-authoritative, sanitized runtime context:
+
+- `locale`
+- `user_message`
+- `intent_context`
+- `report_context`
+- `resolved_assets`
+- `agent_knowledge`
+- `guardrails`
+- selected `source_asset_ids`
+- known forbidden claims and replacement boundaries
+
+The request must not include secrets, raw database rows, tokens, private URLs, raw technical tags, or mutable report-authoring controls.
+
+## 6. Prompt Boundary
+
+The provider prompt must enforce:
+
+- Explain only the existing EQ report and resolved assets.
+- Do not rescore or reinterpret the assessment beyond provided IDs and assets.
+- Do not claim the test measures true emotional ability.
+- Do not compare the module to MSCEIT.
+- Do not use clinical, hiring, certification, guarantee, or job-performance prediction language.
+- Do not offer paid unlocks, premium reports, SKU paths, or purchase prompts.
+- Keep SJT as planned/unavailable unless the backend context explicitly says otherwise.
+- Preserve low-confidence boundaries and recommend cautious reading or retest when the report context indicates low confidence.
+
+## 7. Response Schema
+
+The public runtime endpoint should continue returning `eq.agent_runtime_response.v1`.
+
+Provider output should be normalized into the existing outer shape:
+
+- `schema`
+- `ok`
+- `ready`
+- `mode`
+- `attempt_id`
+- `result_id`
+- `scale_code`
+- `locale`
+- `intent`
+- `intent_context`
+- `assistant_response`
+- `safety`
+- `guardrails`
+- `next_module`
+- `context_summary`
+
+When LLM mode is active, `mode` may be `llm_provider_read_only`, but the public fields and guardrail semantics must remain compatible with the deterministic response. The frontend must not consume raw provider output.
+
+## 8. Safety Validation
+
+Before returning an LLM response, the backend must validate:
+
+- response is valid JSON or can be normalized into the response schema
+- no forbidden claims appear
+- no paid/unlock/SKU language appears
+- no raw technical tags appear
+- no SJT take entry is created when `next_module.available=false`
+- low-confidence reports do not receive strong personality claims
+- source asset IDs are stable content-pack/report asset IDs
+
+If validation fails, the endpoint must return deterministic fallback rather than an unsafe provider response.
+
+## 9. Fallback Policy
+
+Fallback to deterministic mode when:
+
+- feature flag is off
+- provider config is missing
+- context is not ready
+- guardrails are unsafe or incomplete
+- provider times out
+- provider returns an error
+- provider output fails schema validation
+- provider output violates safety checks
+
+The response should remain successful where possible, but `mode` should clearly indicate deterministic fallback.
+
+## 10. Staging-Only Rollout
+
+V2-04 may run a staging-only smoke after:
+
+- backend provider abstraction is merged
+- staging deploy includes the provider code
+- staging flag is explicitly enabled
+- required provider credentials are configured in staging
+- production remains disabled
+
+The smoke must verify:
+
+- en and zh-CN locale behavior
+- normal-confidence and low-confidence boundaries
+- forbidden-claim prompts
+- SJT planned/unavailable state
+- no paywall/SKU/unlock/raw-tag language
+- latency, error rate, and fallback behavior
+- approximate provider cost per message if available
+
+## 11. Future Rollout Boundary
+
+Production LLM rollout is not part of V2-01 through V2-04. A later explicit rollout PR must define production flags, rate limits, monitoring, budget ceilings, incident rollback, logging policy, and acceptance criteria.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T12:40:00+08:00",
+  "updated_at": "2026-06-25T09:57:00Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -61816,7 +61816,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-smoke-02-normal-confidence-report",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "eq_agent_runtime_hardening",
     "title": "PR-EQ-AGENT-SMOKE-02 EQ Agent normal-confidence production smoke report",
     "depends_on": [
@@ -61863,14 +61863,18 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub checks pass: Semgrep, hygiene, content-pack-build-validate, supply-chain, verify-bigfive, verify-mbti-legacy, verify-mbti-v2."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2420 is merged at ae334d3778401afae3d5d4ee01a59f9e96ae1da4, origin/main contains the merge commit, and the remote branch is absent."
       }
     },
     "failure_reason": null,
     "commit_sha": "ffb3dd8fdc976ab59e4036380d8b2f6083d09298",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2420",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T07:53:01Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T12:10:00+08:00",
@@ -61889,6 +61893,195 @@
         "from": "local_checks_passed",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed and PR #2420 mergeStateStatus is CLEAN."
+      },
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled while starting PR-EQ-AGENT-RUNTIME-V2-01 after verifying GitHub PR #2420 merged, origin/main contains ae334d3778401afae3d5d4ee01a59f9e96ae1da4, and the remote branch is absent."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-V2-01": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-v2-01-provider-design",
+    "base": "main",
+    "status": "ready_to_merge",
+    "train_scope": "eq_agent_runtime_v2",
+    "title": "PR-EQ-AGENT-RUNTIME-V2-01 EQ Agent LLM provider design",
+    "depends_on": [
+      "PR-EQ-AGENT-SMOKE-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-SMOKE-02 merged as GitHub PR #2420 at ae334d3778401afae3d5d4ee01a59f9e96ae1da4 and is present in origin/main."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\""
+        ],
+        "evidence": "Docs-only design and PR-train metadata validation passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to docs/audits/eq provider design and docs/codex PR-train metadata."
+      },
+      "github_pr": {
+        "status": "opened",
+        "evidence": "GitHub PR #2421 opened for codex/pr-eq-agent-runtime-v2-01-provider-design."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2421: hygiene, Semgrep, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2."
+      },
+      "merge_state": {
+        "status": "pass",
+        "evidence": "PR #2421 mergeStateStatus is CLEAN."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "2c2d6f43910dafc243b2f1399f60fd97aa631eb8",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2421",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit user authorization and started from latest origin/main in a clean temporary worktree."
+      },
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Added provider design document and V2 PR-train metadata; local docs-only validation passed."
+      },
+      {
+        "at": "2026-06-25T17:50:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened GitHub PR #2421 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-25T17:57:00+08:00",
+        "from": "pr_opened",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed and PR #2421 mergeStateStatus is CLEAN."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-V2-02": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-v2-02-safety-eval-fixtures",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime_v2",
+    "title": "PR-EQ-AGENT-RUNTIME-V2-02 EQ Agent LLM safety eval fixtures",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-V2-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-RUNTIME-V2-01 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-V2-01."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-V2-03": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-v2-03-provider-abstraction",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime_v2",
+    "title": "PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-V2-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-RUNTIME-V2-02 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-V2-02."
+      }
+    ]
+  },
+  "PR-EQ-AGENT-RUNTIME-V2-04": {
+    "repo": "fap-api",
+    "branch": "codex/pr-eq-agent-runtime-v2-04-staging-smoke-report",
+    "base": "main",
+    "status": "pending_dependency",
+    "train_scope": "eq_agent_runtime_v2",
+    "title": "PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report",
+    "depends_on": [
+      "PR-EQ-AGENT-RUNTIME-V2-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for PR-EQ-AGENT-RUNTIME-V2-03 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T17:48:04+08:00",
+        "from": "missing_from_manifest",
+        "to": "pending_dependency",
+        "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-V2-03."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -824,6 +824,148 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: PR-EQ-AGENT-RUNTIME-V2-01
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-SMOKE-02]
+    branch: codex/pr-eq-agent-runtime-v2-01-provider-design
+    title: "PR-EQ-AGENT-RUNTIME-V2-01 EQ Agent LLM provider design"
+    train_scope: eq_agent_runtime_v2
+    scope:
+      - Add a docs-only EQ Agent Runtime V2 provider design.
+      - Define OpenAI-first provider strategy, prompt boundary, retrieval input, response schema, feature flags, fallback, and staging-only rollout gates.
+      - Preserve deterministic read-only runtime as the default production path.
+    allowed_paths:
+      - docs/audits/eq/eq_agent_runtime_v2_provider_design_2026-06-25.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime code, routes, frontend, content assets, scoring, SJT runtime, CMS, SEO, deploy, provider credentials, or production state.
+      - Enable live LLM/provider integration.
+    validation:
+      - git diff --check
+      - git diff --cached --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-V2-02
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-V2-01]
+    branch: codex/pr-eq-agent-runtime-v2-02-safety-eval-fixtures
+    title: "PR-EQ-AGENT-RUNTIME-V2-02 EQ Agent LLM safety eval fixtures"
+    train_scope: eq_agent_runtime_v2
+    scope:
+      - Add LLM provider safety/eval fixtures for forbidden claims, refusal boundaries, low-confidence behavior, hiring/clinical boundaries, paid unlock requests, and SJT availability requests.
+      - Add tests for provider request/response schema, boundary metadata, safe replacement boundaries, and deterministic fallback.
+      - Keep live model calls disabled.
+    allowed_paths:
+      - backend/tests/Fixtures/eq/agent/**
+      - backend/tests/Feature/Report/EqAgentContextApiTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend.
+      - Add live LLM/provider integration or credentials.
+      - Modify EQ questions, scoring, norms, report prose, SJT runtime, commerce, CMS, SEO, deploy, or production state.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - find backend/tests/Fixtures/eq/agent -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-V2-03
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-V2-02]
+    branch: codex/pr-eq-agent-runtime-v2-03-provider-abstraction
+    title: "PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag"
+    train_scope: eq_agent_runtime_v2
+    scope:
+      - Add backend EQ Agent provider abstraction and OpenAI-first adapter behind default-off feature flags.
+      - Preserve deterministic read-only runtime as default and fallback.
+      - Add tests for disabled provider, missing config, invalid/unsafe provider output, fallback, and read-only guardrails.
+    allowed_paths:
+      - backend/app/Services/Eq/**
+      - backend/config/ai.php
+      - backend/config/services.php
+      - backend/tests/Feature/Report/EqAgentContextApiTest.php
+      - backend/tests/Fixtures/eq/agent/**
+      - backend/docs/contracts/openapi.snapshot.json
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend.
+      - Enable production LLM traffic.
+      - Persist chat history or raw provider prompt/response business records.
+      - Modify EQ questions, scoring, norms, report prose, SJT runtime, commerce, CMS, SEO, deploy, or production state.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.3/attempts --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - find backend/tests/Fixtures/eq/agent -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: PR-EQ-AGENT-RUNTIME-V2-04
+    repo: fap-api
+    depends_on: [PR-EQ-AGENT-RUNTIME-V2-03]
+    branch: codex/pr-eq-agent-runtime-v2-04-staging-smoke-report
+    title: "PR-EQ-AGENT-RUNTIME-V2-04 EQ Agent staging LLM smoke report"
+    train_scope: eq_agent_runtime_v2
+    scope:
+      - Add docs-only staging LLM smoke acceptance report after an explicit staging deploy and staging flag enablement.
+      - Verify response quality, safety boundaries, forbidden-claim behavior, latency, cost, fallback, locale behavior, and SJT planned/unavailable state.
+      - Confirm production LLM remains disabled.
+    allowed_paths:
+      - docs/audits/eq/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify runtime code, frontend, content assets, scoring, SJT runtime, CMS, SEO, deploy workflows, provider credentials, or production state.
+      - Enable production LLM/provider traffic.
+    validation:
+      - git diff --check
+      - git diff --cached --check
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: PR-EQ-PER-01
     repo: fap-api
     branch: codex/pr-eq-per-01-all-free-copy-contract-cleanup


### PR DESCRIPTION
## What changed
- Added a docs-only EQ Agent Runtime V2 provider design.
- Added PR-train manifest/state entries for PR-EQ-AGENT-RUNTIME-V2-01 through V2-04.
- Reconciled PR-EQ-AGENT-SMOKE-02 as merged after verifying GitHub PR #2420 and origin/main merge commit evidence.

## Why
- Define the OpenAI-first LLM provider boundary before implementation.
- Preserve the existing deterministic read-only runtime as production default.
- Lock prompt boundaries, retrieval inputs, response schema compatibility, feature flags, fallback behavior, and staging-only smoke gates.

## Validation
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --cached --check`

## Intentionally deferred
- No runtime code changes.
- No provider adapter implementation.
- No live LLM/model calls.
- No frontend changes.
- No SJT enablement.
- No production deploy or feature-flag enablement.

## Repository rule impact
- Content/report authority remains backend content pack and report composer.
- This is docs-only plus PR-train metadata; no API/runtime/CMS/SEO/deploy behavior changes.
