### PR TITLE
PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -846,7 +846,7 @@ class AttemptReadController extends Controller
         $context = json_decode((string) $contextResponse->getContent(), true);
         if (! is_array($context)) {
             return response()->json(
-                $this->eqAgentRuntimeResponder->nonReady($id, 'context_decode_failed', $locale),
+                $this->eqAgentRuntimeResponder->nonReady($id, 'context_decode_failed', [], $locale),
                 202
             );
         }
@@ -856,8 +856,8 @@ class AttemptReadController extends Controller
             : $this->eqAgentRuntimeResponder->nonReady(
                 $id,
                 (string) ($context['reason_code'] ?? 'context_not_ready'),
-                $locale,
-                is_array($context['guardrails'] ?? null) ? $context['guardrails'] : []
+                is_array($context['guardrails'] ?? null) ? $context['guardrails'] : [],
+                $locale
             );
 
         $status = (int) $contextResponse->getStatusCode();

--- a/backend/app/Services/Eq/EqAgentProviderClient.php
+++ b/backend/app/Services/Eq/EqAgentProviderClient.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+interface EqAgentProviderClient
+{
+    public function isConfigured(): bool;
+
+    public function unavailableReason(): ?string;
+
+    public function generate(EqAgentProviderRequest $request): EqAgentProviderResponse;
+}

