### PR TITLE
IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation

### DIFF
--- a/backend/app/Console/Commands/NormsIqImport.php
+++ b/backend/app/Console/Commands/NormsIqImport.php
@@ -8,17 +8,21 @@ use App\Services\Iq\IqNormAuthorityContract;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 final class NormsIqImport extends Command
 {
     private const SCHEMA_VERSION = 'iq.norm_table.v1';
 
+    private const OWNER_BANK_ID = 'IQ_OWNER_ORIGINAL_30';
+
     protected $signature = 'norms:iq:import
         {--file= : IQ norm table JSON file path}
-        {--dry-run=1 : Validate only; writes are intentionally disabled in IQ-NORM-02}
+        {--dry-run=1 : Validate only; set to 0 only for guarded authority activation}
+        {--activate=0 : Persist the validated owner IQ 30 norm authority when dry-run=0}
         {--require-claim-ready=0 : Fail unless the authority metadata is already public-claim eligible}';
 
-    protected $description = 'Validate IQ norm table authority payloads in dry-run mode without importing production data.';
+    protected $description = 'Validate or activate owner IQ 30 norm authority payloads behind the public-claim gate.';
 
     public function handle(): int
     {
@@ -29,8 +33,10 @@ final class NormsIqImport extends Command
         }
 
         $dryRun = $this->isTruthy($this->option('dry-run'));
-        if (! $dryRun) {
-            $this->error('IQ norm import writes are disabled in IQ-NORM-02. Use --dry-run=1.');
+        $activate = $this->isTruthy($this->option('activate'));
+        $requireClaimReady = $this->isTruthy($this->option('require-claim-ready'));
+        if ($dryRun && $activate) {
+            $this->error('activate_requires_dry_run_0');
 
             return self::FAILURE;
         }
@@ -51,9 +57,28 @@ final class NormsIqImport extends Command
 
         $errors = $this->validatePayload($payload);
         $gate = IqNormAuthorityContract::publicClaimGate($this->authorityRecord($payload));
-        $requireClaimReady = $this->isTruthy($this->option('require-claim-ready'));
+        if (! $dryRun && ! $activate) {
+            $errors[] = 'write_mode_requires_activate_1';
+        }
+        if (! $dryRun && ! $requireClaimReady) {
+            $errors[] = 'activate_requires_require_claim_ready_1';
+        }
+        if (! $dryRun && (string) ($payload['bank_id'] ?? '') !== self::OWNER_BANK_ID) {
+            $errors[] = 'owner30_authority_import_requires_bank_iq_owner_original_30';
+        }
         if ($requireClaimReady && ! (bool) ($gate['claim_eligible'] ?? false)) {
             $errors[] = 'authority_not_public_claim_ready:'.(string) ($gate['reason_code'] ?? 'unknown');
+        }
+
+        $existing = DB::table('iq_norm_authorities')
+            ->where('scale_code', IqNormAuthorityContract::SCALE_CODE)
+            ->where('bank_id', (string) ($payload['bank_id'] ?? ''))
+            ->where('norm_table_version', (string) ($payload['norm_table_version'] ?? ''))
+            ->where('population_key', (string) ($payload['population_key'] ?? IqNormAuthorityContract::DEFAULT_POPULATION_KEY))
+            ->where('locale', (string) ($payload['locale'] ?? ''))
+            ->first();
+        if (! $dryRun && $existing !== null) {
+            $errors[] = 'authority_version_already_exists';
         }
 
         if ($errors !== []) {
@@ -65,7 +90,9 @@ final class NormsIqImport extends Command
         }
 
         $rows = (array) ($payload['rows'] ?? []);
-        $this->info('dry-run=1, no write performed.');
+        if ($dryRun) {
+            $this->info('dry-run=1, no write performed.');
+        }
         $this->line(sprintf(
             'validated scale=%s bank=%s version=%s rows=%d claim_eligible=%s',
             (string) ($payload['scale_code'] ?? ''),
@@ -75,15 +102,13 @@ final class NormsIqImport extends Command
             (bool) ($gate['claim_eligible'] ?? false) ? 'true' : 'false'
         ));
 
-        $existing = DB::table('iq_norm_authorities')
-            ->where('scale_code', IqNormAuthorityContract::SCALE_CODE)
-            ->where('bank_id', (string) ($payload['bank_id'] ?? ''))
-            ->where('norm_table_version', (string) ($payload['norm_table_version'] ?? ''))
-            ->where('population_key', (string) ($payload['population_key'] ?? IqNormAuthorityContract::DEFAULT_POPULATION_KEY))
-            ->where('locale', (string) ($payload['locale'] ?? ''))
-            ->exists();
+        if (! $dryRun) {
+            $authorityId = $this->insertAuthority($payload, $gate);
+            $this->info('activated owner IQ 30 norm authority.');
+            $this->line('imported_authority_id='.$authorityId);
+        }
 
-        $this->line('version_lock='.($existing ? 'existing_authority_detected' : 'new_authority_candidate'));
+        $this->line('version_lock='.($existing !== null ? 'existing_authority_detected' : 'new_authority_candidate'));
 
         return self::SUCCESS;
     }
@@ -230,6 +255,7 @@ final class NormsIqImport extends Command
     private function authorityRecord(array $payload): array
     {
         return [
+            'org_id' => $payload['org_id'] ?? 0,
             'scale_code' => $payload['scale_code'] ?? null,
             'bank_id' => $payload['bank_id'] ?? null,
             'norm_table_version' => $payload['norm_table_version'] ?? null,
@@ -247,6 +273,53 @@ final class NormsIqImport extends Command
             'locked' => $payload['locked'] ?? false,
             'retired_at' => $payload['retired_at'] ?? null,
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $gate
+     */
+    private function insertAuthority(array $payload, array $gate): string
+    {
+        $authority = $this->authorityRecord($payload);
+        $rows = (array) ($payload['rows'] ?? []);
+        $authorityId = (string) Str::uuid();
+        $now = now();
+
+        DB::table('iq_norm_authorities')->insert([
+            'id' => $authorityId,
+            'org_id' => (int) ($authority['org_id'] ?? 0),
+            'scale_code' => IqNormAuthorityContract::SCALE_CODE,
+            'bank_id' => self::OWNER_BANK_ID,
+            'norm_table_version' => (string) ($authority['norm_table_version'] ?? ''),
+            'status' => strtolower((string) ($authority['status'] ?? 'production_normed')),
+            'population_key' => (string) ($authority['population_key'] ?? IqNormAuthorityContract::DEFAULT_POPULATION_KEY),
+            'locale' => (string) ($authority['locale'] ?? 'zh-CN'),
+            'sample_size' => (int) ($authority['sample_size'] ?? 0),
+            'mean' => (float) ($authority['mean'] ?? 0.0),
+            'standard_deviation' => (float) ($authority['standard_deviation'] ?? 0.0),
+            'min_raw_score' => (float) ($authority['min_raw_score'] ?? 0.0),
+            'max_raw_score' => (float) ($authority['max_raw_score'] ?? 0.0),
+            'source_kind' => (string) ($authority['source_kind'] ?? 'internal_calibration'),
+            'source_ref' => (string) ($authority['source_ref'] ?? ''),
+            'license_verified' => (bool) ($authority['license_verified'] ?? false),
+            'locked' => (bool) ($authority['locked'] ?? false),
+            'effective_at' => $now,
+            'retired_at' => null,
+            'metadata' => json_encode([
+                'schema_version' => self::SCHEMA_VERSION,
+                'import_scope' => 'IQ-OWNER-30-NORM-AUTHORITY-04A',
+                'bank_id' => self::OWNER_BANK_ID,
+                'rows_count' => count($rows),
+                'rows_sha256' => hash('sha256', json_encode($rows, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: ''),
+                'claim_gate' => $gate,
+                'evidence' => $payload['evidence'] ?? null,
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return $authorityId;
     }
 
     private function numericOrNull(mixed $value): ?float

--- a/backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php
+++ b/backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php
@@ -38,10 +38,11 @@ final class IqNormsImportDryRunTest extends TestCase
         $this->assertSame(0, DB::table('iq_norm_authorities')->count());
     }
 
-    public function test_iq_norm_import_write_mode_is_blocked_in_norm_02(): void
+    public function test_iq_norm_import_write_mode_requires_explicit_activation_and_claim_ready_gate(): void
     {
         $this->artisan('norms:iq:import --file=tests/Fixtures/iq/norms/iq_norm_dry_run_valid.json --dry-run=0')
-            ->expectsOutputToContain('IQ norm import writes are disabled in IQ-NORM-02. Use --dry-run=1.')
+            ->expectsOutputToContain('write_mode_requires_activate_1')
+            ->expectsOutputToContain('activate_requires_require_claim_ready_1')
             ->assertExitCode(1);
 
         $this->assertSame(0, DB::table('iq_norm_authorities')->count());
@@ -54,5 +55,72 @@ final class IqNormsImportDryRunTest extends TestCase
             ->assertExitCode(1);
 
         $this->assertSame(0, DB::table('iq_norm_authorities')->count());
+    }
+
+    public function test_iq_norm_import_activates_claim_ready_owner30_authority(): void
+    {
+        $this->artisan('norms:iq:import --file=tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json --dry-run=0 --activate=1 --require-claim-ready=1')
+            ->expectsOutputToContain('validated scale=IQ_INTELLIGENCE_QUOTIENT bank=IQ_OWNER_ORIGINAL_30 version=iq_owner30_norm_fixture_v1 rows=3 claim_eligible=true')
+            ->expectsOutputToContain('activated owner IQ 30 norm authority.')
+            ->expectsOutputToContain('imported_authority_id=')
+            ->expectsOutputToContain('version_lock=new_authority_candidate')
+            ->assertExitCode(0);
+
+        $authority = DB::table('iq_norm_authorities')->first();
+
+        $this->assertNotNull($authority);
+        $this->assertSame('IQ_OWNER_ORIGINAL_30', $authority->bank_id);
+        $this->assertSame('iq_owner30_norm_fixture_v1', $authority->norm_table_version);
+        $this->assertSame('production_normed', $authority->status);
+        $this->assertSame(1200, (int) $authority->sample_size);
+        $this->assertSame(1, (int) $authority->license_verified);
+        $this->assertSame(1, (int) $authority->locked);
+
+        $metadata = json_decode((string) $authority->metadata, true);
+        $this->assertSame('IQ-OWNER-30-NORM-AUTHORITY-04A', $metadata['import_scope'] ?? null);
+        $this->assertSame(3, $metadata['rows_count'] ?? null);
+        $this->assertTrue((bool) data_get($metadata, 'claim_gate.claim_eligible'));
+    }
+
+    public function test_iq_norm_import_rejects_non_owner30_activation(): void
+    {
+        $fixture = $this->temporaryFixture([
+            'bank_id' => 'IQ_LEGACY_DEMO_BANK',
+        ]);
+
+        $this->artisan('norms:iq:import --file='.$fixture.' --dry-run=0 --activate=1 --require-claim-ready=1')
+            ->expectsOutputToContain('owner30_authority_import_requires_bank_iq_owner_original_30')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, DB::table('iq_norm_authorities')->count());
+    }
+
+    public function test_iq_norm_import_rejects_duplicate_locked_authority_version(): void
+    {
+        $command = 'norms:iq:import --file=tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json --dry-run=0 --activate=1 --require-claim-ready=1';
+
+        $this->artisan($command)
+            ->expectsOutputToContain('activated owner IQ 30 norm authority.')
+            ->assertExitCode(0);
+
+        $this->artisan($command)
+            ->expectsOutputToContain('authority_version_already_exists')
+            ->assertExitCode(1);
+
+        $this->assertSame(1, DB::table('iq_norm_authorities')->count());
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function temporaryFixture(array $overrides): string
+    {
+        $payload = json_decode((string) file_get_contents(base_path('tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json')), true);
+        $payload = array_merge($payload, $overrides);
+        $path = tempnam(sys_get_temp_dir(), 'iq_norm_');
+        $this->assertIsString($path);
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $path;
     }
 }

--- a/backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json
+++ b/backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "iq.norm_table.v1",
+  "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+  "bank_id": "IQ_OWNER_ORIGINAL_30",
+  "norm_table_version": "iq_owner30_norm_fixture_v1",
+  "status": "production_normed",
+  "population_key": "general_adult_online",
+  "locale": "zh-CN",
+  "sample_size": 1200,
+  "mean": 15.0,
+  "standard_deviation": 5.0,
+  "min_raw_score": 0,
+  "max_raw_score": 30,
+  "source_kind": "internal_calibration",
+  "source_ref": "fixture://iq_owner30_norm_fixture_v1",
+  "license_verified": true,
+  "locked": true,
+  "evidence": {
+    "authority_kind": "owner_original_30_calibration_fixture",
+    "claim_basis": "test fixture only; production imports require reviewed calibration evidence",
+    "standardization_population": "general_adult_online",
+    "administration_mode": "online",
+    "score_interpretation": "norm-referenced IQ estimate allowed only after claim gate passes"
+  },
+  "rows": [
+    {"raw_score": 0, "iq_estimate": 55, "percentile": 1, "ci_low": 50, "ci_high": 60},
+    {"raw_score": 15, "iq_estimate": 100, "percentile": 50, "ci_low": 96, "ci_high": 104},
+    {"raw_score": 30, "iq_estimate": 145, "percentile": 99, "ci_low": 140, "ci_high": 150}
+  ]
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T18:45:11+08:00",
+  "updated_at": "2026-06-25T18:51:42+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -62276,7 +62276,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-authority-04a",
     "base": "main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation",
     "depends_on": [
@@ -62311,12 +62311,12 @@
         "evidence": "Changed files are limited to IQ-OWNER-30-NORM-AUTHORITY-04A scope: NormsIqImport command, focused importer tests, claim-ready fixture, and docs/codex train metadata. No frontend, runtime scoring binding, CMS, SEO, deployment, or production norm data import changes."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2424 opened; waiting for GitHub required checks."
+        "status": "pass",
+        "evidence": "PR #2424 GitHub checks passed for head 745b140a41acd530a3519e5bab4367d33cb02777 and mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "454841ba95ef074852658cdcb5a8596efd806f19",
+    "commit_sha": "745b140a41acd530a3519e5bab4367d33cb02777",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2424",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -62341,6 +62341,11 @@
         "at": "2026-06-25T18:45:11+08:00",
         "status": "github_checks_pending",
         "note": "Opened PR #2424 at https://github.com/fermatmind/fap-api/pull/2424. Waiting for GitHub checks; no staging wait, production deploy, CMS write, SEO, frontend, runtime scoring bind, or production norm data import included."
+      },
+      {
+        "at": "2026-06-25T18:51:42+08:00",
+        "status": "ready_to_merge",
+        "note": "PR #2424 GitHub checks passed and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, SEO, frontend, runtime scoring bind, or production norm data import included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T10:38:20Z",
+  "updated_at": "2026-06-25T18:45:11+08:00",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -62276,7 +62276,7 @@
     "repo": "fap-api",
     "branch": "codex/iq-owner-30-norm-authority-04a",
     "base": "main",
-    "status": "local_validated",
+    "status": "github_checks_pending",
     "train_scope": "iq_owner_original_30_launch",
     "title": "IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation",
     "depends_on": [
@@ -62309,11 +62309,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are limited to IQ-OWNER-30-NORM-AUTHORITY-04A scope: NormsIqImport command, focused importer tests, claim-ready fixture, and docs/codex train metadata. No frontend, runtime scoring binding, CMS, SEO, deployment, or production norm data import changes."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2424 opened; waiting for GitHub required checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": "cdf77981324c5aaba4317fff6701607559cd3416",
-    "pr_url": null,
+    "commit_sha": "454841ba95ef074852658cdcb5a8596efd806f19",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2424",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -62332,6 +62336,11 @@
         "at": "2026-06-25T10:38:20Z",
         "status": "committed",
         "note": "Created local scoped commit cdf77981324c5aaba4317fff6701607559cd3416."
+      },
+      {
+        "at": "2026-06-25T18:45:11+08:00",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2424 at https://github.com/fermatmind/fap-api/pull/2424. Waiting for GitHub checks; no staging wait, production deploy, CMS write, SEO, frontend, runtime scoring bind, or production norm data import included."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-25T10:32:00Z",
+  "updated_at": "2026-06-25T10:38:20Z",
   "PR-EQ-ASSET-01": {
     "repo": "fap-api",
     "branch": "codex/pr-eq-asset-01-content-pack-v16",
@@ -62269,6 +62269,69 @@
         "at": "2026-06-25T12:40:58+08:00",
         "status": "ready_to_merge",
         "note": "PR #2418 GitHub checks passed after the freeze harness fix and mergeStateStatus was CLEAN. Ready for squash merge; no staging wait, production deploy, CMS write, search, sitemap, llms, schema, hreflang, canonical, noindex, payment, order, benefit, entitlement, or fap-web work included."
+      }
+    ]
+  },
+  "IQ-OWNER-30-NORM-AUTHORITY-04A": {
+    "repo": "fap-api",
+    "branch": "codex/iq-owner-30-norm-authority-04a",
+    "base": "main",
+    "status": "local_validated",
+    "train_scope": "iq_owner_original_30_launch",
+    "title": "IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation",
+    "depends_on": [
+      "IQ-OWNER-30-SCORING-RUNTIME-BIND-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json updates for IQ-OWNER-30-NORM-AUTHORITY-04A and requested backend Owner 30 norm authority import/activation capability."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "IQ-OWNER-30-SCORING-RUNTIME-BIND-01 is recorded merged with merge commit 953ba036a0d5ca8dad855b9f0f226664dc376fef before this branch started."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/NormsIqImport.php",
+          "php -l backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php",
+          "cd backend && php artisan test tests/Feature/Psychometrics/IqNormsImportDryRunTest.php --no-ansi",
+          "cd backend && php artisan test tests/Feature/Content/IqNormAuthorityTest.php --no-ansi",
+          "cd backend && vendor/bin/pint --test app/Console/Commands/NormsIqImport.php tests/Feature/Psychometrics/IqNormsImportDryRunTest.php",
+          "python3 -m json.tool backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "PASS: PHP syntax checks; IqNormsImportDryRunTest (7 tests, 45 assertions, existing warnings only, exit 0); IqNormAuthorityTest (4 tests, 32 assertions, existing warnings only, exit 0); scoped Pint; fixture/state JSON parse; manifest YAML parse; git diff --check."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to IQ-OWNER-30-NORM-AUTHORITY-04A scope: NormsIqImport command, focused importer tests, claim-ready fixture, and docs/codex train metadata. No frontend, runtime scoring binding, CMS, SEO, deployment, or production norm data import changes."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "cdf77981324c5aaba4317fff6701607559cd3416",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-25T10:32:26Z",
+        "status": "in_progress",
+        "note": "Started backend-only Owner 30 norm authority activation from latest fap-api origin/main in an isolated clean worktree. Scope is guarded norms:iq:import activation, claim-ready fixture/tests, and docs/codex train metadata. No frontend, CMS, SEO, runtime scoring binding, staging deploy, production deploy, or production norm data import."
+      },
+      {
+        "at": "2026-06-25T10:37:20Z",
+        "status": "local_validated",
+        "note": "Local checks and scope validation passed. Guarded activation now requires dry-run=0, activate=1, require-claim-ready=1, IQ_OWNER_ORIGINAL_30 bank, public claim gate pass, and no duplicate authority version."
+      },
+      {
+        "at": "2026-06-25T10:38:20Z",
+        "status": "committed",
+        "note": "Created local scoped commit cdf77981324c5aaba4317fff6701607559cd3416."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -238,6 +238,49 @@ prs:
     deploy_allowed: false
     content_authority: backend
 
+  - id: IQ-OWNER-30-NORM-AUTHORITY-04A
+    repo: fap-api
+    depends_on:
+      - IQ-OWNER-30-SCORING-RUNTIME-BIND-01
+    branch: codex/iq-owner-30-norm-authority-04a
+    title: "IQ-OWNER-30-NORM-AUTHORITY-04A: Add owner IQ 30 norm authority activation"
+    train_scope: iq_owner_original_30_launch
+    status: user_authorized
+    scope:
+      - Add guarded backend import/activation for claim-eligible IQ_OWNER_ORIGINAL_30 norm authority records.
+      - Preserve dry-run validation by default and require explicit activate plus public-claim gate for writes.
+      - Reject non-owner banks, non-claim-ready payloads, and duplicate authority versions.
+      - Store authority evidence metadata without changing runtime scoring, frontend rendering, question bank assets, CMS, SEO, or deployment.
+    allowed_paths:
+      - backend/app/Console/Commands/NormsIqImport.php
+      - backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php
+      - backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend rendering, runtime scoring binding, question bank assets, answer keys, CMS, SEO runtime, sitemap, llms, JSON-LD, staging deploy, or production deploy.
+      - Import production norm data or trigger production writes outside the guarded command and test fixtures.
+      - Enable IQ estimate, percentile, ranking, or normed IQ claims without a claim-eligible backend norm authority.
+      - Emit correct answers, answer keys, solution rules, generator metadata, private provenance, or source capture URLs in public payloads.
+    validation:
+      - php -l backend/app/Console/Commands/NormsIqImport.php
+      - php -l backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php
+      - cd backend && php artisan test tests/Feature/Psychometrics/IqNormsImportDryRunTest.php --no-ansi
+      - cd backend && php artisan test tests/Feature/Content/IqNormAuthorityTest.php --no-ansi
+      - cd backend && vendor/bin/pint --test app/Console/Commands/NormsIqImport.php tests/Feature/Psychometrics/IqNormsImportDryRunTest.php
+      - python3 -m json.tool backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: BIG-FIVE-AGENT-APPROVAL-QUEUE-INTEGRATION-01
     repo: fap-api
     depends_on: []


### PR DESCRIPTION
## What changed
- Added guarded `norms:iq:import` activation support for `IQ_OWNER_ORIGINAL_30` norm authorities.
- Activation now requires explicit `--dry-run=0 --activate=1 --require-claim-ready=1`, the owner 30 bank, a passing public claim gate, and a non-duplicate authority version.
- Added a claim-ready owner 30 norm fixture plus focused importer tests for successful activation, non-owner rejection, duplicate rejection, and missing activation/claim-ready gates.
- Added the authorized `IQ-OWNER-30-NORM-AUTHORITY-04A` PR-train manifest/state entry.

## Why
Owner 30 IQ results must not claim IQ estimates until a locked, license-verified, sample-size-eligible norm authority exists. This PR adds the backend authority import/activation capability without changing runtime scoring or frontend rendering.

## Validation
- `php -l backend/app/Console/Commands/NormsIqImport.php`
- `php -l backend/tests/Feature/Psychometrics/IqNormsImportDryRunTest.php`
- `cd backend && php artisan test tests/Feature/Psychometrics/IqNormsImportDryRunTest.php --no-ansi`
- `cd backend && php artisan test tests/Feature/Content/IqNormAuthorityTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Console/Commands/NormsIqImport.php tests/Feature/Psychometrics/IqNormsImportDryRunTest.php`
- `python3 -m json.tool backend/tests/Fixtures/iq/norms/iq_owner30_claim_ready_valid.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No frontend changes.
- No runtime scoring bind to the activated norm version; that remains `IQ-OWNER-30-NORM-RUNTIME-BIND-04B`.
- No production norm import, CMS write, SEO work, staging deploy, production deploy, DB migration, sitemap, llms, canonical, noindex, or JSON-LD changes.

## Repository rule impact
Backend remains the authority layer for norm claim eligibility. This PR adds guarded backend authority activation only; it does not move content or claim logic into frontend/CMS.