--- a/backend/app/Services/Eq/EqAgentProviderManager.php
+++ b/backend/app/Services/Eq/EqAgentProviderManager.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+use Illuminate\Support\Facades\Log;
+
+final class EqAgentProviderManager
+{
+    public function __construct(
+        private OpenAiEqAgentProviderClient $openAiProvider,
+    ) {}
+
+    public function enabled(): bool
+    {
+        if ((bool) config('ai.eq_agent.llm_enabled', false) !== true) {
+            return false;
+        }
+
+        if ((bool) config('ai.eq_agent.staging_only', true) && app()->environment('production')) {
+            return false;
+        }
+
+        return $this->providerName() === 'openai';
+    }
+
+    public function providerName(): string
+    {
+        return strtolower(trim((string) config('ai.eq_agent.provider', 'openai')));
+    }
+
+    public function unavailableReason(): ?string
+    {
+        if (! $this->enabled()) {
+            return 'eq_agent_llm_disabled';
+        }
+
+        return $this->openAiProvider->unavailableReason();
+    }
+
+    public function tryGenerate(EqAgentProviderRequest $request): ?EqAgentProviderResponse
+    {
+        if (! $this->enabled()) {
+            return null;
+        }
+
+        if (! $this->openAiProvider->isConfigured()) {
+            return null;
+        }
+
+        try {
+            return $this->openAiProvider->generate($request);
+        } catch (\Throwable $e) {
+            Log::warning('EQ_AGENT_PROVIDER_FALLBACK', [
+                'provider' => $this->providerName(),
+                'reason' => $e::class,
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/backend/app/Services/Eq/EqAgentProviderRequest.php
+++ b/backend/app/Services/Eq/EqAgentProviderRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+final class EqAgentProviderRequest
+{
+    /**
+     * @param  array<string,mixed>  $context
+     * @param  array<string,mixed>  $deterministicPayload
+     */
+    public function __construct(
+        public readonly array $context,
+        public readonly array $deterministicPayload,
+        public readonly string $message,
+        public readonly ?string $intent,
+        public readonly string $locale,
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function safeContext(): array
+    {
+        return [
+            'locale' => $this->locale,
+            'intent_context' => $this->arrayOrEmpty($this->context['intent_context'] ?? null),
+            'report_context' => $this->arrayOrEmpty($this->context['report_context'] ?? null),
+            'resolved_assets' => $this->arrayOrEmpty($this->context['resolved_assets'] ?? null),
+            'agent_knowledge' => [
+                'authority' => data_get($this->context, 'agent_knowledge.authority', []),
+                'forbidden_claims' => data_get($this->context, 'agent_knowledge.forbidden_claims', []),
+                'escalation_flags' => data_get($this->context, 'agent_knowledge.escalation_flags', []),
+                'locale_policy' => data_get($this->context, 'agent_knowledge.locale_policy', []),
+            ],
+            'guardrails' => $this->arrayOrEmpty($this->context['guardrails'] ?? null),
+            'current_runtime_boundary' => [
+                'schema' => (string) ($this->deterministicPayload['schema'] ?? 'eq.agent_runtime_response.v1'),
+                'mode' => (string) ($this->deterministicPayload['mode'] ?? 'deterministic_read_only'),
+                'source_asset_ids' => data_get($this->deterministicPayload, 'assistant_response.source_asset_ids', []),
+                'boundary_claim_ids' => data_get($this->deterministicPayload, 'assistant_response.boundary_claim_ids', []),
+                'next_module' => $this->arrayOrEmpty($this->deterministicPayload['next_module'] ?? null),
+                'safety' => $this->arrayOrEmpty($this->deterministicPayload['safety'] ?? null),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+}

--- a/backend/app/Services/Eq/EqAgentProviderResponse.php
+++ b/backend/app/Services/Eq/EqAgentProviderResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+final class EqAgentProviderResponse
+{
+    /**
+     * @param  list<string>  $summaryPoints
+     * @param  list<string>  $sourceAssetIds
+     * @param  list<string>  $boundaryClaimIds
+     * @param  array<string,mixed>  $metadata
+     */
+    public function __construct(
+        public readonly string $text,
+        public readonly array $summaryPoints,
+        public readonly string $followUpQuestion,
+        public readonly array $sourceAssetIds,
+        public readonly array $boundaryClaimIds,
+        public readonly array $metadata = [],
+    ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function assistantResponse(): array
+    {
+        return [
+            'role' => 'assistant',
+            'text' => $this->text,
+            'summary_points' => $this->summaryPoints,
+            'follow_up_question' => $this->followUpQuestion,
+            'source_asset_ids' => $this->sourceAssetIds,
+            'boundary_claim_ids' => $this->boundaryClaimIds,
+        ];
+    }
+}

--- a/backend/app/Services/Eq/EqAgentRuntimeResponder.php
+++ b/backend/app/Services/Eq/EqAgentRuntimeResponder.php
@@ -6,6 +6,10 @@ namespace App\Services\Eq;
 
 final class EqAgentRuntimeResponder
 {
+    public function __construct(
+        private EqAgentProviderManager $providerManager,
+    ) {}
+
     /**
      * @param  array<string,mixed>  $context
      * @return array<string,mixed>
@@ -28,7 +32,7 @@ final class EqAgentRuntimeResponder
         $boundaryIds = array_values(array_unique(array_merge($intentClaimIds, $detectedClaimIds)));
         $sourceAssetIds = $this->sourceAssetIds($resolvedAssets);
 
-        return [
+        $payload = [
             'schema' => 'eq.agent_runtime_response.v1',
             'ok' => true,
             'ready' => true,
@@ -75,6 +79,27 @@ final class EqAgentRuntimeResponder
                 'confidence_label' => (string) data_get($reportContext, 'quality.confidence_label', ''),
             ],
         ];
+
+        $providerResponse = $this->providerManager->tryGenerate(new EqAgentProviderRequest(
+            $context,
+            $payload,
+            $messageText,
+            $intent,
+            $resolvedLocale,
+        ));
+
+        if ($providerResponse !== null && $this->providerResponseIsSafe($providerResponse, $agentKnowledge, $sourceAssetIds, $boundaryIds)) {
+            $payload['mode'] = 'llm_provider_read_only';
+            $payload['assistant_response'] = $this->safeProviderAssistantResponse($providerResponse, $payload['assistant_response'], $sourceAssetIds, $boundaryIds);
+            $payload['safety']['provider_response_validated'] = true;
+            $payload['provider'] = [
+                'name' => 'openai',
+                'fallback_used' => false,
+                'response_id' => (string) ($providerResponse->metadata['response_id'] ?? ''),
+            ];
+        }
+
+        return $payload;
     }
 
     /**
@@ -298,6 +323,77 @@ final class EqAgentRuntimeResponder
             && $guardrails['can_create_paid_unlock_language'] === false
             && $guardrails['can_use_paid_unlock_language'] === false
             && $guardrails['can_expose_raw_technical_tags'] === false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $agentKnowledge
+     * @param  list<string>  $allowedSourceAssetIds
+     * @param  list<string>  $boundaryIds
+     */
+    private function providerResponseIsSafe(
+        EqAgentProviderResponse $response,
+        array $agentKnowledge,
+        array $allowedSourceAssetIds,
+        array $boundaryIds
+    ): bool {
+        if (trim($response->text) === '') {
+            return false;
+        }
+
+        $combinedText = implode("\n", array_merge(
+            [$response->text, $response->followUpQuestion],
+            $response->summaryPoints
+        ));
+
+        if ($this->detectForbiddenClaims($combinedText, $agentKnowledge) !== []) {
+            return false;
+        }
+
+        foreach (['SKU_EQ_60_FULL_299', 'EQ_60_FULL', 'paywall', 'premium', 'unlock', '购买完整报告', '解锁报告', 'profile:', 'quality_level:', 'focus:', 'bucket:', '/take'] as $fragment) {
+            if (str_contains(mb_strtolower($combinedText), mb_strtolower($fragment))) {
+                return false;
+            }
+        }
+
+        if (array_values(array_intersect($response->sourceAssetIds, $allowedSourceAssetIds)) === []) {
+            return false;
+        }
+
+        foreach ($response->boundaryClaimIds as $claimId) {
+            if (! in_array($claimId, $boundaryIds, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string,mixed>  $fallback
+     * @param  list<string>  $allowedSourceAssetIds
+     * @param  list<string>  $boundaryIds
+     * @return array<string,mixed>
+     */
+    private function safeProviderAssistantResponse(
+        EqAgentProviderResponse $response,
+        array $fallback,
+        array $allowedSourceAssetIds,
+        array $boundaryIds
+    ): array {
+        $sourceAssetIds = array_values(array_intersect($response->sourceAssetIds, $allowedSourceAssetIds));
+        $providerBoundaryIds = array_values(array_intersect($response->boundaryClaimIds, $boundaryIds));
+
+        return [
+            'role' => 'assistant',
+            'text' => $response->text,
+            'summary_points' => array_slice($response->summaryPoints, 0, 4),
+            'follow_up_question' => $response->followUpQuestion,
+            'source_asset_ids' => $sourceAssetIds !== [] ? $sourceAssetIds : (array) ($fallback['source_asset_ids'] ?? []),
+            'boundary_claim_ids' => array_values(array_unique(array_merge(
+                (array) ($fallback['boundary_claim_ids'] ?? []),
+                $providerBoundaryIds
+            ))),
+        ];
     }
 
     /**

--- a/backend/app/Services/Eq/OpenAiEqAgentProviderClient.php
+++ b/backend/app/Services/Eq/OpenAiEqAgentProviderClient.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+final class OpenAiEqAgentProviderClient implements EqAgentProviderClient
+{
+    private const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+
+    public function isConfigured(): bool
+    {
+        return $this->apiKey() !== '' && $this->model() !== '';
+    }
+
+    public function unavailableReason(): ?string
+    {
+        if ($this->apiKey() === '') {
+            return 'EQ Agent OpenAI provider is not configured. Set EQ_AGENT_OPENAI_API_KEY or OPENAI_API_KEY.';
+        }
+
+        if ($this->model() === '') {
+            return 'EQ Agent OpenAI provider is not configured. Set EQ_AGENT_OPENAI_MODEL or EQ_AGENT_LLM_MODEL.';
+        }
+
+        return null;
+    }
+
+    public function generate(EqAgentProviderRequest $request): EqAgentProviderResponse
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException((string) $this->unavailableReason());
+        }
+
+        $payload = [
+            'model' => $this->model(),
+            'max_output_tokens' => $this->maxOutputTokens(),
+            'input' => [
+                [
+                    'role' => 'system',
+                    'content' => [[
+                        'type' => 'input_text',
+                        'text' => $this->systemPrompt($request->locale),
+                    ]],
+                ],
+                [
+                    'role' => 'user',
+                    'content' => [[
+                        'type' => 'input_text',
+                        'text' => $this->userPrompt($request),
+                    ]],
+                ],
+            ],
+            'text' => [
+                'format' => [
+                    'type' => 'json_schema',
+                    'name' => 'eq_agent_provider_response',
+                    'strict' => true,
+                    'schema' => $this->responseSchema(),
+                ],
+            ],
+            'metadata' => [
+                'surface' => 'eq_agent_runtime',
+                'locale' => $request->locale,
+                'intent' => trim((string) $request->intent),
+            ],
+        ];
+
+        try {
+            $response = Http::acceptJson()
+                ->withToken($this->apiKey())
+                ->connectTimeout($this->connectTimeoutSeconds())
+                ->timeout($this->requestTimeoutSeconds())
+                ->retry($this->maxRetries(), $this->retrySleepMilliseconds())
+                ->post($this->endpointUrl(), $payload)
+                ->throw();
+        } catch (ConnectionException $e) {
+            throw new RuntimeException('OpenAI EQ Agent provider request failed: connection error.', previous: $e);
+        } catch (RequestException $e) {
+            $status = $e->response?->status();
+            $body = $e->response?->json();
+            $message = is_array($body)
+                ? (string) data_get($body, 'error.message', 'OpenAI EQ Agent provider request failed.')
+                : 'OpenAI EQ Agent provider request failed.';
+
+            throw new RuntimeException(
+                sprintf('OpenAI EQ Agent provider request failed%s: %s', $status ? " with status {$status}" : '', trim($message))
+            );
+        }
+
+        $decoded = $response->json();
+        if (! is_array($decoded)) {
+            throw new RuntimeException('OpenAI EQ Agent provider returned a non-JSON payload.');
+        }
+
+        $structured = $this->extractStructuredOutput($decoded);
+
+        return new EqAgentProviderResponse(
+            trim((string) ($structured['text'] ?? '')),
+            $this->stringList($structured['summary_points'] ?? null),
+            trim((string) ($structured['follow_up_question'] ?? '')),
+            $this->stringList($structured['source_asset_ids'] ?? null),
+            $this->stringList($structured['boundary_claim_ids'] ?? null),
+            [
+                'provider' => 'openai',
+                'model' => $this->model(),
+                'response_id' => (string) ($decoded['id'] ?? ''),
+            ],
+        );
+    }
+
+    private function apiKey(): string
+    {
+        return trim((string) config('ai.eq_agent.openai.api_key', ''));
+    }
+
+    private function model(): string
+    {
+        return trim((string) config('ai.eq_agent.openai.model', config('ai.eq_agent.model', '')));
+    }
+
+    private function endpointUrl(): string
+    {
+        return rtrim((string) config('ai.eq_agent.openai.base_url', self::DEFAULT_BASE_URL), '/').'/responses';
+    }
+
+    private function connectTimeoutSeconds(): int
+    {
+        return max(1, (int) config('ai.eq_agent.openai.connect_timeout_seconds', 5));
+    }
+
+    private function requestTimeoutSeconds(): int
+    {
+        return max(5, (int) config('ai.eq_agent.openai.request_timeout_seconds', 30));
+    }
+
+    private function maxRetries(): int
+    {
+        return max(0, (int) config('ai.eq_agent.openai.max_retries', 0));
+    }
+
+    private function retrySleepMilliseconds(): int
+    {
+        return max(0, (int) config('ai.eq_agent.openai.retry_sleep_milliseconds', 250));
+    }
+
+    private function maxOutputTokens(): int
+    {
+        return max(256, (int) config('ai.eq_agent.openai.max_output_tokens', 900));
+    }
+
+    private function systemPrompt(string $locale): string
+    {
+        return implode("\n", [
+            'You are the FermatMind EQ Agent response layer.',
+            'Explain only the provided EQ self-report context and resolved content assets.',
+            'Do not rescore, reclassify, override the formulation, enable SJT, create paid unlock language, or expose raw technical tags.',
+            'Do not claim true emotional ability, MSCEIT equivalence, certification, hiring suitability, clinical diagnosis, guaranteed outcomes, or job-performance prediction.',
+            'Return JSON only and match the schema exactly.',
+            'Response locale: '.$locale.'.',
+        ]);
+    }
+
+    private function userPrompt(EqAgentProviderRequest $request): string
+    {
+        return json_encode([
+            'user_message' => $request->message,
+            'locale' => $request->locale,
+            'requested_intent' => $request->intent,
+            'safe_context' => $request->safeContext(),
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '{}';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function responseSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['text', 'summary_points', 'follow_up_question', 'source_asset_ids', 'boundary_claim_ids'],
+            'properties' => [
+                'text' => ['type' => 'string'],
+                'summary_points' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'maxItems' => 4,
+                ],
+                'follow_up_question' => ['type' => 'string'],
+                'source_asset_ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'maxItems' => 12,
+                ],
+                'boundary_claim_ids' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'maxItems' => 12,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $decoded
+     * @return array<string,mixed>
+     */
+    private function extractStructuredOutput(array $decoded): array
+    {
+        foreach ((array) ($decoded['output'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            foreach ((array) ($item['content'] ?? []) as $content) {
+                if (! is_array($content)) {
+                    continue;
+                }
+                $text = trim((string) ($content['text'] ?? ''));
+                if ($text === '') {
+                    continue;
+                }
+                $payload = json_decode($text, true);
+                if (is_array($payload)) {
+                    return $payload;
+                }
+            }
+        }
+
+        throw new RuntimeException('OpenAI EQ Agent provider returned no structured output text.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $item): string => trim((string) $item),
+            $value
+        ), static fn (string $item): bool => $item !== ''));
+    }
+}

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -34,4 +34,22 @@ return [
         'prompt_version' => env('AI_NARRATIVE_PROMPT_VERSION', env('AI_PROMPT_VERSION', 'v1.0.0')),
         'fail_open_mode' => env('AI_NARRATIVE_FAIL_OPEN_MODE', 'deterministic'),
     ],
+
+    'eq_agent' => [
+        'llm_enabled' => env('EQ_AGENT_LLM_ENABLED', false),
+        'provider' => env('EQ_AGENT_LLM_PROVIDER', 'openai'),
+        'staging_only' => env('EQ_AGENT_LLM_STAGING_ONLY', true),
+        'model' => env('EQ_AGENT_LLM_MODEL', env('AI_MODEL', '')),
+        'fail_open_mode' => env('EQ_AGENT_LLM_FAIL_OPEN_MODE', 'deterministic'),
+        'openai' => [
+            'base_url' => rtrim((string) env('EQ_AGENT_OPENAI_BASE_URL', env('OPENAI_BASE_URL', 'https://api.openai.com/v1')), '/'),
+            'api_key' => env('EQ_AGENT_OPENAI_API_KEY', env('OPENAI_API_KEY', '')),
+            'model' => env('EQ_AGENT_OPENAI_MODEL', env('EQ_AGENT_LLM_MODEL', env('AI_MODEL', ''))),
+            'connect_timeout_seconds' => (int) env('EQ_AGENT_OPENAI_CONNECT_TIMEOUT', 5),
+            'request_timeout_seconds' => (int) env('EQ_AGENT_OPENAI_REQUEST_TIMEOUT', 30),
+            'max_retries' => (int) env('EQ_AGENT_OPENAI_MAX_RETRIES', 0),
+            'retry_sleep_milliseconds' => (int) env('EQ_AGENT_OPENAI_RETRY_SLEEP_MS', 250),
+            'max_output_tokens' => (int) env('EQ_AGENT_OPENAI_MAX_OUTPUT_TOKENS', 900),
+        ],
+    ],
 ];

--- a/backend/tests/Feature/Report/EqAgentContextApiTest.php
+++ b/backend/tests/Feature/Report/EqAgentContextApiTest.php
@@ -13,6 +13,7 @@ use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -184,6 +185,186 @@ final class EqAgentContextApiTest extends TestCase
         ] as $forbidden) {
             $this->assertStringNotContainsString($forbidden, $json);
         }
+    }
+
+    public function test_eq_agent_runtime_provider_disabled_keeps_deterministic_fallback(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        config()->set('ai.eq_agent.llm_enabled', false);
+        config()->set('ai.eq_agent.openai.api_key', 'test-key');
+        config()->set('ai.eq_agent.openai.model', 'gpt-test');
+        $this->prepareEqContent();
+        Http::fake();
+
+        $anonId = 'anon_eq_agent_provider_disabled';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => 'Help me understand my report.',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'deterministic_read_only')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('next_module.available', false);
+        $this->assertNull($response->json('provider'));
+        Http::assertNothingSent();
+    }
+
+    public function test_eq_agent_runtime_provider_missing_config_fails_closed_to_deterministic(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        config()->set('ai.eq_agent.llm_enabled', true);
+        config()->set('ai.eq_agent.staging_only', false);
+        config()->set('ai.eq_agent.openai.api_key', '');
+        config()->set('ai.eq_agent.openai.model', 'gpt-test');
+        $this->prepareEqContent();
+        Http::fake();
+
+        $anonId = 'anon_eq_agent_provider_missing_config';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => 'Help me understand my report.',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'deterministic_read_only')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_enable_sjt', false);
+        $this->assertNull($response->json('provider'));
+        Http::assertNothingSent();
+    }
+
+    public function test_eq_agent_runtime_openai_provider_response_is_normalized_when_feature_flag_enabled(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        config()->set('ai.eq_agent.llm_enabled', true);
+        config()->set('ai.eq_agent.staging_only', false);
+        config()->set('ai.eq_agent.openai.base_url', 'https://api.openai.test/v1');
+        config()->set('ai.eq_agent.openai.api_key', 'test-key');
+        config()->set('ai.eq_agent.openai.model', 'gpt-test');
+        $this->prepareEqContent();
+
+        Http::fake([
+            'https://api.openai.test/v1/responses' => Http::response([
+                'id' => 'resp_eq_agent_test',
+                'output' => [[
+                    'type' => 'message',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => json_encode([
+                            'text' => 'Your report points to a practical self-report pattern that can be discussed safely.',
+                            'summary_points' => ['Use the report assets.', 'Keep the response read-only.'],
+                            'follow_up_question' => 'Which everyday scene should we discuss first?',
+                            'source_asset_ids' => ['eq.conversion.agent_entry'],
+                            'boundary_claim_ids' => [],
+                        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    ]],
+                ]],
+            ], 200),
+        ]);
+
+        $anonId = 'anon_eq_agent_provider_success';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => 'Help me understand my report.',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'llm_provider_read_only')
+            ->assertJsonPath('assistant_response.text', 'Your report points to a practical self-report pattern that can be discussed safely.')
+            ->assertJsonPath('safety.provider_response_validated', true)
+            ->assertJsonPath('provider.name', 'openai')
+            ->assertJsonPath('provider.fallback_used', false)
+            ->assertJsonPath('provider.response_id', 'resp_eq_agent_test')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_mutate_report', false)
+            ->assertJsonPath('next_module.available', false);
+
+        Http::assertSent(function ($request): bool {
+            $payload = $request->data();
+
+            return $request->url() === 'https://api.openai.test/v1/responses'
+                && data_get($payload, 'model') === 'gpt-test'
+                && data_get($payload, 'text.format.name') === 'eq_agent_provider_response'
+                && str_contains((string) data_get($payload, 'input.1.content.0.text'), 'safe_context')
+                && ! str_contains((string) data_get($payload, 'input.1.content.0.text'), 'profile:');
+        });
+    }
+
+    public function test_eq_agent_runtime_unsafe_provider_output_falls_back_to_deterministic(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        config()->set('ai.eq_agent.llm_enabled', true);
+        config()->set('ai.eq_agent.staging_only', false);
+        config()->set('ai.eq_agent.openai.base_url', 'https://api.openai.test/v1');
+        config()->set('ai.eq_agent.openai.api_key', 'test-key');
+        config()->set('ai.eq_agent.openai.model', 'gpt-test');
+        $this->prepareEqContent();
+
+        Http::fake([
+            'https://api.openai.test/v1/responses' => Http::response([
+                'id' => 'resp_eq_agent_unsafe',
+                'output' => [[
+                    'type' => 'message',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => json_encode([
+                            'text' => 'Pay to unlock SKU_EQ_60_FULL_299 for the premium report.',
+                            'summary_points' => ['unlock'],
+                            'follow_up_question' => 'Do you want the premium version?',
+                            'source_asset_ids' => ['eq.conversion.agent_entry'],
+                            'boundary_claim_ids' => [],
+                        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    ]],
+                ]],
+            ], 200),
+        ]);
+
+        $anonId = 'anon_eq_agent_provider_unsafe';
+        $token = $this->issueFmToken($anonId);
+        $attemptId = $this->createEqAttemptWithResult($anonId, 'en');
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/'.$attemptId.'/eq/agent-runtime/messages', [
+            'locale' => 'en',
+            'intent' => 'understand_my_result',
+            'message' => 'Help me understand my report.',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'deterministic_read_only')
+            ->assertJsonPath('guardrails.read_only', true)
+            ->assertJsonPath('guardrails.can_create_paid_unlock_language', false)
+            ->assertJsonPath('guardrails.can_use_paid_unlock_language', false);
+        $this->assertNull($response->json('provider'));
+
+        $json = json_encode($response->json(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        $this->assertStringNotContainsString('SKU_EQ_60_FULL_299', $json);
+        $this->assertStringNotContainsString('premium report', $json);
     }
 
     public function test_eq_agent_runtime_message_applies_forbidden_claim_boundary(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -871,6 +871,19 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_eq_agent_provider_abstraction_default_off_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Eq/EqAgentProviderClient.php',
+            'backend/app/Services/Eq/EqAgentProviderManager.php',
+            'backend/app/Services/Eq/EqAgentProviderRequest.php',
+            'backend/app/Services/Eq/EqAgentProviderResponse.php',
+            'backend/app/Services/Eq/OpenAiEqAgentProviderClient.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_content_release_guard_command_changes(): void
     {
         $changed = [
@@ -5430,6 +5443,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEqAgentProviderAbstractionDefaultOffChange($file)) {
+                continue;
+            }
+
             if ($this->isEq60FreeReportContractChange($file, $repoRoot, $baseRef)) {
                 continue;
             }
@@ -7505,6 +7522,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEqAgentRuntimeReadOnlyShellChange(string $file): bool
     {
         return $file === 'backend/app/Services/Eq/EqAgentRuntimeResponder.php';
+    }
+
+    private function isEqAgentProviderAbstractionDefaultOffChange(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Eq/EqAgentProviderClient.php',
+            'backend/app/Services/Eq/EqAgentProviderManager.php',
+            'backend/app/Services/Eq/EqAgentProviderRequest.php',
+            'backend/app/Services/Eq/EqAgentProviderResponse.php',
+            'backend/app/Services/Eq/OpenAiEqAgentProviderClient.php',
+        ], true);
     }
 
     private function isCiAuthBypassHardeningFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T10:10:00Z",
+  "updated_at": "2026-06-25T10:32:00Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -61994,7 +61994,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-02-safety-eval-fixtures",
     "base": "main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-02 EQ Agent LLM safety eval fixtures",
     "depends_on": [
@@ -62032,14 +62032,18 @@
       "github_checks": {
         "status": "pending",
         "evidence": "Waiting for GitHub checks on PR #2422."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2422 is merged at 0a991a5e732132fdfe5abbb7cfa94597e68803b2 and origin/main contains the merge commit."
       }
     },
     "failure_reason": null,
-    "commit_sha": "faa72e503cc8af4f0d4d81b0a9f7a1072b23179f",
+    "commit_sha": "e396baf787e7b4a7b095d1b0927cd48952c11a72",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2422",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-25T10:12:54Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-25T17:48:04+08:00",
@@ -62058,6 +62062,12 @@
         "from": "local_checks_passed",
         "to": "pr_opened",
         "notes": "Opened GitHub PR #2422 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-25T18:20:00+08:00",
+        "from": "pr_opened",
+        "to": "merged",
+        "notes": "Reconciled while starting PR-EQ-AGENT-RUNTIME-V2-03 after verifying GitHub PR #2422 merged and origin/main contains 0a991a5e732132fdfe5abbb7cfa94597e68803b2."
       }
     ]
   },
@@ -62065,7 +62075,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-eq-agent-runtime-v2-03-provider-abstraction",
     "base": "main",
-    "status": "pending_dependency",
+    "status": "pr_opened",
     "train_scope": "eq_agent_runtime_v2",
     "title": "PR-EQ-AGENT-RUNTIME-V2-03 EQ Agent provider abstraction and feature flag",
     "depends_on": [
@@ -62077,13 +62087,43 @@
         "evidence": "User explicitly requested the EQ Agent Runtime V2 four-PR plan and authorized adding the PRs to manifest/state before execution."
       },
       "dependency": {
+        "status": "pass",
+        "evidence": "PR-EQ-AGENT-RUNTIME-V2-02 merged as GitHub PR #2422 at 0a991a5e732132fdfe5abbb7cfa94597e68803b2 and is present in origin/main."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.3/attempts --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+          "find backend/tests/Fixtures/eq/agent -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \\;",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "Provider abstraction, default-off OpenAI adapter, fallback behavior, EqAgent, Eq60V5, route-list, runtime freeze, fixture parse, JSON/YAML, and diff checks passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are within PR-EQ-AGENT-RUNTIME-V2-03 allowed_paths."
+      },
+      "github_pr": {
+        "status": "opened",
+        "evidence": "GitHub PR #2423 opened for codex/pr-eq-agent-runtime-v2-03-provider-abstraction."
+      },
+      "github_checks": {
         "status": "pending",
-        "evidence": "Waiting for PR-EQ-AGENT-RUNTIME-V2-02 to merge."
+        "evidence": "Waiting for GitHub checks on PR #2423."
+      },
+      "ci_fix": {
+        "status": "pass",
+        "evidence": "Added BigFive runtime freeze exception for default-off EQ Agent provider abstraction files and verified focused freeze tests locally."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9ca71110ef9b8b7fa0d06c159050cf6c0db9a260",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2423",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62093,6 +62133,24 @@
         "from": "missing_from_manifest",
         "to": "pending_dependency",
         "notes": "Initialized from explicit user authorization; waits for PR-EQ-AGENT-RUNTIME-V2-02."
+      },
+      {
+        "at": "2026-06-25T18:20:00+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed",
+        "notes": "Added provider abstraction, default-off OpenAI adapter, safe provider normalization, and fallback tests; local validation passed."
+      },
+      {
+        "at": "2026-06-25T18:22:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_opened",
+        "notes": "Opened GitHub PR #2423 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-25T18:32:00+08:00",
+        "from": "pr_opened",
+        "to": "pr_opened_ci_fix_pushed",
+        "notes": "Fixed verify-bigfive failure by adding a scoped runtime freeze classifier exception for default-off EQ Agent provider abstraction files."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added EQ Agent provider abstraction and OpenAI-first adapter behind default-off flags.
- Preserved deterministic read-only runtime as default and fallback.
- Added provider disabled, missing config, successful structured response, and unsafe response fallback tests.
- Fixed existing `nonReady` argument ordering in EQ Agent runtime message non-ready paths.
- Reconciled PR-EQ-AGENT-RUNTIME-V2-02 as merged in the PR-train state ledger.

## Why
- Prepare EQ Agent Runtime V2 for a controlled LLM/provider path without enabling live model traffic by default.
- Keep backend report/content assets authoritative and ensure unsafe provider output cannot reach users.

## Validation
- `php -l` on touched PHP files
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.3/attempts --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqAgent --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60V5ReportContractTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff' --no-ansi`
- `find backend/tests/Fixtures/eq/agent -name '*.json' -print -exec python3 -m json.tool {} >/dev/null \;`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production LLM traffic.
- No frontend changes.
- No chat history persistence.
- No SJT enablement.
- No scoring/content/report authority changes.
- No deploy or feature-flag enablement.

## Repository rule impact
- Backend content pack and report composer remain authoritative.
- Adds a default-off API runtime capability with deterministic fallback; no CMS, SEO, or production state changes.
